### PR TITLE
Handle Blizzard localized-object shape in guild profile reads

### DIFF
--- a/api/Repositories/IGuildRepository.cs
+++ b/api/Repositories/IGuildRepository.cs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
+using Newtonsoft.Json;
+using Lfm.Api.Serialization;
+
 namespace Lfm.Api.Repositories;
 
 // ---------------------------------------------------------------------------
@@ -71,17 +74,20 @@ public sealed record BlizzardGuildRosterRaw(
     IReadOnlyList<BlizzardGuildRosterMember>? Members = null);
 
 /// <summary>Faction reference in a Blizzard guild profile response.</summary>
-public sealed record BlizzardGuildProfileFaction(string? Name = null);
+public sealed record BlizzardGuildProfileFaction(
+    [property: JsonConverter(typeof(LocalizedStringConverter))] string? Name = null);
 
 /// <summary>Realm reference in a Blizzard guild profile response.</summary>
-public sealed record BlizzardGuildProfileRealm(string Slug, string? Name = null);
+public sealed record BlizzardGuildProfileRealm(
+    string Slug,
+    [property: JsonConverter(typeof(LocalizedStringConverter))] string? Name = null);
 
 /// <summary>
 /// Blizzard guild profile as stored inside the guild document.
 /// Only the fields used for building the GuildDto are modelled here.
 /// </summary>
 public sealed record BlizzardGuildProfileRaw(
-    string Name,
+    [property: JsonConverter(typeof(LocalizedStringConverter))] string Name,
     BlizzardGuildProfileRealm Realm,
     BlizzardGuildProfileFaction? Faction = null,
     int? MemberCount = null,

--- a/api/Serialization/LocalizedStringConverter.cs
+++ b/api/Serialization/LocalizedStringConverter.cs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Lfm.Api.Serialization;
+
+/// <summary>
+/// Newtonsoft converter that reads either a plain string or Blizzard's
+/// localized-object shape (<c>{ "en_US": "Horde", "de_DE": "Horde", ... }</c>)
+/// into a <see cref="string"/>.
+///
+/// Blizzard's WoW Game Data API emits the object shape when the caller omits
+/// the <c>locale</c> query parameter. The legacy TypeScript ingestion path
+/// persisted responses verbatim into Cosmos, so existing guild documents carry
+/// the object shape at <c>blizzardProfileRaw.faction.name</c> and
+/// <c>blizzardProfileRaw.realm.name</c>. Without this converter the Cosmos
+/// SDK (Newtonsoft-backed) raised <c>JsonReaderException</c> on every read
+/// and /api/guild returned 500 (see 2026-04-20 production incident).
+///
+/// Preference order: <c>en_US</c> → first non-empty localized value → null.
+/// On write we emit the value as a plain string so new documents don't carry
+/// the legacy object shape forward.
+/// </summary>
+internal sealed class LocalizedStringConverter : JsonConverter<string?>
+{
+    public override string? ReadJson(
+        JsonReader reader,
+        Type objectType,
+        string? existingValue,
+        bool hasExistingValue,
+        JsonSerializer serializer)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonToken.Null:
+                return null;
+            case JsonToken.String:
+                return (string?)reader.Value;
+            case JsonToken.StartObject:
+                var obj = JObject.Load(reader);
+                var preferred = obj.Value<string?>("en_US");
+                if (!string.IsNullOrEmpty(preferred)) return preferred;
+                foreach (var prop in obj.Properties())
+                {
+                    if (prop.Value.Type == JTokenType.String)
+                    {
+                        var value = prop.Value.Value<string?>();
+                        if (!string.IsNullOrEmpty(value)) return value;
+                    }
+                }
+                return null;
+            default:
+                // Unknown token — skip the value and fall back to null so a
+                // surprising shape cannot keep taking the worker down.
+                reader.Skip();
+                return null;
+        }
+    }
+
+    public override void WriteJson(JsonWriter writer, string? value, JsonSerializer serializer)
+    {
+        if (value is null)
+            writer.WriteNull();
+        else
+            writer.WriteValue(value);
+    }
+}

--- a/tests/Lfm.Api.Tests/Serialization/LocalizedStringConverterTests.cs
+++ b/tests/Lfm.Api.Tests/Serialization/LocalizedStringConverterTests.cs
@@ -48,9 +48,11 @@ public class LocalizedStringConverterTests
     [Fact]
     public void Reads_localized_object_without_en_US_picks_first_non_empty_value()
     {
-        var json = """{ "name": { "de_DE": "Horde", "fr_FR": "Horde" } }""";
+        // Distinct values so the "first" claim is actually witnessed — identical
+        // values would pass even if the converter walked the object in reverse.
+        var json = """{ "name": { "de_DE": "de-value", "fr_FR": "fr-value" } }""";
         var result = JsonConvert.DeserializeObject<Holder>(json, CosmosLikeSettings);
-        Assert.Equal("Horde", result!.Name);
+        Assert.Equal("de-value", result!.Name);
     }
 
     [Fact]
