### PR TITLE
Convert delete-run confirm to native dialog

### DIFF
--- a/app/Pages/EditRunPage.razor
+++ b/app/Pages/EditRunPage.razor
@@ -3,11 +3,13 @@
 @using Lfm.Contracts.Instances
 @using Lfm.Contracts.Runs
 @attribute [Authorize]
+@implements IAsyncDisposable
 @inject IInstancesClient InstancesClient
 @inject IRunsClient RunsClient
 @inject NavigationManager Nav
 @inject ToastHelper Toast
 @inject IStringLocalizer Loc
+@inject IJSRuntime JS
 
 <PageTitle>@Loc["editRun.title"]</PageTitle>
 
@@ -119,31 +121,32 @@
                 </FluentStack>
             </FluentCard>
 
-            <!-- Delete confirmation -->
-            @if (showDeleteConfirm)
-            {
-                <FluentCard>
-                    <FluentStack Orientation="Orientation.Vertical" VerticalGap="8">
-                        <FluentLabel Typo="Typography.H5">@Loc["editRun.confirmDelete"]</FluentLabel>
-                        <FluentLabel>@Loc["editRun.confirmDeleteBody"]</FluentLabel>
-                        <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="8" Wrap="true">
-                            <FluentButton
-                                Appearance="Appearance.Accent"
-                                OnClick="@HandleDelete"
-                                Disabled="@(saving || deleting)"
-                                Style="background:var(--error)">
-                                @(deleting ? Loc["editRun.deleting"] : Loc["editRun.yesDelete"])
-                            </FluentButton>
-                            <FluentButton
-                                Appearance="Appearance.Outline"
-                                OnClick="@(() => showDeleteConfirm = false)"
-                                Disabled="@(saving || deleting)">
-                                @Loc["common.cancel"]
-                            </FluentButton>
-                        </FluentStack>
+            <!-- Delete confirmation (native <dialog>: focus trap, Esc, focus restore) -->
+            <dialog @ref="deleteDialogRef"
+                    class="confirm-dialog"
+                    aria-labelledby="delete-dialog-title"
+                    aria-describedby="delete-dialog-body">
+                <FluentStack Orientation="Orientation.Vertical" VerticalGap="8">
+                    <FluentLabel Typo="Typography.H5" Id="delete-dialog-title">@Loc["editRun.confirmDelete"]</FluentLabel>
+                    <FluentLabel Id="delete-dialog-body">@Loc["editRun.confirmDeleteBody"]</FluentLabel>
+                    <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="8" Wrap="true">
+                        <FluentButton
+                            Appearance="Appearance.Accent"
+                            OnClick="@HandleDelete"
+                            Disabled="@(saving || deleting)"
+                            Style="background:var(--error)">
+                            @(deleting ? Loc["editRun.deleting"] : Loc["editRun.yesDelete"])
+                        </FluentButton>
+                        <FluentButton
+                            Appearance="Appearance.Outline"
+                            OnClick="@CloseDeleteConfirm"
+                            Disabled="@(saving || deleting)"
+                            autofocus="true">
+                            @Loc["common.cancel"]
+                        </FluentButton>
                     </FluentStack>
-                </FluentCard>
-            }
+                </FluentStack>
+            </dialog>
 
             <!-- Roster grid -->
             <FluentCard>
@@ -175,8 +178,9 @@
     private IReadOnlyList<InstanceDto> instances = [];
     private bool saving;
     private bool deleting;
-    private bool showDeleteConfirm;
     private bool hasSignups;
+    private ElementReference deleteDialogRef;
+    private IJSObjectReference? dialogModule;
 
     // Form fields (initialised from loaded run)
     private string instanceId = string.Empty;
@@ -301,9 +305,16 @@
         Nav.NavigateTo($"/runs/{Uri.EscapeDataString(RunId!)}");
     }
 
-    private void ShowDeleteConfirm()
+    private async Task ShowDeleteConfirm()
     {
-        showDeleteConfirm = true;
+        dialogModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/dialog.js");
+        await dialogModule.InvokeVoidAsync("showModal", deleteDialogRef);
+    }
+
+    private async Task CloseDeleteConfirm()
+    {
+        if (dialogModule is not null)
+            await dialogModule.InvokeVoidAsync("close", deleteDialogRef);
     }
 
     private async Task HandleDelete()
