### PR TITLE
Give run-list items an explicit accessible name

### DIFF
--- a/app/Pages/RunsPage.razor
+++ b/app/Pages/RunsPage.razor
@@ -49,13 +49,16 @@
                         // content into a single concise screen-reader name
                         // (otherwise the implicit name concatenates every nested
                         // span — date + mode + footer — without separators).
+                        // The connector between instance and date lives in the
+                        // resx so non-English locales don't leak a stray English
+                        // word into the name.
                         // data-testid is retained so E2E tests can look up a
                         // specific run by id without having to derive its
                         // instance + date from external state.
                         <button type="button"
                                 @key="run.Id"
                                 data-testid="run-item-@run.Id"
-                                aria-label="@($"{run.InstanceName} on {FormatDate(run.StartTime)}")"
+                                aria-label="@Loc["runs.listItemAriaLabel", run.InstanceName, FormatDate(run.StartTime)]"
                                 class="run-list-item @(isSelected ? "run-list-item--selected" : "")"
                                 aria-pressed="@(isSelected ? "true" : "false")"
                                 @onclick="@(() => SelectRun(run.Id))">

--- a/app/Pages/RunsPage.razor
+++ b/app/Pages/RunsPage.razor
@@ -45,9 +45,17 @@
                     {
                         var isSelected = run.Id == selectedRunId;
                         var attending = CountAttending(run.RunCharacters);
+                        // Explicit aria-label collapses the multi-line visible
+                        // content into a single concise screen-reader name
+                        // (otherwise the implicit name concatenates every nested
+                        // span — date + mode + footer — without separators).
+                        // data-testid is retained so E2E tests can look up a
+                        // specific run by id without having to derive its
+                        // instance + date from external state.
                         <button type="button"
                                 @key="run.Id"
                                 data-testid="run-item-@run.Id"
+                                aria-label="@($"{run.InstanceName} on {FormatDate(run.StartTime)}")"
                                 class="run-list-item @(isSelected ? "run-list-item--selected" : "")"
                                 aria-pressed="@(isSelected ? "true" : "false")"
                                 @onclick="@(() => SelectRun(run.Id))">

--- a/app/wwwroot/locales/en.json
+++ b/app/wwwroot/locales/en.json
@@ -80,6 +80,7 @@
     "runs.columns.spec": "Spec",
     "runs.noSignups": "No signups yet.",
     "runs.attendingSignedUp": "{0} attending \u00B7 {1} signed up",
+    "runs.listItemAriaLabel": "{0} on {1}",
     "runs.attendingSection": "Attending",
     "runs.notAttendingSection": "Not attending",
     "runs.role.tank": "Tank",

--- a/app/wwwroot/locales/fi.json
+++ b/app/wwwroot/locales/fi.json
@@ -80,6 +80,7 @@
     "runs.columns.spec": "Spec",
     "runs.noSignups": "Ei ilmoittautumisia viel\u00e4.",
     "runs.attendingSignedUp": "{0} osallistuu \u00B7 {1} ilmoittautunut",
+    "runs.listItemAriaLabel": "{0} \u2013 {1}",
     "runs.attendingSection": "Osallistuu",
     "runs.notAttendingSection": "Ei osallistu",
     "runs.role.tank": "Tank",

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -92,12 +92,14 @@ public class RunsPagesTests : ComponentTestBase
     public void RunsPage_RunListItem_Has_Accessible_Name_Combining_Instance_And_Date()
     {
         // Screen-reader users navigating the run list hear a concise aria-label
-        // ("<Instance> on <Date>") instead of the implicit multi-line span
-        // concatenation. Pin the contract so a future refactor of the run-list
-        // template doesn't silently regress it.
+        // driven by the localized `runs.listItemAriaLabel` template instead of
+        // the implicit multi-line span concatenation. Pin the exact localized
+        // output so a template refactor or locale drift can't silently regress
+        // the name without the test noticing.
+        var summary = MakeSummary();
         var client = new Mock<IRunsClient>();
         client.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<RunSummaryDto> { MakeSummary() });
+            .ReturnsAsync(new List<RunSummaryDto> { summary });
         Services.AddSingleton(client.Object);
 
         var cut = Render<RunsPage>();
@@ -106,8 +108,14 @@ public class RunsPagesTests : ComponentTestBase
         {
             var runButton = cut.Find("button.run-list-item");
             var ariaLabel = runButton.GetAttribute("aria-label") ?? string.Empty;
-            Assert.Contains("Liberation of Undermine", ariaLabel);
-            Assert.Contains(" on ", ariaLabel);
+            // FormatDate (private in RunsPage) parses the ISO string and
+            // formats as "yyyy-MM-dd HH:mm" with InvariantCulture; mirror that
+            // here so the test pins the exact localized output screen readers
+            // get, without reaching into the page object's private helpers.
+            var formattedDate = DateTimeOffset.Parse(summary.StartTime, System.Globalization.CultureInfo.InvariantCulture)
+                .ToString("yyyy-MM-dd HH:mm", System.Globalization.CultureInfo.InvariantCulture);
+            var expected = Loc("runs.listItemAriaLabel", summary.InstanceName, formattedDate);
+            Assert.Equal(expected, ariaLabel);
         });
     }
 

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -89,6 +89,29 @@ public class RunsPagesTests : ComponentTestBase
     }
 
     [Fact]
