### PR TITLE
i18n: logical properties + dir propagation (RTL foundation)

### DIFF
--- a/app/Layout/MainLayout.razor
+++ b/app/Layout/MainLayout.razor
@@ -22,12 +22,12 @@
 
             <AuthorizeView>
                 <Authorized>
-                    <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="4" Style="margin-left:16px" Class="desktop-nav">
+                    <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="4" Style="margin-inline-start:16px" Class="desktop-nav">
                         <FluentAnchor Href="/runs">@Loc["nav.runs"]</FluentAnchor>
                         <FluentAnchor Href="/guild">@Loc["nav.guild"]</FluentAnchor>
                         <FluentAnchor Href="/characters">@Loc["nav.characters"]</FluentAnchor>
                     </FluentStack>
-                    <div style="margin-left:auto;display:flex;align-items:center;gap:4px">
+                    <div style="margin-inline-start:auto;display:flex;align-items:center;gap:4px">
                         <FluentButton Appearance="Appearance.Stealth"
                                       Class="mobile-nav-toggle"
                                       Title="@Loc["nav.toggleMenu"]"
@@ -47,7 +47,7 @@
                     </div>
                 </Authorized>
                 <NotAuthorized>
-                    <div style="margin-left:auto;display:flex;align-items:center;gap:4px">
+                    <div style="margin-inline-start:auto;display:flex;align-items:center;gap:4px">
                         <FluentButton Appearance="Appearance.Stealth"
                                       Title="@_themeTooltip"
                                       aria-label="@_themeTooltip"

--- a/app/Pages/CharactersPage.razor
+++ b/app/Pages/CharactersPage.razor
@@ -92,7 +92,7 @@
     }
 
     <!-- Forget Me section -->
-    <div style="border-top:1px solid var(--neutral-stroke-rest);padding-top:24px;margin-top:8px">
+    <div style="border-block-start:1px solid var(--neutral-stroke-rest);padding-block-start:24px;margin-block-start:8px">
         <FluentStack Orientation="Orientation.Vertical" VerticalGap="12" Style="max-width:420px">
             <FluentLabel Typo="Typography.H4">@Loc["characters.deleteAccount.title"]</FluentLabel>
             <FluentLabel>@Loc["characters.deleteAccount.body"]</FluentLabel>

--- a/app/Pages/PrivacyPolicyPage.razor
+++ b/app/Pages/PrivacyPolicyPage.razor
@@ -57,7 +57,7 @@
 <a href="mailto:contact@example.com"
    aria-hidden="true"
    tabindex="-1"
-   style="position: absolute; left: -9999px; opacity: 0; pointer-events: none;">
+   style="position: absolute; inset-inline-start: -9999px; opacity: 0; pointer-events: none;">
     contact@example.com
 </a>
 

--- a/app/wwwroot/css/app.css
+++ b/app/wwwroot/css/app.css
@@ -210,8 +210,8 @@ a, .btn-link {
 
 .run-list-item--selected {
     background: var(--neutral-fill-secondary-rest);
-    border-left: 3px solid var(--accent-fill-rest);
-    padding-left: 13px;
+    border-inline-start: 3px solid var(--accent-fill-rest);
+    padding-inline-start: 13px;
 }
 
 .run-list-item__header {
@@ -353,7 +353,7 @@ a, .btn-link {
     padding: 10px 12px 10px 9px;
     background: var(--neutral-fill-rest);
     border-radius: calc(var(--control-corner-radius) * 1px);
-    border-left: 3px solid var(--class-color, var(--neutral-stroke-rest));
+    border-inline-start: 3px solid var(--class-color, var(--neutral-stroke-rest));
     min-height: 44px;
 }
 

--- a/app/wwwroot/js/lfm-interop.js
+++ b/app/wwwroot/js/lfm-interop.js
@@ -3,7 +3,10 @@
 // .NET without passing JavaScript source strings to `eval`, which is
 // blocked by the site CSP (`script-src 'self' 'wasm-unsafe-eval'`).
 window.lfmSetDocumentLang = function (lang) {
+    const rtlPrimaries = ["ar", "he", "fa", "ur", "yi", "ji", "iw", "ps"];
+    const primary = (lang || "en").toLowerCase().split(/[-_]/)[0];
     document.documentElement.lang = lang;
+    document.documentElement.dir = rtlPrimaries.includes(primary) ? "rtl" : "ltr";
 };
 
 window.lfmGetBrowserLanguage = function () {


### PR DESCRIPTION
## Summary

Phase 3 of the responsive-design remediation. Closes 2 findings from the 2026-04-18 review.

**Findings resolved:**
- `blazor.HC-1`: physical directional properties swapped for logical equivalents across `MainLayout.razor` (3 `margin-left` → `margin-inline-start`), `CharactersPage.razor` (1 `border-top`/`padding-top`/`margin-top` → `border-block-start`/`padding-block-start`/`margin-block-start`), `PrivacyPolicyPage.razor` (1 `left: -9999px` → `inset-inline-start: -9999px`), and `app.css` (2 `border-left`/`padding-left` → `border-inline-start`/`padding-inline-start` on `.run-list-item--selected` and `.character-row`).
- `RD-DIR-1`: `lfmSetDocumentLang` now sets `document.documentElement.dir` based on the primary-language code, with the RTL list `["ar","he","fa","ur","yi","ji","iw","ps"]`.

No LTR behavioural change; these are identity transforms under `dir="ltr"`. RTL support is now a one-line flip when an Arabic/Hebrew locale is added.

## Scope

5 files, 1 commit, +11 / −8.

## Out of scope (deferred, not migrated)

- `padding: 10px 12px 10px 9px` shorthand in `.character-row` — physical-directional implication, but logical-property shorthand (`padding-block` / `padding-inline`) needs different values; deferring to a follow-up.
- `top`/`left` on `.skip-link`, `#blazor-error-ui`, `.loading-progress` — browser-fixed-axis UI elements, no writing-mode dependence.
- Adding an actual RTL locale — this phase lands the foundation only; `en` + `fi` stay the locale set.

## Test plan

- [x] `dotnet format lfm.sln --verify-no-changes` — clean
- [x] `dotnet build lfm.sln -c Release` — 0 warnings, 0 errors
- [x] `dotnet test tests/Lfm.App.Tests/...` — 127 / 127
- [ ] **Manual RTL smoke** (reviewer): DevTools → set `<html dir="rtl">` → confirm navbar logo lands on the right, run-list-item selected accent stripe lands on the right, character-row class-color stripe lands on the right. Revert to `ltr` and confirm LTR pass is unchanged.

## Known limitations

- No RTL locale ships yet — foundation only. Visual RTL verification requires a manual DevTools flip.
- `prefers-color-scheme` initial detection is Phase 4's job, not this one.