### PR TITLE
Harden CI workflow token and gitleaks integrity

### DIFF
--- a/.github/workflows/analyze-infra.yml
+++ b/.github/workflows/analyze-infra.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Run PSRule analysis
         uses: microsoft/ps-rule@46451b8f5258c41beb5ae69ed7190ccbba84112c # v2.9.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -27,6 +27,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,8 @@ jobs:
       app: ${{ steps.resolve.outputs.app }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter
@@ -130,6 +132,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,6 +30,8 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -20,11 +20,17 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install gitleaks
         run: |
-          GITLEAKS_VERSION="8.24.3"
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar xz -C /usr/local/bin gitleaks
+          set -euo pipefail
+          V=8.30.1
+          curl -sSfLO "https://github.com/gitleaks/gitleaks/releases/download/v${V}/gitleaks_${V}_linux_x64.tar.gz"
+          curl -sSfLO "https://github.com/gitleaks/gitleaks/releases/download/v${V}/gitleaks_${V}_checksums.txt"
+          grep " gitleaks_${V}_linux_x64.tar.gz$" "gitleaks_${V}_checksums.txt" | sha256sum -c -
+          sudo tar xz -C /usr/local/bin gitleaks -f "gitleaks_${V}_linux_x64.tar.gz"
+          rm -f "gitleaks_${V}_linux_x64.tar.gz" "gitleaks_${V}_checksums.txt"
 
       - name: Run gitleaks
         run: gitleaks detect --source . --verbose --redact

--- a/.github/workflows/stryker-nightly.yml
+++ b/.github/workflows/stryker-nightly.yml
@@ -27,6 +27,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -128,6 +128,8 @@ Repository-level evidence always in place on `main`:
 - Lockfile-enforced restore on CI (`RestoreLockedMode` gated on `$(CI)` in [`Directory.Build.props`](Directory.Build.props)) — transitive package drift fails the CI build. Enforced on 7 of 8 projects; the Blazor WASM project ([`app/Lfm.App.csproj`](app/Lfm.App.csproj)) opts out because its SDK-bundled implicit refs (`Microsoft.NET.Sdk.WebAssembly.Pack`, `Microsoft.DotNet.HotReload.WebAssembly.Browser`) drift independently of the pinned SDK version, making locked-mode impractical there. SDK version itself is pinned via `rollForward: disable` in [`global.json`](global.json).
 - [`NuGet.config`](NuGet.config) — `<clear />` + `nuget.org` only, plus `<packageSourceMapping>` pinning every package ID to `nuget.org` (defense against dependency confusion)
 - `CycloneDX` SBOM tool pinned via [`.config/dotnet-tools.json`](.config/dotnet-tools.json) — release job restores from the tool manifest rather than installing an unpinned global tool
+- `persist-credentials: false` on every `actions/checkout` step in every workflow — `GITHUB_TOKEN` is not left on disk for subsequent steps to reuse
+- Gitleaks release asset integrity verified via SHA-256 checksum file before extraction
 - [`LICENSE`](LICENSE) — AGPL-3.0-or-later, project license
 - [`NOTICE`](NOTICE) — copyright and "how to apply" pointer
 - [`REUSE.toml`](REUSE.toml) — collective license coverage for files


### PR DESCRIPTION
## Summary

Closes two findings from the 2026-04-17 supply-chain audit:

- `gh.HC-7` — `actions/checkout` persists `GITHUB_TOKEN` by default, including in the release job (`contents: write`). Fix: blanket `persist-credentials: false` on all 9 checkouts that didn't already have it.
- `gh.HC-8` — gitleaks binary fetched via `curl | tar` with version pin but no integrity check. Fix: download + checksum verify via the release's `checksums.txt` before extraction.

`SECURITY.md § Supply-chain evidence` updated inline with the two new controls.

## Stacked on PR #12

This branch is stacked on `claude/supply-chain-dep-integrity` (PR #12). After PR #12 merges to `main`, rebase this branch to pick up the clean delta. The `SECURITY.md` edit appends two bullets after PR #12's three; if PR #12's exact wording changes during review, this PR's rebase may surface a trivial context conflict.

## Test plan

- [ ] CI green
- [ ] `secrets-scan` job green (the new install step produces a working `gitleaks` binary)
- [ ] `grep -c 'persist-credentials: false' .github/workflows/*.yml` totals 11 (2 pre-existing + 9 added)
