### PR TITLE
Fix enrich character id parsing and 404 passthrough

### DIFF
--- a/api/Functions/RaiderCharacterEnrichFunction.cs
+++ b/api/Functions/RaiderCharacterEnrichFunction.cs
@@ -86,6 +86,10 @@ public sealed class RaiderCharacterEnrichFunction(
             {
                 return new ObjectResult(new { error = "Upstream rate-limited" }) { StatusCode = 429 };
             }
+            catch (HttpRequestException ex) when ((int?)ex.StatusCode == 404)
+            {
+                return new NotFoundObjectResult(new { error = "Character not found on Blizzard" });
+            }
             catch (HttpRequestException)
             {
                 return new ObjectResult(new { error = "Failed to fetch character from Blizzard" }) { StatusCode = 502 };

--- a/api/Functions/RaiderCharacterEnrichFunction.cs
+++ b/api/Functions/RaiderCharacterEnrichFunction.cs
@@ -31,13 +31,16 @@ public sealed class RaiderCharacterEnrichFunction(
     {
         var principal = ctx.GetPrincipal();
 
-        // Parse {id} as "{region}-{realm}-{name}" (lowercased).
-        var parts = id.Split('-', 3);
-        if (parts.Length != 3)
+        // Parse {id} as "{region}-{realm-slug}-{name}" (lowercased). Realm slugs may
+        // contain dashes (e.g. "the-maelstrom"); character names cannot. First/last
+        // dash positions uniquely identify the region and name boundaries.
+        var firstDash = id.IndexOf('-');
+        var lastDash = id.LastIndexOf('-');
+        if (firstDash <= 0 || lastDash <= firstDash)
             return new BadRequestObjectResult(new { error = "Invalid character id" });
-        var region = parts[0].ToLowerInvariant();
-        var realm = parts[1].ToLowerInvariant();
-        var lowerName = parts[2].ToLowerInvariant();
+        var region = id[..firstDash].ToLowerInvariant();
+        var realm = id[(firstDash + 1)..lastDash].ToLowerInvariant();
+        var lowerName = id[(lastDash + 1)..].ToLowerInvariant();
 
         var raider = await repo.GetByBattleNetIdAsync(principal.BattleNetId, ct);
         if (raider is null)

--- a/tests/Lfm.Api.Tests/RaiderCharacterEnrichFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RaiderCharacterEnrichFunctionTests.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
+using System.Text.Json;
 using Lfm.Api.Auth;
 using Lfm.Api.Functions;
 using Lfm.Api.Repositories;
@@ -105,7 +106,9 @@ public class RaiderCharacterEnrichFunctionTests
         var fn = MakeFunction(repo.Object, profileClient.Object);
         var result = await fn.Run(MakeRequest(), CharId, MakeCtx(), CancellationToken.None);
 
-        Assert.IsType<NotFoundObjectResult>(result);
+        var notFound = Assert.IsType<NotFoundObjectResult>(result);
+        var body = JsonSerializer.SerializeToElement(notFound.Value);
+        Assert.Equal("Character not found on Blizzard", body.GetProperty("error").GetString());
     }
 
     // ---- helpers ----

--- a/tests/Lfm.Api.Tests/RaiderCharacterEnrichFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RaiderCharacterEnrichFunctionTests.cs
@@ -91,6 +91,23 @@ public class RaiderCharacterEnrichFunctionTests
             Times.Once);
     }
 
+    [Fact]
+    public async Task Returns_404_when_Blizzard_returns_404()
+    {
+        var raider = MakeRaider(accountChars: [("stormreaver", "Shalena")]);
+        var repo = RepoReturning(raider);
+        var profileClient = new Mock<IBlizzardProfileClient>();
+        profileClient.Setup(p => p.GetCharacterProfileAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException(
+                "Not Found", inner: null, statusCode: System.Net.HttpStatusCode.NotFound));
+
+        var fn = MakeFunction(repo.Object, profileClient.Object);
+        var result = await fn.Run(MakeRequest(), CharId, MakeCtx(), CancellationToken.None);
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
     // ---- helpers ----
     private static RaiderCharacterEnrichFunction MakeFunction(
         IRaidersRepository repo, IBlizzardProfileClient profile)

--- a/tests/Lfm.Api.Tests/RaiderCharacterEnrichFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RaiderCharacterEnrichFunctionTests.cs
@@ -75,6 +75,22 @@ public class RaiderCharacterEnrichFunctionTests
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
+    [Fact]
+    public async Task Calls_Blizzard_with_dashed_realm_slug_intact()
+    {
+        const string dashedId = "eu-the-maelstrom-kalmatar";
+        var raider = MakeRaider(accountChars: [("the-maelstrom", "Kalmatar")]);
+        var repo = RepoReturning(raider);
+        var profileClient = MakeProfileClient();
+
+        var fn = MakeFunction(repo.Object, profileClient.Object);
+        await fn.Run(MakeRequest(), dashedId, MakeCtx(), CancellationToken.None);
+
+        profileClient.Verify(p => p.GetCharacterProfileAsync(
+            "the-maelstrom", "kalmatar", It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
     // ---- helpers ----
     private static RaiderCharacterEnrichFunction MakeFunction(
         IRaidersRepository repo, IBlizzardProfileClient profile)


### PR DESCRIPTION
## Summary

- `Split('-', 3)` in the enrich id parser truncated dashed realm slugs (`the-maelstrom` → `the`), sending broken URLs to Blizzard and flattening every 404 into a generic 502. Parse via first-/last-dash now, so region, realm (possibly dashed), and name decompose uniquely.
- Blizzard 404 on enrich now surfaces as a 404 with a `Character not found on Blizzard` envelope instead of 502 — lets the SPA distinguish legitimately-missing characters (renamed / hidden / deleted) from a transient upstream failure.
- Adds a specification test per fix; each was watched fail for the expected reason before the production change.

## Investigation

App Insights on the production 502 burst showed the outbound Blizzard call for `eu-the-maelstrom-kalmatar` went to `/profile/wow/character/the/maelstrom-kalmatar` and returned 404 in ~18 ms. The ~29-49 ms total response times ruled out a real Blizzard round-trip failure — the function was sending malformed URLs and mapping the resulting 404 to 502.

## Test Plan

- [ ] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` — expect 382/382 passing (was 380 before the two new tests).
- [ ] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error` — clean.
- [ ] Manual: after deploy, run enrich against a character on a dashed-realm (e.g. `the-maelstrom`, `argent-dawn`) and verify a 200 with a populated portrait/spec.
- [ ] Manual: run enrich against a character the owner has since renamed on Blizzard and verify the response is 404 with `{ "error": "Character not found on Blizzard" }`, not 502.