### PR TITLE
Drop NetworkIdle waits in Logout E2E

### DIFF
--- a/tests/Lfm.E2E/Infrastructure/StackFixture.cs
+++ b/tests/Lfm.E2E/Infrastructure/StackFixture.cs
@@ -187,6 +187,28 @@ public class StackFixture : IAsyncLifetime
             }
             """);
 
+        // Normalize env-specific appsettings the publish step may have copied.
+        // Blazor's WebAssemblyHostConfiguration fetches appsettings.{Environment}.json
+        // at startup and fails with System.Text.Json ExpectedJsonTokens when the
+        // body is empty — which happens when the source files are sandbox-masked to
+        // /dev/null and publish copies them as zero-byte artifacts. Overwriting
+        // each env variant with a valid empty-object JSON keeps the config loader
+        // happy regardless of the host filesystem's state. Matches the build env
+        // name set by WasmApplicationEnvironmentName=Production in Lfm.App.csproj.
+        foreach (var envFile in new[]
+        {
+            "appsettings.Production.json",
+            "appsettings.Development.json",
+            "appsettings.Local.json",
+        })
+        {
+            var envPath = Path.Combine(appWwwroot, envFile);
+            if (File.Exists(envPath))
+            {
+                await File.WriteAllTextAsync(envPath, "{}");
+            }
+        }
+
         try
         {
             await WaitForHttp($"http://localhost:{_apiPort}/api/health", timeoutSec: 120);

--- a/tests/Lfm.E2E/Specs/AuthSpec.cs
+++ b/tests/Lfm.E2E/Specs/AuthSpec.cs
@@ -108,8 +108,7 @@ public class AuthSpec(AuthFixture fixture, ITestOutputHelper output)
 
         try
         {
-            await authPage.GotoAsync($"{fixture.Stack.AppBaseUrl}/runs",
-                new() { WaitUntil = WaitUntilState.NetworkIdle });
+            await authPage.GotoAsync($"{fixture.Stack.AppBaseUrl}/runs");
 
             var navBar = new NavBar(authPage);
             // Explicit 15s timeout — <fluent-button> component upgrade can lag
@@ -117,17 +116,21 @@ public class AuthSpec(AuthFixture fixture, ITestOutputHelper output)
             await Assertions.Expect(navBar.SignOutButton).ToBeVisibleAsync(new() { Timeout = 15000 });
 
             // Sign out navigates to /api/battlenet/logout (forceLoad)
-            // which clears the cookie and redirects to app base URL
+            // which clears the cookie and redirects to app base URL.
             await navBar.ClickSignOutAsync();
 
-            await authPage.WaitForURLAsync(
+            // Use the auto-retrying ToHaveURLAsync assertion instead of WaitForURLAsync:
+            // WaitUntilState.NetworkIdle does not settle cleanly through the forceLoad
+            // redirect + Blazor WASM re-bootstrap chain, which previously timed out.
+            await Assertions.Expect(authPage).ToHaveURLAsync(
                 new System.Text.RegularExpressions.Regex(@"^http://localhost:\d+/?$"),
                 new() { Timeout = 15000 });
 
-            // Verify session cleared — protected route redirects to login.
-            // NetworkIdle lets Blazor fetch /api/me (now 401) and fire RedirectToLogin before the assertion.
-            await authPage.GotoAsync($"{fixture.Stack.AppBaseUrl}/runs",
-                new() { WaitUntil = WaitUntilState.NetworkIdle });
+            // Verify session cleared — revisit a protected route and confirm the
+            // SPA redirects to /login. Goto's default WaitUntil=Load plus the
+            // auto-retrying URL assertion give Blazor enough time to fetch
+            // /api/me (now 401) and fire RedirectToLogin.
+            await authPage.GotoAsync($"{fixture.Stack.AppBaseUrl}/runs");
             await Assertions.Expect(authPage).ToHaveURLAsync(
                 new System.Text.RegularExpressions.Regex(@"/login\?redirect=%2Fruns"),
                 new() { Timeout = 15000 });


### PR DESCRIPTION
## Summary

Closes #57.

`AuthSpec.Logout_ClickSignOut_ClearsSessionAndRedirects` was timing out at 15 s on the URL wait that follows `NavBar.ClickSignOutAsync()`. The sign-out click triggers a `forceLoad: true` navigation to `/api/battlenet/logout`, which clears the cookie and redirects back to the app base URL, which then triggers a full Blazor WASM re-bootstrap. Networking is active throughout that chain, so `WaitUntilState.NetworkIdle` does not settle cleanly even when `NetworkIdle` does fire — `E-HC-F3` (wall-clock-style budgeted wait that's brittle by construction at the E2E layer).

- Drop both `GotoAsync(..., WaitUntil = WaitUntilState.NetworkIdle)` options. Default `WaitUntilState.Load` is fine; subsequent `Expect(...).ToBeVisibleAsync` / `Expect(page).ToHaveURLAsync` assertions carry the real wait.
- Replace the non-retrying `page.WaitForURLAsync` with the auto-retrying `Expect(page).ToHaveURLAsync` assertion.

No wait-strategy in the test is wall-clock-budgeted now; every wait waits on an observable predicate.

## Test plan

- [x] `dotnet build tests/Lfm.E2E/Lfm.E2E.csproj -c Release` — green.
- [x] `dotnet format tests/Lfm.E2E/Lfm.E2E.csproj --verify-no-changes --severity error` — green.
- [x] Single-test run: `AuthSpec.Logout_ClickSignOut_ClearsSessionAndRedirects` now **passes in 2 s** (previously timed out at 15 s).

## Stacking notes

Branched off #56 (`claude/e2e-blazor-json-error`) so the E2E stack actually boots — without that bootstrap fix, no UI-waiting E2E test can be verified. When #56 merges, this branch rebases onto `main` cleanly (only a test file is touched).