### PR TITLE
Force run-list-item to fill sidebar width

### DIFF
--- a/app/Components/RunListItem.razor.css
+++ b/app/Components/RunListItem.razor.css
@@ -7,6 +7,14 @@
 .run-list-item {
     all: unset;
     box-sizing: border-box;
+    /* Explicit inline-size: <button> + `all: unset` + `display: grid` doesn't
+       inherit block-level stretch behaviour across browsers, so the element
+       would otherwise size to its content. With the full-card background
+       washes gone (PR #69) that variance became visible — short rows
+       (e.g. LFR with no shortages) rendered narrower than busier rows in
+       the same group. Force every item to fill the sidebar so the
+       border-inline-end divider and kind stripe align on every row. */
+    inline-size: 100%;
     display: grid;
     gap: 4px;
     padding-block: 10px;
@@ -16,8 +24,7 @@
     border-block-end: 1px solid var(--neutral-stroke-rest);
     /* Kind = inline-start stripe (dungeon / raid), mirroring the class-color
        side accent on CharacterRow. Difficulty is already signalled by the
-       DifficultyPill so it stays off the card surface, and no full-card
-       background wash runs so every item sits at the same visual width. */
+       DifficultyPill so it stays off the card surface. */
     border-inline-start: 3px solid var(--kind-accent, transparent);
 }
 


### PR DESCRIPTION
## Summary

`.run-list-item` is a `<button>` with `all: unset` + `display: grid`. Without an explicit inline-size, the element sizes to its content — longer rows (with shortage pills / longer text) stretch wider than shorter rows (LFR with no shortages) in the same group.

Before [#69](https://github.com/lfm-org/lfm/pull/69) the full-card background washes (`--kind-tint` + `--instance-bg`) painted the grid's box-model, which gave the illusion of uniform width even though the element box itself varied. Removing those washes exposed the underlying layout issue: the bottom divider (`border-block-end`) and the kind stripe (`border-inline-start`) no longer align across rows, and LFR-only cards visibly render narrower than dungeon/raid rows.

Fix: `inline-size: 100%` on `.run-list-item` so every row stretches to fill the sidebar regardless of content.

## Changes

- `app/Components/RunListItem.razor.css` — added `inline-size: 100%` to the base `.run-list-item` rule, with an in-code comment explaining why `<button>` + `all: unset` + `display: grid` doesn't stretch by default.

No env / schema / config changes.

## Test plan

- [x] `dotnet build lfm.sln -c Release` — 0/0
- [x] `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release` — 150/150
- [x] `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release` — 129/129
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error` — clean
- [ ] Manual mobile browser check at ~375 px: LFR row and raid rows share the same left and right edges; kind stripe and divider align across the list.

## Testing note

bUnit renders components but does not compute layout, so an automated regression guard for "every row has the same width" would need an E2E (Playwright) test, which is out of scope for a one-line CSS fix. The regression is caught by visual inspection and the `responsive-design` quick review, not by unit/component tests.
