### PR TITLE
Tighten 4 E2E tests with weak assertions (P1 audit fixes)

### DIFF
--- a/tests/Lfm.App.Tests/CharactersPagesTests.cs
+++ b/tests/Lfm.App.Tests/CharactersPagesTests.cs
@@ -156,6 +156,42 @@ public class CharactersPagesTests : ComponentTestBase
     }
 
     [Fact]
+    public void CharactersPage_RefreshButton_Click_Replaces_Character_List()
+    {
+        // Proves the "Refresh from Battle.net" button is wired to
+        // IBattleNetClient.RefreshCharactersAsync and that its returned
+        // list replaces the currently-rendered cards. This used to be an
+        // E2E test that asserted only an outbound HTTP request was fired
+        // (E-HC-F10); the integration-layer contract is covered by
+        // BattleNetCharactersRefreshFunctionTests, and the user-observable
+        // re-render is bUnit territory.
+        this.AddAuthorization().SetAuthorized("player#1234");
+        var battleNet = new Mock<IBattleNetClient>();
+        battleNet.Setup(c => c.GetCharactersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CharactersFetchResult.Cached(new List<CharacterDto> { MakeChar("Arthas") }));
+        battleNet.Setup(c => c.RefreshCharactersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CharacterDto> { MakeChar("Sylvanas", "silvermoon") });
+        battleNet.Setup(c => c.GetPortraitsAsync(It.IsAny<IEnumerable<CharacterPortraitRequest>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IDictionary<string, string>?)null);
+        var me = new Mock<IMeClient>();
+        Services.AddSingleton(battleNet.Object);
+        Services.AddSingleton(me.Object);
+
+        var cut = Render<CharactersPage>();
+        cut.WaitForAssertion(() => Assert.Contains("Arthas", cut.Markup));
+
+        var refreshButton = cut.FindAll("fluent-button")
+            .First(b => b.TextContent.Contains(Loc("characters.refresh")));
+        refreshButton.Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Sylvanas", cut.Markup);
+            Assert.DoesNotContain("Arthas", cut.Markup);
+        });
+    }
+
+    [Fact]
     public void CharactersPage_Renders_Multiple_Characters()
     {
         this.AddAuthorization().SetAuthorized("player#1234");

--- a/tests/Lfm.E2E/Pages/CharactersPage.cs
+++ b/tests/Lfm.E2E/Pages/CharactersPage.cs
@@ -13,10 +13,6 @@ public class CharactersPage(IPage page)
     public ILocator Heading =>
         _page.GetByText("My Characters");
 
-    // The refresh button — "Refresh from Battle.net"
-    public ILocator RefreshButton =>
-        _page.GetByRole(AriaRole.Button, new() { Name = "Refresh from Battle.net" });
-
     // Character cards rendered in the grid (FluentCard elements within the grid div)
     public ILocator CharacterList =>
         _page.Locator("div[style*='grid-template-columns'] fluent-card");
@@ -38,11 +34,6 @@ public class CharactersPage(IPage page)
     public async Task<bool> IsLoadedAsync()
     {
         return await Heading.IsVisibleAsync();
-    }
-
-    public async Task ClickRefreshAsync()
-    {
-        await RefreshButton.ClickAsync();
     }
 
     public async Task<int> GetCharacterCountAsync()

--- a/tests/Lfm.E2E/Seeds/DefaultSeed.cs
+++ b/tests/Lfm.E2E/Seeds/DefaultSeed.cs
@@ -155,6 +155,26 @@ public static class DefaultSeed
                                     ["name"] = "Mage",
                                 },
                             },
+                            // Keep in sync with raider.characters above: the characters
+                            // endpoint iterates wow_accounts[*].characters to build the
+                            // card list, so a mismatch here shows as missing cards in
+                            // the UI and drove CharactersPage_Loads_DisplaysCharacterList
+                            // to tolerate an empty render as a pass.
+                            new Dictionary<string, object?>
+                            {
+                                ["name"] = "Aelrinalt",
+                                ["level"] = 80,
+                                ["realm"] = new Dictionary<string, object?>
+                                {
+                                    ["slug"] = "test-realm",
+                                    ["name"] = "Test Realm",
+                                },
+                                ["playable_class"] = new Dictionary<string, object?>
+                                {
+                                    ["id"] = 2,
+                                    ["name"] = "Paladin",
+                                },
+                            },
                         },
                     },
                 },

