### PR TITLE
Add tampered + expired cookie sub-lane S browser-enforcement tests

### DIFF
--- a/tests/Lfm.E2E/Specs/BrowserSecuritySpec.cs
+++ b/tests/Lfm.E2E/Specs/BrowserSecuritySpec.cs
@@ -15,9 +15,9 @@ namespace Lfm.E2E.Specs;
 // prove. This spec replaces the deleted SecuritySpec.cs whose 19 tests all
 // asserted server response headers without ever touching a browser (`E-HC-S1`).
 //
-// The four tests below pin contracts the real Static Web Apps deployment
-// enforces in production, replicated locally by StackFixture's Kestrel host
-// (which sets the same globalHeaders the production platform sets).
+// The tests below pin contracts the real Static Web Apps deployment enforces
+// in production, replicated locally by StackFixture's Kestrel host (which sets
+// the same globalHeaders the production platform sets).
 [Collection("BrowserSecurity")]
 [Trait("Category", "Security")]
 public class BrowserSecuritySpec(BrowserSecurityFixture fixture, ITestOutputHelper output)
@@ -175,5 +175,97 @@ public class BrowserSecuritySpec(BrowserSecurityFixture fixture, ITestOutputHelp
             """);
 
         Assert.NotEqual(true, pwnedFlag);
+    }
+
+    [Fact]
+    public async Task TamperedSessionCookie_AccessingProtectedRoute_RedirectsToLogin()
+    {
+        // Establish a real authenticated session, then corrupt the cookie so
+        // the server cannot decrypt it. The server rejects the tampered cookie
+        // with 401; the SPA must honour that rejection by routing the user to
+        // /login. This proves browser-side handling of a rejected session —
+        // the integration-layer CorsMiddlewareTests / AuthMiddlewareTests
+        // prove the server-side rejection, but not the SPA's response to it.
+        var authContext = await AuthHelper.AuthenticatedContextAsync(
+            fixture.Stack.Browser,
+            fixture.Stack.ApiBaseUrl,
+            fixture.Stack.AppBaseUrl);
+        try
+        {
+            var original = (await authContext.CookiesAsync())
+                .First(c => c.Name == "battlenet_token");
+            await authContext.AddCookiesAsync(
+            [
+                new Cookie
+                {
+                    Name = original.Name,
+                    Value = "TAMPERED-" + original.Value,
+                    Domain = original.Domain,
+                    Path = original.Path,
+                    HttpOnly = original.HttpOnly,
+                    Secure = original.Secure,
+                    SameSite = original.SameSite,
+                    Expires = original.Expires,
+                },
+            ]);
+
+            var tamperedPage = await authContext.NewPageAsync();
+            await tamperedPage.GotoAsync($"{fixture.Stack.AppBaseUrl}/runs");
+
+            await Assertions.Expect(tamperedPage).ToHaveURLAsync(
+                new System.Text.RegularExpressions.Regex(@"/login\?redirect=%2Fruns"),
+                new() { Timeout = 15000 });
+        }
+        finally
+        {
+            await authContext.CloseAsync();
+        }
+    }
+
+    [Fact]
+    public async Task ExpiredSessionCookie_AccessingProtectedRoute_RedirectsToLogin()
+    {
+        // Re-add the session cookie with an Expires timestamp in the past so
+        // the Chromium cookie jar treats it as expired and drops it before
+        // sending the request. The backend then sees an anonymous request,
+        // returns 401, and the SPA routes to /login. Proves *browser*
+        // cookie-jar expiry enforcement — even though the encrypted
+        // principal inside the cookie is still valid, the browser's own
+        // Expires check must prevent the cookie from leaving the jar.
+        var authContext = await AuthHelper.AuthenticatedContextAsync(
+            fixture.Stack.Browser,
+            fixture.Stack.ApiBaseUrl,
+            fixture.Stack.AppBaseUrl);
+        try
+        {
+            var original = (await authContext.CookiesAsync())
+                .First(c => c.Name == "battlenet_token");
+            var pastExpiry = DateTimeOffset.UtcNow.AddHours(-1).ToUnixTimeSeconds();
+            await authContext.AddCookiesAsync(
+            [
+                new Cookie
+                {
+                    Name = original.Name,
+                    Value = original.Value,
+                    Domain = original.Domain,
+                    Path = original.Path,
+                    HttpOnly = original.HttpOnly,
+                    Secure = original.Secure,
+                    SameSite = original.SameSite,
+                    Expires = pastExpiry,
+                },
+            ]);
+
+            var expiredPage = await authContext.NewPageAsync();
+            await expiredPage.GotoAsync($"{fixture.Stack.AppBaseUrl}/runs");
+
+            await Assertions.Expect(expiredPage).ToHaveURLAsync(
+                new System.Text.RegularExpressions.Regex(@"/login\?redirect=%2Fruns"),
+                new() { Timeout = 15000 });
+        }
+        finally
+        {
+            await authContext.CloseAsync();
+        }
     }
 }


### PR DESCRIPTION
## Summary

Partial fix for #51 — 2 of the 3 auth-matrix rows the audit flagged (`Gap-AuthZ`).

**Added:**
- `TamperedSessionCookie_AccessingProtectedRoute_RedirectsToLogin` — authenticates normally, overwrites `battlenet_token` with a mangled prefix, navigates to `/runs`. Server rejects the tampered cookie (can't decrypt); SPA routes to `/login`. Proves browser-side handling of a rejected session that unit-level `AuthMiddleware` tests cannot see.
- `ExpiredSessionCookie_AccessingProtectedRoute_RedirectsToLogin` — authenticates normally, re-adds the cookie with `Expires` in the past so Chromium's jar drops it before send. Server sees anonymous request; SPA routes to `/login`. Proves browser cookie-jar expiry enforcement — the encrypted principal inside the cookie is still valid, so the assertion is strictly about the browser's own `Expires` check, not the server's.

**Deferred:**
- **Cross-user deep-link access** — this app's routable resources are all scoped per-logged-in user (no `/guild/{id}` or `/user/{battleNetId}/...`), so there's no obvious deep-linkable "user B's resource" to target. That row needs a separate design conversation about what the cross-user assertion should prove — I'm leaving #51 open so it can be reopened with that scope.

## Test plan

- [x] `dotnet build tests/Lfm.E2E/Lfm.E2E.csproj -c Release` — green.
- [x] `dotnet format tests/Lfm.E2E/Lfm.E2E.csproj --verify-no-changes --severity error` — green.
- [x] Smoke against live stack: both new tests pass, ~1 s each.