### PR TITLE
Gitignore docs/superpowers/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ infra/parameters.prod.*.json
 
 # Superpowers
 .superpowers
+docs/superpowers/
 
 # E2E test artifacts (screenshots, traces, DOM snapshots, JSON reports)
 artifacts/


### PR DESCRIPTION
## Summary

Add `docs/superpowers/` to `.gitignore` so brainstorming specs and implementation plans live only as local working artifacts, not committed to any remote.

## Why

Previously, `docs/superpowers/` was "intentionally absent from the public repo" via filter-on-push. This PR simplifies that policy: the directory is now gitignored outright, so specs and plans never enter git history at all.

## Test plan

- [ ] CI green (no-op for content; only `.gitignore` changes)
- [ ] `git check-ignore -v docs/superpowers/anything.md` reports the new rule