### PR TITLE
Handle localized-object shape in reference-data reads

### DIFF
--- a/api/Repositories/InstancesRepository.cs
+++ b/api/Repositories/InstancesRepository.cs
@@ -3,10 +3,28 @@
 
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
 using Lfm.Api.Options;
+using Lfm.Api.Serialization;
 using Lfm.Contracts.Instances;
 
 namespace Lfm.Api.Repositories;
+
+/// <summary>
+/// Projection row for <see cref="InstancesRepository.ListAsync"/>.
+///
+/// We cannot project the Cosmos query directly into <see cref="InstanceDto"/>
+/// because legacy documents store <c>c.name</c> as Blizzard's localized-object
+/// shape (<c>{ "en_US": "…", … }</c>). <see cref="InstanceDto"/> lives in
+/// <c>Lfm.Contracts</c> and has no JSON converter, so Newtonsoft (via the
+/// Cosmos SDK) raised <c>JsonReaderException</c> on every /api/instances call —
+/// the same class of failure as the 2026-04-20 /api/guild incident.
+/// </summary>
+internal sealed record InstanceListRow(
+    string Id,
+    [property: JsonConverter(typeof(LocalizedStringConverter))] string Name,
+    string ModeKey,
+    string Expansion);
 
 public sealed class InstancesRepository(CosmosClient client, IOptions<CosmosOptions> cosmosOpts) : IInstancesRepository
 {
@@ -16,14 +34,17 @@ public sealed class InstancesRepository(CosmosClient client, IOptions<CosmosOpti
     public async Task<IReadOnlyList<InstanceDto>> ListAsync(CancellationToken ct)
     {
         // Each row is one (instanceId, modeKey) pair. The document id is "{instanceId}:{modeKey}".
-        // We project instanceId as 'id' so that InstanceDto.Id receives the instance id string.
+        // We project instanceId as 'id' so that the projection row's Id is the bare instance id.
         var query = new QueryDefinition("SELECT c.instanceId AS id, c.name, c.modeKey, c.expansion FROM c");
         var results = new List<InstanceDto>();
-        using var iterator = _container.GetItemQueryIterator<InstanceDto>(query);
+        using var iterator = _container.GetItemQueryIterator<InstanceListRow>(query);
         while (iterator.HasMoreResults)
         {
             var page = await iterator.ReadNextAsync(ct);
-            results.AddRange(page);
+            foreach (var row in page)
+            {
+                results.Add(new InstanceDto(row.Id, row.Name, row.ModeKey, row.Expansion));
+            }
         }
         return results;
     }

--- a/api/Repositories/SpecializationsRepository.cs
+++ b/api/Repositories/SpecializationsRepository.cs
@@ -3,10 +3,28 @@
 
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
 using Lfm.Api.Options;
+using Lfm.Api.Serialization;
 using Lfm.Contracts.Specializations;
 
 namespace Lfm.Api.Repositories;
+
+/// <summary>
+/// Projection row for <see cref="SpecializationsRepository.ListAsync"/>.
+///
+/// Mirrors <c>InstanceListRow</c>: we cannot project Cosmos directly into
+/// <see cref="SpecializationDto"/> because legacy documents store <c>c.name</c>
+/// as Blizzard's localized-object shape, and <see cref="SpecializationDto"/>
+/// has no converter. Same root cause as the 2026-04-20 /api/guild and
+/// /api/instances incidents.
+/// </summary>
+internal sealed record SpecializationListRow(
+    int Id,
+    [property: JsonConverter(typeof(LocalizedStringConverter))] string Name,
+    int ClassId,
+    string Role,
+    string? IconUrl);
 
 public sealed class SpecializationsRepository(CosmosClient client, IOptions<CosmosOptions> cosmosOpts) : ISpecializationsRepository
 {
@@ -15,15 +33,18 @@ public sealed class SpecializationsRepository(CosmosClient client, IOptions<Cosm
 
     public async Task<IReadOnlyList<SpecializationDto>> ListAsync(CancellationToken ct)
     {
-        // Project specId → id so that SpecializationDto.Id (int) receives the numeric
+        // Project specId → id so that the projection row's Id (int) receives the numeric
         // spec id rather than the Cosmos string document id.
         var query = new QueryDefinition("SELECT c.specId AS id, c.name, c.classId, c.role, c.iconUrl FROM c");
         var results = new List<SpecializationDto>();
-        using var iterator = _container.GetItemQueryIterator<SpecializationDto>(query);
+        using var iterator = _container.GetItemQueryIterator<SpecializationListRow>(query);
         while (iterator.HasMoreResults)
         {
             var page = await iterator.ReadNextAsync(ct);
-            results.AddRange(page);
+            foreach (var row in page)
+            {
+                results.Add(new SpecializationDto(row.Id, row.Name, row.ClassId, row.Role, row.IconUrl));
+            }
         }
         return results;
     }

--- a/tests/Lfm.Api.Tests/Serialization/LocalizedStringConverterTests.cs
+++ b/tests/Lfm.Api.Tests/Serialization/LocalizedStringConverterTests.cs
@@ -299,6 +299,48 @@ public class LocalizedStringConverterTests
     }
 
     [Fact]
+    public void InstanceListRow_deserializes_with_localized_name()
+    {
+        // Shape of the row produced by InstancesRepository.ListAsync's projection:
+        //   SELECT c.instanceId AS id, c.name, c.modeKey, c.expansion FROM c
+        // Legacy documents store c.name as the no-locale object; projecting
+        // directly into InstanceDto (no converter) crashed every /api/instances
+        // call with JsonReaderException — same root cause as the 2026-04-20
+        // /api/guild incident, retriggered when editing a run.
+        var json = """
+        {
+          "id": "67",
+          "name": { "en_US": "Icecrown Citadel", "de_DE": "Eiskronenzitadelle" },
+          "modeKey": "NORMAL:25",
+          "expansion": "WRATH_OF_THE_LICH_KING"
+        }
+        """;
+
+        var row = JsonConvert.DeserializeObject<InstanceListRow>(json, CosmosLikeSettings);
+
+        Assert.Equal("Icecrown Citadel", row!.Name);
+    }
+
+    [Fact]
+    public void InstanceListRow_deserializes_with_plain_string_name()
+    {
+        // Newly-written documents use the plain-string shape via
+        // LocalizedStringConverter.WriteJson — must keep working.
+        var json = """
+        {
+          "id": "67",
+          "name": "Icecrown Citadel",
+          "modeKey": "NORMAL:25",
+          "expansion": "WRATH_OF_THE_LICH_KING"
+        }
+        """;
+
+        var row = JsonConvert.DeserializeObject<InstanceListRow>(json, CosmosLikeSettings);
+
+        Assert.Equal("Icecrown Citadel", row!.Name);
+    }
+
+    [Fact]
     public void SpecializationDocument_deserializes_with_localized_name()
     {
         var json = """

--- a/tests/Lfm.Api.Tests/Serialization/LocalizedStringConverterTests.cs
+++ b/tests/Lfm.Api.Tests/Serialization/LocalizedStringConverterTests.cs
@@ -359,6 +359,47 @@ public class LocalizedStringConverterTests
         Assert.Equal("Elemental", doc!.Name);
     }
 
+    [Fact]
+    public void SpecializationListRow_deserializes_with_localized_name()
+    {
+        // Shape of the row produced by SpecializationsRepository.ListAsync's
+        // projection: SELECT c.specId AS id, c.name, c.classId, c.role, c.iconUrl FROM c.
+        // Same root cause as InstanceListRow / /api/guild: legacy documents
+        // store c.name as Blizzard's no-locale object, and SpecializationDto
+        // (in Lfm.Contracts, no converter) cannot accept that shape.
+        var json = """
+        {
+          "id": 262,
+          "name": { "en_US": "Elemental", "de_DE": "Elementar" },
+          "classId": 7,
+          "role": "DAMAGE",
+          "iconUrl": null
+        }
+        """;
+
+        var row = JsonConvert.DeserializeObject<SpecializationListRow>(json, CosmosLikeSettings);
+
+        Assert.Equal("Elemental", row!.Name);
+    }
+
+    [Fact]
+    public void SpecializationListRow_deserializes_with_plain_string_name()
+    {
+        var json = """
+        {
+          "id": 262,
+          "name": "Elemental",
+          "classId": 7,
+          "role": "DAMAGE",
+          "iconUrl": null
+        }
+        """;
+
+        var row = JsonConvert.DeserializeObject<SpecializationListRow>(json, CosmosLikeSettings);
+
+        Assert.Equal("Elemental", row!.Name);
+    }
+
     // Record used only by the converter unit tests above.
     private sealed record Holder(
         [property: JsonConverter(typeof(LocalizedStringConverter))] string? Name = null);


### PR DESCRIPTION
## Summary

- `/api/instances` has been returning 500 since before today; it surfaces in the UI when editing a run (the edit page fetches the instance list for its dropdown). Same root cause as the 2026-04-20 `/api/guild` incident: legacy Cosmos documents store Blizzard's localized-object shape (`{ "en_US": "…", "de_DE": "…", … }`) at `c.name`, and Newtonsoft (via the Cosmos SDK) throws `JsonReaderException` when deserialising into a string field that has no `LocalizedStringConverter`.
- Both reference-data repositories projected directly into a DTO in `shared/Lfm.Contracts/`, where the converter is unreachable. This PR introduces an internal projection row per repository (`InstanceListRow`, `SpecializationListRow`) that carries the converter on `Name`, and maps to the public DTO after the read.
- Full audit of every Cosmos read site in `api/Repositories/` confirms the other read paths (`RunsRepository`, `RaidersRepository`, `GuildRepository`) already project into `*Document` types whose localized fields all carry the converter. No remaining sites.

## Changes

- `api/Repositories/InstancesRepository.cs` — new internal `InstanceListRow`; `ListAsync` projects into it and maps to `InstanceDto`.
- `api/Repositories/SpecializationsRepository.cs` — same pattern with `SpecializationListRow` → `SpecializationDto`.
- `tests/Lfm.Api.Tests/Serialization/LocalizedStringConverterTests.cs` — four regression tests (localized-object + plain-string shape for each of the two new row types). Each localized-object test was runtime-verified to reproduce the exact prod `JsonReaderException` when the `[JsonConverter]` attribute is removed.

No schema changes. No env changes. No infra changes. No UI changes.

## Test plan

- [x] `dotnet build lfm.sln -c Release`
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` — 386 / 386 passing
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- [x] Verified both new regression tests fail (`Newtonsoft.Json.JsonReaderException: Error reading string...`) when the `[JsonConverter(typeof(LocalizedStringConverter))]` attribute is removed from the `Name` field on the new row type — same exception seen in prod.
- [ ] Deploy + hit `/api/instances` and `/api/specializations` in the affected environment; confirm 200 and non-empty body.
- [ ] Edit a run in the UI; confirm the instance dropdown populates.
