### PR TITLE
Auto-refresh characters on 204 NoContent

### DIFF
--- a/app/Lfm.App.Core/Services/BattleNetClient.cs
+++ b/app/Lfm.App.Core/Services/BattleNetClient.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
+using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using Lfm.Contracts.Characters;
@@ -14,16 +15,24 @@ public sealed class BattleNetClient(IHttpClientFactory factory) : IBattleNetClie
         PropertyNameCaseInsensitive = true,
     };
 
-    public async Task<IReadOnlyList<CharacterDto>?> GetCharactersAsync(CancellationToken ct)
+    public async Task<CharactersFetchResult> GetCharactersAsync(CancellationToken ct)
     {
         var http = factory.CreateClient("api");
         try
         {
-            return await http.GetFromJsonAsync<List<CharacterDto>>("api/battlenet/characters", JsonOptions, ct);
+            var response = await http.GetAsync("api/battlenet/characters", ct);
+            if (response.StatusCode == HttpStatusCode.NoContent)
+                return new CharactersFetchResult.NeedsRefresh();
+            if (!response.IsSuccessStatusCode)
+                return new CharactersFetchResult.Error();
+            var chars = await response.Content.ReadFromJsonAsync<List<CharacterDto>>(JsonOptions, ct);
+            return chars is null
+                ? new CharactersFetchResult.Error()
+                : new CharactersFetchResult.Cached(chars);
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException or JsonException)
         {
-            return null;
+            return new CharactersFetchResult.Error();
         }
     }
 

--- a/app/Lfm.App.Core/Services/CharactersFetchResult.cs
+++ b/app/Lfm.App.Core/Services/CharactersFetchResult.cs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Contracts.Characters;
+
+namespace Lfm.App.Services;
+
+/// <summary>
+/// Result of <see cref="IBattleNetClient.GetCharactersAsync"/>.  The backend
+/// returns 204 No Content when no cached account profile summary exists (or the
+/// 15-minute cooldown has expired), signalling that the caller must POST to
+/// /api/battlenet/characters/refresh before characters can be shown.  That
+/// signal is distinct from a transport/server error, so callers must handle it
+/// separately from an error.
+/// </summary>
+public abstract record CharactersFetchResult
+{
+    public sealed record Cached(IReadOnlyList<CharacterDto> Characters) : CharactersFetchResult;
+
+    public sealed record NeedsRefresh : CharactersFetchResult;
+
+    public sealed record Error : CharactersFetchResult;
+}

--- a/app/Lfm.App.Core/Services/IBattleNetClient.cs
+++ b/app/Lfm.App.Core/Services/IBattleNetClient.cs
@@ -7,7 +7,7 @@ namespace Lfm.App.Services;
 
 public interface IBattleNetClient
 {
-    Task<IReadOnlyList<CharacterDto>?> GetCharactersAsync(CancellationToken ct);
+    Task<CharactersFetchResult> GetCharactersAsync(CancellationToken ct);
 
     Task<IReadOnlyList<CharacterDto>?> RefreshCharactersAsync(CancellationToken ct);
 

--- a/app/Pages/CharactersPage.razor
+++ b/app/Pages/CharactersPage.razor
@@ -182,19 +182,28 @@
         state = new LoadingState<IReadOnlyList<CharacterDto>>.Loading();
         try
         {
-            var chars = await BattleNetClient.GetCharactersAsync(CancellationToken.None);
-            if (chars is null)
+            var result = await BattleNetClient.GetCharactersAsync(CancellationToken.None);
+            switch (result)
             {
-                state = new LoadingState<IReadOnlyList<CharacterDto>>.Failure(Loc["characters.error.loadFailed"]);
-            }
-            else
-            {
-                state = new LoadingState<IReadOnlyList<CharacterDto>>.Success(chars);
-                foreach (var c in chars)
-                    cardState[CharKey(c)] = (c.ClassId is not null && c.ActiveSpecId is not null)
-                        ? EnrichState.Enriched
-                        : EnrichState.Pending;
-                _ = LoadPortraitsAsync(chars);
+                case CharactersFetchResult.Cached cached:
+                    ApplyCharacters(cached.Characters);
+                    break;
+
+                case CharactersFetchResult.NeedsRefresh:
+                    // Backend has no cached profile (or cooldown expired) and asks
+                    // us to fetch fresh from Blizzard.  Without this fallback, a
+                    // first visit to /characters shows "load failed" until the
+                    // user clicks the refresh button.
+                    var fresh = await BattleNetClient.RefreshCharactersAsync(CancellationToken.None);
+                    if (fresh is null)
+                        state = new LoadingState<IReadOnlyList<CharacterDto>>.Failure(Loc["characters.error.loadFailed"]);
+                    else
+                        ApplyCharacters(fresh);
+                    break;
+
+                default:
+                    state = new LoadingState<IReadOnlyList<CharacterDto>>.Failure(Loc["characters.error.loadFailed"]);
+                    break;
             }
         }
         catch (Exception ex)
@@ -205,6 +214,16 @@
         {
             loading = false;
         }
+    }
+
+    private void ApplyCharacters(IReadOnlyList<CharacterDto> chars)
+    {
+        state = new LoadingState<IReadOnlyList<CharacterDto>>.Success(chars);
+        foreach (var c in chars)
+            cardState[CharKey(c)] = (c.ClassId is not null && c.ActiveSpecId is not null)
+                ? EnrichState.Enriched
+                : EnrichState.Pending;
+        _ = LoadPortraitsAsync(chars);
     }
 
     private async Task RefreshCharacters()