@@ -82,7 +84,7 @@ public class LocalizedStringConverterTests
     {
         var holder = new Holder("Horde");
         var json = JsonConvert.SerializeObject(holder, CosmosLikeSettings);
-        Assert.Contains("\"name\":\"Horde\"", json);
+        Assert.Equal("""{"name":"Horde"}""", json);
     }
 
     // ------------------------------------------------------------------

--- a/tests/Lfm.Api.Tests/Serialization/LocalizedStringConverterTests.cs
+++ b/tests/Lfm.Api.Tests/Serialization/LocalizedStringConverterTests.cs
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Repositories;
+using Lfm.Api.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Xunit;
+
+namespace Lfm.Api.Tests.Serialization;
+
+/// <summary>
+/// Regression coverage for the production bug where guild documents written by
+/// the legacy pipeline (no <c>locale</c> query param) store Blizzard's localized
+/// *object* shape at paths like <c>blizzardProfileRaw.faction.name</c>:
+/// <code>{ "en_US": "Horde", "de_DE": "Horde", ... }</code>
+/// The .NET reader, expecting a plain string, threw
+/// <c>Newtonsoft.Json.JsonReaderException</c> on every /api/guild call.
+/// </summary>
+public class LocalizedStringConverterTests
+{
+    private static readonly JsonSerializerSettings CosmosLikeSettings = new()
+    {
+        ContractResolver = new CamelCasePropertyNamesContractResolver(),
+        NullValueHandling = NullValueHandling.Ignore,
+    };
+
+    // ------------------------------------------------------------------
+    // Converter unit tests
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Reads_plain_string_value()
+    {
+        var json = """{ "name": "Horde" }""";
+        var result = JsonConvert.DeserializeObject<Holder>(json, CosmosLikeSettings);
+        Assert.Equal("Horde", result!.Name);
+    }
+
+    [Fact]
+    public void Reads_localized_object_prefers_en_US()
+    {
+        var json = """{ "name": { "en_US": "Horde", "de_DE": "Horde", "fr_FR": "Horde" } }""";
+        var result = JsonConvert.DeserializeObject<Holder>(json, CosmosLikeSettings);
+        Assert.Equal("Horde", result!.Name);
+    }
+
+    [Fact]
+    public void Reads_localized_object_without_en_US_picks_first_non_empty_value()
+    {
+        var json = """{ "name": { "de_DE": "Horde", "fr_FR": "Horde" } }""";
+        var result = JsonConvert.DeserializeObject<Holder>(json, CosmosLikeSettings);
+        Assert.Equal("Horde", result!.Name);
+    }
+
+    [Fact]
+    public void Reads_null_as_null()
+    {
+        var json = """{ "name": null }""";
+        var result = JsonConvert.DeserializeObject<Holder>(json, CosmosLikeSettings);
+        Assert.Null(result!.Name);
+    }
+
+    [Fact]
+    public void Reads_empty_object_as_null()
+    {
+        var json = """{ "name": {} }""";
+        var result = JsonConvert.DeserializeObject<Holder>(json, CosmosLikeSettings);
+        Assert.Null(result!.Name);
+    }
+
+    [Fact]
+    public void Missing_field_stays_null()
+    {
+        var json = "{}";
+        var result = JsonConvert.DeserializeObject<Holder>(json, CosmosLikeSettings);
+        Assert.Null(result!.Name);
+    }
+
+    [Fact]
+    public void Writes_string_value_as_plain_string()
+    {
+        var holder = new Holder("Horde");
+        var json = JsonConvert.SerializeObject(holder, CosmosLikeSettings);
+        Assert.Contains("\"name\":\"Horde\"", json);
+    }
+
+    // ------------------------------------------------------------------
+    // End-to-end: GuildDocument deserialization matches the production path
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void GuildDocument_deserializes_with_localized_faction_name()
+    {
+        // Shape written by Blizzard's profile endpoint when called without
+        // locale=en_US — this is the exact payload that triggers the prod bug.
+        var json = """
+        {
+          "id": "12345",
+          "guildId": 12345,
+          "realmSlug": "test-realm",
+          "blizzardProfileRaw": {
+            "name": "Test Guild",
+            "realm": { "slug": "test-realm", "name": "Test Realm" },
+            "faction": {
+              "type": "HORDE",
+              "name": { "en_US": "Horde", "de_DE": "Horde", "fr_FR": "Horde" }
+            },
+            "memberCount": 42,
+            "achievementPoints": 1234
+          }
+        }
+        """;
+
+        var doc = JsonConvert.DeserializeObject<GuildDocument>(json, CosmosLikeSettings);
+
+        Assert.NotNull(doc);
+        Assert.NotNull(doc!.BlizzardProfileRaw);
+        Assert.NotNull(doc.BlizzardProfileRaw!.Faction);
+        Assert.Equal("Horde", doc.BlizzardProfileRaw.Faction!.Name);
+    }
+
+    [Fact]
+    public void GuildDocument_deserializes_with_localized_realm_name()
+    {
+        var json = """
+        {
+          "id": "12345",
+          "guildId": 12345,
+          "realmSlug": "test-realm",
+          "blizzardProfileRaw": {
+            "name": "Test Guild",
+            "realm": {
+              "slug": "test-realm",
+              "name": { "en_US": "Test Realm", "de_DE": "Test Reich" }
+            }
+          }
+        }
+        """;
+
+        var doc = JsonConvert.DeserializeObject<GuildDocument>(json, CosmosLikeSettings);
+
+        Assert.Equal("Test Realm", doc!.BlizzardProfileRaw!.Realm.Name);
+    }
+
+    [Fact]
+    public void GuildDocument_still_deserializes_with_plain_string_faction_name()
+    {
+        // The locale=en_US shape must keep working.
+        var json = """
+        {
+          "id": "12345",
+          "guildId": 12345,
+          "realmSlug": "test-realm",
+          "blizzardProfileRaw": {
+            "name": "Test Guild",
+            "realm": { "slug": "test-realm", "name": "Test Realm" },
+            "faction": { "type": "HORDE", "name": "Horde" }
+          }
+        }
+        """;
+
+        var doc = JsonConvert.DeserializeObject<GuildDocument>(json, CosmosLikeSettings);
+
+        Assert.Equal("Horde", doc!.BlizzardProfileRaw!.Faction!.Name);
+    }
+
+    // Record used only by the converter unit tests above.
+    private sealed record Holder(
+        [property: JsonConverter(typeof(LocalizedStringConverter))] string? Name = null);
+}


