### PR TITLE
Extend localized-string converter to runs, raider, and reference docs

### DIFF
--- a/api/Repositories/IInstancesRepository.cs
+++ b/api/Repositories/IInstancesRepository.cs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
+using Newtonsoft.Json;
+using Lfm.Api.Serialization;
 using Lfm.Contracts.Instances;
 
 namespace Lfm.Api.Repositories;
@@ -18,7 +20,7 @@ public sealed record InstanceDocument(
     string Id,
     /// <summary>Blizzard instance id as string (e.g. "67"). Projected as 'id' by ListAsync.</summary>
     string InstanceId,
-    string Name,
+    [property: JsonConverter(typeof(LocalizedStringConverter))] string Name,
     /// <summary>Mode key, e.g. "NORMAL:25" or "HEROIC:5".</summary>
     string ModeKey,
     string Expansion);

--- a/api/Repositories/IRaidersRepository.cs
+++ b/api/Repositories/IRaidersRepository.cs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
 using System.Text.Json.Serialization;
+using Lfm.Api.Serialization;
 
 namespace Lfm.Api.Repositories;
 
@@ -38,7 +39,9 @@ public sealed record BlizzardAccountProfileSummary(
 // Field names match the camelCase keys the TS refresh handler writes to Cosmos.
 // ---------------------------------------------------------------------------
 
-public sealed record StoredCharacterSpecialization(int Id, string? Name = null);
+public sealed record StoredCharacterSpecialization(
+    int Id,
+    [property: Newtonsoft.Json.JsonConverter(typeof(LocalizedStringConverter))] string? Name = null);
 
 public sealed record StoredSpecializationsSummary(
     StoredCharacterSpecialization? ActiveSpecialization = null,
@@ -69,7 +72,7 @@ public sealed record StoredSelectedCharacter(
     StoredSpecializationsSummary? SpecializationsSummary = null,
     BlizzardCharacterMediaSummary? MediaSummary = null,
     int? ClassId = null,
-    string? ClassName = null,
+    [property: Newtonsoft.Json.JsonConverter(typeof(LocalizedStringConverter))] string? ClassName = null,
     int? Level = null,
     int? GuildId = null,
     string? GuildName = null,

--- a/api/Repositories/IRunsRepository.cs
+++ b/api/Repositories/IRunsRepository.cs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
+using Newtonsoft.Json;
+using Lfm.Api.Serialization;
+
 namespace Lfm.Api.Repositories;
 
 /// <summary>
@@ -16,14 +19,14 @@ public sealed record RunCharacterEntry(
     string CharacterRealm,
     int CharacterLevel,
     int CharacterClassId,
-    string CharacterClassName,
+    [property: JsonConverter(typeof(LocalizedStringConverter))] string CharacterClassName,
     int CharacterRaceId,
-    string CharacterRaceName,
+    [property: JsonConverter(typeof(LocalizedStringConverter))] string CharacterRaceName,
     string RaiderBattleNetId,
     string DesiredAttendance,
     string ReviewedAttendance,
     int? SpecId,
-    string? SpecName,
+    [property: JsonConverter(typeof(LocalizedStringConverter))] string? SpecName,
     string? Role);
 
 public sealed record RunDocument(
@@ -36,7 +39,7 @@ public sealed record RunDocument(
     string CreatorGuild,
     int? CreatorGuildId,
     int InstanceId,
-    string InstanceName,
+    [property: JsonConverter(typeof(LocalizedStringConverter))] string InstanceName,
     string? CreatorBattleNetId,
     string CreatedAt,
     int Ttl,

--- a/api/Repositories/ISpecializationsRepository.cs
+++ b/api/Repositories/ISpecializationsRepository.cs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
+using Newtonsoft.Json;
+using Lfm.Api.Serialization;
 using Lfm.Contracts.Specializations;
 
 namespace Lfm.Api.Repositories;
@@ -13,7 +15,7 @@ public sealed record SpecializationDocument(
     /// <summary>Cosmos document id and partition key: string form of the numeric spec id.</summary>
     string Id,
     int SpecId,
-    string Name,
+    [property: JsonConverter(typeof(LocalizedStringConverter))] string Name,
     int ClassId,
     string Role,
     string? IconUrl);

--- a/tests/Lfm.Api.Tests/Serialization/LocalizedStringConverterTests.cs
+++ b/tests/Lfm.Api.Tests/Serialization/LocalizedStringConverterTests.cs
@@ -40,9 +40,11 @@ public class LocalizedStringConverterTests
     [Fact]
     public void Reads_localized_object_prefers_en_US()
     {
-        var json = """{ "name": { "en_US": "Horde", "de_DE": "Horde", "fr_FR": "Horde" } }""";
+        // Distinct values across locales so the en_US preference is actually
+        // witnessed — identical values would pass even if another key won.
+        var json = """{ "name": { "en_US": "en-value", "de_DE": "de-value", "fr_FR": "fr-value" } }""";
         var result = JsonConvert.DeserializeObject<Holder>(json, CosmosLikeSettings);
-        Assert.Equal("Horde", result!.Name);
+        Assert.Equal("en-value", result!.Name);
     }
 
     [Fact]
@@ -96,6 +98,8 @@ public class LocalizedStringConverterTests
     {
         // Shape written by Blizzard's profile endpoint when called without
         // locale=en_US — this is the exact payload that triggers the prod bug.
+        // Distinct per-locale values so the en_US preference is witnessed in
+        // the end-to-end record wiring, not only in the converter unit test.
         var json = """
         {
           "id": "12345",
@@ -106,7 +110,7 @@ public class LocalizedStringConverterTests
             "realm": { "slug": "test-realm", "name": "Test Realm" },
             "faction": {
               "type": "HORDE",
-              "name": { "en_US": "Horde", "de_DE": "Horde", "fr_FR": "Horde" }
+              "name": { "en_US": "Horde", "de_DE": "Horde-DE", "fr_FR": "Horde-FR" }
             },
             "memberCount": 42,
             "achievementPoints": 1234

--- a/tests/Lfm.Api.Tests/Serialization/LocalizedStringConverterTests.cs
+++ b/tests/Lfm.Api.Tests/Serialization/LocalizedStringConverterTests.cs
@@ -167,6 +167,152 @@ public class LocalizedStringConverterTests
         Assert.Equal("Horde", doc!.BlizzardProfileRaw!.Faction!.Name);
     }
 
+    // ------------------------------------------------------------------
+    // End-to-end: RunDocument deserialization (second prod failure, same
+    // root cause but at runCharacters[].specName and neighbouring fields).
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void RunDocument_deserializes_with_localized_character_spec_class_race_and_instance_names()
+    {
+        // Minimal shape of a run document as stored in Cosmos, using Blizzard's
+        // no-locale localized-object shape for every Blizzard-sourced name.
+        var json = """
+        {
+          "id": "run-1",
+          "startTime": "2026-04-20T18:00:00Z",
+          "signupCloseTime": "2026-04-20T17:30:00Z",
+          "description": "",
+          "modeKey": "NORMAL:25",
+          "visibility": "GUILD",
+          "creatorGuild": "Test Guild",
+          "creatorGuildId": 12345,
+          "instanceId": 67,
+          "instanceName": { "en_US": "Gluttonous Abomination", "de_DE": "Gefrässige Abscheulichkeit" },
+          "creatorBattleNetId": "bnet-1",
+          "createdAt": "2026-04-20T17:00:00Z",
+          "ttl": 604800,
+          "runCharacters": [
+            {
+              "id": "rc-1",
+              "characterId": "char-1",
+              "characterName": "Thrall",
+              "characterRealm": "test-realm",
+              "characterLevel": 80,
+              "characterClassId": 7,
+              "characterClassName": { "en_US": "Shaman", "de_DE": "Schamane" },
+              "characterRaceId": 2,
+              "characterRaceName": { "en_US": "Orc", "de_DE": "Orc" },
+              "raiderBattleNetId": "bnet-1",
+              "desiredAttendance": "YES",
+              "reviewedAttendance": "PENDING",
+              "specId": 262,
+              "specName": { "en_US": "Elemental", "de_DE": "Elementar" },
+              "role": "DAMAGE"
+            }
+          ]
+        }
+        """;
+
+        var doc = JsonConvert.DeserializeObject<RunDocument>(json, CosmosLikeSettings);
+
+        Assert.NotNull(doc);
+        Assert.Equal("Gluttonous Abomination", doc!.InstanceName);
+        var character = Assert.Single(doc.RunCharacters);
+        Assert.Equal("Shaman", character.CharacterClassName);
+        Assert.Equal("Orc", character.CharacterRaceName);
+        Assert.Equal("Elemental", character.SpecName);
+    }
+
+    // ------------------------------------------------------------------
+    // End-to-end: RaiderDocument deserialization — the raider doc is read
+    // on nearly every authenticated endpoint, so any localized-object
+    // payload buried in it would take the whole API down.
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void RaiderDocument_deserializes_with_localized_stored_character_class_and_spec_names()
+    {
+        // The raider doc's StoredSelectedCharacter.ClassName and its nested
+        // SpecializationsSummary.ActiveSpecialization.Name come from legacy
+        // Blizzard profile fetches; either may have been stored as a
+        // localized object. The live Blizzard HTTP path uses STJ and always
+        // requests locale=en_US, so BlizzardAccountProfileSummary is out of
+        // scope here.
+        var json = """
+        {
+          "id": "bnet-1",
+          "battleNetId": "bnet-1",
+          "selectedCharacterId": "char-1",
+          "locale": null,
+          "characters": [
+            {
+              "id": "char-1",
+              "region": "eu",
+              "realm": "test-realm",
+              "name": "Thrall",
+              "classId": 7,
+              "className": { "en_US": "Shaman", "de_DE": "Schamane" },
+              "specializationsSummary": {
+                "activeSpecialization": {
+                  "id": 262,
+                  "name": { "en_US": "Elemental", "de_DE": "Elementar" }
+                }
+              }
+            }
+          ]
+        }
+        """;
+
+        var doc = JsonConvert.DeserializeObject<RaiderDocument>(json, CosmosLikeSettings);
+
+        Assert.NotNull(doc);
+        var stored = Assert.Single(doc!.Characters!);
+        Assert.Equal("Shaman", stored.ClassName);
+        Assert.Equal("Elemental", stored.SpecializationsSummary!.ActiveSpecialization!.Name);
+    }
+
+    // ------------------------------------------------------------------
+    // End-to-end: reference-data containers (instances, specializations)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void InstanceDocument_deserializes_with_localized_name()
+    {
+        var json = """
+        {
+          "id": "67:NORMAL:25",
+          "instanceId": "67",
+          "name": { "en_US": "Icecrown Citadel", "de_DE": "Eiskronenzitadelle" },
+          "modeKey": "NORMAL:25",
+          "expansion": "WRATH_OF_THE_LICH_KING"
+        }
+        """;
+
+        var doc = JsonConvert.DeserializeObject<InstanceDocument>(json, CosmosLikeSettings);
+
+        Assert.Equal("Icecrown Citadel", doc!.Name);
+    }
+
+    [Fact]
+    public void SpecializationDocument_deserializes_with_localized_name()
+    {
+        var json = """
+        {
+          "id": "262",
+          "specId": 262,
+          "name": { "en_US": "Elemental", "de_DE": "Elementar" },
+          "classId": 7,
+          "role": "DAMAGE",
+          "iconUrl": null
+        }
+        """;
+
+        var doc = JsonConvert.DeserializeObject<SpecializationDocument>(json, CosmosLikeSettings);
+
+        Assert.Equal("Elemental", doc!.Name);
+    }
+
     // Record used only by the converter unit tests above.
     private sealed record Holder(
         [property: JsonConverter(typeof(LocalizedStringConverter))] string? Name = null);


### PR DESCRIPTION
## Summary

Same root cause as #39 but a different endpoint. Production `/api/runs` now throws `Newtonsoft.Json.JsonReaderException: "Unexpected character encountered while parsing value: {. Path '[0].runCharacters[0].specName', line 1, position 1035"` — another stored field (Blizzard-sourced localized string) persisted as a localized object. Apply the existing `LocalizedStringConverter` to every Cosmos-stored `*Name` field sourced from Blizzard's localized APIs.

Annotated fields:
- `RunDocument.InstanceName`
- `RunCharacterEntry.CharacterClassName`, `.CharacterRaceName`, `.SpecName`
- `StoredSelectedCharacter.ClassName`
- `StoredCharacterSpecialization.Name`
- `InstanceDocument.Name`
- `SpecializationDocument.Name`

## Out of scope

- `BlizzardRealmRef`, `BlizzardNamedRef`, `BlizzardSpecializationRef`, `BlizzardCharacterProfileResponse`, `BlizzardCharacterGuildRef` — these types are deserialized by `System.Text.Json` in `BlizzardProfileClient` from live HTTP responses (always `locale=en_US`), never through the Newtonsoft/Cosmos path, so the Newtonsoft converter wouldn't fire on them anyway.

## Env / schema changes

- None. Reader-side tolerance only.

## Test plan

- [x] `dotnet build lfm.sln -c Release` — 0 warnings, 0 errors
- [x] `dotnet test tests/Lfm.Api.Tests/…` — 380/380 pass (4 new tests: run document, stored-character, instance, specialization)
- [x] `dotnet test tests/Lfm.App.Tests/…` — 135/135
- [x] `dotnet test tests/Lfm.App.Core.Tests/…` — 89/89
- [x] `dotnet format --verify-no-changes` — clean
- [ ] Post-merge: watch App Insights for absence of `JsonReaderException` on `/api/runs`, `/api/instances`, `/api/specializations`