--- a/tests/Lfm.E2E/Specs/AccessibilitySpec.cs
+++ b/tests/Lfm.E2E/Specs/AccessibilitySpec.cs
@@ -299,23 +299,29 @@ public class AccessibilitySpec(AccessibilityFixture fixture, ITestOutputHelper o
     [Fact]
     public async Task InteractiveElements_ReachableViaTab()
     {
+        // WCAG 2.1.1 (Keyboard): interactive controls must be reachable via Tab.
+        // Asserting only Assert.NotEmpty(focusedTags) passes for any tab stop —
+        // the skip link alone would satisfy it — and a regression that made the
+        // sign-in button unreachable would go undetected. Walk the tab sequence
+        // and assert the sign-in button is actually one of the stops (`E-HC-F1`).
         var loginPage = new LoginPage(Page!);
         await loginPage.GotoAsync(fixture.Stack.AppBaseUrl);
         await Assertions.Expect(loginPage.Heading).ToBeVisibleAsync(new() { Timeout = 15000 });
 
-        // Collect all elements reachable by Tab (up to 20 tabs)
-        var focusedTags = new List<string>();
+        // Collect (tag, text) for each focusable tab stop, up to 20 stops.
+        var stops = new List<(string Tag, string Text)>();
         for (var i = 0; i < 20; i++)
         {
             await Page!.Keyboard.PressAsync("Tab");
             var tag = await Page.EvaluateAsync<string>(
                 "() => document.activeElement?.tagName?.toUpperCase() ?? ''");
             if (string.IsNullOrEmpty(tag) || tag == "BODY") break;
-            focusedTags.Add(tag);
+            var text = await Page.EvaluateAsync<string>(
+                "() => (document.activeElement?.textContent ?? '').trim()");
+            stops.Add((tag, text));
         }
 
-        // The login page must have at least the sign-in button reachable via Tab
-        Assert.NotEmpty(focusedTags);
+        Assert.Contains(stops, s => s.Text.Contains("Sign in with Battle.net"));
     }
 
     [Fact]

--- a/tests/Lfm.E2E/Specs/NavigationSpec.cs
+++ b/tests/Lfm.E2E/Specs/NavigationSpec.cs
@@ -64,6 +64,14 @@ public class NavigationSpec(NavigationFixture fixture, ITestOutputHelper output)
             await instancesPage.GotoAsync(fixture.Stack.AppBaseUrl);
 
             await Assertions.Expect(instancesPage.Heading).ToBeVisibleAsync(new() { Timeout = 15000 });
+
+            // DefaultSeed seeds one instance ("Liberation of Undermine"); the test
+            // name promises a data display, so assert the grid actually rendered it
+            // instead of only pinning the page heading.
+            await Assertions.Expect(instancesPage.InstanceRows)
+                .ToHaveCountAsync(1, new() { Timeout = 15000 });
+            await Assertions.Expect(authPage.GetByText("Liberation of Undermine"))
+                .ToBeVisibleAsync(new() { Timeout = 10000 });
         }
         finally
         {

--- a/tests/Lfm.E2E/Specs/ProfileSpec.cs
+++ b/tests/Lfm.E2E/Specs/ProfileSpec.cs
@@ -82,31 +82,12 @@ public class ProfileSpec(ProfileFixture fixture, ITestOutputHelper output)
             .ToBeVisibleAsync(new() { Timeout = 10000 });
     }
 
-    [Fact]
-    public async Task RefreshCharactersButton_DispatchesRefreshRequest()
-    {
-        // Verifies the refresh button is wired to the correct API route.
-        // The actual refresh outcome (updated character data) is not asserted
-        // here — the seeded raider has accountProfileRefreshedAt = now, so the
-        // server returns 429 and no data update happens. Asserting the
-        // user-observable update would require a freshly-aged raider in the
-        // seed; for now the test pins the wire-up only.
-        var charactersPage = new CharactersPage(Page!);
-
-        await charactersPage.GotoAsync(fixture.Stack.AppBaseUrl);
-        await Assertions.Expect(charactersPage.Heading).ToBeVisibleAsync(new() { Timeout = 15000 });
-
-        await Assertions.Expect(charactersPage.RefreshButton).ToBeVisibleAsync(new() { Timeout = 10000 });
-
-        var refreshRequestTask = Page!.WaitForRequestAsync(
-            req => req.Url.Contains("/api/battlenet/characters/refresh"),
-            new() { Timeout = 10000 });
-
-        await charactersPage.ClickRefreshAsync();
-
-        var refreshRequest = await refreshRequestTask;
-        Assert.Contains("/api/battlenet/characters/refresh", refreshRequest.Url);
-    }
+    // RefreshCharactersButton_DispatchesRefreshRequest was removed in favour of
+    // CharactersPage_RefreshButton_Click_Replaces_Character_List in
+    // tests/Lfm.App.Tests/CharactersPagesTests.cs. The bUnit test proves the
+    // user-observable outcome (the rendered card list changes) without needing
+    // a full stack bringup or the E2E-only 429 cooldown dance. The refresh
+    // endpoint's own contract is covered by BattleNetCharactersRefreshFunctionTests.
 
     // -------------------------------------------------------------------------
     // Guild tests (4.3)

