### PR TITLE
Fix E2E Blazor WASM bootstrap failing on empty appsettings.{Env}.json

### DIFF
--- a/tests/Lfm.E2E/Infrastructure/StackFixture.cs
+++ b/tests/Lfm.E2E/Infrastructure/StackFixture.cs
@@ -187,6 +187,28 @@ public class StackFixture : IAsyncLifetime
             }
             """);
 
+        // Normalize env-specific appsettings the publish step may have copied.
+        // Blazor's WebAssemblyHostConfiguration fetches appsettings.{Environment}.json
+        // at startup and fails with System.Text.Json ExpectedJsonTokens when the
+        // body is empty — which happens when the source files are sandbox-masked to
+        // /dev/null and publish copies them as zero-byte artifacts. Overwriting
+        // each env variant with a valid empty-object JSON keeps the config loader
+        // happy regardless of the host filesystem's state. Matches the build env
+        // name set by WasmApplicationEnvironmentName=Production in Lfm.App.csproj.
+        foreach (var envFile in new[]
+        {
+            "appsettings.Production.json",
+            "appsettings.Development.json",
+            "appsettings.Local.json",
+        })
+        {
+            var envPath = Path.Combine(appWwwroot, envFile);
+            if (File.Exists(envPath))
+            {
+                await File.WriteAllTextAsync(envPath, "{}");
+            }
+        }
+
         try
         {
             await WaitForHttp($"http://localhost:{_apiPort}/api/health", timeoutSec: 120);


### PR DESCRIPTION
## Summary

Every UI-waiting E2E test was failing with the same browser-console error:

```
[ERROR] ManagedError: AggregateException_ctor_DefaultMessage
        (ExpectedJsonTokens LineNumber: 0 | BytePositionInLine: 0.)
```

DOM snapshots were empty `<html><head></head><body></body></html>` — Blazor never made it past bootstrap.

**Root cause:** `WebAssemblyHostConfiguration` fetches `appsettings.{Environment}.json` (with `WasmApplicationEnvironmentName=Production` in `Lfm.App.csproj`) at startup. The source files `appsettings.Production.json`, `appsettings.Local.json`, `appsettings.Development.json` are sandbox-masked to `/dev/null` via `.claude/settings.json`'s read-deny list. `dotnet publish` copies them as **zero-byte artifacts** into the published `wwwroot/`. The E2E Kestrel host then serves them as `200 OK` with an empty body, which `System.Text.Json` cannot parse at byte 0.

`StackFixture` already rewrites `appsettings.json` in the publish dir to inject the dynamic API port; extend the same pattern to write valid `{}` for each env variant when the empty file is present. No source or product code is modified — fix is scoped to the E2E test infrastructure.

## Results

| Before | After |
|---|---|
| 3 / 52 passing | **51 / 53 passing** |

The two remaining failures are pre-existing and **unrelated** to this fix:

1. `AuthSpec.Logout_ClickSignOut_ClearsSessionAndRedirects` — `WaitUntilState.NetworkIdle` times out on the post-sign-out navigation (the SPA redirects to `/login` immediately, so network-idle never fires). Existing wait-strategy smell in the test.
2. `AuthSpec.SignIn_ClickButton_RedirectsToBattleNetOAuth` — Chrome 147's Private Network Access block on the favicon load when the test parks on `about:blank` at the end of the flow. Browser-version change, not a product regression.

Both are candidates for separate fixes; this PR deliberately scopes to the JSON bootstrap issue so the reviewer can see the large delta without noise.

## Test plan

- [x] `dotnet build tests/Lfm.E2E/Lfm.E2E.csproj -c Release` — green.
- [x] `dotnet format tests/Lfm.E2E/Lfm.E2E.csproj --verify-no-changes --severity error` — green.
- [x] Single-test smoke: `AuthSpec.LoginPage_Renders_ShowsSignInButton` passes in 948 ms (previously failed on the JSON error).
- [x] Full E2E suite: 51 / 53 passing in 52 s (previously 3 / 52).