### PR DESCRIPTION
## Summary

Fixes the production `/api/guild` 500 observed on 2026-04-20. Newtonsoft (via the Cosmos SDK) was throwing `JsonReaderException` at `blizzardProfileRaw.faction.name` on every read because stored guild documents carry Blizzard's localized-object shape (`{ "en_US": "Horde", "de_DE": "Horde", ... }`) while the .NET model expected a plain string.

- Add `LocalizedStringConverter` — a Newtonsoft `JsonConverter<string?>` that reads either a plain string or a localized object (preferring `en_US`, falling back to the first non-empty value), and writes as a plain string so new documents don't carry the legacy shape forward.
- Apply it to the three `string` fields under `BlizzardGuildProfileRaw` (`Name`, `Realm.Name`, `Faction.Name`) — same localization risk applies to each.
- Ten regression tests including the exact production payload, deserialized through a Cosmos-like Newtonsoft settings object.

## Root cause notes

App Insights (2026-04-20 05:55:54) showed `Newtonsoft.Json.JsonReaderException: "Unexpected character encountered while parsing value: {. Path 'blizzardProfileRaw.faction.name', line 1, position 2071."` immediately after the `guilds` container read. Legacy TypeScript ingestion persisted Blizzard responses verbatim; calls made without `locale=en_US` return localized objects for every name field. The new .NET writers pass `locale=en_US`, so going forward new documents will use the plain-string shape — but read-side tolerance is still required for the existing data.

The concurrent `/api/runs` 503/165 ms observed in the same window was a separate Y1 Consumption cold-start timeout (`TimeoutException: "Timed out waiting for the function start call"` on unrelated invocations); not addressed in this PR.

## Env / schema changes

- None. Document shape is unchanged; this only relaxes the reader.

## Test plan

- [x] `dotnet build lfm.sln -c Release` — 0 warnings, 0 errors.
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` — 376/376 pass (10 new).
- [x] `dotnet format lfm.sln --verify-no-changes --severity error` — clean.
- [ ] Post-merge: watch `/api/guild` in App Insights for the absence of `JsonReaderException` on the next cold start cycle.
