### PR TITLE
responsive: port host HTML to §4.5 baseline + OS-theme detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,6 @@ app/wwwroot/appsettings.Development.json
 
 # Chrome local installation
 .chrome/
+
+# Generated from index.html.template by GenerateStaticTemplates MSBuild target.
+app/wwwroot/index.html

--- a/app/Lfm.App.csproj
+++ b/app/Lfm.App.csproj
@@ -66,6 +66,8 @@
       <SecurityTxtDest>$(MSBuildProjectDirectory)/wwwroot/.well-known/security.txt</SecurityTxtDest>
       <SwaConfigSource>$(MSBuildProjectDirectory)/wwwroot/staticwebapp.config.json.template</SwaConfigSource>
       <SwaConfigDest>$(MSBuildProjectDirectory)/wwwroot/staticwebapp.config.json</SwaConfigDest>
+      <IndexHtmlSource>$(MSBuildProjectDirectory)/wwwroot/index.html.template</IndexHtmlSource>
+      <IndexHtmlDest>$(MSBuildProjectDirectory)/wwwroot/index.html</IndexHtmlDest>
     </PropertyGroup>
 
     <!-- Use bash sed for substitution: safe for plain-text template replacement
@@ -83,6 +85,11 @@
         -e 's|{{STORAGE_ACCOUNT_NAME}}|$(StorageAccountName)|g' \
         '$(SwaConfigSource)' &gt; '$(SwaConfigDest)'&quot;"
           Condition="Exists('$(SwaConfigSource)')" />
+
+    <Exec Command="bash -c &quot;sed \
+        -e 's|{{API_HOSTNAME}}|$(ApiHostname)|g' \
+        '$(IndexHtmlSource)' &gt; '$(IndexHtmlDest)'&quot;"
+          Condition="Exists('$(IndexHtmlSource)')" />
   </Target>
 
 </Project>

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -76,4 +76,22 @@ catch
     // JS interop may fail during prerendering; default to English.
 }
 
+try
+{
+    var storedTheme = await js.InvokeAsync<string?>("lfmGetStoredTheme");
+    if (string.IsNullOrEmpty(storedTheme))
+    {
+        var preferred = await js.InvokeAsync<string>("lfmGetPrefersColorScheme");
+        var themeService = host.Services.GetRequiredService<IThemeService>();
+        themeService.SetMode(preferred == "light"
+            ? Microsoft.FluentUI.AspNetCore.Components.DesignThemeModes.Light
+            : Microsoft.FluentUI.AspNetCore.Components.DesignThemeModes.Dark);
+    }
+}
+catch
+{
+    // JS interop may fail during prerendering or if localStorage is blocked.
+    // Keep the ThemeService default (Dark).
+}
+
 await host.RunAsync();

--- a/app/packages.lock.json
+++ b/app/packages.lock.json
@@ -37,12 +37,6 @@
         "resolved": "10.0.6",
         "contentHash": "XuQG+YPThyn8F8EZCAnckdG2G2lMWDhJaEa1wk26aLGh3M86QsoJvvpNU/VuIeET3UiW7RA8SHU6CXbAxtvMVw=="
       },
-      "Microsoft.DotNet.HotReload.WebAssembly.Browser": {
-        "type": "Direct",
-        "requested": "[10.0.104, )",
-        "resolved": "10.0.104",
-        "contentHash": "OkWFygvFdm9emwxRW5ahcsU6saKO9EOYCFVNEXWl+23A4ssZy40VCQuqPhyurU7IyaPEhgA4iXh0/o7fhyNngA=="
-      },
       "Microsoft.Extensions.Http": {
         "type": "Direct",
         "requested": "[10.0.6, )",

--- a/app/wwwroot/index.html.template
+++ b/app/wwwroot/index.html.template
@@ -3,9 +3,13 @@
 
 <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content" />
+    <meta name="color-scheme" content="light dark" />
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
     <title>Lfm.App</title>
     <base href="/" />
+    <link rel="preconnect" href="https://{{API_HOSTNAME}}" crossorigin />
     <link rel="stylesheet" href="css/app.css" />
     <link rel="icon" type="image/png" href="favicon.png" />
     <link href="Lfm.App.styles.css" rel="stylesheet" />

--- a/app/wwwroot/js/lfm-interop.js
+++ b/app/wwwroot/js/lfm-interop.js
@@ -12,3 +12,19 @@ window.lfmSetDocumentLang = function (lang) {
 window.lfmGetBrowserLanguage = function () {
     return navigator.language || navigator.userLanguage || 'en';
 };
+
+window.lfmGetPrefersColorScheme = function () {
+    try {
+        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    } catch {
+        return 'light';
+    }
+};
+
+window.lfmGetStoredTheme = function () {
+    try {
+        return window.localStorage.getItem('lfm-theme') || null;
+    } catch {
+        return null;
+    }
+};


### PR DESCRIPTION
## Summary

Phase 4 of the responsive-design remediation. Closes 2 findings.

**Findings resolved:**
- `blazor.HC-7`: host HTML now carries the §4.5 baseline — `viewport-fit=cover`, `interactive-widget=resizes-content`, `color-scheme` meta, `theme-color` per scheme, `preconnect` to the API origin.
- `RD-THEME-1`: `Program.cs` detects OS `prefers-color-scheme` on first boot (when no `lfm-theme` is persisted in `localStorage`) and initialises `ThemeService.Mode` accordingly. User toggle still wins once persisted.

## Changes

- New `app/wwwroot/index.html.template` — the `<head>` rewrite. `{{API_HOSTNAME}}` is substituted at build time by the existing `GenerateStaticTemplates` MSBuild target (mirrors the `security.txt` / `staticwebapp.config.json` pattern already in `app/Lfm.App.csproj`).
- Tracked `app/wwwroot/index.html` removed; added to `.gitignore` (follows the `staticwebapp.config.json` pattern).
- `app/wwwroot/js/lfm-interop.js` gains `lfmGetPrefersColorScheme` and `lfmGetStoredTheme` helpers.
- `app/Program.cs` adds a second try/catch after the existing language-detection block to apply the OS theme preference.

## Incidental

- `app/packages.lock.json`: 6-line removal of `Microsoft.DotNet.HotReload.WebAssembly.Browser`, a stale direct-reference entry that no longer exists in `Lfm.App.csproj`. Lockfile is regenerated by the build (the project sets `<RestoreLockedMode>false</RestoreLockedMode>` specifically to allow this kind of drift). Noting in case a reviewer wants this split into a separate PR.

## Test plan

- [x] `dotnet format lfm.sln --verify-no-changes` — clean
- [x] `API_HOSTNAME=api.test.local dotnet build lfm.sln -c Release` — generated `index.html` contains `<link rel="preconnect" href="https://api.test.local" crossorigin />`
- [x] `dotnet test tests/Lfm.App.Tests/...` — 127 / 127
- [ ] **Manual verification** (reviewer):
  - Start app, inspect `<head>` — confirm `viewport-fit=cover`, `color-scheme`, `theme-color` per scheme, `preconnect`.
  - `localStorage.removeItem('lfm-theme')`, set OS light mode, reload — app boots light.
  - Toggle theme, reload — persisted choice wins over OS.
  - Lighthouse audit — no "missing color-scheme" / "missing theme-color" warnings.

## Scope

5 tracked-file changes + 1 deletion, 1 commit, +50 / −8.

## Known limitations

- No LCP image preload — landing page has no hero; `Runs` is auth-only.
- No font preload — system-font stack, no `@font-face`.