### PR TITLE
a11y: fix keyboard operation, focus management, heading structure

### DIFF
--- a/app/App.razor
+++ b/app/App.razor
@@ -16,7 +16,6 @@
                         <FluentProgressRing />
                     </Authorizing>
                 </AuthorizeRouteView>
-                <FocusOnNavigate RouteData="@routeData" Selector="h1" />
             </Found>
         </Router>
     </CascadingAuthenticationState>

--- a/app/Layout/MainLayout.razor
+++ b/app/Layout/MainLayout.razor
@@ -76,7 +76,7 @@
     </AuthorizeView>
 
     <!-- Page content -->
-    <main id="main-content" tabindex="-1" style="flex:1;padding:24px 16px;outline:none">
+    <main id="main-content" tabindex="-1" @ref="mainRef" style="flex:1;padding-block:24px;padding-inline:16px">
         @Body
     </main>
 
@@ -101,6 +101,8 @@
 
 @code {
     private bool _showMobileMenu;
+    private bool _navigated;
+    private ElementReference mainRef;
     private string _themeIcon = "\u2600\ufe0f";
     private string _themeTooltip = string.Empty;
 
@@ -139,6 +141,7 @@
     private void OnLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
     {
         _showMobileMenu = false;
+        _navigated = true;
         InvokeAsync(StateHasChanged);
     }
 
@@ -147,6 +150,12 @@
         if (firstRender)
         {
             await JS.InvokeVoidAsync("lfmSetDocumentLang", LocaleService.CurrentLocale);
+        }
+
+        if (_navigated)
+        {
+            _navigated = false;
+            try { await mainRef.FocusAsync(); } catch { /* element may be stale during teardown */ }
         }
     }
 

--- a/app/Layout/MainLayout.razor
+++ b/app/Layout/MainLayout.razor
@@ -76,7 +76,7 @@
     </AuthorizeView>
 
     <!-- Page content -->
-    <main id="main-content" tabindex="-1" @ref="mainRef" style="flex:1;padding-block:24px;padding-inline:16px">
+    <main id="main-content" tabindex="-1" @ref="_mainRef" style="flex:1;padding-block:24px;padding-inline:16px">
         @Body
     </main>
 
@@ -102,7 +102,7 @@
 @code {
     private bool _showMobileMenu;
     private bool _navigated;
-    private ElementReference mainRef;
+    private ElementReference _mainRef;
     private string _themeIcon = "\u2600\ufe0f";
     private string _themeTooltip = string.Empty;
 
@@ -155,7 +155,12 @@
         if (_navigated)
         {
             _navigated = false;
-            try { await mainRef.FocusAsync(); } catch { /* element may be stale during teardown */ }
+            try
+            {
+                await _mainRef.FocusAsync();
+            }
+            catch (InvalidOperationException) { /* mainRef not bound yet — page is being torn down. */ }
+            catch (Microsoft.JSInterop.JSDisconnectedException) { /* JS channel disposed during teardown. */ }
         }
     }
 

--- a/app/Pages/CharactersPage.razor
+++ b/app/Pages/CharactersPage.razor
@@ -13,7 +13,7 @@
 
 <FluentStack Orientation="Orientation.Vertical" VerticalGap="16">
     <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="12" Style="align-items:center">
-        <FluentLabel Typo="Typography.H3" Style="flex:1">@Loc["characters.title"]</FluentLabel>
+        <FluentLabel Typo="Typography.H1" Style="flex:1">@Loc["characters.title"]</FluentLabel>
         <FluentButton Appearance="Appearance.Outline" OnClick="@RefreshCharacters" Disabled="@loading">
             @Loc["characters.refresh"]
         </FluentButton>

--- a/app/Pages/CharactersPage.razor
+++ b/app/Pages/CharactersPage.razor
@@ -58,7 +58,7 @@
                             @onclick="@(() => HandleSelectCharacter(c))">
                         @if (isSelected)
                         {
-                            <div style="position:absolute;top:8px;right:8px;background:var(--accent-fill-rest);color:var(--foreground-on-accent-rest);font-size:0.7em;padding:2px 8px;border-radius:10px;z-index:1;pointer-events:none">@Loc["characters.active"]</div>
+                            <span style="display:inline-block;position:absolute;top:8px;right:8px;background:var(--accent-fill-rest);color:var(--foreground-on-accent-rest);font-size:0.7em;padding:2px 8px;border-radius:10px;z-index:1;pointer-events:none">@Loc["characters.active"]</span>
                         }
                         <FluentCard Style="padding:12px">
                             <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="12" Style="align-items:center">

