### PR TITLE
Add BlobReferenceClient for wow container reads

### DIFF
--- a/api/Options/StorageOptions.cs
+++ b/api/Options/StorageOptions.cs
@@ -12,4 +12,20 @@ public sealed class StorageOptions
     // Required in production (Flex Consumption has ephemeral local storage).
     // When null/empty, Program.cs falls back to filesystem persistence (local dev / E2E).
     public string? DataProtectionBlobUri { get; init; }
+
+    // Service-level blob endpoint, e.g. https://<account>.blob.core.windows.net
+    // or http://azurite:10000/devstoreaccount1 for Azurite in E2E.
+    // Consumed by BlobReferenceClient for reading static reference data under the
+    // wow container. When null/empty, BlobReferenceClient is not registered and
+    // reference endpoints return 500 — intended for local dev without Azurite.
+    public string? BlobServiceUri { get; init; }
+
+    // Connection string for Azurite (key-based auth). Prefer BlobServiceUri +
+    // DefaultAzureCredential in production; this field exists for E2E where
+    // Azurite only supports shared-key auth.
+    public string? BlobConnectionString { get; init; }
+
+    // Name of the container holding Blizzard reference data under reference/{kind}/.
+    // Defaults to "wow" to match lfmstore/wow in infra/modules/storage.bicep.
+    public string WowContainerName { get; init; } = "wow";
 }

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Azure.Cosmos;
 using Azure.Identity;
+using Azure.Storage.Blobs;
 using Lfm.Api.Auth;
 using Lfm.Api.Options;
 using Microsoft.AspNetCore.Builder;
@@ -102,6 +103,27 @@ builder.Services.AddSingleton<CosmosClient>(sp =>
         ? new CosmosClient(opts.Endpoint, new DefaultAzureCredential(), clientOptions)
         : new CosmosClient(opts.Endpoint, opts.AuthKey, clientOptions);
 });
+
+// Static Blizzard reference data lives in blob — see docs/storage-architecture.md.
+// BlobContainerClient binds to the "wow" container at startup; auth picks the
+// connection string first (Azurite in E2E) and falls back to managed identity.
+builder.Services.AddSingleton<BlobContainerClient>(sp =>
+{
+    var opts = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<StorageOptions>>().Value;
+    if (!string.IsNullOrEmpty(opts.BlobConnectionString))
+    {
+        var service = new BlobServiceClient(opts.BlobConnectionString);
+        return service.GetBlobContainerClient(opts.WowContainerName);
+    }
+    if (!string.IsNullOrEmpty(opts.BlobServiceUri))
+    {
+        var service = new BlobServiceClient(new Uri(opts.BlobServiceUri), new DefaultAzureCredential());
+        return service.GetBlobContainerClient(opts.WowContainerName);
+    }
+    throw new InvalidOperationException(
+        "Storage:BlobServiceUri or Storage:BlobConnectionString must be configured for reference-data reads.");
+});
+builder.Services.AddSingleton<Lfm.Api.Services.IBlobReferenceClient, Lfm.Api.Services.BlobReferenceClient>();
 
 builder.Services.AddScoped<Lfm.Api.Repositories.IInstancesRepository, Lfm.Api.Repositories.InstancesRepository>();
 builder.Services.AddScoped<Lfm.Api.Repositories.ISpecializationsRepository, Lfm.Api.Repositories.SpecializationsRepository>();

--- a/api/Services/BlobReferenceClient.cs
+++ b/api/Services/BlobReferenceClient.cs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Runtime.CompilerServices;
+using Azure;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Newtonsoft.Json;
+
+namespace Lfm.Api.Services;
+
+/// <inheritdoc />
+public sealed class BlobReferenceClient(BlobContainerClient container) : IBlobReferenceClient
+{
+    private static readonly JsonSerializerSettings JsonSettings = new()
+    {
+        // Legacy TS-ingested blobs use camelCase at the top level
+        // (e.g. "modeKey"). Matching is case-insensitive by default in Newtonsoft,
+        // but Blizzard fields use snake_case ("playable_class"). The records we
+        // deserialize into carry explicit [JsonProperty] attributes where needed.
+        NullValueHandling = NullValueHandling.Ignore,
+        MissingMemberHandling = MissingMemberHandling.Ignore,
+    };
+
+    public async Task<T?> GetAsync<T>(string blobName, CancellationToken ct) where T : class
+    {
+        var blob = container.GetBlobClient(blobName);
+        try
+        {
+            var response = await blob.DownloadContentAsync(ct);
+            var json = response.Value.Content.ToString();
+            return JsonConvert.DeserializeObject<T>(json, JsonSettings);
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            return null;
+        }
+    }
+
+    public async IAsyncEnumerable<T> ListAsync<T>(
+        string prefix,
+        [EnumeratorCancellation] CancellationToken ct) where T : class
+    {
+        await foreach (var blob in container.GetBlobsAsync(BlobTraits.None, BlobStates.None, prefix, ct))
+        {
+            if (IsManifestBlob(blob.Name)) continue;
+
+            var value = await GetAsync<T>(blob.Name, ct);
+            if (value is not null)
+                yield return value;
+        }
+    }
+
+    private static bool IsManifestBlob(string blobName)
+        => blobName.EndsWith("/index.json", StringComparison.Ordinal)
+        || blobName.EndsWith("/meta.json", StringComparison.Ordinal);
+}

