### PR TITLE
Pin outlier workflows to SHA

### DIFF
--- a/.github/workflows/dep-license-check.yml
+++ b/.github/workflows/dep-license-check.yml
@@ -26,12 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
           global-json-file: global.json
 

--- a/.github/workflows/license-compliance.yml
+++ b/.github/workflows/license-compliance.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: REUSE lint
-        uses: fsfe/reuse-action@v6
+        uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v6


### PR DESCRIPTION
## Summary

- Convert `actions/checkout@v6`, `actions/setup-dotnet@v5`, and `fsfe/reuse-action@v6` in [.github/workflows/dep-license-check.yml](.github/workflows/dep-license-check.yml) and [.github/workflows/license-compliance.yml](.github/workflows/license-compliance.yml) to SHA pins with `# vX` comments
- Aligns these two outliers with the rest of the repo's workflows, all of which already pin to SHA
- Dependabot reads the `# vX` trailing comment and will bump both the SHA and the comment in future updates

SHAs used (resolved from the respective tag's target commit):
- `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6`
- `actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5`
- `fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v6`

## Test plan

- [ ] `dep-license-check` runs successfully on this PR
- [ ] `reuse-lint` runs successfully on this PR