### PR TITLE
perf: set explicit image dimensions and loading hints

### DIFF
--- a/app/Pages/CharactersPage.razor
+++ b/app/Pages/CharactersPage.razor
@@ -64,11 +64,17 @@
                             <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="12" Style="align-items:center">
                                 @if (!string.IsNullOrEmpty(portraitSrc))
                                 {
-                                    <img src="@portraitSrc" alt="@c.Name" style="width:48px;height:48px;border-radius:50%;object-fit:cover;" />
+                                    <img src="@portraitSrc"
+                                         alt="@c.Name"
+                                         class="character-portrait"
+                                         width="48"
+                                         height="48"
+                                         loading="lazy"
+                                         decoding="async" />
                                 }
                                 else
                                 {
-                                    <div style="width:48px;height:48px;border-radius:50%;background:var(--neutral-fill-rest);display:flex;align-items:center;justify-content:center;font-weight:600">
+                                    <div class="character-portrait character-portrait--placeholder">
                                         @c.Name.Substring(0, 1).ToUpperInvariant()
                                     </div>
                                 }

--- a/app/Pages/GuildPage.razor
+++ b/app/Pages/GuildPage.razor
@@ -73,7 +73,13 @@
                         <FluentLabel>@dto.Guild.RealmName@(dto.Guild.FactionName != null ? $" \u00b7 {dto.Guild.FactionName}" : "")</FluentLabel>
                         @if (dto.Guild.CrestEmblemUrl != null)
                         {
-                            <img src="@dto.Guild.CrestEmblemUrl" alt="@Loc["guild.crestAlt"]" style="width:88px;height:88px;border-radius:8px;object-fit:cover;" />
+                            <img src="@dto.Guild.CrestEmblemUrl"
+                                 alt="@Loc["guild.crestAlt"]"
+                                 class="guild-crest"
+                                 width="88"
+                                 height="88"
+                                 loading="lazy"
+                                 decoding="async" />
                         }
                     </FluentStack>
                 </FluentCard>

--- a/app/wwwroot/css/app.css
+++ b/app/wwwroot/css/app.css
@@ -472,3 +472,27 @@ a, .btn-link {
     opacity: 0.6;
     cursor: not-allowed;
 }
+
+/* Character portrait + placeholder — shared sizing. */
+.character-portrait {
+    inline-size: 48px;
+    block-size: 48px;
+    border-radius: 50%;
+    object-fit: cover;
+}
+
+.character-portrait--placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+    background: var(--neutral-fill-rest);
+}
+
+/* Guild crest — fixed dimensions from Blizzard CDN. */
+.guild-crest {
+    inline-size: 88px;
+    block-size: 88px;
+    border-radius: 8px;
+    object-fit: cover;
+}


### PR DESCRIPTION
## Summary

Phase 6 — final implementation phase of the responsive-design remediation. Closes the `RD-IMG-1` finding.

**Findings resolved:**
- `RD-IMG-1`: Character portraits (`CharactersPage`) and guild crest (`GuildPage`) now carry `width`, `height`, `loading="lazy"`, `decoding="async"` attributes. Inline `style=` blocks folded into `.character-portrait` / `.character-portrait--placeholder` / `.guild-crest` CSS classes (logical properties: `inline-size` / `block-size`).

No `fetchpriority` — neither image is an LCP candidate (Characters is auth-gated; crest is below the H1).

## Scope

3 files, 1 commit, tests unchanged (130 / 130).

## Test plan

- [x] `dotnet format lfm.sln --verify-no-changes` — clean
- [x] `dotnet build lfm.sln -c Release` — 0 warnings, 0 errors
- [x] `dotnet test tests/Lfm.App.Tests/...` — 130 / 130
- [ ] **Manual verification** (reviewer): inspect `<img>` in DevTools Elements panel — confirm `width`/`height`/`loading`/`decoding` attrs present. No visual regression vs pre-Phase-6.
- [ ] Lighthouse CLS — static signal only; runtime metric requires RUM.

## Out of scope

- `<picture>` + `srcset` — Blizzard CDN serves fixed sizes; self-hosting is a separate decision.
- Deferred items (Phase 7 = GitHub issues, not a PR): `RD-DIALOG-1`, `blazor.HC-8`, `RD-COLOR-1`, `RD-TEXT-EXPAND-1`, `RD-OVERFLOW-1`.

## Remediation summary (post-Phase 6)

Out of the 19 findings from the 2026-04-18 review:
- **5 block** → all closed (Phase 1).
- **9 warn** → all 9 closed (Phases 1-6).
- **5 info** → deferred to Phase 7 GitHub issues.