### PR TITLE
Update E2E selectors and date format for UI migrations

### DIFF
--- a/tests/Lfm.E2E/Pages/GuildPage.cs
+++ b/tests/Lfm.E2E/Pages/GuildPage.cs
@@ -9,9 +9,9 @@ public class GuildPage(IPage page)
 {
     private readonly IPage _page = page;
 
-    // Page heading rendered by FluentLabel Typo=H3. Use typo attribute to disambiguate from nav links.
+    // Page heading rendered by FluentLabel Typo=H1. Use typo attribute to disambiguate from nav links.
     public ILocator Heading =>
-        _page.Locator("[typo='h3']").Filter(new() { HasTextString = "Guild" });
+        _page.Locator("[typo='h1']").Filter(new() { HasTextString = "Guild" });
 
     // The guild name heading rendered inside the card (H4)
     public ILocator GuildNameHeading =>

--- a/tests/Lfm.E2E/Pages/RunsPage.cs
+++ b/tests/Lfm.E2E/Pages/RunsPage.cs
@@ -70,13 +70,13 @@ public class RunsPage(IPage page)
     public ILocator ModeKeyInput =>
         _page.Locator("#modekey-input input");
 
-    /// <summary>Start Time text field — inner input of FluentTextField.</summary>
+    /// <summary>Start Time native &lt;input type="datetime-local"&gt; element.</summary>
     public ILocator StartTimeInput =>
-        _page.Locator("#starttime-input input");
+        _page.Locator("#starttime-input");
 
-    /// <summary>Signup Close Time text field — inner input of FluentTextField.</summary>
+    /// <summary>Signup Close Time native &lt;input type="datetime-local"&gt; element.</summary>
     public ILocator SignupCloseTimeInput =>
-        _page.Locator("#signupclose-input input");
+        _page.Locator("#signupclose-input");
 
     /// <summary>Visibility dropdown on the create-run form.</summary>
     public ILocator VisibilitySelect =>

--- a/tests/Lfm.E2E/Specs/AccessibilitySpec.cs
+++ b/tests/Lfm.E2E/Specs/AccessibilitySpec.cs
@@ -206,7 +206,7 @@ public class AccessibilitySpec(AccessibilityFixture fixture, ITestOutputHelper o
 
         // Wait for the Guild page heading (use typo attribute to disambiguate from nav)
         await Assertions.Expect(
-            page.Locator("[typo='h3']").Filter(new() { HasTextString = "Guild" }))
+            page.Locator("[typo='h1']").Filter(new() { HasTextString = "Guild" }))
             .ToBeVisibleAsync(new() { Timeout = 15000 });
 
         await AccessibilityHelper.ScanAndAssert(page, Output, "/guild");

--- a/tests/Lfm.E2E/Specs/RunsSpec.cs
+++ b/tests/Lfm.E2E/Specs/RunsSpec.cs
@@ -77,10 +77,12 @@ public class RunsSpec(RunsFixture fixture, ITestOutputHelper output)
         // Fill in required form fields with a unique run name via description.
         // Use a future date anchored to UtcNow so the test does not become a
         // time bomb the way the seeded run did (see DefaultSeed.SeedRunAsync).
+        // The native <input type="datetime-local"> accepts no timezone suffix;
+        // the browser interprets the value as wall-clock local time.
         var uniqueRunName = $"E2E-Create-{Guid.NewGuid():N}";
         await runsPage.ModeKeyInput.FillAsync("NORMAL:25");
         await runsPage.StartTimeInput.FillAsync(
-            DateTimeOffset.UtcNow.AddDays(30).ToString("yyyy-MM-ddTHH:mm:ssZ"));
+            DateTimeOffset.UtcNow.AddDays(30).ToString("yyyy-MM-ddTHH:mm:ss"));
         await runsPage.DescriptionInput.FillAsync(uniqueRunName);
 
         // Submit
@@ -264,8 +266,10 @@ public class RunsSpec(RunsFixture fixture, ITestOutputHelper output)
 
             var uniqueDescription = $"E2E-Delete-{Guid.NewGuid():N}";
             await runsPage.ModeKeyInput.FillAsync("HEROIC:25");
+            // Native <input type="datetime-local"> rejects a Z suffix; the
+            // browser interprets the value as wall-clock local time.
             await runsPage.StartTimeInput.FillAsync(
-                DateTimeOffset.UtcNow.AddDays(60).ToString("yyyy-MM-ddTHH:mm:ssZ"));
+                DateTimeOffset.UtcNow.AddDays(60).ToString("yyyy-MM-ddTHH:mm:ss"));
             await runsPage.DescriptionInput.FillAsync(uniqueDescription);
             await deletePage.Keyboard.PressAsync("Tab");
             await runsPage.CreateRunSubmitButton.ClickAsync();


### PR DESCRIPTION
## Summary

Two recent UI migrations left the E2E layer with stale selectors that fail deterministically:

- **Guild page heading promoted H3 → H1** (`9ecb1bc`): update `[typo='h3']` → `[typo='h1']` in `GuildPage.cs` and `AccessibilitySpec.cs`. Was breaking `AccessibilitySpec.GuildPage_MeetsWcag22AA` and `ProfileSpec.GuildPage_Loads_DisplaysGuildInfo`.
- **Datetime fields migrated to native `<input type="datetime-local">`** (`828036b`): update `RunsPage.cs` locators to target `#starttime-input` / `#signupclose-input` directly (the native input *is* the input, not an inner child of a FluentTextField). Was breaking `RunsSpec.CreateRun_SubmitForm_AppearsInList` and `RunsSpec.DeleteRun_Confirm_RemovedFromList`.
- **Fill values drop the `Z` suffix** in `RunsSpec.cs`: `datetime-local` rejects a timezone marker; the browser interprets the value as wall-clock local time (UTC in the Dockerised Chromium container, which matches `DateTimeOffset.UtcNow`).

Orthogonal to #31 (production tz round-trip bug). These four tests pass with this PR alone; `EditRun_ModifyFields_ChangesReflected` needs #31 as well.

## Test plan

- [x] `dotnet build tests/Lfm.E2E/Lfm.E2E.csproj -c Release` clean
- [x] `dotnet format lfm.sln --verify-no-changes` clean
- [x] Full E2E suite green on a combined branch with #31 — all 53 tests pass in 32 s (`.test-determinism/e2e/run-verify-both-fixes/run.trx`)

AI-assisted.