--- a/app/Pages/CharactersPage.razor
+++ b/app/Pages/CharactersPage.razor
@@ -49,10 +49,13 @@
                     var wrapperStyle = isSelected
                         ? "position:relative;cursor:default;outline:2px solid var(--accent-fill-rest);outline-offset:-1px;border-radius:4px"
                         : "position:relative;cursor:pointer";
-                    <div @key="@CharKey(c)"
-                         data-char-id="@CharKey(c)"
-                         style="@wrapperStyle"
-                         @onclick="@(() => HandleSelectCharacter(c))">
+                    <button type="button"
+                            class="character-card"
+                            @key="@CharKey(c)"
+                            data-char-id="@CharKey(c)"
+                            aria-pressed="@(isSelected ? "true" : "false")"
+                            style="@wrapperStyle"
+                            @onclick="@(() => HandleSelectCharacter(c))">
                         @if (isSelected)
                         {
                             <div style="position:absolute;top:8px;right:8px;background:var(--accent-fill-rest);color:var(--foreground-on-accent-rest);font-size:0.7em;padding:2px 8px;border-radius:10px;z-index:1;pointer-events:none">@Loc["characters.active"]</div>
@@ -82,7 +85,7 @@
                                 </FluentStack>
                             </FluentStack>
                         </FluentCard>
-                    </div>
+                    </button>
                 }
             </div>
             break;

--- a/app/Pages/CreateRunPage.razor
+++ b/app/Pages/CreateRunPage.razor
@@ -12,7 +12,7 @@
 <PageTitle>@Loc["createRun.title"]</PageTitle>
 
 <FluentStack Orientation="Orientation.Vertical" VerticalGap="16" Style="max-width:600px">
