### PR TITLE
Speed up CI/CD deploys

### DIFF
--- a/.github/actions/setup-dotnet-cached/action.yml
+++ b/.github/actions/setup-dotnet-cached/action.yml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 LFM contributors
+
+name: 'Setup .NET with NuGet cache'
+description: 'Sets up .NET via global.json and restores the NuGet package cache. Optionally caches ~/.dotnet/tools.'
+
+inputs:
+  cache-tools:
+    description: 'Cache ~/.dotnet/tools keyed on .config/dotnet-tools.json'
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
+      with:
+        global-json-file: global.json
+
+    - name: Cache NuGet packages
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        path: ~/.nuget/packages
+        key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', 'global.json') }}
+        restore-keys: nuget-${{ runner.os }}-
+
+    - name: Cache dotnet tools
+      if: inputs.cache-tools == 'true'
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        path: ~/.dotnet/tools
+        key: dotnet-tools-${{ runner.os }}-${{ hashFiles('.config/dotnet-tools.json') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,29 +50,8 @@ jobs:
       - name: Build
         run: dotnet build lfm.sln -c Release --no-restore -p:TreatWarningsAsErrors=true
 
-      - name: Test API
-        run: >
-          dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj
-          -c Release --no-build
-          --logger "trx;LogFileName=api-tests.trx"
-          --logger "console;verbosity=normal"
-          --results-directory ./artifacts/test-results
-
-      - name: Test App
-        run: >
-          dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj
-          -c Release --no-build
-          --logger "trx;LogFileName=app-tests.trx"
-          --logger "console;verbosity=normal"
-          --results-directory ./artifacts/test-results
-
-      - name: Test App.Core
-        run: >
-          dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj
-          -c Release --no-build
-          --logger "trx;LogFileName=app-core-tests.trx"
-          --logger "console;verbosity=normal"
-          --results-directory ./artifacts/test-results
+      - name: Tests (parallel)
+        run: ./scripts/run-tests-parallel.sh ./artifacts/test-results
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,16 +30,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
-        with:
-          global-json-file: global.json
-
-      - name: Cache NuGet packages
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', 'global.json') }}
-          restore-keys: nuget-${{ runner.os }}-
+      - uses: ./.github/actions/setup-dotnet-cached
 
       - name: Restore
         run: dotnet restore lfm.sln

--- a/.github/workflows/dep-license-check.yml
+++ b/.github/workflows/dep-license-check.yml
@@ -31,15 +31,9 @@ jobs:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
+        uses: ./.github/actions/setup-dotnet-cached
         with:
-          global-json-file: global.json
-
-      - name: Cache dotnet tools
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: ~/.dotnet/tools
-          key: dotnet-tools-${{ runner.os }}-${{ hashFiles('.config/dotnet-tools.json') }}
+          cache-tools: 'true'
 
       - name: Restore tools
         run: dotnet tool restore

--- a/.github/workflows/dep-license-check.yml
+++ b/.github/workflows/dep-license-check.yml
@@ -24,6 +24,7 @@ permissions:
 jobs:
   dep-license-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/dep-license-check.yml
+++ b/.github/workflows/dep-license-check.yml
@@ -35,6 +35,12 @@ jobs:
         with:
           global-json-file: global.json
 
+      - name: Cache dotnet tools
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.dotnet/tools
+          key: dotnet-tools-${{ runner.os }}-${{ hashFiles('.config/dotnet-tools.json') }}
+
       - name: Restore tools
         run: dotnet tool restore
 

--- a/.github/workflows/deploy-app-build.yml
+++ b/.github/workflows/deploy-app-build.yml
@@ -29,16 +29,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
-        with:
-          global-json-file: global.json
-
-      - name: Cache NuGet packages
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', 'global.json') }}
-          restore-keys: nuget-${{ runner.os }}-
+      - uses: ./.github/actions/setup-dotnet-cached
 
       - name: Restore
         run: dotnet restore lfm.sln

--- a/.github/workflows/deploy-app-build.yml
+++ b/.github/workflows/deploy-app-build.yml
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 LFM contributors
+
+name: Deploy App - Build
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-app-build-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  NUGET_XMLDOC_MODE: skip
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
+        with:
+          global-json-file: global.json
+
+      - name: Cache NuGet packages
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', 'global.json') }}
+          restore-keys: nuget-${{ runner.os }}-
+
+      - name: Restore
+        run: dotnet restore lfm.sln
+
+      - name: Audit dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          dotnet list lfm.sln package --vulnerable --include-transitive --format json > audit.json
+          count=$(jq '[.. | objects | select(has("vulnerabilities")) | .vulnerabilities[]] | length' audit.json)
+          if [ "$count" -gt 0 ]; then
+            echo "FAIL: vulnerable packages must be resolved before deploy" >&2
+            jq '.' audit.json >&2
+            exit 1
+          fi
+
+      - name: Build
+        run: dotnet build lfm.sln -c Release --no-restore -p:TreatWarningsAsErrors=true
+
+      - name: Tests (parallel)
+        run: ./scripts/run-tests-parallel.sh ./artifacts/test-results
+
+      - name: Publish API
+        run: dotnet publish api/Lfm.Api.csproj -c Release -o ./publish/api --no-build
+
+      - name: Publish App
+        env:
+          PRIVACY_EMAIL: ${{ vars.PRIVACY_EMAIL }}
+          EXPIRES_SECURITY_TXT: ${{ vars.EXPIRES_SECURITY_TXT }}
+          FRONTEND_HOSTNAME: ${{ vars.FRONTEND_HOSTNAME }}
+          SECURITY_POLICY_URL: ${{ vars.SECURITY_POLICY_URL }}
+          API_HOSTNAME: ${{ vars.API_HOSTNAME }}
+          STORAGE_ACCOUNT_NAME: ${{ vars.STORAGE_ACCOUNT_NAME }}
+        run: dotnet publish app/Lfm.App.csproj -c Release -o ./publish/app --no-build
+
+      - name: Install brotli
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends brotli
+
+      - name: Check bundle size budget
+        run: ./scripts/check-bundle-size.sh ./publish/app/wwwroot 5
+
+      - name: Upload API publish artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: deploy-app-publish-api
+          path: ./publish/api
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload App publish artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: deploy-app-publish-app
+          path: ./publish/app
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -15,77 +15,26 @@ concurrency:
   group: deploy-app
   cancel-in-progress: false
 
-env:
-  DOTNET_NOLOGO: true
-  DOTNET_CLI_TELEMETRY_OPTOUT: true
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-  NUGET_XMLDOC_MODE: skip
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
-      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
+      - name: Download API publish artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
-          global-json-file: global.json
+          name: deploy-app-publish-api
+          path: ./publish/api
 
-      - name: Cache NuGet packages
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      - name: Download App publish artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
-          path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', 'global.json') }}
-          restore-keys: nuget-${{ runner.os }}-
-
-      - name: Restore
-        run: dotnet restore lfm.sln
-
-      - name: Audit dependencies
-        shell: bash
-        run: |
-          set -euo pipefail
-          dotnet list lfm.sln package --vulnerable --include-transitive --format json > audit.json
-          count=$(jq '[.. | objects | select(has("vulnerabilities")) | .vulnerabilities[]] | length' audit.json)
-          if [ "$count" -gt 0 ]; then
-            echo "FAIL: vulnerable packages must be resolved before deploy" >&2
-            jq '.' audit.json >&2
-            exit 1
-          fi
-
-      - name: Build
-        run: dotnet build lfm.sln -c Release --no-restore -p:TreatWarningsAsErrors=true
-
-      - name: Test API
-        run: dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release --no-build
-
-      - name: Test App
-        run: dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --no-build
-
-      - name: Test App.Core
-        run: dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release --no-build
-
-      - name: Publish API
-        run: dotnet publish api/Lfm.Api.csproj -c Release -o ./publish/api --no-build
-
-      - name: Publish App
-        env:
-          PRIVACY_EMAIL: ${{ vars.PRIVACY_EMAIL }}
-          EXPIRES_SECURITY_TXT: ${{ vars.EXPIRES_SECURITY_TXT }}
-          FRONTEND_HOSTNAME: ${{ vars.FRONTEND_HOSTNAME }}
-          SECURITY_POLICY_URL: ${{ vars.SECURITY_POLICY_URL }}
-          API_HOSTNAME: ${{ vars.API_HOSTNAME }}
-          STORAGE_ACCOUNT_NAME: ${{ vars.STORAGE_ACCOUNT_NAME }}
-        run: dotnet publish app/Lfm.App.csproj -c Release -o ./publish/app --no-build
-
-      - name: Install brotli
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends brotli
-
-      - name: Check bundle size budget
-        run: ./scripts/check-bundle-size.sh ./publish/app/wwwroot 5
+          name: deploy-app-publish-app
+          path: ./publish/app
 
       - uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -99,25 +99,11 @@ jobs:
           app-name: ${{ vars.FUNCTION_APP_NAME }}
           package: ./publish/api
 
-      - name: Verify API health
-        run: |
-          set -euo pipefail
-          url="https://${{ vars.API_HOSTNAME }}/api/health/ready"
-          for i in $(seq 1 12); do
-            status=$(curl -s -o /dev/null -w "%{http_code}" "$url")
-            if [ "$status" = "200" ]; then
-              echo "Health check passed (attempt $i)"
-              exit 0
-            fi
-            echo "Attempt $i: got $status, retrying in 10s..."
-            sleep 10
-          done
-          echo "Health check failed after 2 minutes" >&2
-          exit 1
-
       - name: Set production API base URL
+        env:
+          API_HOSTNAME: ${{ vars.API_HOSTNAME }}
         run: |
-          jq --arg url "https://${{ vars.API_HOSTNAME }}" '.ApiBaseUrl = $url' \
+          jq --arg url "https://${API_HOSTNAME}" '.ApiBaseUrl = $url' \
             ./publish/app/wwwroot/appsettings.json > tmp.json \
             && mv tmp.json ./publish/app/wwwroot/appsettings.json
           rm -f ./publish/app/wwwroot/appsettings.json.br \
@@ -130,3 +116,8 @@ jobs:
           app_location: ./publish/app/wwwroot
           skip_app_build: true
           action: upload
+
+      - name: Verify API health
+        env:
+          API_HOSTNAME: ${{ vars.API_HOSTNAME }}
+        run: ./scripts/wait-api-ready.sh "https://${API_HOSTNAME}/api/health/ready"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,6 +96,8 @@ jobs:
     secrets: inherit
 
   analyze-infra:
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.infra == 'true'
     uses: ./.github/workflows/analyze-infra.yml
     secrets: inherit
 
@@ -113,7 +115,7 @@ jobs:
     if: |
       always() &&
       needs.secrets-scan.result == 'success' &&
-      needs.analyze-infra.result == 'success' &&
+      (needs.analyze-infra.result == 'success' || needs.analyze-infra.result == 'skipped') &&
       needs.detect-changes.outputs.app == 'true' &&
       (needs.deploy-infra.result == 'success' || needs.deploy-infra.result == 'skipped')
     uses: ./.github/workflows/deploy-app.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,6 +101,14 @@ jobs:
     uses: ./.github/workflows/analyze-infra.yml
     secrets: inherit
 
+  build-app:
+    needs: [detect-changes, secrets-scan]
+    if: |
+      needs.secrets-scan.result == 'success' &&
+      needs.detect-changes.outputs.app == 'true'
+    uses: ./.github/workflows/deploy-app-build.yml
+    secrets: inherit
+
   deploy-infra:
     needs: [detect-changes, secrets-scan, analyze-infra]
     if: |
@@ -111,11 +119,12 @@ jobs:
     secrets: inherit
 
   deploy-app:
-    needs: [detect-changes, secrets-scan, analyze-infra, deploy-infra]
+    needs: [detect-changes, secrets-scan, analyze-infra, build-app, deploy-infra]
     if: |
       always() &&
       needs.secrets-scan.result == 'success' &&
       (needs.analyze-infra.result == 'success' || needs.analyze-infra.result == 'skipped') &&
+      needs.build-app.result == 'success' &&
       needs.detect-changes.outputs.app == 'true' &&
       (needs.deploy-infra.result == 'success' || needs.deploy-infra.result == 'skipped')
     uses: ./.github/workflows/deploy-app.yml

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,16 +33,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
-        with:
-          global-json-file: global.json
-
-      - name: Cache NuGet packages
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', 'global.json') }}
-          restore-keys: nuget-${{ runner.os }}-
+      - uses: ./.github/actions/setup-dotnet-cached
 
       - name: Install Azure Functions Core Tools
         run: |

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -22,15 +22,27 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Cache gitleaks binary
+        id: gitleaks-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: /opt/gitleaks/gitleaks
+          key: gitleaks-${{ runner.os }}-8.30.1
+
       - name: Install gitleaks
+        if: steps.gitleaks-cache.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
           V=8.30.1
           curl -sSfLO "https://github.com/gitleaks/gitleaks/releases/download/v${V}/gitleaks_${V}_linux_x64.tar.gz"
           curl -sSfLO "https://github.com/gitleaks/gitleaks/releases/download/v${V}/gitleaks_${V}_checksums.txt"
           grep " gitleaks_${V}_linux_x64.tar.gz$" "gitleaks_${V}_checksums.txt" | sha256sum -c -
-          sudo tar xz -C /usr/local/bin gitleaks -f "gitleaks_${V}_linux_x64.tar.gz"
+          sudo mkdir -p /opt/gitleaks
+          sudo tar xz -C /opt/gitleaks gitleaks -f "gitleaks_${V}_linux_x64.tar.gz"
           rm -f "gitleaks_${V}_linux_x64.tar.gz" "gitleaks_${V}_checksums.txt"
+
+      - name: Add gitleaks to PATH
+        run: echo "/opt/gitleaks" >> "$GITHUB_PATH"
 
       - name: Run gitleaks
         run: gitleaks detect --source . --verbose --redact

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -16,6 +16,7 @@ jobs:
   gitleaks:
     name: Gitleaks
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/stryker-nightly.yml
+++ b/.github/workflows/stryker-nightly.yml
@@ -30,22 +30,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
+      - uses: ./.github/actions/setup-dotnet-cached
         with:
-          global-json-file: global.json
-
-      - name: Cache NuGet packages
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', 'global.json') }}
-          restore-keys: nuget-${{ runner.os }}-
-
-      - name: Cache dotnet tools
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: ~/.dotnet/tools
-          key: dotnet-tools-${{ runner.os }}-${{ hashFiles('.config/dotnet-tools.json') }}
+          cache-tools: 'true'
 
       - name: Restore tools
         run: dotnet tool restore

--- a/.github/workflows/stryker-nightly.yml
+++ b/.github/workflows/stryker-nightly.yml
@@ -41,6 +41,12 @@ jobs:
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', 'global.json') }}
           restore-keys: nuget-${{ runner.os }}-
 
+      - name: Cache dotnet tools
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.dotnet/tools
+          key: dotnet-tools-${{ runner.os }}-${{ hashFiles('.config/dotnet-tools.json') }}
+
       - name: Restore tools
         run: dotnet tool restore
 

--- a/scripts/run-tests-parallel.sh
+++ b/scripts/run-tests-parallel.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 LFM contributors
+#
+# Runs the three .NET test projects concurrently, captures each log, and
+# returns non-zero if any fails. Designed for a single runner with shared
+# build artifacts (uses --no-build), so no extra restore/build cost.
+#
+# Usage: scripts/run-tests-parallel.sh <results-dir>
+
+set -uo pipefail
+
+RESULTS_DIR="${1:-./artifacts/test-results}"
+mkdir -p "$RESULTS_DIR"
+
+run_test() {
+  local project="$1"
+  local name="$2"
+  dotnet test "$project" -c Release --no-build \
+    --logger "trx;LogFileName=${name}.trx" \
+    --logger "console;verbosity=normal" \
+    --results-directory "$RESULTS_DIR" \
+    > "$RESULTS_DIR/${name}.log" 2>&1
+}
+
+run_test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj api-tests &
+pid_api=$!
+run_test tests/Lfm.App.Tests/Lfm.App.Tests.csproj app-tests &
+pid_app=$!
+run_test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj app-core-tests &
+pid_core=$!
+
+fail=0
+wait "$pid_api" || fail=$?
+wait "$pid_app" || fail=$?
+wait "$pid_core" || fail=$?
+
+print_group() {
+  local title="$1"
+  local file="$2"
+  echo "::group::$title"
+  [ -f "$file" ] && cat "$file"
+  echo "::endgroup::"
+}
+
+print_group "API test output"       "$RESULTS_DIR/api-tests.log"
+print_group "App test output"       "$RESULTS_DIR/app-tests.log"
+print_group "App.Core test output"  "$RESULTS_DIR/app-core-tests.log"
+
+exit "$fail"

--- a/scripts/wait-api-ready.sh
+++ b/scripts/wait-api-ready.sh
@@ -14,7 +14,8 @@ attempts="${2:-12}"
 sleep_seconds="${3:-10}"
 
 for i in $(seq 1 "$attempts"); do
-  status=$(curl -s -o /dev/null -w "%{http_code}" "$url" || echo "000")
+  status=$(curl -s -o /dev/null --max-time 10 -w "%{http_code}" "$url" || true)
+  status="${status:-000}"
   if [ "$status" = "200" ]; then
     echo "Health check passed (attempt $i)"
     exit 0

--- a/scripts/wait-api-ready.sh
+++ b/scripts/wait-api-ready.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 LFM contributors
+#
+# Polls a health-check URL until it returns HTTP 200, up to a 120-second
+# ceiling. Used after Azure Functions deploy to confirm the API is warm.
+#
+# Usage: scripts/wait-api-ready.sh <url> [attempts] [sleep-seconds]
+
+set -euo pipefail
+
+url="${1:?url required}"
+attempts="${2:-12}"
+sleep_seconds="${3:-10}"
+
+for i in $(seq 1 "$attempts"); do
+  status=$(curl -s -o /dev/null -w "%{http_code}" "$url" || echo "000")
+  if [ "$status" = "200" ]; then
+    echo "Health check passed (attempt $i)"
+    exit 0
+  fi
+  echo "Attempt $i/$attempts: got $status, retrying in ${sleep_seconds}s..."
+  sleep "$sleep_seconds"
+done
+
+echo "Health check failed after $((attempts * sleep_seconds))s" >&2
+exit 1


### PR DESCRIPTION
## Summary

- **Split `deploy-app` into build + deploy jobs.** `build-app` now runs in parallel with `deploy-infra` instead of after it. On mixed pushes (infra + app) this removes ~6–8 min of serialized build/test/publish from the critical path. Build uploads `deploy-app-publish-api` / `deploy-app-publish-app` artifacts; `deploy-app` downloads them.
- **Gate `analyze-infra` on infra-only changes.** App-only deploys no longer pay the ~1–2 min PSRule cost. Downstream `deploy-app` accepts `analyze-infra.result == 'skipped'` in addition to `success`.
- **Reorder SWA deploy before API health check.** The 1–2 min SWA upload now overlaps with the Azure Functions cold-start, so the terminal health check usually exits on the first attempt. Polling loop extracted to `scripts/wait-api-ready.sh` (keeps the 120 s ceiling).
- **Parallelize the three `dotnet test` projects** in CI and the new `build-app` job via `scripts/run-tests-parallel.sh`. Shared `bin/obj`, no extra checkout/restore cost. ~1–2 min saved.
- **Cache gitleaks binary** by version in `secrets-scan.yml`; checksum verification only runs on cache miss. ~30 s saved per run.
- **Cache `~/.dotnet/tools`** in `stryker-nightly.yml` and `dep-license-check.yml`, keyed on `.config/dotnet-tools.json`.
- **Composite action `.github/actions/setup-dotnet-cached`** consolidates `actions/setup-dotnet` + NuGet cache (+ optional tools cache) across ci, e2e, stryker-nightly, dep-license-check, and deploy-app-build.
- **Add `timeout-minutes: 10`** to `secrets-scan` and `dep-license-check` jobs (`gha.HC-13` fix from the devsecops audit).

## Test plan

- [ ] CI run on this branch: confirm parallel test step passes for all three projects and total verify time drops vs a recent main baseline.
- [ ] Merge + observe first deploy on main: check the run graph shows `build-app` running concurrently with `deploy-infra` (mixed push) or `analyze-infra` skipped (app-only push).
- [ ] Confirm first HTTP request to `https://${FRONTEND_HOSTNAME}` after the reordered SWA + health step does not 5xx — the terminal health assertion still enforces the 120 s ceiling.
- [ ] Next secrets-scan run: first run populates the gitleaks cache; second run should skip the install step (look for "Install gitleaks" marked skipped).
- [ ] Next stryker/license run: same for `~/.dotnet/tools`.
- [ ] No env/schema changes. No UI changes.
