### PR TITLE
Split bundled route + navbar E2E tests into per-journey assertions

### DIFF
--- a/tests/Lfm.E2E/Specs/AccessControlSpec.cs
+++ b/tests/Lfm.E2E/Specs/AccessControlSpec.cs
@@ -83,25 +83,34 @@ public class AccessControlSpec(AccessControlFixture fixture, ITestOutputHelper o
     }
 
     [Fact]
-    public async Task PublicRoute_Unauthenticated_RendersWithoutRedirect()
+    public async Task PublicLandingPage_Unauthenticated_RendersWithoutRedirect()
     {
-        // Landing page
-        await Page!.GotoAsync($"{fixture.Stack.AppBaseUrl}/",
-            new() { WaitUntil = WaitUntilState.NetworkIdle });
-        Assert.DoesNotContain("/login?redirect", Page.Url);
+        var landingPage = new LandingPage(Page!);
+        await landingPage.GotoAsync(fixture.Stack.AppBaseUrl);
 
-        // Login page
-        await Page.GotoAsync($"{fixture.Stack.AppBaseUrl}/login",
-            new() { WaitUntil = WaitUntilState.NetworkIdle });
-        var loginPage = new LoginPage(Page);
+        await Assertions.Expect(landingPage.Heading).ToBeVisibleAsync(new() { Timeout = 10000 });
+        Assert.DoesNotContain("/login?redirect", Page!.Url);
+    }
+
+    [Fact]
+    public async Task PublicLoginPage_Unauthenticated_RendersWithoutRedirect()
+    {
+        var loginPage = new LoginPage(Page!);
+        await loginPage.GotoAsync(fixture.Stack.AppBaseUrl);
+
         await Assertions.Expect(loginPage.Heading).ToBeVisibleAsync(new() { Timeout = 10000 });
-        Assert.Contains("/login", Page.Url);
+        Assert.Contains("/login", Page!.Url);
         Assert.DoesNotContain("redirect=", Page.Url);
+    }
 
-        // Privacy page
-        await Page.GotoAsync($"{fixture.Stack.AppBaseUrl}/privacy",
-            new() { WaitUntil = WaitUntilState.NetworkIdle });
-        Assert.Contains("/privacy", Page.Url);
+    [Fact]
+    public async Task PublicPrivacyPage_Unauthenticated_RendersWithoutRedirect()
+    {
+        var privacyPage = new PrivacyPage(Page!);
+        await privacyPage.GotoAsync(fixture.Stack.AppBaseUrl);
+
+        await Assertions.Expect(privacyPage.Heading).ToBeVisibleAsync(new() { Timeout = 10000 });
+        Assert.Contains("/privacy", Page!.Url);
         Assert.DoesNotContain("/login?redirect", Page.Url);
     }
 }

--- a/tests/Lfm.E2E/Specs/NavigationSpec.cs
+++ b/tests/Lfm.E2E/Specs/NavigationSpec.cs
@@ -104,7 +104,7 @@ public class NavigationSpec(NavigationFixture fixture, ITestOutputHelper output)
     }
 
     [Fact]