-    <FluentLabel Typo="Typography.H3">@Loc["createRun.title"]</FluentLabel>
+    <FluentLabel Typo="Typography.H1">@Loc["createRun.title"]</FluentLabel>
 
     @if (loadError != null)
     {

--- a/app/Pages/EditRunPage.razor
+++ b/app/Pages/EditRunPage.razor
@@ -12,7 +12,7 @@
 <PageTitle>@Loc["editRun.title"]</PageTitle>
 
 <FluentStack Orientation="Orientation.Vertical" VerticalGap="16" Style="max-width:800px">
-    <FluentLabel Typo="Typography.H3">@Loc["editRun.title"]</FluentLabel>
+    <FluentLabel Typo="Typography.H1">@Loc["editRun.title"]</FluentLabel>
 
     @switch (state)
     {

--- a/app/Pages/GoodbyePage.razor
+++ b/app/Pages/GoodbyePage.razor
@@ -4,7 +4,7 @@
 <PageTitle>@Loc["goodbye.title"] — @Loc["nav.logo"]</PageTitle>
 
 <FluentStack Orientation="Orientation.Vertical" VerticalGap="16" HorizontalAlignment="HorizontalAlignment.Center">
-    <FluentLabel Typo="Typography.H2">@Loc["goodbye.title"]</FluentLabel>
+    <FluentLabel Typo="Typography.H1">@Loc["goodbye.title"]</FluentLabel>
     <FluentLabel>@Loc["goodbye.body1"]</FluentLabel>
     <FluentLabel>@Loc["goodbye.body2"]</FluentLabel>
     <a href="/login">

--- a/app/Pages/GuildAdminPage.razor
+++ b/app/Pages/GuildAdminPage.razor
@@ -10,7 +10,7 @@
 <PageTitle>@Loc["guildAdmin.title"]</PageTitle>
 
 <FluentStack Orientation="Orientation.Vertical" VerticalGap="16">
-    <FluentLabel Typo="Typography.H3">@Loc["guildAdmin.title"]</FluentLabel>
+    <FluentLabel Typo="Typography.H1">@Loc["guildAdmin.title"]</FluentLabel>
 
     @if (loadError != null)
     {

--- a/app/Pages/GuildPage.razor
+++ b/app/Pages/GuildPage.razor
@@ -8,7 +8,7 @@
 <PageTitle>@Loc["guild.title"]</PageTitle>
 
 <FluentStack Orientation="Orientation.Vertical" VerticalGap="12">
-    <FluentLabel Typo="Typography.H3">@Loc["guild.title"]</FluentLabel>
+    <FluentLabel Typo="Typography.H1">@Loc["guild.title"]</FluentLabel>
 
     @switch (state)
     {

--- a/app/Pages/InstancesPage.razor
+++ b/app/Pages/InstancesPage.razor
@@ -8,7 +8,7 @@
 <PageTitle>@Loc["instances.title"]</PageTitle>
 
 <FluentStack Orientation="Orientation.Vertical" VerticalGap="12">
-  <FluentLabel Typo="Typography.H3">@Loc["instances.title"]</FluentLabel>
+  <FluentLabel Typo="Typography.H1">@Loc["instances.title"]</FluentLabel>
 
   @switch (state)
   {

--- a/app/Pages/LoginFailedPage.razor
+++ b/app/Pages/LoginFailedPage.razor
@@ -5,7 +5,7 @@
 <PageTitle>@Loc["loginFailed.title"] — @Loc["nav.logo"]</PageTitle>
 
 <FluentStack Orientation="Orientation.Vertical" VerticalGap="16" HorizontalAlignment="HorizontalAlignment.Center">
-    <FluentLabel Typo="Typography.H3">@Loc["loginFailed.title"]</FluentLabel>
+    <FluentLabel Typo="Typography.H1">@Loc["loginFailed.title"]</FluentLabel>
     <FluentLabel>@Loc["loginFailed.subtitle"]</FluentLabel>
     <FluentAnchor Href="/login" Appearance="Appearance.Outline">@Loc["loginFailed.button"]</FluentAnchor>
 </FluentStack>

--- a/app/Pages/LoginPage.razor
+++ b/app/Pages/LoginPage.razor
@@ -6,7 +6,7 @@
 <PageTitle>@Loc["login.title"] — @Loc["nav.logo"]</PageTitle>
 
 <FluentStack Orientation="Orientation.Vertical" VerticalGap="16" HorizontalAlignment="HorizontalAlignment.Center">
-    <FluentLabel Typo="Typography.H2">@Loc["login.title"]</FluentLabel>
+    <FluentLabel Typo="Typography.H1">@Loc["login.title"]</FluentLabel>
     <FluentLabel>@Loc["login.subtitle"]</FluentLabel>
     <FluentButton Appearance="Appearance.Accent" OnClick="@NavigateToLogin">@Loc["login.button"]</FluentButton>
 </FluentStack>

--- a/app/Pages/NotFound.razor
+++ b/app/Pages/NotFound.razor
@@ -2,5 +2,5 @@
 @layout MainLayout
 @inject IStringLocalizer Loc
 
-<h3>@Loc["notFound.title"]</h3>
+<h1>@Loc["notFound.title"]</h1>
 <p>@Loc["notFound.body"]</p>

--- a/app/Pages/PrivacyPolicyPage.razor
+++ b/app/Pages/PrivacyPolicyPage.razor
@@ -6,7 +6,7 @@
 
 <FluentStack Orientation="Orientation.Vertical" VerticalGap="24">
     <FluentStack Orientation="Orientation.Vertical" VerticalGap="4">
-        <FluentLabel Typo="Typography.H2">@Loc["privacy.title"]</FluentLabel>
+        <FluentLabel Typo="Typography.H1">@Loc["privacy.title"]</FluentLabel>
         <FluentLabel>@Loc["privacy.lastUpdated"]</FluentLabel>
     </FluentStack>
 

--- a/app/Pages/RunsPage.razor
+++ b/app/Pages/RunsPage.razor
@@ -49,7 +49,7 @@
                                 @key="run.Id"
                                 data-testid="run-item-@run.Id"
                                 class="run-list-item @(isSelected ? "run-list-item--selected" : "")"
-                                aria-pressed="@isSelected"
+                                aria-pressed="@(isSelected ? "true" : "false")"
                                 @onclick="@(() => SelectRun(run.Id))">
                             <span class="run-list-item__header">
                                 <span class="run-list-item__title">@run.InstanceName</span>

--- a/app/Pages/RunsPage.razor
+++ b/app/Pages/RunsPage.razor
@@ -45,19 +45,21 @@
                     {
                         var isSelected = run.Id == selectedRunId;
                         var attending = CountAttending(run.RunCharacters);
-                        <div @key="run.Id"
-                             data-testid="run-item-@run.Id"
-                             class="run-list-item @(isSelected ? "run-list-item--selected" : "")"
-                             @onclick="@(() => SelectRun(run.Id))">
-                            <div class="run-list-item__header">
+                        <button type="button"
+                                @key="run.Id"
+                                data-testid="run-item-@run.Id"
+                                class="run-list-item @(isSelected ? "run-list-item--selected" : "")"
+                                aria-pressed="@isSelected"
+                                @onclick="@(() => SelectRun(run.Id))">
+                            <span class="run-list-item__header">
                                 <span class="run-list-item__title">@run.InstanceName</span>
                                 <DifficultyPill ModeKey="@run.ModeKey" />
-                            </div>
+                            </span>
                             <span class="run-list-item__date">@FormatDate(run.StartTime)</span>
                             <span class="run-list-item__footer">
                                 @Loc["runs.attendingSignedUp", attending, run.RunCharacters.Count]
                             </span>
-                        </div>
+                        </button>
                     }
                 </div>
 

--- a/app/Pages/RunsPage.razor
+++ b/app/Pages/RunsPage.razor
@@ -11,7 +11,7 @@
 
 <FluentStack Orientation="Orientation.Vertical" VerticalGap="12">
     <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="12" Style="align-items:center">
-        <FluentLabel Typo="Typography.H3" Style="flex:1">@Loc["runs.title"]</FluentLabel>
+        <FluentLabel Typo="Typography.H1" Style="flex:1">@Loc["runs.title"]</FluentLabel>
         <FluentButton Appearance="Appearance.Accent" OnClick="@(() => Nav.NavigateTo("/runs/new"))">
             @Loc["runs.create"]
         </FluentButton>

--- a/app/wwwroot/css/app.css
+++ b/app/wwwroot/css/app.css
@@ -180,6 +180,11 @@ a, .btn-link {
     border-bottom: 1px solid var(--neutral-stroke-rest);
 }
 
+.run-list-item:focus-visible {
+    outline: 2px solid var(--accent-fill-rest);
+    outline-offset: -2px;
+}
+
 .run-list-item:last-child {
     border-bottom: none;
 }
@@ -412,4 +417,10 @@ a, .btn-link {
     box-sizing: border-box;
     display: block;
     cursor: pointer;
+}
+
+.character-card:focus-visible {
+    outline: 2px solid var(--accent-fill-rest);
+    outline-offset: 2px;
+    border-radius: 4px;
 }

--- a/app/wwwroot/css/app.css
+++ b/app/wwwroot/css/app.css
@@ -166,7 +166,8 @@ a, .btn-link {
     }
 }
 
-/* Run list items — rendered as <button> for keyboard activation. */
+/* Run list items — rendered as <button> for keyboard activation.
+   all: unset relies on .runs-sidebar setting color + font for text inheritance. */
 .run-list-item {
     all: unset;
     box-sizing: border-box;

--- a/app/wwwroot/css/app.css
+++ b/app/wwwroot/css/app.css
@@ -29,10 +29,6 @@ html, body {
     color: var(--foreground-on-accent-rest);
 }
 
-h1:focus {
-    outline: none;
-}
-
 a, .btn-link {
     color: var(--accent-fill-rest);
 }

--- a/app/wwwroot/css/app.css
+++ b/app/wwwroot/css/app.css
@@ -166,8 +166,11 @@ a, .btn-link {
     }
 }
 
-/* Run list items */
+/* Run list items — rendered as <button> for keyboard activation. */
 .run-list-item {
+    all: unset;
+    box-sizing: border-box;
+    width: 100%;
     display: flex;
     flex-direction: column;
     gap: 4px;

--- a/app/wwwroot/css/app.css
+++ b/app/wwwroot/css/app.css
@@ -404,3 +404,12 @@ a, .btn-link {
     background: var(--neutral-stroke-rest);
     color: var(--neutral-foreground-rest);
 }
+
+/* Character card — rendered as <button> for keyboard activation.
+   all: unset relies on ancestor layout setting color + font for text inheritance. */
+.character-card {
+    all: unset;
+    box-sizing: border-box;
+    display: block;
+    cursor: pointer;
+}

--- a/tests/Lfm.App.Tests/CharactersPagesTests.cs
+++ b/tests/Lfm.App.Tests/CharactersPagesTests.cs
@@ -508,6 +508,30 @@ public class CharactersPagesTests : ComponentTestBase
     }
 
     [Fact]
+    public void CharactersPage_Character_Card_Is_A_Button()
+    {
+        this.AddAuthorization().SetAuthorized("player#1234");
+        var battleNet = new Mock<IBattleNetClient>();
+        battleNet.Setup(c => c.GetCharactersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { MakeChar("Arthas") });
+        battleNet.Setup(c => c.GetPortraitsAsync(It.IsAny<IEnumerable<CharacterPortraitRequest>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IDictionary<string, string>?)null);
+        var me = new Mock<IMeClient>();
+        me.Setup(c => c.GetAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeMeResponse());
+        Services.AddSingleton(battleNet.Object);
+        Services.AddSingleton(me.Object);
+
+        var cut = Render<CharactersPage>();
+
+        cut.WaitForAssertion(() =>
+        {
+            var cards = cut.FindAll("button.character-card");
+            Assert.NotEmpty(cards);
+        });
+    }
+
+    [Fact]
     public void Click_on_Failed_card_retries_enrich_then_PUTs()
     {
         this.AddAuthorization().SetAuthorized("player#1234");

--- a/tests/Lfm.App.Tests/HeadingStructureTests.cs
+++ b/tests/Lfm.App.Tests/HeadingStructureTests.cs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Bunit;
+using Bunit.TestDoubles;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Lfm.App.Pages;
+using Lfm.App.Services;
+using Lfm.Contracts.Characters;
+using Lfm.Contracts.Guild;
+using Lfm.Contracts.Instances;
+using Lfm.Contracts.Me;
+using Lfm.Contracts.Runs;
+using Xunit;
+
+namespace Lfm.App.Tests;
+
+public class HeadingStructureTests : ComponentTestBase
+{
+    private void WireAuthStubs()
+    {
+        var battleNet = new Mock<IBattleNetClient>();
+        battleNet.Setup(c => c.GetCharactersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<CharacterDto>?)null);
+        battleNet.Setup(c => c.GetPortraitsAsync(It.IsAny<IEnumerable<CharacterPortraitRequest>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IDictionary<string, string>?)null);
+        var me = new Mock<IMeClient>();
+        me.Setup(c => c.GetAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MeResponse?)null);
+        var guild = new Mock<IGuildClient>();
+        guild.Setup(c => c.GetAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GuildDto?)null);
+        var runs = new Mock<IRunsClient>();
+        runs.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<RunSummaryDto>());
+        var instances = new Mock<IInstancesClient>();
+        instances.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<InstanceDto>());
+
+        Services.AddSingleton(battleNet.Object);
+        Services.AddSingleton(me.Object);
+        Services.AddSingleton(guild.Object);
+        Services.AddSingleton(runs.Object);
+        Services.AddSingleton(instances.Object);
+    }
+
+    [Theory]
+    [InlineData(typeof(LandingPage))]
+    [InlineData(typeof(LoginPage))]
+    [InlineData(typeof(LoginFailedPage))]
+    [InlineData(typeof(GoodbyePage))]
+    [InlineData(typeof(PrivacyPolicyPage))]
+    [InlineData(typeof(NotFound))]
+    public void UnauthenticatedPage_Renders_Exactly_One_H1(Type pageType)
+    {
+        this.AddAuthorization();
+        WireAuthStubs();
+
+        var cut = this.GetType().GetMethod(nameof(RenderByType), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .MakeGenericMethod(pageType)
+            .Invoke(this, null)!;
+        var markup = (string)cut.GetType().GetProperty("Markup")!.GetValue(cut)!;
+
+        var h1Count = System.Text.RegularExpressions.Regex.Matches(markup, "<h1(\\s|>)").Count;
+        Assert.Equal(1, h1Count);
+    }
+
+    private IRenderedComponent<T> RenderByType<T>() where T : Microsoft.AspNetCore.Components.IComponent
+        => Render<T>();
+
+    [Theory]
+    [InlineData(typeof(RunsPage))]
+    [InlineData(typeof(CharactersPage))]
+    [InlineData(typeof(GuildPage))]
+    [InlineData(typeof(GuildAdminPage))]
+    [InlineData(typeof(CreateRunPage))]
+    [InlineData(typeof(InstancesPage))]
+    public void AuthenticatedPage_Renders_Exactly_One_H1(Type pageType)
+    {
+        this.AddAuthorization().SetAuthorized("player#1234");
+        WireAuthStubs();
+
+        var cut = this.GetType().GetMethod(nameof(RenderByType), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .MakeGenericMethod(pageType)
+            .Invoke(this, null)!;
+        var markup = (string)cut.GetType().GetProperty("Markup")!.GetValue(cut)!;
+
+        var h1Count = System.Text.RegularExpressions.Regex.Matches(markup, "<h1(\\s|>)").Count;
+        Assert.Equal(1, h1Count);
+    }
+}

--- a/tests/Lfm.App.Tests/HeadingStructureTests.cs
+++ b/tests/Lfm.App.Tests/HeadingStructureTests.cs
@@ -75,6 +75,7 @@ public class HeadingStructureTests : ComponentTestBase
     [InlineData(typeof(GuildPage))]
     [InlineData(typeof(GuildAdminPage))]
     [InlineData(typeof(CreateRunPage))]
+    [InlineData(typeof(EditRunPage))]
     [InlineData(typeof(InstancesPage))]
     public void AuthenticatedPage_Renders_Exactly_One_H1(Type pageType)
     {

--- a/tests/Lfm.App.Tests/LayoutTests.cs
+++ b/tests/Lfm.App.Tests/LayoutTests.cs
@@ -114,4 +114,19 @@ public class LayoutTests : ComponentTestBase
         var toggle = cut.Find("fluent-button[aria-label='Switch to light mode']");
         Assert.NotNull(toggle);
     }
+
+    [Fact]
+    public void MainLayout_Main_Element_Has_Ref_For_Focus_Management()
+    {
+        this.AddAuthorization();
+        var cut = Render<MainLayout>(p =>
+            p.Add(x => x.Body, builder => builder.AddContent(0, "page content")));
+
+        // The <main> must exist and be focusable (tabindex=-1).
+        var main = cut.Find("main#main-content");
+        Assert.NotNull(main);
+        Assert.Equal("-1", main.GetAttribute("tabindex"));
+        // The FocusOnNavigate component with Selector="h1" must be gone — focus is now driven by MainLayout's LocationChanged handler.
+        Assert.DoesNotContain("FocusOnNavigate", cut.Markup);
+    }
 }

--- a/tests/Lfm.App.Tests/RunsPageKeyboardTests.cs
+++ b/tests/Lfm.App.Tests/RunsPageKeyboardTests.cs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Bunit;
+using Bunit.TestDoubles;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Lfm.App.Pages;
+using Lfm.App.Services;
+using Lfm.Contracts.Runs;
+using Xunit;
+
+namespace Lfm.App.Tests;
+
+public class RunsPageKeyboardTests : ComponentTestBase
+{
+    private static readonly string FutureStartTime =
+        DateTimeOffset.UtcNow.AddDays(30).ToString("o");
+    private static readonly string FutureSignupCloseTime =
+        DateTimeOffset.UtcNow.AddDays(30).AddHours(-2).ToString("o");
+    private static readonly string PastCreatedAt =
+        DateTimeOffset.UtcNow.AddDays(-14).ToString("o");
+
+    private static RunSummaryDto MakeRun(string id, string name) =>
+        new(
+            Id: id,
+            StartTime: FutureStartTime,
+            SignupCloseTime: FutureSignupCloseTime,
+            Description: "",
+            ModeKey: "MYTHIC",
+            Visibility: "PUBLIC",
+            CreatorGuild: "Test",
+            CreatorGuildId: null,
+            InstanceId: 1,
+            InstanceName: name,
+            CreatorBattleNetId: null,
+            CreatedAt: PastCreatedAt,
+            Ttl: 604800,
+            RunCharacters: Array.Empty<RunCharacterDto>());
+
+    [Fact]
+    public void RunsPage_Run_List_Item_Is_A_Button()
+    {
+        this.AddAuthorization().SetAuthorized("player#1234");
+        var runs = new Mock<IRunsClient>();
+        runs.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { MakeRun("r1", "Mythic Test") });
+        Services.AddSingleton(runs.Object);
+
+        var cut = Render<RunsPage>();
+
+        cut.WaitForAssertion(() =>
+        {
+            // The list row MUST be a <button>, not a <div>.
+            var buttons = cut.FindAll("button.run-list-item");
+            Assert.NotEmpty(buttons);
+
+            var divs = cut.FindAll("div.run-list-item");
+            Assert.Empty(divs);
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 of the responsive-design remediation. Closes the 5 block-level WCAG findings from the 2026-04-18 full-sweep review of `app/`.

**Findings resolved:**
- `HC-CRIT-1` + `HC-CRIT-2`: clickable `<div @onclick>` on run-list rows and character cards → `<button type="button">` (SC 2.1.1 Keyboard, SC 4.1.2 Name/Role/Value).
- `RD-FOCUS-1`: removed `h1:focus { outline: none }` and `<main outline:none>` so keyboard focus is visible (SC 2.4.7).
- `RD-H1-1`: every route now opens with exactly one semantic `<h1>` (was H2/H3 on 12 of 13 routes) — `<FluentLabel Typo="Typography.H1">` on 11 pages + raw `<h1>` on NotFound (SC 1.3.1, 2.4.6, 2.4.10).
- `blazor.HC-3`: focus moves to `<main>` after each navigation via `ElementReference.FocusAsync()` in `MainLayout.razor` (replaces `<FocusOnNavigate Selector="h1">`, which previously only worked on the landing page).

## Approach

- `<h1>` semantic flip is a minimal per-page change: `Typography.H3` → `Typography.H1` on the top `FluentLabel`. Confirmed `FluentLabel` emits the real HTML tag, not a div with CSS styling.
- Focus-on-navigate uses `_navigated` flag set in `OnLocationChanged` + `await _mainRef.FocusAsync()` in `OnAfterRenderAsync`. Catches `InvalidOperationException` and `JSDisconnectedException` for teardown races.
- Clickable-div conversion uses `all: unset` + explicit `:focus-visible` outlines with `var(--accent-fill-rest)`. `aria-pressed` uses the lowercase string-ternary form (`@(isSelected ? "true" : "false")`) for ARIA spec conformance.

## Test plan

- [x] `dotnet format lfm.sln --verify-no-changes` — clean
- [x] `dotnet build lfm.sln -c Release` — 0 warnings, 0 errors
- [x] `dotnet test tests/Lfm.Api.Tests/...` — 366 / 366
- [x] `dotnet test tests/Lfm.App.Tests/...` — 126 / 126 (13 new)
- [x] `dotnet test tests/Lfm.App.Core.Tests/...` — 89 / 89
- [ ] **Manual browser pass** (reviewer) — tab through each route, confirm focus ring visible on `<main>` and on list/card buttons; press `Enter`/`Space` on run-list-item and character-card to confirm activation; screen reader announces "heading level 1" on every route
- [ ] Lighthouse / axe-core audit (reviewer)

## New tests

- `HeadingStructureTests.cs` — 13 theory cases (one per route) asserting exactly one `<h1>`
- `RunsPageKeyboardTests.cs` — asserts `button.run-list-item` renders; no `div.run-list-item` remains
- `CharactersPagesTests.CharactersPage_Character_Card_Is_A_Button` — asserts `button.character-card` renders
- `LayoutTests.MainLayout_Main_Element_Has_Ref_For_Focus_Management` — lock-in for `<main tabindex="-1">` + absence of `<FocusOnNavigate>`

## Known limitations

- `<FluentCard>` (a custom element wrapping `<div>` children) nested inside `<button class="character-card">` is technically non-phrasing content inside an interactive element. Browsers tolerate it via error recovery; screen readers announce the card text correctly. Tracked as future Fluent-UI composition debt; not a WCAG blocker.
- No LCP / CLS / INP numbers claimed — static signals only. Runtime Core Web Vitals need RUM.
- `prefers-reduced-motion` and `dir="rtl"` visual verification are Phase 2/3 scope.

## Scope

14 commits, 20 files, +264 / -32. Part of a 6-phase remediation; remaining phases (mobile viewport, i18n foundation, host boilerplate, forms, images) ship as separate PRs per `docs/superpowers/plans/2026-04-19-responsive-design-remediation.md`.