--- a/api/Services/IBlobReferenceClient.cs
+++ b/api/Services/IBlobReferenceClient.cs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+namespace Lfm.Api.Services;
+
+/// <summary>
+/// Reads JSON blobs from the static Blizzard reference container
+/// (<c>lfmstore/wow/</c> in production, Azurite locally).
+///
+/// See <c>docs/storage-architecture.md</c> for the store split — static Blizzard
+/// reference data lives here; dynamic per-user/guild/run data lives in Cosmos.
+/// </summary>
+public interface IBlobReferenceClient
+{
+    /// <summary>
+    /// Reads a single JSON blob by name and deserializes it to <typeparamref name="T"/>
+    /// using Newtonsoft so that <see cref="Lfm.Api.Serialization.LocalizedStringConverter"/>
+    /// attributes on <typeparamref name="T"/>'s properties are honored.
+    /// Returns null when the blob does not exist (the reader treats 404 as empty).
+    /// </summary>
+    Task<T?> GetAsync<T>(string blobName, CancellationToken ct) where T : class;
+
+    /// <summary>
+    /// Enumerates every blob under <paramref name="prefix"/>, deserializing each one,
+    /// skipping manifest-shaped blobs (<c>index.json</c>, <c>meta.json</c>) so callers
+    /// receive only per-id detail documents.
+    /// </summary>
+    IAsyncEnumerable<T> ListAsync<T>(string prefix, CancellationToken ct) where T : class;
+}


### PR DESCRIPTION
## Summary

Foundation for moving `/api/instances` and `/api/reference/specializations` off the (never-provisioned) Cosmos containers and onto blob reads from `lfmstore/wow/reference/`. Follows the rule established in `docs/storage-architecture.md`.

- Adds `Lfm.Api.Services.IBlobReferenceClient` + implementation that reads JSON blobs from a `BlobContainerClient`, deserializing with Newtonsoft so `LocalizedStringConverter` attributes are honored. `GetAsync<T>` returns null on 404; `ListAsync<T>(prefix)` enumerates a prefix and skips manifest-shaped blobs (`index.json`, `meta.json`).
- Extends `Lfm.Api.Options.StorageOptions` with `BlobServiceUri`, `BlobConnectionString`, and `WowContainerName` (default `wow`). The connection-string path exists for Azurite in E2E; production uses the URI + `DefaultAzureCredential`.
- Wires `BlobContainerClient` + `IBlobReferenceClient` into DI in `api/Program.cs`.

Runtime-neutral on its own — no handler calls these yet. The instances/specs read repositories flip to blob in the next PRs.

## Env / schema changes

New optional config keys under the `Storage` section:
- `Storage__BlobServiceUri` — e.g. `https://lfmstore.blob.core.windows.net` (prod).
- `Storage__BlobConnectionString` — Azurite connection string for E2E; leave unset in prod.
- `Storage__WowContainerName` — defaults to `wow`.

Production already has the required RBAC: the Function App managed identity has `Storage Blob Data Owner` on `lfmstore`, verified via `az role assignment list`.

## Test plan

- [ ] CI green: `dotnet build lfm.sln -c Release`, `dotnet test tests/Lfm.Api.Tests`, format check.
- [ ] Deploy smoke: `/api/health` still 200 (new code is registered but not called on any existing route).
- [ ] Follow-up PR rewires `InstancesRepository.ListAsync` to use this client; that's when `/api/instances` stops 500ing.
