### PR TITLE
Fix mobile nav collapse and responsive run list

### DIFF
--- a/app/Components/DifficultyPill.razor
+++ b/app/Components/DifficultyPill.razor
@@ -12,6 +12,7 @@
         var (difficulty, _) = RunMode.Parse(modeKey);
         return difficulty switch
         {
+            "MYTHIC_KEYSTONE" => "M+",
             "MYTHIC" => "Mythic",
             "HEROIC" => "Heroic",
             "NORMAL" => "Normal",
@@ -25,6 +26,7 @@
         var (difficulty, _) = RunMode.Parse(modeKey);
         return difficulty switch
         {
+            "MYTHIC_KEYSTONE" => "mplus",
             "MYTHIC" => "mythic",
             "HEROIC" => "heroic",
             "NORMAL" => "normal",

--- a/app/Components/RunListItem.razor.css
+++ b/app/Components/RunListItem.razor.css
@@ -79,11 +79,15 @@
     display: flex;
     align-items: center;
     gap: 8px;
+    /* Let the difficulty pill drop below the title at narrow widths or long
+       titles (e.g. a wide M+ keystone pill next to a long instance name)
+       instead of squeezing the title to nothing. */
+    flex-wrap: wrap;
 }
 
 .run-list-item__title {
     font-weight: 600;
-    flex: 1;
+    flex: 1 1 auto;
     min-inline-size: 0;
     overflow-wrap: anywhere;
     line-height: 1.3;

--- a/app/Layout/MainLayout.razor
+++ b/app/Layout/MainLayout.razor
@@ -22,11 +22,13 @@
 
             <AuthorizeView>
                 <Authorized>
-                    <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="4" Style="margin-inline-start:16px" Class="desktop-nav">
+                    @* Plain <div> (not FluentStack) so `.desktop-nav { display: none }` isn't
+                       overridden by FluentStack's inline display:flex at narrow viewports. *@
+                    <div class="desktop-nav">
                         <FluentAnchor Href="/runs">@Loc["nav.runs"]</FluentAnchor>
                         <FluentAnchor Href="/guild">@Loc["nav.guild"]</FluentAnchor>
                         <FluentAnchor Href="/characters">@Loc["nav.characters"]</FluentAnchor>
-                    </FluentStack>
+                    </div>
                     <div style="margin-inline-start:auto;display:flex;align-items:center;gap:4px">
                         <FluentButton Appearance="Appearance.Stealth"
                                       Class="mobile-nav-toggle"

--- a/app/Pages/RunsPage.razor.css
+++ b/app/Pages/RunsPage.razor.css
@@ -19,7 +19,11 @@
     overflow: hidden;
 }
 
-@media (min-width: 48em) {
+/* Two-column split only on genuine desktop widths.
+   At 48em the sidebar + gap + page padding left the detail pane around 420px,
+   which cramped the roster grid and edit form. 64em gives the detail pane
+   ~640px+ and keeps the whole tablet range on a single-column layout. */
+@media (min-width: 64em) {
     .runs-layout {
         flex-direction: row;
     }

--- a/app/wwwroot/css/app.css
+++ b/app/wwwroot/css/app.css
@@ -133,9 +133,14 @@ a, .btn-link {
     top: 0;
 }
 
-/* Responsive navigation — mobile-first cascade. */
+/* Responsive navigation — mobile-first cascade.
+   .desktop-nav is a plain <div> (not FluentStack) so the display:none here wins:
+   FluentStack injects inline display:flex, which would outrank any CSS rule. */
 .desktop-nav {
     display: none;
+    margin-inline-start: 1rem;
+    gap: 0.25rem;
+    align-items: center;
 }
 
 .mobile-nav-toggle {
@@ -183,7 +188,11 @@ a, .btn-link {
  * pick a neutral text color that clears 4.5:1 — black on #ff8000 (8.36:1),
  * white on #a335ee (4.88:1). See issue #28.
  */
-.difficulty-pill--mythic {
+.difficulty-pill--mythic,
+.difficulty-pill--mplus {
+    /* M+ (mythic keystone) is a mythic-tier difficulty variant, so it reuses
+       the brand-canonical mythic orange. The "M+" label keeps the two visually
+       distinct. Contrast pair locked by DifficultyPillContrastTests. */
     color: #000;
     background: #ff8000;
     border-color: #ff8000;
@@ -203,6 +212,16 @@ a, .btn-link {
 .difficulty-pill--lfr {
     color: var(--neutral-foreground-hint-rest);
     border-color: var(--neutral-stroke-rest);
+}
+
+/* Forced-colors mode (Windows High Contrast / user-forced palette) overrides
+   `color` and `background` with system colors, collapsing the brand-colored
+   pills. Keep the boundary visible via a system-color border so the pill
+   stays a non-text contrast cue (SC 1.4.11). */
+@media (forced-colors: active) {
+    .difficulty-pill {
+        border: 1px solid ButtonText;
+    }
 }
 
 /* Character row */

--- a/tests/Lfm.App.Tests/DifficultyPillContrastTests.cs
+++ b/tests/Lfm.App.Tests/DifficultyPillContrastTests.cs
@@ -6,12 +6,13 @@ using Xunit;
 namespace Lfm.App.Tests;
 
 /// <summary>
-/// Locks the .difficulty-pill--{mythic,heroic} color + background pairs against
+/// Locks the .difficulty-pill--{mythic,mplus,heroic} color + background pairs against
 /// WCAG 2.2 AA 1.4.3 (text contrast ≥ 4.5:1). Relates to issue #28.
 ///
 /// WoW difficulty colors are brand-canonical and cannot be altered. To clear
 /// 4.5:1 they sit on the pill *background*, with a neutral text color:
 ///   - mythic #ff8000 carries black text (8.36:1).
+///   - mplus (M+ / mythic keystone) reuses the mythic orange/black pair.
 ///   - heroic #a335ee carries white text (4.88:1).
 ///
 /// If you change the CSS pairs, update this test — the test is the contract,
@@ -22,6 +23,7 @@ public class DifficultyPillContrastTests
     public static TheoryData<string, string, string> PillTextOnBackground() => new()
     {
         { "mythic", "#000000", "#ff8000" },
+        { "mplus", "#000000", "#ff8000" },
         { "heroic", "#ffffff", "#a335ee" },
     };
 

--- a/tests/Lfm.App.Tests/DifficultyPillTests.cs
+++ b/tests/Lfm.App.Tests/DifficultyPillTests.cs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Bunit;
+using Lfm.App.Components;
+using Xunit;
+
+namespace Lfm.App.Tests;
+
+/// <summary>
+/// Locks the <see cref="DifficultyPill"/> label + CSS-class mapping.
+///
+/// The mapping is load-bearing for two reasons:
+///   1. The visible label is what users read in the run list — "M+" is
+///      short enough to fit beside a title in a narrow sidebar, whereas
+///      the raw "MYTHIC_KEYSTONE" difficulty string wrapped awkwardly.
+///   2. The CSS class suffix (`difficulty-pill--{variant}`) is the contract
+///      with `app.css` styling + with <see cref="DifficultyPillContrastTests"/>.
+/// </summary>
+public class DifficultyPillTests : ComponentTestBase
+{
+    [Theory]
+    [InlineData("MYTHIC_KEYSTONE", "M+", "mplus")]
+    [InlineData("mythic_keystone:5", "M+", "mplus")]
+    [InlineData("MYTHIC", "Mythic", "mythic")]
+    [InlineData("MYTHIC:25", "Mythic", "mythic")]
+    [InlineData("HEROIC", "Heroic", "heroic")]
+    [InlineData("NORMAL", "Normal", "normal")]
+    [InlineData("LFR", "LFR", "lfr")]
+    public void Renders_Expected_Label_And_Class(string modeKey, string expectedLabel, string expectedVariant)
+    {
+        var cut = Render<DifficultyPill>(p => p.Add(x => x.ModeKey, modeKey));
+
+        var pill = cut.Find(".difficulty-pill");
+        Assert.Contains(expectedLabel, pill.TextContent);
+        Assert.Contains($"difficulty-pill--{expectedVariant}", pill.ClassName);
+    }
+
+    [Fact]
+    public void MythicKeystone_Does_Not_Leak_Raw_Enum_Text()
+    {
+        var cut = Render<DifficultyPill>(p => p.Add(x => x.ModeKey, "MYTHIC_KEYSTONE"));
+
+        var pill = cut.Find(".difficulty-pill");
+        Assert.DoesNotContain("keystone", pill.TextContent, System.StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("_", pill.TextContent);
+    }
+
+    [Fact]
+    public void Unknown_Difficulty_Falls_Back_To_TitleCased_Label()
+    {
+        var cut = Render<DifficultyPill>(p => p.Add(x => x.ModeKey, "PVP"));
+
+        var pill = cut.Find(".difficulty-pill");
+        // Title-case rule: first letter upper, rest lower (invariant) — not
+        // CultureInfo.TextInfo.ToTitleCase, which is locale-sensitive.
+        Assert.Equal("Pvp", pill.TextContent.Trim());
+        Assert.Contains("difficulty-pill--unknown", pill.ClassName);
+    }
+}

--- a/tests/Lfm.App.Tests/LayoutTests.cs
+++ b/tests/Lfm.App.Tests/LayoutTests.cs
@@ -116,6 +116,48 @@ public class LayoutTests : ComponentTestBase
     }
 
     [Fact]
+    public void MainLayout_Desktop_Nav_Is_A_Plain_Div_So_Display_None_Wins_On_Mobile()
+    {
+        // The desktop nav must be a plain <div class="desktop-nav"> — wrapping
+        // it in a FluentStack injects inline display:flex, which would outrank
+        // the `.desktop-nav { display: none }` rule at narrow viewports and
+        // cause both the desktop links and the hamburger to render at the same
+        // time on mobile (the bug the screenshot was pointing at).
+        var auth = this.AddAuthorization();
+        auth.SetAuthorized("player#1234");
+
+        var cut = Render<MainLayout>(p =>
+            p.Add(x => x.Body, builder => builder.AddContent(0, "page content")));
+
+        cut.WaitForAssertion(() =>
+        {
+            var desktopNav = cut.Find("div.desktop-nav");
+            Assert.Equal("div", desktopNav.TagName, ignoreCase: true);
+        });
+    }
+
+    [Fact]
+    public void MainLayout_Shows_Mobile_Nav_Toggle_Button_When_Authenticated()
+    {
+        // The hamburger is what users tap on narrow viewports once the
+        // desktop nav hides. If the toggle disappears, navigation is stranded.
+        // Asserting `[aria-label]` presence guards against a regression where
+        // the glyph renders but the button is unlabelled to assistive tech.
+        var auth = this.AddAuthorization();
+        auth.SetAuthorized("player#1234");
+
+        var cut = Render<MainLayout>(p =>
+            p.Add(x => x.Body, builder => builder.AddContent(0, "page content")));
+
+        cut.WaitForAssertion(() =>
+        {
+            var toggle = cut.Find(".mobile-nav-toggle");
+            Assert.NotNull(toggle);
+            Assert.False(string.IsNullOrWhiteSpace(toggle.GetAttribute("aria-label")));
+        });
+    }
+
+    [Fact]
     public void MainLayout_Main_Element_Has_Ref_For_Focus_Management()
     {
         this.AddAuthorization();


### PR DESCRIPTION
## Summary

Four mobile responsive fixes on the runs page, verified against the `souroldgeezer-design:responsive-design` rubric (WCAG 2.2 AA + i18n + CWV) and the `test-quality-audit` rubric.

- **Nav collapse on mobile.** `desktop-nav` was a `FluentStack` whose inline `display:flex` outranked `.desktop-nav { display: none }`, so on narrow viewports both the desktop links *and* the hamburger rendered. Swapped the wrapper to a plain `<div class="desktop-nav">` so the CSS rule wins; `.desktop-nav` now owns its own flex properties in `rem` units.
- **`Mythic_keystone` → `M+`.** `DifficultyPill` now maps `MYTHIC_KEYSTONE` to label `M+` with a dedicated `difficulty-pill--mplus` CSS variant. The variant shares the brand-mythic orange/black pair (8.36:1, covered by `DifficultyPillContrastTests`).
- **Run-list title + pill wrap cleanly.** `.run-list-item__header` gets `flex-wrap: wrap` and the title switches to `flex: 1 1 auto` so the difficulty pill drops below the title at narrow widths or long instance names instead of squeezing the title to ellipsis.
- **Two-column split stays desktop-only.** `.runs-layout` / `.runs-sidebar` media query moved from `48em` to `64em` — at `48em` the detail pane was ~420 px and cramped the roster grid + edit form; at `64em` it clears ~640 px.

Side benefits from the responsive-design audit, applied in-PR:
- `.desktop-nav` spacing migrated from `px` to `rem` (SC 1.4.4 resize-text).
- Added `@media (forced-colors: active)` border fallback for difficulty pills so the chip boundary survives Windows High Contrast (SC 1.4.11).

## Changes

- `app/Layout/MainLayout.razor` — plain `<div>` for desktop nav wrapper.
- `app/Components/DifficultyPill.razor` — `MYTHIC_KEYSTONE` mapping.
- `app/Components/RunListItem.razor.css` — `flex-wrap` on header, `flex: 1 1 auto` on title.
- `app/Pages/RunsPage.razor.css` — 48em → 64em two-column breakpoint.
- `app/wwwroot/css/app.css` — `.desktop-nav` rules, `.difficulty-pill--mplus`, forced-colors fallback.
- Tests: `DifficultyPillTests` (new), `DifficultyPillContrastTests` (+mplus row), `LayoutTests` (desktop-nav-is-a-div + mobile-toggle-has-aria-label).

No env / schema / config changes.

## Test plan

- [x] `dotnet build lfm.sln -c Release` — 0 warnings / 0 errors
- [x] `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release` — 138/138 pass
- [x] `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release` — 131/131 pass
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` — 382/382 pass
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error` — clean
- [x] `responsive-design` quick review — 0 blocks; the 2 info findings in changed code (`px`→`rem` on `.desktop-nav`; forced-colors fallback) were fixed in-PR
- [x] `test-quality-audit` quick — all 5 tests classified **specification**, 0 characterization, 0 blocks; the `LC-2` presence-only smell was upgraded to also assert `aria-label`, and the `HC-3` pasted-literal `"Pvp"` got an invariant-title-case comment
- [ ] Manual mobile browser check at ~375 px width: desktop nav links hidden, hamburger visible, runs list stacks full-width, M+ pill renders as "M+"
- [ ] Manual tablet check at ~800 px width: still single-column (no squeezed detail pane)
- [ ] Manual desktop check at ≥1024 px width: two-column split kicks in with sidebar `clamp(18rem, 28vw, 22rem)` and usable detail pane

## Screenshots

(Add before/after at 375 px width when reviewing.)