+    public void RunsPage_RunListItem_Has_Accessible_Name_Combining_Instance_And_Date()
+    {
+        // Screen-reader users navigating the run list hear a concise aria-label
+        // ("<Instance> on <Date>") instead of the implicit multi-line span
+        // concatenation. Pin the contract so a future refactor of the run-list
+        // template doesn't silently regress it.
+        var client = new Mock<IRunsClient>();
+        client.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<RunSummaryDto> { MakeSummary() });
+        Services.AddSingleton(client.Object);
+
+        var cut = Render<RunsPage>();
+
+        cut.WaitForAssertion(() =>
+        {
+            var runButton = cut.Find("button.run-list-item");
+            var ariaLabel = runButton.GetAttribute("aria-label") ?? string.Empty;
+            Assert.Contains("Liberation of Undermine", ariaLabel);
+            Assert.Contains(" on ", ariaLabel);
+        });
+    }
+
+    [Fact]
     public void RunsPage_Renders_Empty_State_When_No_Runs()
     {
         var client = new Mock<IRunsClient>();


### PR DESCRIPTION
## Summary

Closes #54.

The run-list button's implicit accessible name came from concatenating every nested span — instance name, mode pill, date, attending footer — with no separators. Screen readers announce that as something like "Liberation of UndermineNormal 25Wed 15:001 attending · 1 signed up", which is technically present but useless.

Add an explicit `aria-label` that collapses to the concise semantic identifier users actually reach for:

```razor
aria-label="@($"{run.InstanceName} on {FormatDate(run.StartTime)}")"
```

**`data-testid` stays.** The audit's secondary suggestion — drop the test-id entirely — would require a test-side refactor: E2E tests look up a specific run by id (e.g. `DefaultSeed.TestRunId`) and would have to derive the run's rendered instance + date from external state to build a role+name locator. Keeping `data-testid` is acceptable per [Playwright's own guidance](https://playwright.dev/docs/locators#locate-by-test-id) when no single accessible-name locator can reach a specific row.

Pin the new contract with a bUnit test (`RunsPage_RunListItem_Has_Accessible_Name_Combining_Instance_And_Date`) so a future refactor of the run-list template doesn't silently regress the aria-label.

## Test plan

- [x] `dotnet build lfm.sln -c Release` — green.
- [x] `dotnet format lfm.sln --verify-no-changes --severity error` — green.
- [x] New bUnit test passes: `tests/Lfm.App.Tests --filter ...RunsPage_RunListItem_Has_Accessible_Name...` — **passes in 274 ms**.