### PR TITLE
Stop mutating shared seed in GuildAdmin and EditRun E2E tests

### DIFF
--- a/tests/Lfm.E2E/Specs/ProfileSpec.cs
+++ b/tests/Lfm.E2E/Specs/ProfileSpec.cs
@@ -147,22 +147,36 @@ public class ProfileSpec(ProfileFixture fixture, ITestOutputHelper output)
         await Assertions.Expect(guildAdminPage.Heading).ToBeVisibleAsync(new() { Timeout = 15000 });
         await Assertions.Expect(guildAdminPage.SaveButton).ToBeVisibleAsync(new() { Timeout = 10000 });
 
+        // Snapshot the seeded slogan so the test can restore it — the guild
+        // document is shared across the whole suite and mutating its slogan
+        // permanently would leak across future runs.
+        var originalSlogan = await guildAdminPage.SloganField.InputValueAsync();
         var newSlogan = $"E2E updated slogan {Guid.NewGuid():N}";
-        await guildAdminPage.SloganField.FillAsync(newSlogan);
 
-        await guildAdminPage.SaveButton.ClickAsync();
+        try
+        {
+            await guildAdminPage.SloganField.FillAsync(newSlogan);
+            await guildAdminPage.SaveButton.ClickAsync();
 
-        // Success message should appear confirming the save.
-        await Assertions.Expect(guildAdminPage.SuccessMessage).ToBeVisibleAsync(new() { Timeout = 15000 });
+            // Success message should appear confirming the save.
+            await Assertions.Expect(guildAdminPage.SuccessMessage).ToBeVisibleAsync(new() { Timeout = 15000 });
 
-        // Re-read: reload the page and verify the persisted slogan round-tripped
-        // through Cosmos. The success banner alone proves the API returned 200 —
-        // it does not prove the value persisted, which a future regression that
-        // swallows the body would silently break.
-        await guildAdminPage.GotoAsync(fixture.Stack.AppBaseUrl);
-        await Assertions.Expect(guildAdminPage.SloganField).ToBeVisibleAsync(new() { Timeout = 15000 });
-        var persistedSlogan = await guildAdminPage.SloganField.InputValueAsync();
-        Assert.Equal(newSlogan, persistedSlogan);
+            // Re-read: reload the page and verify the persisted slogan round-tripped
+            // through Cosmos. The success banner alone proves the API returned 200 —
+            // it does not prove the value persisted, which a future regression that
+            // swallows the body would silently break.
+            await guildAdminPage.GotoAsync(fixture.Stack.AppBaseUrl);
+            await Assertions.Expect(guildAdminPage.SloganField).ToBeVisibleAsync(new() { Timeout = 15000 });
+            var persistedSlogan = await guildAdminPage.SloganField.InputValueAsync();
+            Assert.Equal(newSlogan, persistedSlogan);
+        }
+        finally
+        {
+            // Restore the seeded slogan so sibling tests see a clean fixture.
+            await guildAdminPage.SloganField.FillAsync(originalSlogan);
+            await guildAdminPage.SaveButton.ClickAsync();
+            await Assertions.Expect(guildAdminPage.SuccessMessage).ToBeVisibleAsync(new() { Timeout = 15000 });
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/tests/Lfm.E2E/Specs/RunsSpec.cs
+++ b/tests/Lfm.E2E/Specs/RunsSpec.cs
@@ -190,9 +190,10 @@ public class RunsSpec(RunsFixture fixture, ITestOutputHelper output)
     [Fact]
     public async Task EditRun_ModifyFields_ChangesReflected()
     {
-        var encodedId = Uri.EscapeDataString(DefaultSeed.TestRunId);
-
-        // Log API requests to debug 400 errors
+        // Create a dedicated run instead of editing the shared seed. Mutating the
+        // seeded description leaves a permanent diff on runs/{TestRunId} that
+        // would leak into every subsequent test run against the same database.
+        // Mirrors the per-test factory pattern in DeleteRun_Confirm_RemovedFromList.
         Page!.Request += (_, req) =>
         {
             if (req.Url.Contains("/api/runs/") && req.Method is "PUT" or "PATCH")
@@ -204,11 +205,13 @@ public class RunsSpec(RunsFixture fixture, ITestOutputHelper output)
                 Log($"[API RESP] {resp.Status} {resp.Url}");
         };
 
+        var runsPage = new RunsPage(Page);
+        var createdRunId = await CreateFreshRunAsync(runsPage);
+        var encodedId = Uri.EscapeDataString(createdRunId);
+
         await Page.GotoAsync(
             $"{fixture.Stack.AppBaseUrl}/runs/{encodedId}/edit",
             new() { WaitUntil = WaitUntilState.NetworkIdle });
-
-        var runsPage = new RunsPage(Page);
 
         // Wait for the edit form to load
         await Assertions.Expect(runsPage.SaveChangesButton).ToBeVisibleAsync(new() { Timeout = 15000 });
@@ -227,9 +230,44 @@ public class RunsSpec(RunsFixture fixture, ITestOutputHelper output)
         await Page.GotoAsync(
             $"{fixture.Stack.AppBaseUrl}/runs/{encodedId}",
             new() { WaitUntil = WaitUntilState.NetworkIdle });
-        await Assertions.Expect(runsPage.AttendingHeading).ToBeVisibleAsync(new() { Timeout = 15000 });
         await Assertions.Expect(Page.GetByText(updatedDescription)).ToBeVisibleAsync(
-            new() { Timeout = 10000 });
+            new() { Timeout = 15000 });
+    }
+
+    /// <summary>
+    /// Creates a fresh run via the create-run form and returns the new run id.
+    /// Callers use this to scope destructive mutations to a per-test document so
+    /// no test bleeds state into <c>runs/{DefaultSeed.TestRunId}</c>.
+    /// </summary>
+    private async Task<string> CreateFreshRunAsync(RunsPage runsPage)
+    {
+        await runsPage.NavigateToCreateRunAsync(fixture.Stack.AppBaseUrl);
+        await Page!.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        // FluentUI <fluent-select> does not yet expose ARIA combobox roles to
+        // Playwright (microsoft/fluentui-blazor#2614); target by element id.
+        var instanceSelect = Page.Locator("#instance-select");
+        await instanceSelect.ClickAsync();
+        var firstRealOption = Page.Locator("#instance-select fluent-option").Nth(1);
+        await firstRealOption.WaitForAsync(new() { Timeout = 10000 });
+        await firstRealOption.ClickAsync();
+
+        await runsPage.ModeKeyInput.FillAsync("NORMAL:25");
+        // Native <input type="datetime-local"> rejects a Z suffix.
+        await runsPage.StartTimeInput.FillAsync(
+            DateTimeOffset.UtcNow.AddDays(30).ToString("yyyy-MM-ddTHH:mm:ss"));
+        await runsPage.DescriptionInput.FillAsync($"E2E-Scratch-{Guid.NewGuid():N}");
+
+        await runsPage.CreateRunSubmitButton.ClickAsync();
+
+        // The pre-submit URL is /runs/new — exclude it from the match.
+        await Page.WaitForURLAsync(
+            new System.Text.RegularExpressions.Regex(@"/runs/(?!new$)[^/]+$"),
+            new() { Timeout = 20000 });
+
+        var detailUrl = Page.Url;
+        var runId = detailUrl.Substring(detailUrl.LastIndexOf('/') + 1);
+        return Uri.UnescapeDataString(runId);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes #49.

Two round-trip E2E tests wrote to **shared Cosmos documents** and left the mutation in place (`E-HC-F5`):

- `ProfileSpec.GuildAdmin_UpdateSettings_ChangesReflected` overwrote `guilds/{TestGuildId}.slogan`.
- `RunsSpec.EditRun_ModifyFields_ChangesReflected` overwrote `runs/{TestRunId}.description`.

Currently benign (no sibling test asserts on either field), but the coupling is latent — any future test that reads those fields inherits whatever the previous run left behind.

**Guild fix:** snapshot the seeded slogan before editing; restore it in `finally`. Simple because the seeded guild document is specific (the primary test user is pinned as its admin in `DefaultSeed`).

**Run fix:** create a dedicated run via the create-run form and edit **that**, mirroring the per-test-factory pattern already used by `DeleteRun_Confirm_RemovedFromList`. Extract the create-run dance into a private `CreateFreshRunAsync` helper on `RunsSpec` so `DeleteRun` can adopt it in a follow-up if we want to DRY further.

## Test plan

- [x] `dotnet build tests/Lfm.E2E/Lfm.E2E.csproj -c Release` — green.
- [x] `dotnet format tests/Lfm.E2E/Lfm.E2E.csproj --verify-no-changes --severity error` — green.
- [x] Smoke against live stack: `GuildAdmin_UpdateSettings_ChangesReflected` passes in 2 s, `EditRun_ModifyFields_ChangesReflected` passes in 3 s.