@@ -320,14 +331,22 @@
             {
                 Toast.ShowError(Loc["editRun.deleteFailed"]);
                 deleting = false;
-                showDeleteConfirm = false;
+                await CloseDeleteConfirm();
             }
         }
         catch
         {
             Toast.ShowError("Failed to delete run. Please try again.");
             deleting = false;
-            showDeleteConfirm = false;
+            await CloseDeleteConfirm();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (dialogModule is not null)
+        {
+            try { await dialogModule.DisposeAsync(); } catch { }
         }
     }
 

--- a/app/wwwroot/css/app.css
+++ b/app/wwwroot/css/app.css
@@ -505,3 +505,19 @@ a, .btn-link {
     overflow-x: auto;
     scrollbar-gutter: stable both-edges;
 }
+
+/* Native <dialog> used for destructive confirmation. The browser handles the
+ * focus trap, Esc, and focus restoration; we only theme the surface. */
+.confirm-dialog {
+    max-inline-size: min(100%, 480px);
+    padding: 24px;
+    border: 1px solid var(--neutral-stroke-rest);
+    border-radius: var(--control-corner-radius, 4px);
+    background: var(--neutral-layer-1, Canvas);
+    color: var(--neutral-foreground-rest, CanvasText);
+    box-shadow: 0 8px 32px rgb(0 0 0 / 0.25);
+}
+
+.confirm-dialog::backdrop {
+    background: rgb(0 0 0 / 0.5);
+}

--- a/app/wwwroot/js/dialog.js
+++ b/app/wwwroot/js/dialog.js
@@ -1,0 +1,6 @@
+// Native <dialog> interop for Blazor WASM. The browser handles focus trap,
+// Esc dismissal, inert siblings, and focus restoration — we only need to
+// forward showModal() / close() because HTMLDialogElement is not projected
+// to .NET.
+export function showModal(el) { el.showModal(); }
+export function close(el) { el.close(); }

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -403,4 +403,38 @@ public class RunsPagesTests : ComponentTestBase
         Assert.Equal(OriginalStart, captured!.StartTime);
         Assert.Equal(OriginalSignup, captured.SignupCloseTime);
     }
+
+    // RD-DIALOG-1 (#26): the delete confirmation renders as a native <dialog>
+    // so focus trap, Esc dismissal, and focus restoration come from the browser
+    // for free. Clicking "Delete run" must open it via the dialog.js interop
+    // module rather than flipping a render flag.
+    [Fact]
+    public void EditRunPage_Delete_Button_Opens_Native_Dialog_Via_Interop()
+    {
+        var instancesClient = new Mock<IInstancesClient>();
+        var runsClient = new Mock<IRunsClient>();
+        runsClient.Setup(c => c.GetAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeDetail());
+        instancesClient.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<InstanceDto>());
+        Services.AddSingleton(instancesClient.Object);
+        Services.AddSingleton(runsClient.Object);
+
+        var dialogModule = JSInterop.SetupModule("./js/dialog.js");
+
+        var cut = Render<EditRunPage>(p => p.Add(x => x.RunId, "run-1"));
+
+        cut.WaitForAssertion(() =>
+            Assert.Contains(Loc("editRun.deleteRun"), cut.Markup));
+
+        var dialog = cut.Find("dialog");
+        Assert.Equal("delete-dialog-title", dialog.GetAttribute("aria-labelledby"));
+        Assert.Equal("delete-dialog-body", dialog.GetAttribute("aria-describedby"));
+
+        var deleteButton = cut.FindAll("fluent-button")
+            .First(b => b.TextContent.Contains(Loc("editRun.deleteRun")));
+        deleteButton.Click();
+
+        cut.WaitForAssertion(() => dialogModule.VerifyInvoke("showModal"));
+    }
 }


### PR DESCRIPTION
## Summary

Closes #26. Replace the inline `FluentCard` delete confirmation on `EditRunPage` with a native `<dialog>` opened via `showModal()` through a minimal JS-interop module (`wwwroot/js/dialog.js`). The browser now handles focus trap, `Esc` dismissal, inert siblings, and focus restoration — the four gaps the review called out. Cancel is the `autofocus` target so a keyboard user defaults to the non-destructive choice.

Follows `blazor.PAT-razor-dialog` from the responsive-design Blazor-WASM extension over `<FluentDialog>` because it keeps the bundle untouched and the implementation is a few lines per side.

## Test plan

- [x] `dotnet build lfm.sln -c Release` — clean
- [x] `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release` — 132/132 passing, new bUnit test asserts dialog a11y attributes + `showModal` interop on click
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error` — clean
- [ ] Manual smoke: open `/runs/{id}/edit`, click "Delete run", confirm dialog gains focus, `Esc` dismisses, Cancel restores focus to trigger

AI-assisted.
