### PR TITLE
responsive: svh + mobile-first breakpoints + hover/motion gates

### DIFF
--- a/app/Layout/MainLayout.razor
+++ b/app/Layout/MainLayout.razor
@@ -11,7 +11,7 @@
 
 <FluentToastProvider />
 
-<div style="min-height:100vh;display:flex;flex-direction:column">
+<div style="min-block-size:100svh;display:flex;flex-direction:column">
     <!-- Skip-to-content link for keyboard users -->
     <a href="#main-content" class="skip-link">@Loc["a11y.skipToContent"]</a>
 

--- a/app/wwwroot/css/app.css
+++ b/app/wwwroot/css/app.css
@@ -19,8 +19,10 @@ html, body {
     border-radius: 5px;
 }
 
-::-webkit-scrollbar-thumb:hover {
-    background: var(--neutral-foreground-hint-rest);
+@media (hover: hover) and (pointer: fine) {
+    ::-webkit-scrollbar-thumb:hover {
+        background: var(--neutral-foreground-hint-rest);
+    }
 }
 
 /* Text selection theming */
@@ -84,7 +86,12 @@ a, .btn-link {
         .loading-progress circle:last-child {
             stroke: var(--accent-fill-rest, #1b6ec2);
             stroke-dasharray: calc(3.141 * var(--blazor-load-percentage, 0%) * 0.8), 500%;
-            transition: stroke-dasharray 0.05s ease-in-out;
+        }
+
+        @media (prefers-reduced-motion: no-preference) {
+            .loading-progress circle:last-child {
+                transition: stroke-dasharray 0.05s ease-in-out;
+            }
         }
 
 .loading-progress-text {
@@ -114,39 +121,45 @@ a, .btn-link {
     top: 0;
 }
 
-/* Responsive navigation */
-.mobile-nav-toggle {
+/* Responsive navigation — mobile-first cascade. */
+.desktop-nav {
     display: none;
+}
+
+.mobile-nav-toggle {
+    display: inline-flex;
 }
 
 .mobile-menu {
     display: none;
 }
 
-@media (max-width: 768px) {
+.mobile-menu.open {
+    display: flex;
+}
+
+@media (min-width: 48em) {
     .desktop-nav {
-        display: none !important;
+        display: inline-flex;
     }
 
-    .mobile-nav-toggle {
-        display: inline-flex !important;
-    }
-
-    .mobile-menu.open {
-        display: flex;
+    .mobile-nav-toggle,
+    .mobile-menu {
+        display: none;
     }
 }
 
-/* RunsPage responsive layout */
+/* RunsPage responsive layout — mobile-first cascade. */
 .runs-layout {
     display: flex;
+    flex-direction: column;
     gap: 16px;
     align-items: flex-start;
-    width: 100%;
+    inline-size: 100%;
 }
 
 .runs-sidebar {
-    width: 300px;
+    inline-size: 100%;
     flex-shrink: 0;
     background: var(--fill-color);
     color: var(--neutral-foreground-rest);
@@ -156,13 +169,13 @@ a, .btn-link {
     overflow: hidden;
 }
 
-@media (max-width: 768px) {
+@media (min-width: 48em) {
     .runs-layout {
-        flex-direction: column;
+        flex-direction: row;
     }
 
     .runs-sidebar {
-        width: 100%;
+        inline-size: 300px;
     }
 }
 
@@ -189,8 +202,10 @@ a, .btn-link {
     border-bottom: none;
 }
 
-.run-list-item:hover:not(.run-list-item--selected) {
-    background: var(--neutral-fill-hover);
+@media (hover: hover) and (pointer: fine) {
+    .run-list-item:hover:not(.run-list-item--selected) {
+        background: var(--neutral-fill-hover);
+    }
 }
 
 .run-list-item--selected {
@@ -299,13 +314,13 @@ a, .btn-link {
 
 .roster-role-grid {
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: 1fr;
     gap: 16px;
 }
 
-@media (max-width: 768px) {
+@media (min-width: 48em) {
     .roster-role-grid {
-        grid-template-columns: 1fr;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 2 of the responsive-design remediation. Closes 4 findings from the 2026-04-18 review.

**Findings resolved:**
- `blazor.HC-10`: `min-height:100vh` on the app shell → `min-block-size:100svh` (prevents footer clip when iOS Safari URL bar is visible).
- `blazor.LC-1` / responsive-design §3.5: three desktop-first `@media (max-width: 768px)` blocks → mobile-first `@media (min-width: 48em)` (mobile nav, runs-layout, roster-role-grid). `48em` = `768/16` — same threshold in `em` so user zoom doesn't shift it.
- `RD-HOVER-1`: `:hover` rules on `::-webkit-scrollbar-thumb` and `.run-list-item` are now gated behind `@media (hover: hover) and (pointer: fine)` (no stuck hover on touch).
- `RD-MOTION-1`: `.loading-progress circle:last-child` transition gated behind `@media (prefers-reduced-motion: no-preference)` (users with reduced motion see an instantaneous progress indicator).

Logical-property slip-ins on touched lines: `min-height → min-block-size`, `width → inline-size`.

## Test plan

- [x] `dotnet format lfm.sln --verify-no-changes` — clean
- [x] `dotnet build lfm.sln -c Release` — 0 warnings, 0 errors
- [x] `dotnet test tests/Lfm.App.Tests/...` — 127 / 127 (no new tests; this phase is CSS-only)
- [ ] **Manual browser pass** (reviewer): DevTools responsive mode at 320 / 375 / 767 / 768 / 1024 px — mobile nav visible ≤767 px, desktop nav visible ≥768 px. Mobile Safari (or simulator) — footer visible without URL-bar clip. OS "Reduce Motion" — loading ring stops animating. Touch input — tap a run row, no stuck hover.

## Scope

2 files, 1 commit. Part of a 6-phase remediation; Phase 1 merged in #20.

## Known limitations

- Container queries on `runs-layout` / `roster-role-grid` are deferred — mobile-first `@media` is the prerequisite.
- Runtime CWV (LCP / CLS / INP) not claimed — static signals only.