### PR TITLE
Move kind highlight to side accent; drop full-card washes

### DIFF
--- a/app/Components/RunListItem.razor
+++ b/app/Components/RunListItem.razor
@@ -11,7 +11,6 @@
         data-current-user="@_isCurrentUserClass"
         aria-label="@_ariaLabel"
         aria-pressed="@(IsSelected ? "true" : "false")"
-        style="@_instanceStyle"
         @onclick="HandleClick">
     <span class="run-list-item__header">
         <span class="run-list-item__title">@Run.InstanceName</span>
@@ -54,7 +53,6 @@
     private RunRoleCounts _counts;
     private string _ariaLabel = "";
     private string _compositionAria = "";
-    private string _instanceStyle = "";
 
     protected override void OnParametersSet()
     {
@@ -66,7 +64,6 @@
         _ariaLabel = Loc["runs.listItemAriaLabel", Run.InstanceName, FormatDate(Run.StartTime)].Value;
         _compositionAria = Loc["runs.compositionAria",
             _counts.Tank.Attending, _counts.Healer.Attending, _counts.Dps.Attending].Value;
-        _instanceStyle = $"--instance-bg:{RunVisualization.GetInstanceGradient(Run.InstanceId)}";
     }
 
     private Task HandleClick() => OnSelected.InvokeAsync(Run.Id);

--- a/app/Components/RunListItem.razor.css
+++ b/app/Components/RunListItem.razor.css
@@ -14,11 +14,11 @@
     cursor: pointer;
     color: var(--neutral-foreground-rest);
     border-block-end: 1px solid var(--neutral-stroke-rest);
-    /* Difficulty edge = left stripe; kind tint + instance gradient composite as layered backgrounds. */
-    border-inline-start: 3px solid var(--difficulty-accent, transparent);
-    background:
-        var(--kind-tint, transparent),
-        var(--instance-bg, transparent);
+    /* Kind = inline-start stripe (dungeon / raid), mirroring the class-color
+       side accent on CharacterRow. Difficulty is already signalled by the
+       DifficultyPill so it stays off the card surface, and no full-card
+       background wash runs so every item sits at the same visual width. */
+    border-inline-start: 3px solid var(--kind-accent, transparent);
 }
 
 @media (prefers-reduced-motion: no-preference) {
@@ -36,32 +36,31 @@
     outline-offset: -2px;
 }
 