--- a/tests/Lfm.App.Core.Tests/Services/BattleNetClientTests.cs
+++ b/tests/Lfm.App.Core.Tests/Services/BattleNetClientTests.cs
@@ -36,7 +36,7 @@ public class BattleNetClientTests
     // ── GetCharactersAsync ───────────────────────────────────────────────────
 
     [Fact]
-    public async Task GetCharactersAsync_returns_characters_on_success()
+    public async Task GetCharactersAsync_returns_Cached_on_success()
     {
         var (client, handler) = MakeClient(StubHttpMessageHandler.Json(
             HttpStatusCode.OK,
@@ -44,9 +44,9 @@ public class BattleNetClientTests
 
         var result = await client.GetCharactersAsync(CancellationToken.None);
 
-        Assert.NotNull(result);
-        Assert.Equal(2, result!.Count);
-        Assert.Equal("Char-A", result[0].Name);
+        var cached = Assert.IsType<CharactersFetchResult.Cached>(result);
+        Assert.Equal(2, cached.Characters.Count);
+        Assert.Equal("Char-A", cached.Characters[0].Name);
         Assert.Equal(HttpMethod.Get, handler.LastRequest!.Method);
         Assert.Equal("/api/battlenet/characters", handler.LastRequest.RequestUri!.PathAndQuery);
     }
@@ -64,42 +64,58 @@ public class BattleNetClientTests
 
         var result = await client.GetCharactersAsync(CancellationToken.None);
 
-        Assert.NotNull(result);
-        Assert.Single(result!);
-        Assert.Equal("Lower", result![0].Name);
-        Assert.Equal("eu", result[0].Region);
+        var cached = Assert.IsType<CharactersFetchResult.Cached>(result);
+        var single = Assert.Single(cached.Characters);
+        Assert.Equal("Lower", single.Name);
+        Assert.Equal("eu", single.Region);
     }
 
     [Fact]
-    public async Task GetCharactersAsync_returns_null_when_server_returns_5xx()
+    public async Task GetCharactersAsync_returns_NeedsRefresh_on_204()
+    {
+        // Backend returns 204 when no cached account profile exists (or the
+        // 15-minute cooldown expired), signalling the caller must POST to
+        // /api/battlenet/characters/refresh. Regression guard for the bug where
+        // /characters showed "load failed" on first visit until the user
+        // clicked refresh manually.
+        var (client, handler) = MakeClient(new StubHttpMessageHandler(HttpStatusCode.NoContent));
+
+        var result = await client.GetCharactersAsync(CancellationToken.None);
+
+        Assert.IsType<CharactersFetchResult.NeedsRefresh>(result);
+        Assert.Equal(1, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task GetCharactersAsync_returns_Error_when_server_returns_5xx()
     {
         var (client, handler) = MakeClient(new StubHttpMessageHandler(HttpStatusCode.ServiceUnavailable));
 
         var result = await client.GetCharactersAsync(CancellationToken.None);
 
-        Assert.Null(result);
+        Assert.IsType<CharactersFetchResult.Error>(result);
         Assert.Equal(1, handler.CallCount);
     }
 
     [Fact]
-    public async Task GetCharactersAsync_returns_null_when_handler_throws_HttpRequestException()
+    public async Task GetCharactersAsync_returns_Error_when_handler_throws_HttpRequestException()
     {
         var (client, handler) = MakeClient(StubHttpMessageHandler.Throws(new HttpRequestException("network down")));
 
         var result = await client.GetCharactersAsync(CancellationToken.None);
 
-        Assert.Null(result);
+        Assert.IsType<CharactersFetchResult.Error>(result);
         Assert.Equal(1, handler.CallCount);
     }
 
     [Fact]
-    public async Task GetCharactersAsync_returns_null_when_handler_throws_JsonException()
+    public async Task GetCharactersAsync_returns_Error_when_handler_throws_JsonException()
     {
         var (client, handler) = MakeClient(StubHttpMessageHandler.Throws(new JsonException("bad payload")));
 
         var result = await client.GetCharactersAsync(CancellationToken.None);
 
-        Assert.Null(result);
+        Assert.IsType<CharactersFetchResult.Error>(result);
         Assert.Equal(1, handler.CallCount);
     }
 

--- a/tests/Lfm.App.Tests/CharactersPagesTests.cs
+++ b/tests/Lfm.App.Tests/CharactersPagesTests.cs
@@ -46,7 +46,7 @@ public class CharactersPagesTests : ComponentTestBase
     {
         this.AddAuthorization().SetAuthorized("player#1234");
         var battleNet = new Mock<IBattleNetClient>();
-        var tcs = new TaskCompletionSource<IReadOnlyList<CharacterDto>?>();
+        var tcs = new TaskCompletionSource<CharactersFetchResult>();
         battleNet.Setup(c => c.GetCharactersAsync(It.IsAny<CancellationToken>())).Returns(tcs.Task);
         battleNet.Setup(c => c.GetPortraitsAsync(It.IsAny<IEnumerable<CharacterPortraitRequest>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IDictionary<string, string>?)null);
@@ -65,7 +65,7 @@ public class CharactersPagesTests : ComponentTestBase
         this.AddAuthorization().SetAuthorized("player#1234");
         var battleNet = new Mock<IBattleNetClient>();
         battleNet.Setup(c => c.GetCharactersAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<CharacterDto> { MakeChar() });
+            .ReturnsAsync(new CharactersFetchResult.Cached(new List<CharacterDto> { MakeChar() }));
         battleNet.Setup(c => c.GetPortraitsAsync(It.IsAny<IEnumerable<CharacterPortraitRequest>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IDictionary<string, string>?)null);
         var me = new Mock<IMeClient>();
@@ -83,7 +83,7 @@ public class CharactersPagesTests : ComponentTestBase
         this.AddAuthorization().SetAuthorized("player#1234");
         var battleNet = new Mock<IBattleNetClient>();
         battleNet.Setup(c => c.GetCharactersAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<CharacterDto>());
+            .ReturnsAsync(new CharactersFetchResult.Cached(new List<CharacterDto>()));
         battleNet.Setup(c => c.GetPortraitsAsync(It.IsAny<IEnumerable<CharacterPortraitRequest>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IDictionary<string, string>?)null);
         var me = new Mock<IMeClient>();
@@ -112,12 +112,12 @@ public class CharactersPagesTests : ComponentTestBase
     }
 
     [Fact]
-    public void CharactersPage_Renders_Error_When_Client_Returns_Null()
+    public void CharactersPage_Renders_Error_When_Client_Returns_Error()
     {
         this.AddAuthorization().SetAuthorized("player#1234");
         var battleNet = new Mock<IBattleNetClient>();
         battleNet.Setup(c => c.GetCharactersAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync((IReadOnlyList<CharacterDto>?)null);
+            .ReturnsAsync(new CharactersFetchResult.Error());
         var me = new Mock<IMeClient>();
         Services.AddSingleton(battleNet.Object);
         Services.AddSingleton(me.Object);
@@ -128,12 +128,40 @@ public class CharactersPagesTests : ComponentTestBase
     }
 
     [Fact]
+    public void CharactersPage_Auto_Refreshes_When_Client_Returns_NeedsRefresh()
+    {
+        // Regression guard for bug: first visit to /characters used to show
+        // "load failed" until the user clicked refresh.  Backend returns 204
+        // (NeedsRefresh) when no cached account profile exists; the page must
+        // auto-POST to /refresh in that case.
+        this.AddAuthorization().SetAuthorized("player#1234");
+        var battleNet = new Mock<IBattleNetClient>();
+        battleNet.Setup(c => c.GetCharactersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CharactersFetchResult.NeedsRefresh());
+        battleNet.Setup(c => c.RefreshCharactersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CharacterDto> { MakeChar("Arthas") });
+        battleNet.Setup(c => c.GetPortraitsAsync(It.IsAny<IEnumerable<CharacterPortraitRequest>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IDictionary<string, string>?)null);
+        var me = new Mock<IMeClient>();
+        Services.AddSingleton(battleNet.Object);
+        Services.AddSingleton(me.Object);
+
+        var cut = Render<CharactersPage>();
+
+        cut.WaitForAssertion(() =>
+        {
+            battleNet.Verify(c => c.RefreshCharactersAsync(It.IsAny<CancellationToken>()), Times.Once);
+            Assert.Contains("Arthas", cut.Markup);
+        });
+    }
+
+    [Fact]
     public void CharactersPage_Renders_Multiple_Characters()
     {
         this.AddAuthorization().SetAuthorized("player#1234");
         var battleNet = new Mock<IBattleNetClient>();
         battleNet.Setup(c => c.GetCharactersAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<CharacterDto> { MakeChar("Arthas"), MakeChar("Sylvanas") });
+            .ReturnsAsync(new CharactersFetchResult.Cached(new List<CharacterDto> { MakeChar("Arthas"), MakeChar("Sylvanas") }));
         battleNet.Setup(c => c.GetPortraitsAsync(It.IsAny<IEnumerable<CharacterPortraitRequest>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IDictionary<string, string>?)null);
         var me = new Mock<IMeClient>();
@@ -155,7 +183,7 @@ public class CharactersPagesTests : ComponentTestBase
         this.AddAuthorization().SetAuthorized("player#1234");
         var battleNet = new Mock<IBattleNetClient>();
         battleNet.Setup(c => c.GetCharactersAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<CharacterDto>());
+            .ReturnsAsync(new CharactersFetchResult.Cached(new List<CharacterDto>()));
         battleNet.Setup(c => c.GetPortraitsAsync(It.IsAny<IEnumerable<CharacterPortraitRequest>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IDictionary<string, string>?)null);
         var me = new Mock<IMeClient>();
@@ -175,7 +203,7 @@ public class CharactersPagesTests : ComponentTestBase
         this.AddAuthorization().SetAuthorized("player#1234");
         var battleNet = new Mock<IBattleNetClient>();
         battleNet.Setup(c => c.GetCharactersAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<CharacterDto> { MakeChar("Arthas") });
+            .ReturnsAsync(new CharactersFetchResult.Cached(new List<CharacterDto> { MakeChar("Arthas") }));
         battleNet.Setup(c => c.GetPortraitsAsync(It.IsAny<IEnumerable<CharacterPortraitRequest>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IDictionary<string, string>?)null);
         var me = new Mock<IMeClient>();
@@ -200,7 +228,7 @@ public class CharactersPagesTests : ComponentTestBase
         this.AddAuthorization().SetAuthorized("player#1234");
         var battleNet = new Mock<IBattleNetClient>();
         battleNet.Setup(c => c.GetCharactersAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<CharacterDto> { MakeChar("Arthas"), MakeChar("Sylvanas") });
+            .ReturnsAsync(new CharactersFetchResult.Cached(new List<CharacterDto> { MakeChar("Arthas"), MakeChar("Sylvanas") }));
         battleNet.Setup(c => c.GetPortraitsAsync(It.IsAny<IEnumerable<CharacterPortraitRequest>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IDictionary<string, string>?)null);
         var me = new Mock<IMeClient>();
@@ -224,7 +252,7 @@ public class CharactersPagesTests : ComponentTestBase
         this.AddAuthorization().SetAuthorized("player#1234");
         var battleNet = new Mock<IBattleNetClient>();
         battleNet.Setup(c => c.GetCharactersAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<CharacterDto> { MakeChar("Arthas"), MakeChar("Sylvanas") });
+            .ReturnsAsync(new CharactersFetchResult.Cached(new List<CharacterDto> { MakeChar("Arthas"), MakeChar("Sylvanas") }));
         battleNet.Setup(c => c.GetPortraitsAsync(It.IsAny<IEnumerable<CharacterPortraitRequest>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IDictionary<string, string>?)null);
         var me = new Mock<IMeClient>();
@@ -250,7 +278,7 @@ public class CharactersPagesTests : ComponentTestBase
         this.AddAuthorization().SetAuthorized("player#1234");
         var battleNet = new Mock<IBattleNetClient>();
         battleNet.Setup(c => c.GetCharactersAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<CharacterDto> { MakeChar("Arthas") });
+            .ReturnsAsync(new CharactersFetchResult.Cached(new List<CharacterDto> { MakeChar("Arthas") }));
         battleNet.Setup(c => c.GetPortraitsAsync(It.IsAny<IEnumerable<CharacterPortraitRequest>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IDictionary<string, string>?)null);
         var me = new Mock<IMeClient>();
@@ -289,7 +317,7 @@ public class CharactersPagesTests : ComponentTestBase
 
         var battleNet = new Mock<IBattleNetClient>();
         battleNet.Setup(c => c.GetCharactersAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(chars);
+            .ReturnsAsync(new CharactersFetchResult.Cached(chars));
         battleNet.Setup(c => c.GetPortraitsAsync(It.IsAny<IEnumerable<CharacterPortraitRequest>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IDictionary<string, string>?)null);
 
@@ -348,7 +376,7 @@ public class CharactersPagesTests : ComponentTestBase
 
         var battleNet = new Mock<IBattleNetClient>();
         battleNet.Setup(c => c.GetCharactersAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(chars);
+            .ReturnsAsync(new CharactersFetchResult.Cached(chars));
         battleNet.Setup(c => c.GetPortraitsAsync(It.IsAny<IEnumerable<CharacterPortraitRequest>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IDictionary<string, string>?)null);
 
@@ -409,7 +437,7 @@ public class CharactersPagesTests : ComponentTestBase
         var battleNet = new Mock<IBattleNetClient>();
         // MakeChar returns a char with ClassId/ActiveSpecId set → starts Enriched.
         battleNet.Setup(c => c.GetCharactersAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<CharacterDto> { MakeChar("Arthas"), MakeChar("Sylvanas") });
+            .ReturnsAsync(new CharactersFetchResult.Cached(new List<CharacterDto> { MakeChar("Arthas"), MakeChar("Sylvanas") }));
         battleNet.Setup(c => c.GetPortraitsAsync(It.IsAny<IEnumerable<CharacterPortraitRequest>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IDictionary<string, string>?)null);
         var me = new Mock<IMeClient>();
@@ -454,7 +482,7 @@ public class CharactersPagesTests : ComponentTestBase
 
         var battleNet = new Mock<IBattleNetClient>();
         battleNet.Setup(c => c.GetCharactersAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(chars);
+            .ReturnsAsync(new CharactersFetchResult.Cached(chars));
         battleNet.Setup(c => c.GetPortraitsAsync(It.IsAny<IEnumerable<CharacterPortraitRequest>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IDictionary<string, string>?)null);
 
@@ -513,7 +541,7 @@ public class CharactersPagesTests : ComponentTestBase
         this.AddAuthorization().SetAuthorized("player#1234");
         var battleNet = new Mock<IBattleNetClient>();
         battleNet.Setup(c => c.GetCharactersAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[] { MakeChar("Arthas") });
+            .ReturnsAsync(new CharactersFetchResult.Cached(new[] { MakeChar("Arthas") }));
         battleNet.Setup(c => c.GetPortraitsAsync(It.IsAny<IEnumerable<CharacterPortraitRequest>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IDictionary<string, string>?)null);
         var me = new Mock<IMeClient>();
@@ -556,7 +584,7 @@ public class CharactersPagesTests : ComponentTestBase
 
         var battleNet = new Mock<IBattleNetClient>();
         battleNet.Setup(c => c.GetCharactersAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(chars);
+            .ReturnsAsync(new CharactersFetchResult.Cached(chars));
         battleNet.Setup(c => c.GetPortraitsAsync(It.IsAny<IEnumerable<CharacterPortraitRequest>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IDictionary<string, string>?)null);
 
@@ -608,7 +636,7 @@ public class CharactersPagesTests : ComponentTestBase
         this.AddAuthorization().SetAuthorized("player#1234");
         var battleNet = new Mock<IBattleNetClient>();
         battleNet.Setup(c => c.GetCharactersAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<CharacterDto> { MakeChar("Arthas"), MakeChar("Sylvanas") });
+            .ReturnsAsync(new CharactersFetchResult.Cached(new List<CharacterDto> { MakeChar("Arthas"), MakeChar("Sylvanas") }));
         battleNet.Setup(c => c.GetPortraitsAsync(It.IsAny<IEnumerable<CharacterPortraitRequest>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IDictionary<string, string>?)null);
         var me = new Mock<IMeClient>();

--- a/tests/Lfm.App.Tests/HeadingStructureTests.cs
+++ b/tests/Lfm.App.Tests/HeadingStructureTests.cs
@@ -22,7 +22,7 @@ public class HeadingStructureTests : ComponentTestBase
     {
         var battleNet = new Mock<IBattleNetClient>();
         battleNet.Setup(c => c.GetCharactersAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync((IReadOnlyList<CharacterDto>?)null);
+            .ReturnsAsync(new CharactersFetchResult.Error());
         battleNet.Setup(c => c.GetPortraitsAsync(It.IsAny<IEnumerable<CharacterPortraitRequest>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IDictionary<string, string>?)null);
         var me = new Mock<IMeClient>();


### PR DESCRIPTION
## Summary

Fixes the bug where navigating to `/characters` shows "load failed" on the first visit, and only works after clicking the refresh button.

The `GET /api/battlenet/characters` endpoint returns **204 No Content** when no cached account profile exists (or the 15-minute cooldown expired), signalling that the caller should `POST /api/battlenet/characters/refresh`. The Blazor client collapsed 204 into `null` via `GetFromJsonAsync` (empty body → `JsonException`), making 204 indistinguishable from a real error, and the page showed failure. Manual refresh worked because it's a different endpoint that always calls Blizzard.

### Changes

- New `CharactersFetchResult` discriminated union: `Cached(list)` / `NeedsRefresh` / `Error`.
- `BattleNetClient.GetCharactersAsync` now inspects the status code and returns `NeedsRefresh` on 204.
- `CharactersPage.LoadCharacters` dispatches on the result and auto-calls `RefreshCharactersAsync` when the backend signals `NeedsRefresh`.

### Env / schema changes

None.

## Test plan

- [x] `dotnet test tests/Lfm.App.Core.Tests` — 90 passing (includes new `GetCharactersAsync_returns_NeedsRefresh_on_204` regression guard)
- [x] `dotnet test tests/Lfm.App.Tests` — 136 passing (includes new `CharactersPage_Auto_Refreshes_When_Client_Returns_NeedsRefresh` bUnit test)
- [x] `dotnet test tests/Lfm.Api.Tests` — 380 passing
- [x] `dotnet build lfm.sln -c Release` clean
- [x] `dotnet format lfm.sln --verify-no-changes --severity error` clean
- [ ] Manual smoke: log in as a new / cache-expired user, navigate to `/characters`, confirm characters load without clicking refresh
- [ ] Manual smoke: with warm cache, navigate to `/characters`, confirm characters load from cache (no auto-refresh triggered)

## Notes

The PR does not touch the page markup — only the `LoadCharacters` code-behind — so no UI screenshots.