### PR TITLE
Close SignIn E2E page instead of parking on about:blank

### DIFF
--- a/tests/Lfm.E2E/Specs/AuthSpec.cs
+++ b/tests/Lfm.E2E/Specs/AuthSpec.cs
@@ -71,10 +71,18 @@ public class AuthSpec(AuthFixture fixture, ITestOutputHelper output)
 
         await loginRequestTask;
 
-        // Park the page on about:blank so the disposal-time console-error
-        // assertion does not pick up the 404 cascade for the offline external
-        // Battle.net assets the browser tried to load after the redirect.
-        await Page.GotoAsync("about:blank");
+        // Close the page instead of parking on about:blank:
+        //   1. Cancels the pending navigation to the unreachable Battle.net
+        //      OAuth URL so the 404 cascade for its offline assets never
+        //      reaches the console.
+        //   2. Keeps the origin on localhost; Chrome 147's Private Network
+        //      Access enforcement would otherwise retroactively flag the
+        //      prior loopback favicon load once the origin switched to
+        //      `null` via about:blank (#58).
+        // Nulling Page lets the E2ETestBase DisposeAsync skip its post-test
+        // screenshot/trace capture on the now-closed page.
+        await Page.CloseAsync();
+        Page = null;
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes #58.

`SignIn_ClickButton_RedirectsToBattleNetOAuth` previously navigated to `about:blank` after clicking sign-in to silence the 404 cascade from the unreachable Battle.net OAuth redirect. Chrome 147 now treats that origin transition to `null` as a trigger to re-evaluate [Private Network Access](https://developer.chrome.com/blog/private-network-access-preflight/) policy, which retroactively flags the prior localhost favicon load as a cross-origin loopback violation. The resulting console errors (`ERR_FAILED`, `more-private address space 'loopback'`) land in `E2ETestBase`'s post-test console-error check and fail the test despite the assertion having already passed.

Replace `await Page.GotoAsync("about:blank")` with `await Page.CloseAsync()` + `Page = null`:

- **Same cancellation effect** on the pending navigation to the offline Battle.net OAuth URL that the `about:blank` trick was guarding against.
- **No origin transition**, so Chrome's PNA never re-evaluates the already-loaded favicon.
- **Nulling `Page`** lets `E2ETestBase.DisposeAsync` skip its post-test screenshot/trace capture on the now-closed page. The surrounding `BrowserContext` is still closed by `AuthSpec.DisposeAsync`.

## Test plan

- [x] `dotnet build tests/Lfm.E2E/Lfm.E2E.csproj -c Release` — green.
- [x] `dotnet format tests/Lfm.E2E/Lfm.E2E.csproj --verify-no-changes --severity error` — green.
- [x] Single-test run: `AuthSpec.SignIn_ClickButton_RedirectsToBattleNetOAuth` now **passes in 1 s** (previously failed at `DisposeAsync` with `Access to resource at '…/favicon.png' from origin 'null' has been blocked by CORS policy` + `ERR_FAILED`).

## Stacking notes

Branched off #56 (`claude/e2e-blazor-json-error`) so the stack boots. Touches only a different method in `AuthSpec.cs` than #59 — the two can merge in any order with trivial rebase.