### PR TITLE
Wrap data grids in a labelled scroll region

### DIFF
--- a/app/Components/AttendanceRosterSection.razor
+++ b/app/Components/AttendanceRosterSection.razor
@@ -5,7 +5,7 @@
     @GroupLabel (@Characters.Count)
 </FluentLabel>
 
-<div style="overflow-x:auto">
+<div class="scroll-region" role="region" tabindex="0" aria-label="@Loc["roster.tableAriaLabel", GroupLabel]">
 <FluentDataGrid Items="@Characters.AsQueryable()" TGridItem="RunCharacterDto"
                 GridTemplateColumns="@GridColumns">
     <TemplateColumn Title="@Loc["runs.columns.character"]">

--- a/app/Pages/InstancesPage.razor
+++ b/app/Pages/InstancesPage.razor
@@ -20,7 +20,7 @@
       <FluentMessageBar Intent="MessageIntent.Error">@f.Message</FluentMessageBar>
       break;
     case LoadingState<IReadOnlyList<InstanceDto>>.Success s:
-      <div style="overflow-x:auto">
+      <div class="scroll-region" role="region" tabindex="0" aria-label="@Loc["instances.tableAriaLabel"]">
       <FluentDataGrid Items="@s.Value.AsQueryable()" TGridItem="InstanceDto">
         <PropertyColumn Property="@(i => i.Name)" Title="@Loc["instances.columns.name"]" />
         <PropertyColumn Property="@(i => i.ModeKey)" Title="@Loc["instances.columns.mode"]" />

--- a/app/wwwroot/css/app.css
+++ b/app/wwwroot/css/app.css
@@ -496,3 +496,12 @@ a, .btn-link {
     border-radius: 8px;
     object-fit: cover;
 }
+
+/* Horizontally scrollable data grids. `role="region" tabindex="0"` wraps
+ * these so keyboard users can reach the overflow (SC 1.4.10 Reflow).
+ * `scrollbar-gutter: stable both-edges` prevents content jump when the
+ * scrollbar appears. */
+.scroll-region {
+    overflow-x: auto;
+    scrollbar-gutter: stable both-edges;
+}

--- a/app/wwwroot/locales/en.json
+++ b/app/wwwroot/locales/en.json
@@ -179,9 +179,12 @@
     "guildAdmin.saveError": "An error occurred while saving.",
 
     "instances.title": "Instances",
+    "instances.tableAriaLabel": "Instances table",
     "instances.columns.name": "Name",
     "instances.columns.mode": "Mode",
     "instances.columns.expansion": "Expansion",
+
+    "roster.tableAriaLabel": "Roster for {0}",
 
     "notFound.title": "Not Found",
     "notFound.body": "Sorry, the content you are looking for does not exist.",

--- a/app/wwwroot/locales/fi.json
+++ b/app/wwwroot/locales/fi.json
@@ -179,9 +179,12 @@
     "guildAdmin.saveError": "Virhe tallennettaessa.",
 
     "instances.title": "Instanssit",
+    "instances.tableAriaLabel": "Instanssitaulukko",
     "instances.columns.name": "Nimi",
     "instances.columns.mode": "Tila",
     "instances.columns.expansion": "Lis\u00e4osa",
+
+    "roster.tableAriaLabel": "Ryhm\u00e4n {0} kokoonpano",
 
     "notFound.title": "Ei l\u00f6ytynyt",
     "notFound.body": "Etsim\u00e4\u00e4si sis\u00e4lt\u00f6\u00e4 ei ole olemassa.",

--- a/tests/Lfm.App.Tests/InstancesPageTests.cs
+++ b/tests/Lfm.App.Tests/InstancesPageTests.cs
@@ -40,4 +40,27 @@ public class InstancesPageTests : ComponentTestBase
         var cut = Render<InstancesPage>();
         cut.WaitForAssertion(() => Assert.Contains("Liberation of Undermine", cut.Markup));
     }
+
+    // RD-OVERFLOW-1 (#30): the grid sits in an overflow-x wrapper so wide
+    // tables stay reachable on narrow screens. Expose it to assistive tech
+    // as a scrollable region (role=region, tabindex=0, aria-label).
+    [Fact]
+    public void Grid_Is_Wrapped_In_Labelled_Scroll_Region()
+    {
+        var client = new Mock<IInstancesClient>();
+        client.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<InstanceDto>
+            {
+                new("liberation", "Liberation of Undermine", "raid", "tww")
+            });
+        Services.AddSingleton(client.Object);
+
+        var cut = Render<InstancesPage>();
+        cut.WaitForAssertion(() => Assert.Contains("Liberation of Undermine", cut.Markup));
+
+        var region = cut.Find("div.scroll-region");
+        Assert.Equal("region", region.GetAttribute("role"));
+        Assert.Equal("0", region.GetAttribute("tabindex"));
+        Assert.Equal(Loc("instances.tableAriaLabel"), region.GetAttribute("aria-label"));
+    }
 }


### PR DESCRIPTION
## Summary

Closes #30. The `<div style="overflow-x:auto">` wrappers on `InstancesPage` and `AttendanceRosterSection` were invisible to assistive tech — a keyboard user could not focus the scrollable area to reach overflow columns. Convert both to `role="region" tabindex="0" aria-label="…"` on a new `.scroll-region` utility class that also sets `scrollbar-gutter: stable both-edges` to prevent content jump when the scrollbar appears.

Locale keys added: `instances.tableAriaLabel`, `roster.tableAriaLabel` (with `{0}` placeholder for the group label). Both `en` and `fi` updated.

## Test plan

- [x] `dotnet build lfm.sln -c Release` — clean
- [x] `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release` — 132/132 passing, new bUnit assertion on `InstancesPage` wrapper attributes
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error` — clean

AI-assisted.