--- a/tests/Lfm.E2E/Specs/ProfileSpec.cs
+++ b/tests/Lfm.E2E/Specs/ProfileSpec.cs
@@ -71,24 +71,15 @@ public class ProfileSpec(ProfileFixture fixture, ITestOutputHelper output)
 
         await Assertions.Expect(charactersPage.Heading).ToBeVisibleAsync(new() { Timeout = 15000 });
 
-        // The characters page may show "No characters found" if the API returns data
-        // that the client can't deserialize. Verify the page loaded without crashing.
-        var noCharsMessage = Page.GetByText("No characters found");
-        var firstCard = charactersPage.CharacterList.First;
-
-        // Wait for either cards or the "no characters" message
-        await Assertions.Expect(noCharsMessage.Or(firstCard))
-            .ToBeVisibleAsync(new() { Timeout = 15000 });
-
-        if (await firstCard.IsVisibleAsync())
-        {
-            var count = await charactersPage.GetCharacterCountAsync();
-            Log($"Character cards rendered: {count}");
-        }
-        else
-        {
-            Log("Characters page loaded but no cards rendered — API data may not match client DTOs");
-        }
+        // DefaultSeed populates accountProfileSummary.wow_accounts[0].characters
+        // with exactly two characters (Aelrin + Aelrinalt); the characters endpoint
+        // must return both and the page must render one card per character.
+        await Assertions.Expect(charactersPage.CharacterList)
+            .ToHaveCountAsync(2, new() { Timeout = 15000 });
+        await Assertions.Expect(Page.GetByText("Aelrin", new() { Exact = true }))
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+        await Assertions.Expect(Page.GetByText("Aelrinalt", new() { Exact = true }))
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes the four P1 findings from the 2026-04-20 test-quality audit of `tests/Lfm.E2E/`:

- **#45** — `CharactersPage_Loads_DisplaysCharacterList` tolerated an empty render as a pass. Added the missing second character to `DefaultSeed.accountProfileSummary` so the seed is internally consistent, and assert `ToHaveCountAsync(2)` + both names visible. (`E-HC-F1`)
- **#46** — `InstancesPage_Loads_DisplaysRaidInstances` asserted only the page heading, not the grid rows. Assert `InstanceRows.ToHaveCountAsync(1)` and the seeded instance name. (`E-HC-F1`)
- **#47** — `RefreshCharactersButton_DispatchesRefreshRequest` proved only an outbound HTTP request. Deleted the E2E test and added `CharactersPage_RefreshButton_Click_Replaces_Character_List` as a bUnit component test in `Lfm.App.Tests` that clicks the button and asserts the rendered card list swaps. Also removed the now-unused `RefreshButton` / `ClickRefreshAsync` from the `CharactersPage` page object. (`E-HC-F10` → moved down the pyramid)
- **#48** — `InteractiveElements_ReachableViaTab` asserted `NotEmpty(focusedTags)` — passed for any focusable element. Capture `(tag, text)` per stop and assert the sign-in button's label is among them, matching the specificity of the sibling `TabFromBody_FirstStopIsSkipToContentLink`. (`E-HC-F1`)

No production code was modified. The `DefaultSeed` change adds one character entry; everything else is test-side.

## Test plan

- [x] `dotnet build lfm.sln -c Release` — green.
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error` — green.
- [x] `dotnet test tests/Lfm.App.Tests/... --filter "FullyQualifiedName~CharactersPage_RefreshButton_Click_Replaces_Character_List"` — **passes**.
- [ ] Full E2E suite — not run as part of this PR. An unrelated pre-existing Blazor WASM bootstrap issue (`ExpectedJsonTokens` JSON parse error at byte 0) is causing every UI-waiting E2E test to fail in the local stack regardless of branch; being tracked separately. Tests that do not wait for Blazor UI (3 `BrowserSecuritySpec` tests) still pass.