-/* Difficulty palette — canonical WoW item quality colors (brand, do not adjust). */
-.run-list-item[data-difficulty="mythic"] {
-    --difficulty-accent: #ff8000;
-}
-
-.run-list-item[data-difficulty="heroic"] {
-    --difficulty-accent: #a335ee;
-}
-
-.run-list-item[data-difficulty="normal"] {
-    --difficulty-accent: var(--accent-fill-rest);
-}
-
-.run-list-item[data-difficulty="lfr"] {
-    --difficulty-accent: var(--neutral-stroke-rest);
-}
-
-/* Run-kind wash — dungeon = blue, raid = green; subtle tint on top of the per-instance gradient. */
+/* Run-kind side accent — canonical WoW dungeon blue / raid green. The hex
+   values are brand-immutable (issue #28); raid green (#1eff00) does not
+   clear SC 1.4.11 (3:1) against a light-theme surface at 1.26:1. We accept
+   the trade-off because kind is redundantly communicated through the
+   composition target counts rendered on every item (D X/5 = dungeon,
+   D X/14+ = raid) and through the difficulty pill's size context — so the
+   stripe is decorative reinforcement, not the sole identifier. SC 1.4.11's
+   "also available through text" exemption applies. */
 .run-list-item[data-kind="dungeon"] {
-    --kind-tint: linear-gradient(color-mix(in oklch, #0070dd 14%, transparent),
-            color-mix(in oklch, #0070dd 14%, transparent));
+    --kind-accent: #0070dd;
 }
 
 .run-list-item[data-kind="raid"] {
-    --kind-tint: linear-gradient(color-mix(in oklch, #1eff00 10%, transparent),
-            color-mix(in oklch, #1eff00 10%, transparent));
+    --kind-accent: #1eff00;
+}
+
+/* Forced-colors mode (Windows High Contrast) overrides custom-property
+   colors with system colors, collapsing --kind-accent to transparent.
+   Re-establish the stripe via a system color so the kind cue survives. */
+@media (forced-colors: active) {
+
+    .run-list-item[data-kind="dungeon"],
+    .run-list-item[data-kind="raid"] {
+        border-inline-start-color: Highlight;
+    }
 }
 
 @media (hover: hover) and (pointer: fine) {
@@ -73,6 +72,8 @@
 .run-list-item--selected {
     background-color: var(--neutral-fill-secondary-rest);
     border-inline-start-width: 5px;
+    /* Ensure unknown-kind items still get a visible selection stripe. */
+    border-inline-start-color: var(--kind-accent, var(--accent-fill-rest));
 }
 
 .run-list-item__header {

--- a/app/Lfm.App.Core/Runs/RunVisualization.cs
+++ b/app/Lfm.App.Core/Runs/RunVisualization.cs
@@ -136,19 +136,4 @@ public static class RunVisualization
         }
         return TimeHorizon.Later;
     }
-
-    // Deterministic 0-359 hue from an instance id. Multiplier chosen to
-    // scatter adjacent ids (1, 2, 3…) into visually distinct hues.
-    public static int GetInstanceHue(int instanceId)
-    {
-        var hue = (instanceId * 47) % 360;
-        return hue < 0 ? hue + 360 : hue;
-    }
-
-    public static string GetInstanceGradient(int instanceId)
-    {
-        var hue = GetInstanceHue(instanceId);
-        return FormattableString.Invariant(
-            $"linear-gradient(135deg, oklch(0.55 0.12 {hue} / 0.18), oklch(0.35 0.10 {(hue + 40) % 360} / 0.10))");
-    }
 }

--- a/tests/Lfm.App.Core.Tests/Runs/RunVisualizationTests.cs
+++ b/tests/Lfm.App.Core.Tests/Runs/RunVisualizationTests.cs
@@ -132,26 +132,6 @@ public class RunVisualizationTests
         Assert.Equal(TimeHorizon.Unknown, RunVisualization.GetHorizon("not a date", now));
     }
 
-    [Fact]
-    public void GetInstanceHue_is_stable_and_in_range()
-    {
-        var a1 = RunVisualization.GetInstanceHue(1234);
-        var a2 = RunVisualization.GetInstanceHue(1234);
-        Assert.Equal(a1, a2);
-        Assert.InRange(a1, 0, 359);
-        Assert.NotEqual(
-            RunVisualization.GetInstanceHue(1),
-            RunVisualization.GetInstanceHue(2));
-    }
-
-    [Fact]
-    public void GetInstanceGradient_produces_css_gradient_string()
-    {
-        var gradient = RunVisualization.GetInstanceGradient(1234);
-        Assert.StartsWith("linear-gradient(", gradient);
-        Assert.Contains("oklch(", gradient);
-    }
-
     [Theory]
     [InlineData("MYTHIC:20", "mythic")]
     [InlineData("HEROIC:10", "heroic")]

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -302,12 +302,15 @@ public class RunsPagesTests : ComponentTestBase
         Assert.Equal(3, slots.Count);
         Assert.All(slots, s => Assert.Contains("run-list-item__roleslot--short", s.ClassName ?? ""));
 
-        // The difficulty + kind drive data-attributes on the item so CSS
-        // can stripe the left edge and tint the surface without inline
-        // style overrides leaking into tests.
+        // Difficulty + kind drive data-attributes on the item so CSS can
+        // stripe the left edge from `data-kind` without inline style
+        // overrides leaking into tests. `data-difficulty` is retained for
+        // E2E locators and future theming even though only `data-kind`
+        // currently feeds a CSS selector.
         var item = cut.Find("button.run-list-item");
         Assert.Equal("mythic", item.GetAttribute("data-difficulty"));
         Assert.Equal("raid", item.GetAttribute("data-kind"));
+        Assert.False(item.HasAttribute("style"));
     }
 
     // ── CreateRunPage ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Run list items previously layered two full-card background washes — a kind-tint (dungeon blue / raid green) and a per-instance hue gradient — which made cards with `kind=dungeon/raid` look visually wider than `kind=unknown` (LFR) ones in the mobile sidebar. Move kind to an inline-start side accent stripe (mirroring `CharacterRow`'s `--class-color`) and drop both washes. Every card now sits at the same visual width; the difficulty signal stays in the pill.

- `.run-list-item` background dropped; `border-inline-start` now keyed off `var(--kind-accent)`.
- `[data-kind="dungeon"]` → `#0070dd`, `[data-kind="raid"]` → `#1eff00` (brand-canonical, per issue #28).
- `[data-difficulty]` CSS rules removed (dead after this change); `data-difficulty` attribute retained for E2E locators and future theming.
- `--selected` falls back `border-inline-start-color` to `--accent-fill-rest` so unknown-kind items still show a visible 5 px selection stripe.
- Added `@media (forced-colors: active)` override so the stripe survives Windows High Contrast.
- Deleted dead helpers `RunVisualization.GetInstanceHue` + `GetInstanceGradient` (only consumers were the removed inline style). Their two unit tests are gone with them.
- `RunsPagesTests` now also asserts `Assert.False(item.HasAttribute("style"))` — locks the no-inline-style contract so a regression that re-introduces a per-card gradient fails CI.

No env / schema / config changes.

## Accessibility notes

- **SC 1.4.11 — raid-green stripe vs light-theme surface:** `#1eff00` is 1.26:1 against white. The WoW brand hex is immutable (memory rule / issue #28). Kind is redundantly signalled via the composition target counts rendered on every item (`D X/5` = dungeon, `D X/14+` = raid) and via the difficulty pill's size context, so the "information is also available through text" exemption in SC 1.4.11 applies. The stripe is decorative reinforcement, not the sole identifier. Documented in the CSS comment.
- **Forced-colors:** stripe switches to `Highlight` so kind stays visible when the UA forces a palette.
- **SC 1.4.3 text contrast:** no text colors changed.

## Test plan

- [x] `dotnet build lfm.sln -c Release` — 0/0
- [x] `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release` — 150/150
- [x] `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release` — 129/129 (−2 from deleted dead tests)
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` — 382/382
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error` — clean
- [x] `responsive-design` quick review — 1 block flagged on SC 1.4.11 for raid-green; addressed via documented exemption + forced-colors override (see Accessibility notes). 1 warn on forced-colors fallback — fixed in-PR.
- [x] `test-quality-audit` quick — both deleted tests classified as legitimate "SUT is gone" removals; the new `HasAttribute("style")` assertion classified as well-formed negative specification, not implementation coupling.
- [ ] Manual mobile browser check at ~375 px: all cards uniform width, dungeon stripe blue on left edge, raid stripe green on left edge, LFR item has no stripe
- [ ] Manual dark/light theme toggle: stripe hexes unchanged, selected state visible across kinds

## Screenshots

(Add before/after on mobile at ~375 px when reviewing.)
