### PR TITLE
Rescan LoginPage a11y after focusing the sign-in button

### DIFF
--- a/tests/Lfm.E2E/Specs/AccessibilitySpec.cs
+++ b/tests/Lfm.E2E/Specs/AccessibilitySpec.cs
@@ -61,7 +61,16 @@ public class AccessibilitySpec(AccessibilityFixture fixture, ITestOutputHelper o
         var loginPage = new LoginPage(Page);
         await Assertions.Expect(loginPage.Heading).ToBeVisibleAsync(new() { Timeout = 15000 });
 
-        await AccessibilityHelper.ScanAndAssert(Page, Output, "/login");
+        await AccessibilityHelper.ScanAndAssert(Page, Output, "/login (load)");
+
+        // Re-scan after keyboard-focusing the sign-in button. The focus
+        // indicator styles, any aria-describedby tooltips, and the focused
+        // element's contrast against its focus ring only surface after
+        // interaction — a load-time scan alone misses those (`E-HC-A2`).
+        await AccessibilityHelper.ScanAfterAsync(Page, Output, "/login (sign-in focused)", async () =>
+        {
+            await loginPage.SignInButton.FocusAsync();
+        });
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Partial fix for #52.

`LoginPage_MeetsWcag22AA` previously scanned only at page load. The focus indicator, any focus-state `aria-describedby` tooltips, and the contrast between the focused element and its focus ring only surface after interaction (`E-HC-A2`).

Add an `AccessibilityHelper.ScanAfterAsync` rescan after keyboard-focusing the sign-in button. Matches the pattern already used by `RunsPage` / `CharactersPage` / `GuildAdminPage` interaction rescans.

**Deferred** (kept #52 open): `RunDetailPage` and `InstancesPage`. Both are essentially static on the deep-linked URLs they're scanned at — the useful interactions (selecting a run, opening the edit form) navigate away from the scanned URL. Those need their own `ScanAfter` targets designed before we add them.

## Test plan

- [x] `dotnet build tests/Lfm.E2E/Lfm.E2E.csproj -c Release` — green.
- [x] `dotnet format tests/Lfm.E2E/Lfm.E2E.csproj --verify-no-changes --severity error` — green.
- [x] Smoke against live stack: `AccessibilitySpec.LoginPage_MeetsWcag22AA` passes in 1 s (now includes the focus rescan).