### PR TITLE
Disable e2e auto-trigger

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,17 +4,11 @@
 name: E2E
 
 on:
+  # Auto-trigger on PRs disabled: flaky WCAG checks against FluentUI shadow DOM
+  # produce intermittent failures, and the full stack (Cosmos + Azurite + Functions
+  # + Playwright) chews through runner minutes on every push. Run manually from
+  # the Actions tab when an E2E signal is actually needed.
   workflow_dispatch:
-  pull_request:
-    branches: [main]
-    paths:
-      - 'api/**'
-      - 'app/**'
-      - 'shared/**'
-      - 'tests/**'
-      - 'lfm.sln'
-      - 'global.json'
-      - '.github/workflows/e2e.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Remove the `pull_request` trigger from `e2e.yml`. Keep `workflow_dispatch` so the suite can still be run manually from the Actions tab when needed.

## Why

- Flaky: WCAG axe scans against FluentUI shadow-DOM elements produce intermittent label/timing failures (e.g. `GuildAdminPage_MeetsWcag22AA` on `/guild/admin` failed once in PR #12's run while passing on #13's parallel run of the same code).
- Cost: full E2E stack (testcontainers Cosmos + Azurite + Functions + Playwright) is the heaviest job in the repo and runs on every PR touching `api/`, `app/`, `shared/`, or `tests/`.

## Test plan

- [ ] `e2e.yml` no longer appears in the checks list of new PRs
- [ ] Manual "Run workflow" button still works on the Actions tab → `E2E` workflow