-    public async Task Navbar_Links_NavigateCorrectly()
+    public async Task NavbarCharactersLink_Click_NavigatesToCharactersPage()
     {
         var authContext = await AuthHelper.AuthenticatedContextAsync(
             fixture.Stack.Browser,
@@ -114,29 +114,59 @@ public class NavigationSpec(NavigationFixture fixture, ITestOutputHelper output)
 
         try
         {
-            await authPage.GotoAsync($"{fixture.Stack.AppBaseUrl}/runs",
-                new() { WaitUntil = WaitUntilState.NetworkIdle });
+            await authPage.RouteAsync("**/api/battlenet/character-portraits", async route =>
+            {
+                await route.FulfillAsync(new()
+                {
+                    Status = 200,
+                    ContentType = "application/json",
+                    Body = "{\"portraits\":{}}",
+                });
+            });
+
+            await authPage.GotoAsync($"{fixture.Stack.AppBaseUrl}/runs");
 
             var navBar = new NavBar(authPage);
-
-            // Verify authenticated nav links are visible and clickable
-            await Assertions.Expect(navBar.RunsLink).ToBeVisibleAsync(new() { Timeout = 10000 });
-            await Assertions.Expect(navBar.GuildLink).ToBeVisibleAsync(new() { Timeout = 10000 });
             await Assertions.Expect(navBar.CharactersLink).ToBeVisibleAsync(new() { Timeout = 10000 });
 
-            // Navigate via the Characters link
             await navBar.CharactersLink.ClickAsync();
-            await authPage.WaitForURLAsync(
-                new System.Text.RegularExpressions.Regex(@"/characters$"),
-                new() { Timeout = 15000 });
-            Assert.Contains("/characters", authPage.Url);
 
-            // Navigate via the Guild link
+            // Prove the link reached the destination UI, not just the URL.
+            var charactersPage = new CharactersPage(authPage);
+            await Assertions.Expect(charactersPage.Heading).ToBeVisibleAsync(new() { Timeout = 15000 });
+            await Assertions.Expect(authPage).ToHaveURLAsync(
+                new System.Text.RegularExpressions.Regex(@"/characters$"),
+                new() { Timeout = 10000 });
+        }
+        finally
+        {
+            await authContext.CloseAsync();
+        }
+    }
+
+    [Fact]
+    public async Task NavbarGuildLink_Click_NavigatesToGuildPage()
+    {
+        var authContext = await AuthHelper.AuthenticatedContextAsync(
+            fixture.Stack.Browser,
+            fixture.Stack.ApiBaseUrl,
+            fixture.Stack.AppBaseUrl);
+        var authPage = await authContext.NewPageAsync();
+
+        try
+        {
+            await authPage.GotoAsync($"{fixture.Stack.AppBaseUrl}/runs");
+
+            var navBar = new NavBar(authPage);
+            await Assertions.Expect(navBar.GuildLink).ToBeVisibleAsync(new() { Timeout = 10000 });
+
             await navBar.GuildLink.ClickAsync();
-            await authPage.WaitForURLAsync(
+
+            var guildPage = new GuildPage(authPage);
+            await Assertions.Expect(guildPage.Heading).ToBeVisibleAsync(new() { Timeout = 15000 });
+            await Assertions.Expect(authPage).ToHaveURLAsync(
                 new System.Text.RegularExpressions.Regex(@"/guild$"),
-                new() { Timeout = 15000 });
-            Assert.Contains("/guild", authPage.Url);
+                new() { Timeout = 10000 });
         }
         finally
         {


### PR DESCRIPTION
## Summary

Closes #50.

Two E2E tests bundled multiple user journeys behind URL-only assertions (`E-LC-6` / `E-HC-F1`):

- `AccessControlSpec.PublicRoute_Unauthenticated_RendersWithoutRedirect` exercised landing, login, and privacy in one body but only asserted `DoesNotContain("/login?redirect", Url)` on the landing and privacy branches. A landing-page regression that rendered a blank body would pass.
- `NavigationSpec.Navbar_Links_NavigateCorrectly` chained two navbar clicks, duplicated the auto-retrying URL wait with a redundant `Assert.Contains(Url)` check, and never visited the destination page content.

Split each into one-outcome-per-test; replace URL-only proofs with page-heading visibility assertions driven by the existing page objects. The Characters variant also stubs the fire-and-forget portrait endpoint to match the other characters-page tests.

**Before (2 tests):**
- `PublicRoute_Unauthenticated_RendersWithoutRedirect`
- `Navbar_Links_NavigateCorrectly`

**After (5 tests):**
- `PublicLandingPage_Unauthenticated_RendersWithoutRedirect`
- `PublicLoginPage_Unauthenticated_RendersWithoutRedirect`
- `PublicPrivacyPage_Unauthenticated_RendersWithoutRedirect`
- `NavbarCharactersLink_Click_NavigatesToCharactersPage`
- `NavbarGuildLink_Click_NavigatesToGuildPage`

## Test plan

- [x] `dotnet build tests/Lfm.E2E/Lfm.E2E.csproj -c Release` — green.
- [x] `dotnet format tests/Lfm.E2E/Lfm.E2E.csproj --verify-no-changes --severity error` — green.
- [x] Smoke against live stack: all 5 new tests pass, ~1 s each.