### PR TITLE
Preserve UTC round-trip on run datetime form save

### DIFF
--- a/app/Pages/CreateRunPage.razor
+++ b/app/Pages/CreateRunPage.razor
@@ -120,8 +120,13 @@
     private string visibility = "PUBLIC";
     private string description = string.Empty;
 
+    // The native <input type="datetime-local"> binds wall-clock time with no
+    // offset, so we must convert back to UTC before sending — otherwise the
+    // stored value would differ from the user's intent by the browser's TZ
+    // offset and round-trips through EditRunPage would drift on every save.
+    // Use "o" so the stored string matches what EditRunPage emits on re-save.
     private static string? ToIsoOrNull(DateTime? dt) =>
-        dt is null ? null : dt.Value.ToString("yyyy-MM-ddTHH:mm:ss");
+        dt is null ? null : dt.Value.ToUniversalTime().ToString("o");
 
     private static readonly Dictionary<string, object> ModeKeyAttrs = new()
     {

--- a/app/Pages/EditRunPage.razor
+++ b/app/Pages/EditRunPage.razor
@@ -191,8 +191,14 @@
             : DateTimeOffset.TryParse(iso, out var dto) ? dto.LocalDateTime
             : null;
 
+    // The native <input type="datetime-local"> binds wall-clock time with no
+    // offset, so we must convert back to UTC before sending — otherwise the
+    // round-trip would shift the stored value by the browser's TZ offset and
+    // the API's locked-field check would reject unchanged values as changed.
+    // Use "o" to preserve full tick precision so the round-trip is byte-stable
+    // against stored values written with sub-second precision.
     private static string? ToIsoOrNull(DateTime? dt) =>
-        dt is null ? null : dt.Value.ToString("yyyy-MM-ddTHH:mm:ss");
+        dt is null ? null : dt.Value.ToUniversalTime().ToString("o");
 
     private static readonly Dictionary<string, object> ModeKeyAttrs = new()
     {

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -363,4 +363,44 @@ public class RunsPagesTests : ComponentTestBase
         cut.WaitForAssertion(() =>
             Assert.Contains(Loc("editRun.error.notFound"), cut.Markup));
     }
+
+    // Regression: save without editing datetime fields must preserve the
+    // original UTC ISO string byte-for-byte. A prior migration to native
+    // <input type="datetime-local"> stripped the timezone on round-trip,
+    // causing the API's locked-field check to reject description-only edits
+    // on runs with signups (400 "Cannot change start time after signups").
+    [Fact]
+    public void EditRunPage_Save_Without_Edit_Preserves_Utc_Iso_Round_Trip()
+    {
+        const string OriginalStart = "2026-05-20T15:30:45.1234567Z";
+        const string OriginalSignup = "2026-05-20T15:00:45.1234567Z";
+
+        var instancesClient = new Mock<IInstancesClient>();
+        instancesClient.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<InstanceDto> { new("1", "Liberation of Undermine", "raid", "tww") });
+
+        UpdateRunRequest? captured = null;
+        var runsClient = new Mock<IRunsClient>();
+        runsClient.Setup(c => c.GetAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeDetail() with { StartTime = OriginalStart, SignupCloseTime = OriginalSignup });
+        runsClient.Setup(c => c.UpdateAsync("run-1", It.IsAny<UpdateRunRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<string, UpdateRunRequest, CancellationToken>((_, req, _) => captured = req)
+            .ReturnsAsync((RunDetailDto?)null);
+
+        Services.AddSingleton(instancesClient.Object);
+        Services.AddSingleton(runsClient.Object);
+
+        var cut = Render<EditRunPage>(p => p.Add(x => x.RunId, "run-1"));
+
+        cut.WaitForAssertion(() =>
+            Assert.Contains(Loc("editRun.saveChanges"), cut.Markup));
+
+        var saveButton = cut.FindAll("fluent-button")
+            .First(b => b.TextContent.Contains(Loc("editRun.saveChanges")));
+        saveButton.Click();
+
+        cut.WaitForAssertion(() => Assert.NotNull(captured));
+        Assert.Equal(OriginalStart, captured!.StartTime);
+        Assert.Equal(OriginalSignup, captured.SignupCloseTime);
+    }
 }


### PR DESCRIPTION
## Summary

- Edit/Create run forms migrated to native `<input type="datetime-local">` bound to `DateTime?`. On save the value was emitted as a naive local string with no tz, so the API's locked-field check in `RunsUpdateFunction` rejected description-only edits on runs with signups (400 "Cannot change start time after signups") whenever the browser TZ ≠ UTC.
- `ToIsoOrNull` now converts to UTC and uses the `"o"` round-trip format, so a value loaded via `ParseIso` re-emits byte-identical to what was stored (incl. `.fffffff` sub-seconds used by `DefaultSeed`).
- Adds a bUnit regression test that captures the submitted `UpdateRunRequest` and asserts byte-identity for `StartTime` / `SignupCloseTime` after save-without-edit. Verified failing before the fix (`Expected "…15:30:45.1234567Z" / Actual "…18:30:45"`).

Same fix applied to `CreateRunPage` so runs created by the client end up stored as UTC rather than naive local time.

## Test plan

- [x] `dotnet build lfm.sln -c Release` clean
- [x] `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj` — 131 passed (incl. new regression test)
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj` — 366 passed
- [x] `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj` — 89 passed
- [x] `dotnet format lfm.sln --verify-no-changes` clean
- [x] Full E2E suite green on a combined branch with #2 — `EditRun_ModifyFields_ChangesReflected` passes

AI-assisted.