### PR TITLE
Automate Dependabot PR handling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,15 +15,24 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      actions-minor:
+        update-types: [minor, patch]
 
   - package-ecosystem: docker
     directory: /api
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      docker-patch:
+        update-types: [patch]
 
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      docker-patch:
+        update-types: [patch]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 LFM contributors
+
+name: Dependabot Auto-Merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36 # v3.0.0
+
+      - name: Enable auto-merge for low-risk updates
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          (steps.meta.outputs.update-type == 'version-update:semver-minor' &&
+           steps.meta.outputs.package-ecosystem != 'docker')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --rebase "$PR_URL"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -104,6 +104,16 @@ The Azure Functions `dotnet-isolated` prebuilt base image runs as the base image
 
 **Retire when:** Microsoft ships OIDC support for the SWA deploy action.
 
+### Dependabot auto-merge for low-risk bumps
+
+`.github/workflows/dependabot-auto-merge.yml` enables GitHub's native auto-merge on Dependabot PRs matching a fixed policy: patch for every ecosystem, and minor for every ecosystem except docker. Major bumps and docker minor bumps stay manual.
+
+**Trust boundary:** the `dependabot/fetch-metadata` action (SHA-pinned) and GitHub's Dependabot service for correct tag→SHA resolution. Compromise of either would allow a malicious low-risk-level version bump to land after passing CI.
+
+**Compensating controls:** the `protect-main` ruleset's required status checks (CI, secrets-scan, analyze-infra) run the full build + unit/component tests + vulnerable-package audit + bundle-size budget before any auto-merge can complete. A failure in any required check keeps the PR open for manual review.
+
+**Retire when:** never (permanent on a hobby-project cost stance).
+
 ## Supply-chain evidence (per release)
 
 Every `push: main` that runs the deploy workflow produces a GitHub


### PR DESCRIPTION
## Summary

Enables GitHub's native auto-merge on Dependabot PRs for low-risk bumps, groups the remaining ungrouped ecosystems to reduce weekly PR surface, and documents the trust boundary in SECURITY.md.

### Policy

| Ecosystem | Patch | Minor | Major |
|---|---|---|---|
| github-actions | auto | auto | manual |
| nuget (grouped `dotnet-minor`) | auto | auto | manual |
| docker | auto | manual | manual |

Docker minor stays manual because base image minor bumps can shift the runtime user/filesystem layout; patches cannot. All other minor bumps are as safe as patches because CI rebuilds, runs unit+component tests, and the vuln audit before any PR can merge.

### What this adds

- `.github/workflows/dependabot-auto-merge.yml` — 30-line workflow pinned to `dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36` (v3.0.0). Uses `on: pull_request` (not `pull_request_target`), job-level `if: github.actor == 'dependabot[bot]'` guard, env-var sanitization on PR URL.
- `.github/dependabot.yml` — adds `actions-minor` group (github-actions minor+patch) and `docker-patch` groups on both docker ecosystems (patches only).
- `SECURITY.md` — new §Known Exceptions entry naming the trust boundary (Dependabot's tag→SHA resolution + `dependabot/fetch-metadata`) and the compensating controls (required status checks).

### Pre-merge audit

Ran `devsecops-audit` quick mode against the proposed workflow. One info-level finding (unused `alert-lookup: true`) was applied before this PR; no block/warn findings. Positive signals: `gha.POS-1`, `gha.POS-3`, `DSO-POS-5`. Full details in the plan file referenced below.

### One-time manual step (cannot be done via PR)

After merge: **Settings → General → Pull Requests → "Allow auto-merge"** → enable. Without this, `gh pr merge --auto` returns 422 and the workflow step fails visibly in the Actions log.

### Plan reference

`.claude/plans/create-a-table-of-humming-crystal.md` (local) — contains the full design rationale, pre-merge audit transcript, and verification plan.

## Test plan

- [ ] CI passes on this PR (workflow itself doesn't run because the guard `github.actor == 'dependabot[bot]'` skips non-Dependabot PRs — the workflow just needs to parse).
- [ ] After merge, enable "Allow auto-merge" in repo settings.
- [ ] Wait for next Monday's Dependabot run. Expected: one grouped github-actions PR with all minor+patch bumps; `auto-merge` job shows "enabled" in PR timeline; all 3 required checks pass; PR auto-merges with rebase.
- [ ] Confirm a major bump (if any this cycle) is **not** auto-merged. The `if:` excludes `version-update:semver-major`.
- [ ] Confirm normal non-Dependabot PRs show the job as "skipped" (job-level guard short-circuits).
