### PR TITLE
Fix API 404s: carry .azurefunctions via explicit tar

### DIFF
--- a/.github/workflows/deploy-app-build.yml
+++ b/.github/workflows/deploy-app-build.yml
@@ -71,6 +71,19 @@ jobs:
       - name: Check bundle size budget
         run: ./scripts/check-bundle-size.sh ./publish/app/wwwroot 5
 
+      # dotnet publish emits `.azurefunctions/` (FunctionMetadataLoader + worker
+      # extensions). upload-artifact defaults `include-hidden-files: false` on
+      # purpose — setting it to true would widen the artifact to any hidden
+      # path the build happens to produce (`.git/config`, `.env`, `.npmrc` …).
+      # Tar exactly the one hidden directory we need into a normal-named file
+      # so the artifact stays hidden-free while still carrying the Functions
+      # runtime metadata. Reversed in deploy-app.yml.
+      - name: Archive .azurefunctions metadata
+        run: |
+          set -euo pipefail
+          tar -cf ./publish/api/azurefunctions.tar -C ./publish/api .azurefunctions
+          rm -rf ./publish/api/.azurefunctions
+
       - name: Upload API publish artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -30,6 +30,14 @@ jobs:
           name: deploy-app-publish-api
           path: ./publish/api
 
+      # Reverses deploy-app-build.yml's `Archive .azurefunctions metadata`
+      # step. See that step for the why.
+      - name: Restore .azurefunctions metadata
+        run: |
+          set -euo pipefail
+          tar -xf ./publish/api/azurefunctions.tar -C ./publish/api
+          rm ./publish/api/azurefunctions.tar
+
       - name: Download App publish artifact
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:


### PR DESCRIPTION
## Summary

- Hotfix for #72. `actions/upload-artifact@v4+` defaults `include-hidden-files: false`, so splitting `deploy-app` into build/deploy jobs silently stripped the `.azurefunctions/` directory out of the API publish artifact. Without `FunctionMetadataLoader.dll` + the extension-bundle metadata, the Functions host starts but registers zero routes, so every `/api/*` call 404s — including `wait-api-ready.sh` hitting `/api/health/ready`.
- **Approach:** explicitly tar just the `.azurefunctions/` directory into a normal-named `azurefunctions.tar` in the build job, upload with `include-hidden-files` left at the safe default, and untar on the deploy side. This keeps the artifact hidden-free while still carrying the Functions runtime metadata.
- Rejected alternative: `include-hidden-files: true` on the upload. Works, but widens the artifact to any hidden path `dotnet publish` might emit in the future (`.git/config`, `.env`, `.npmrc`) — a known upload-artifact footgun that `include-hidden-files: false` was specifically chosen to block.
- Verified locally: `tar -cf azurefunctions.tar .azurefunctions` + `tar -xf` preserves the directory structure and file modes for all six entries (`FunctionMetadataLoader.dll`, `function.deps.json`, worker extensions, Host.Storage DLLs).

## Test plan

- [ ] Merge and confirm the next deploy passes `Verify API health` without 404s.
- [ ] Confirm `/api/health/ready` and `/api/guild` respond 200 post-deploy.
- [ ] Confirm the uploaded artifact on the run's artifact page contains `azurefunctions.tar` (a normal file) and no hidden paths.
- [ ] No Bicep / Cosmos / DNS changes; this is a build-artifact packaging fix only.
