### PR TITLE
Move instances read to blob with portrait URL

### DIFF
--- a/api/Repositories/IInstancesRepository.cs
+++ b/api/Repositories/IInstancesRepository.cs
@@ -1,37 +1,23 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
-using Newtonsoft.Json;
-using Lfm.Api.Serialization;
 using Lfm.Contracts.Instances;
 
 namespace Lfm.Api.Repositories;
 
 /// <summary>
-/// Cosmos document stored in the "instances" container.
-/// Each document represents one (instance, mode) pair.
-/// Partition key: /id  (set to document id = "{instanceId}:{modeKey}").
+/// Reads the static Blizzard journal-instance reference data set.
 ///
-/// instanceId is stored as a string so that SELECT c.instanceId AS id can be
-/// projected directly into InstanceDto.Id (string) by ListAsync.
+/// Source: blob container <c>lfmstore/wow/reference/journal-instance/</c> — see
+/// <c>docs/storage-architecture.md</c>. The ingester that populates this is
+/// <c>WowUpdateFunction</c> / <c>WowUpdateTimerFunction</c> (Phase 3).
 /// </summary>
-public sealed record InstanceDocument(
-    /// <summary>Cosmos document id and partition key: "{instanceId}:{modeKey}".</summary>
-    string Id,
-    /// <summary>Blizzard instance id as string (e.g. "67"). Projected as 'id' by ListAsync.</summary>
-    string InstanceId,
-    [property: JsonConverter(typeof(LocalizedStringConverter))] string Name,
-    /// <summary>Mode key, e.g. "NORMAL:25" or "HEROIC:5".</summary>
-    string ModeKey,
-    string Expansion);
-
 public interface IInstancesRepository
 {
-    Task<IReadOnlyList<InstanceDto>> ListAsync(CancellationToken ct);
-
     /// <summary>
-    /// Upserts a batch of instance documents (one per mode).
-    /// Existing documents with the same id are replaced.
+    /// Returns one <see cref="InstanceDto"/> per (instance, mode) pair across every
+    /// instance present in blob. An instance with no modes yields a single row with
+    /// <c>ModeKey = "UNKNOWN:0"</c> so the frontend dropdown always has a selection.
     /// </summary>
-    Task UpsertBatchAsync(IEnumerable<InstanceDocument> documents, CancellationToken ct);
+    Task<IReadOnlyList<InstanceDto>> ListAsync(CancellationToken ct);
 }

--- a/api/Repositories/InstancesRepository.cs
+++ b/api/Repositories/InstancesRepository.cs
@@ -1,59 +1,147 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
-using Microsoft.Azure.Cosmos;
-using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
-using Lfm.Api.Options;
 using Lfm.Api.Serialization;
+using Lfm.Api.Services;
 using Lfm.Contracts.Instances;
+using Newtonsoft.Json;
 
 namespace Lfm.Api.Repositories;
 
 /// <summary>
-/// Projection row for <see cref="InstancesRepository.ListAsync"/>.
-///
-/// We cannot project the Cosmos query directly into <see cref="InstanceDto"/>
-/// because legacy documents store <c>c.name</c> as Blizzard's localized-object
-/// shape (<c>{ "en_US": "…", … }</c>). <see cref="InstanceDto"/> lives in
-/// <c>Lfm.Contracts</c> and has no JSON converter, so Newtonsoft (via the
-/// Cosmos SDK) raised <c>JsonReaderException</c> on every /api/instances call —
-/// the same class of failure as the 2026-04-20 /api/guild incident.
+/// Manifest entry emitted by the ingester (Phase 3) at
+/// <c>reference/journal-instance/index.json</c>. When present, the reader returns
+/// this directly — one blob GET for the whole list endpoint. When absent (first
+/// deploy, pre-ingest), the reader falls back to enumerating per-id detail blobs.
 /// </summary>
-internal sealed record InstanceListRow(
-    string Id,
-    [property: JsonConverter(typeof(LocalizedStringConverter))] string Name,
-    string ModeKey,
-    string Expansion);
+internal sealed record InstanceIndexEntry(
+    int Id,
+    string Name,
+    IReadOnlyList<InstanceIndexMode>? Modes,
+    string? Expansion,
+    string? PortraitUrl);
 
-public sealed class InstancesRepository(CosmosClient client, IOptions<CosmosOptions> cosmosOpts) : IInstancesRepository
+internal sealed record InstanceIndexMode(string ModeKey);
+
+/// <summary>
+/// Verbatim Blizzard journal-instance detail as stored at
+/// <c>reference/journal-instance/{id}.json</c>. Legacy TS-ingested blobs
+/// carry localized-object names; the converter handles both shapes.
+/// </summary>
+internal sealed record JournalInstanceBlob(
+    int Id,
+    [property: JsonConverter(typeof(LocalizedStringConverter))] string Name,
+    JournalInstanceExpansionBlob? Expansion = null,
+    IReadOnlyList<JournalInstanceModeBlob>? Modes = null);
+
+internal sealed record JournalInstanceExpansionBlob(
+    [property: JsonConverter(typeof(LocalizedStringConverter))] string? Name = null);
+
+internal sealed record JournalInstanceModeBlob(
+    JournalModeRefBlob? Mode,
+    int? Players);
+
+internal sealed record JournalModeRefBlob(string Type);
+
+internal sealed record MediaAssetBlob(string Key, string Value);
+
+internal sealed record MediaAssetsBlob(IReadOnlyList<MediaAssetBlob>? Assets = null);
+
+public sealed class InstancesRepository(IBlobReferenceClient blobs) : IInstancesRepository
 {
-    private const string ContainerName = "instances";
-    private readonly Container _container = client.GetContainer(cosmosOpts.Value.DatabaseName, ContainerName);
+    private const string Prefix = "reference/journal-instance/";
+    private const string MediaPrefix = "reference/journal-instance-media/";
+    private const string ManifestName = "reference/journal-instance/index.json";
 
     public async Task<IReadOnlyList<InstanceDto>> ListAsync(CancellationToken ct)
     {
-        // Each row is one (instanceId, modeKey) pair. The document id is "{instanceId}:{modeKey}".
-        // We project instanceId as 'id' so that the projection row's Id is the bare instance id.
-        var query = new QueryDefinition("SELECT c.instanceId AS id, c.name, c.modeKey, c.expansion FROM c");
-        var results = new List<InstanceDto>();
-        using var iterator = _container.GetItemQueryIterator<InstanceListRow>(query);
-        while (iterator.HasMoreResults)
+        // Fast path: single GET of the manifest produced by the ingester (Phase 3).
+        var manifest = await blobs.GetAsync<List<InstanceIndexEntry>>(ManifestName, ct);
+        if (manifest is not null)
+            return ExpandManifest(manifest);
+
+        // Fallback: enumerate per-id detail blobs + tolerantly fetch media for portraits.
+        // Runs on the first deploy before the ingester has emitted a manifest.
+        var rows = new List<InstanceDto>();
+        await foreach (var detail in blobs.ListAsync<JournalInstanceBlob>(Prefix, ct))
         {
-            var page = await iterator.ReadNextAsync(ct);
-            foreach (var row in page)
+            var portraitUrl = await ResolvePortraitUrlAsync(detail.Id, ct);
+            var expansion = detail.Expansion?.Name ?? "";
+            var instanceId = detail.Id.ToString();
+
+            if (detail.Modes is null || detail.Modes.Count == 0)
             {
-                results.Add(new InstanceDto(row.Id, row.Name, row.ModeKey, row.Expansion));
+                rows.Add(new InstanceDto(
+                    Id: $"{instanceId}:UNKNOWN:0",
+                    Name: detail.Name,
+                    ModeKey: "UNKNOWN:0",
+                    Expansion: expansion,
+                    PortraitUrl: portraitUrl));
+                continue;
+            }
+
+            foreach (var mode in detail.Modes)
+            {
+                var modeType = mode.Mode?.Type ?? "UNKNOWN";
+                var modeKey = $"{modeType}:{mode.Players ?? 0}";
+                rows.Add(new InstanceDto(
+                    Id: $"{instanceId}:{modeKey}",
+                    Name: detail.Name,
+                    ModeKey: modeKey,
+                    Expansion: expansion,
+                    PortraitUrl: portraitUrl));
             }
         }
-        return results;
+        return rows;
     }
 
-    public async Task UpsertBatchAsync(IEnumerable<InstanceDocument> documents, CancellationToken ct)
+    private async Task<string?> ResolvePortraitUrlAsync(int instanceId, CancellationToken ct)
     {
-        foreach (var doc in documents)
+        var media = await blobs.GetAsync<MediaAssetsBlob>($"{MediaPrefix}{instanceId}.json", ct);
+        if (media?.Assets is null) return null;
+
+        // Blizzard journal-instance media returns assets keyed "tile" (newer) or
+        // "image" (legacy). Prefer tile; fall back to image.
+        foreach (var key in new[] { "tile", "image" })
         {
-            await _container.UpsertItemAsync(doc, new Microsoft.Azure.Cosmos.PartitionKey(doc.Id), cancellationToken: ct);
+            foreach (var asset in media.Assets)
+            {
+                if (asset.Key == key && !string.IsNullOrEmpty(asset.Value))
+                    return asset.Value;
+            }
         }
+        return null;
+    }
+
+    private static IReadOnlyList<InstanceDto> ExpandManifest(List<InstanceIndexEntry> manifest)
+    {
+        var rows = new List<InstanceDto>();
+        foreach (var entry in manifest)
+        {
+            var expansion = entry.Expansion ?? "";
+            var instanceId = entry.Id.ToString();
+
+            if (entry.Modes is null || entry.Modes.Count == 0)
+            {
+                rows.Add(new InstanceDto(
+                    Id: $"{instanceId}:UNKNOWN:0",
+                    Name: entry.Name,
+                    ModeKey: "UNKNOWN:0",
+                    Expansion: expansion,
+                    PortraitUrl: entry.PortraitUrl));
+                continue;
+            }
+
+            foreach (var mode in entry.Modes)
+            {
+                rows.Add(new InstanceDto(
+                    Id: $"{instanceId}:{mode.ModeKey}",
+                    Name: entry.Name,
+                    ModeKey: mode.ModeKey,
+                    Expansion: expansion,
+                    PortraitUrl: entry.PortraitUrl));
+            }
+        }
+        return rows;
     }
 }

--- a/api/Services/ReferenceSync.cs
+++ b/api/Services/ReferenceSync.cs
@@ -21,7 +21,6 @@ namespace Lfm.Api.Services;
 /// </summary>
 public sealed class ReferenceSync(
     IBlizzardGameDataClient gameData,
-    IInstancesRepository instancesRepo,
     ISpecializationsRepository specsRepo,
     ILogger<ReferenceSync> logger) : IReferenceSync
 {
@@ -64,67 +63,16 @@ public sealed class ReferenceSync(
     // Instance sync
     // ---------------------------------------------------------------------------
 
-    private async Task<int> SyncInstancesAsync(string token, CancellationToken ct)
-    {
-        var index = await gameData.GetJournalInstanceIndexAsync(token, ct);
-        var documents = new List<InstanceDocument>();
-
-        foreach (var entry in index.Instances)
-        {
-            BlizzardJournalInstanceDetail detail;
-            while (true)
-            {
-                try
-                {
-                    detail = await gameData.GetJournalInstanceAsync(entry.Id, token, ct);
-                    break;
-                }
-                catch (HttpRequestException ex) when ((int?)ex.StatusCode == 429)
-                {
-                    await Task.Delay(TimeSpan.FromSeconds(1), ct);
-                }
-                catch (Exception ex)
-                {
-                    logger.LogWarning(ex, "Skipping instance {Id}: detail fetch failed", entry.Id);
-                    detail = null!;
-                    break;
-                }
-            }
-            if (detail is null) continue;
-
-            var expansion = detail.Expansion?.Name ?? "";
-            var modes = detail.Modes ?? [];
-
-            var instanceIdStr = detail.Id.ToString();
-
-            if (modes.Count == 0)
-            {
-                // No modes — store a sentinel record with modeKey "UNKNOWN:0"
-                documents.Add(new InstanceDocument(
-                    Id: $"{instanceIdStr}:UNKNOWN:0",
-                    InstanceId: instanceIdStr,
-                    Name: detail.Name,
-                    ModeKey: "UNKNOWN:0",
-                    Expansion: expansion));
-            }
-            else
-            {
-                foreach (var mode in modes)
-                {
-                    var modeKey = $"{mode.Mode.Type}:{mode.Players ?? 0}";
-                    documents.Add(new InstanceDocument(
-                        Id: $"{instanceIdStr}:{modeKey}",
-                        InstanceId: instanceIdStr,
-                        Name: detail.Name,
-                        ModeKey: modeKey,
-                        Expansion: expansion));
-                }
-            }
-        }
-
-        await instancesRepo.UpsertBatchAsync(documents, ct);
-        return documents.Count;
-    }
+    private static Task<int> SyncInstancesAsync(string token, CancellationToken ct)
+        // Reference data moved from Cosmos to blob — see docs/storage-architecture.md.
+        // Phase 1 rewired the reader (InstancesRepository now reads lfmstore/wow/reference/
+        // journal-instance/). Phase 3 will re-implement this sync writing to blob. Until
+        // then admin POST /api/wow/update reports "instances" as "failed:"; production
+        // blobs remain as ingested by the legacy TS job (2026-03-30) and the reader
+        // serves those.
+        => throw new NotImplementedException(
+            "Instance sync is being rewritten to write blobs in Phase 3. " +
+            "Existing lfmstore/wow/reference/journal-instance/ blobs remain readable via InstancesRepository.");
 
     // ---------------------------------------------------------------------------
     // Specialization sync

--- a/shared/Lfm.Contracts/Instances/InstanceDto.cs
+++ b/shared/Lfm.Contracts/Instances/InstanceDto.cs
@@ -3,4 +3,9 @@
 
 namespace Lfm.Contracts.Instances;
 
-public sealed record InstanceDto(string Id, string Name, string ModeKey, string Expansion);
+public sealed record InstanceDto(
+    string Id,
+    string Name,
+    string ModeKey,
+    string Expansion,
+    string? PortraitUrl = null);

--- a/tests/Lfm.Api.Tests/ReferenceSyncTests.cs
+++ b/tests/Lfm.Api.Tests/ReferenceSyncTests.cs
@@ -15,31 +15,6 @@ public class ReferenceSyncTests
 
     private const string FakeToken = "fake-bnet-token";
 
-    private static BlizzardJournalInstanceIndex MakeJournalInstanceIndex(params (int Id, string Name)[] entries) =>
-        new(entries.Select(e => new BlizzardIndexEntry(e.Id, e.Name)).ToList());
-
-    private static BlizzardJournalInstanceDetail MakeJournalInstanceDetail(
-        int id,
-        string name,
-        string? expansionName = "The War Within",
-        params (string ModeType, int Players)[] modes)
-    {
-        var modeRecords = modes
-            .Select(m => new BlizzardJournalInstanceMode(
-                Mode: new BlizzardJournalModeRef(m.ModeType, m.ModeType),
-                Players: m.Players,
-                IsTracked: true))
-            .ToList();
-        return new BlizzardJournalInstanceDetail(
-            Id: id,
-            Name: name,
-            Category: new BlizzardJournalInstanceCategory("RAID"),
-            Expansion: expansionName is null ? null : new BlizzardJournalExpansion(11, expansionName),
-            MinimumLevel: 80,
-            Modes: modeRecords,
-            Media: null);
-    }
-
     private static BlizzardPlayableSpecIndex MakeSpecIndex(params (int Id, string Name)[] entries) =>
         new(entries.Select(e => new BlizzardIndexEntry(e.Id, e.Name)).ToList());
 
@@ -57,112 +32,34 @@ public class ReferenceSyncTests
     private static (
         ReferenceSync sut,
         Mock<IBlizzardGameDataClient> blizzard,
-        Mock<IInstancesRepository> instances,
         Mock<ISpecializationsRepository> specs,
         TestLogger<ReferenceSync> logger) MakeSut()
     {
         var blizzard = new Mock<IBlizzardGameDataClient>();
         blizzard.Setup(b => b.GetClientCredentialsTokenAsync(It.IsAny<CancellationToken>())).ReturnsAsync(FakeToken);
-        blizzard.Setup(b => b.GetJournalInstanceIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeJournalInstanceIndex());
         blizzard.Setup(b => b.GetPlayableSpecIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
             .ReturnsAsync(MakeSpecIndex());
-
-        var instances = new Mock<IInstancesRepository>();
-        instances.Setup(r => r.UpsertBatchAsync(It.IsAny<IEnumerable<InstanceDocument>>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
 
         var specs = new Mock<ISpecializationsRepository>();
         specs.Setup(r => r.UpsertBatchAsync(It.IsAny<IEnumerable<SpecializationDocument>>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         var logger = new TestLogger<ReferenceSync>();
-        var sut = new ReferenceSync(blizzard.Object, instances.Object, specs.Object, logger);
+        var sut = new ReferenceSync(blizzard.Object, specs.Object, logger);
 
-        return (sut, blizzard, instances, specs, logger);
+        return (sut, blizzard, specs, logger);
     }
 
-    // ── Happy path ───────────────────────────────────────────────────────────
+    // ── Instance sync: stubbed (Phase 1 moved reads to blob; Phase 3 rewrites the writer) ─
 
     [Fact]
-    public async Task SyncAllAsync_syncs_instances_and_specializations_in_order()
+    public async Task SyncAllAsync_reports_instances_as_failed_pending_phase_3_blob_writer()
     {
-        var (sut, blizzard, instances, specs, _) = MakeSut();
-        blizzard.Setup(b => b.GetJournalInstanceIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeJournalInstanceIndex((10, "Liberation of Undermine")));
-        blizzard.Setup(b => b.GetJournalInstanceAsync(10, FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeJournalInstanceDetail(10, "Liberation of Undermine", modes: ("HEROIC", 25)));
-        blizzard.Setup(b => b.GetPlayableSpecIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeSpecIndex((257, "Holy")));
-        blizzard.Setup(b => b.GetPlayableSpecAsync(257, FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeSpecDetail(257, "Holy", classId: 5, roleType: "HEALER"));
-        blizzard.Setup(b => b.GetPlayableSpecMediaAsync(257, FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BlizzardMediaAssets(new[] { new BlizzardMediaAsset("icon", "https://render.example/icon.jpg") }));
-
-        var response = await sut.SyncAllAsync(CancellationToken.None);
-
-        Assert.Equal(2, response.Results.Count);
-        Assert.Equal("instances", response.Results[0].Name);
-        Assert.StartsWith("synced", response.Results[0].Status);
-        Assert.Equal("specializations", response.Results[1].Name);
-        Assert.StartsWith("synced", response.Results[1].Status);
-
-        instances.Verify(r => r.UpsertBatchAsync(
-            It.Is<IEnumerable<InstanceDocument>>(docs => docs.Count() == 1),
-            It.IsAny<CancellationToken>()), Times.Once);
-        specs.Verify(r => r.UpsertBatchAsync(
-            It.Is<IEnumerable<SpecializationDocument>>(docs => docs.Count() == 1),
-            It.IsAny<CancellationToken>()), Times.Once);
-    }
-
-    [Fact]
-    public async Task SyncAllAsync_emits_one_document_per_mode_for_multi_mode_instance()
-    {
-        var (sut, blizzard, instances, _, _) = MakeSut();
-        blizzard.Setup(b => b.GetJournalInstanceIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeJournalInstanceIndex((10, "Multi")));
-        blizzard.Setup(b => b.GetJournalInstanceAsync(10, FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeJournalInstanceDetail(10, "Multi", modes: new[]
-            {
-                ("NORMAL", 25),
-                ("HEROIC", 25),
-                ("MYTHIC", 20),
-            }));
-
-        await sut.SyncAllAsync(CancellationToken.None);
-
-        instances.Verify(r => r.UpsertBatchAsync(
-            It.Is<IEnumerable<InstanceDocument>>(docs => docs.Count() == 3),
-            It.IsAny<CancellationToken>()), Times.Once);
-    }
-
-    [Fact]
-    public async Task SyncAllAsync_emits_unknown_mode_sentinel_when_modes_list_is_empty()
-    {
-        var (sut, blizzard, instances, _, _) = MakeSut();
-        blizzard.Setup(b => b.GetJournalInstanceIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeJournalInstanceIndex((42, "Solo Dungeon")));
-        blizzard.Setup(b => b.GetJournalInstanceAsync(42, FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeJournalInstanceDetail(42, "Solo Dungeon", modes: Array.Empty<(string, int)>()));
-
-        await sut.SyncAllAsync(CancellationToken.None);
-
-        instances.Verify(r => r.UpsertBatchAsync(
-            It.Is<IEnumerable<InstanceDocument>>(docs =>
-                docs.Count() == 1
-                && docs.Single().ModeKey == "UNKNOWN:0"
-                && docs.Single().Id == "42:UNKNOWN:0"),
-            It.IsAny<CancellationToken>()), Times.Once);
-    }
-
-    // ── Resilience ───────────────────────────────────────────────────────────
-
-    [Fact]
-    public async Task SyncAllAsync_records_failure_for_instances_but_still_syncs_specializations()
-    {
-        var (sut, blizzard, instances, specs, logger) = MakeSut();
-        blizzard.Setup(b => b.GetJournalInstanceIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new HttpRequestException("blizzard 503"));
+        // Phase 1: SyncInstancesAsync throws NotImplementedException so the admin
+        // endpoint surfaces a clear "failed: ..." message, while the reader in
+        // InstancesRepository continues to serve the existing blob data. Spec sync
+        // (still Cosmos-backed in commit B) runs to completion.
+        var (sut, blizzard, specs, logger) = MakeSut();
         blizzard.Setup(b => b.GetPlayableSpecIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
             .ReturnsAsync(MakeSpecIndex((257, "Holy")));
         blizzard.Setup(b => b.GetPlayableSpecAsync(257, FakeToken, It.IsAny<CancellationToken>()))
@@ -175,38 +72,20 @@ public class ReferenceSyncTests
         Assert.Equal(2, response.Results.Count);
         Assert.Equal("instances", response.Results[0].Name);
         Assert.StartsWith("failed:", response.Results[0].Status);
+        Assert.Contains("Phase 3", response.Results[0].Status);
         Assert.Equal("specializations", response.Results[1].Name);
         Assert.StartsWith("synced", response.Results[1].Status);
 
-        instances.Verify(r => r.UpsertBatchAsync(It.IsAny<IEnumerable<InstanceDocument>>(), It.IsAny<CancellationToken>()), Times.Never);
         specs.Verify(r => r.UpsertBatchAsync(It.IsAny<IEnumerable<SpecializationDocument>>(), It.IsAny<CancellationToken>()), Times.Once);
         Assert.Contains(logger.Entries, e => e.Level == LogLevel.Error && (e.Message ?? "").Contains("instances"));
     }
 
-    [Fact]
-    public async Task SyncAllAsync_skips_instance_when_detail_fetch_fails_but_continues_index()
-    {
-        var (sut, blizzard, instances, _, logger) = MakeSut();
-        blizzard.Setup(b => b.GetJournalInstanceIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeJournalInstanceIndex((1, "Skipped"), (2, "Worked")));
-        blizzard.Setup(b => b.GetJournalInstanceAsync(1, FakeToken, It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new HttpRequestException("404"));
-        blizzard.Setup(b => b.GetJournalInstanceAsync(2, FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeJournalInstanceDetail(2, "Worked", modes: ("HEROIC", 25)));
-
-        var response = await sut.SyncAllAsync(CancellationToken.None);
-
-        Assert.StartsWith("synced", response.Results[0].Status);
-        instances.Verify(r => r.UpsertBatchAsync(
-            It.Is<IEnumerable<InstanceDocument>>(docs => docs.Count() == 1 && docs.Single().Name == "Worked"),
-            It.IsAny<CancellationToken>()), Times.Once);
-        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Warning && (e.Message ?? "").Contains("Skipping"));
-    }
+    // ── Spec sync: still Cosmos-backed in commit B ───────────────────────────
 
     [Fact]
     public async Task SyncAllAsync_continues_when_spec_media_fetch_fails_with_null_icon_url()
     {
-        var (sut, blizzard, _, specs, logger) = MakeSut();
+        var (sut, blizzard, specs, logger) = MakeSut();
         blizzard.Setup(b => b.GetPlayableSpecIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
             .ReturnsAsync(MakeSpecIndex((257, "Holy")));
         blizzard.Setup(b => b.GetPlayableSpecAsync(257, FakeToken, It.IsAny<CancellationToken>()))
@@ -226,36 +105,9 @@ public class ReferenceSyncTests
     }
 
     [Fact]
-    public async Task SyncAllAsync_retries_instance_after_429_and_still_writes_document()
-    {
-        var (sut, blizzard, instances, _, _) = MakeSut();
-        blizzard.Setup(b => b.GetJournalInstanceIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeJournalInstanceIndex((10, "Liberation of Undermine")));
-
-        var callCount = 0;
-        blizzard
-            .Setup(b => b.GetJournalInstanceAsync(10, FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(() =>
-            {
-                callCount++;
-                if (callCount == 1)
-                    throw new HttpRequestException("rate limited", null, System.Net.HttpStatusCode.TooManyRequests);
-                return MakeJournalInstanceDetail(10, "Liberation of Undermine", modes: ("HEROIC", 25));
-            });
-
-        var response = await sut.SyncAllAsync(CancellationToken.None);
-
-        Assert.StartsWith("synced", response.Results[0].Status);
-        Assert.Equal(2, callCount);
-        instances.Verify(r => r.UpsertBatchAsync(
-            It.Is<IEnumerable<InstanceDocument>>(docs => docs.Count() == 1),
-            It.IsAny<CancellationToken>()), Times.Once);
-    }
-
-    [Fact]
     public async Task SyncAllAsync_retries_specialization_after_429_and_still_writes_document()
     {
-        var (sut, blizzard, _, specs, _) = MakeSut();
+        var (sut, blizzard, specs, _) = MakeSut();
         blizzard.Setup(b => b.GetPlayableSpecIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
             .ReturnsAsync(MakeSpecIndex((257, "Holy")));
         blizzard.Setup(b => b.GetPlayableSpecMediaAsync(257, FakeToken, It.IsAny<CancellationToken>()))
@@ -292,7 +144,7 @@ public class ReferenceSyncTests
     public async Task SyncAllAsync_maps_blizzard_role_type_to_DPS_when_not_HEALER_or_TANK(
         string blizzardRoleType, string expectedRole)
     {
-        var (sut, blizzard, _, specs, _) = MakeSut();
+        var (sut, blizzard, specs, _) = MakeSut();
         blizzard.Setup(b => b.GetPlayableSpecIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
             .ReturnsAsync(MakeSpecIndex((1, "X")));
         blizzard.Setup(b => b.GetPlayableSpecAsync(1, FakeToken, It.IsAny<CancellationToken>()))

--- a/tests/Lfm.Api.Tests/Repositories/InstancesRepositoryTests.cs
+++ b/tests/Lfm.Api.Tests/Repositories/InstancesRepositoryTests.cs
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Runtime.CompilerServices;
+using Lfm.Api.Repositories;
+using Lfm.Api.Services;
+using Moq;
+using Xunit;
+
+namespace Lfm.Api.Tests.Repositories;
+
+/// <summary>
+/// Covers <see cref="InstancesRepository.ListAsync"/> against a mocked
+/// <see cref="IBlobReferenceClient"/>: both the manifest fast path and the
+/// per-id detail fallback, plus the portrait-media lookup and its tolerance
+/// of missing blobs.
+/// </summary>
+public class InstancesRepositoryTests
+{
+    private static IAsyncEnumerable<T> AsAsync<T>(params T[] items) => AsAsyncImpl(items);
+
+    private static async IAsyncEnumerable<T> AsAsyncImpl<T>(
+        T[] items,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        foreach (var item in items)
+        {
+            ct.ThrowIfCancellationRequested();
+            yield return item;
+            await Task.Yield();
+        }
+    }
+
+    // ── Manifest fast path ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ListAsync_returns_manifest_rows_one_per_mode_with_portrait_url()
+    {
+        var blobs = new Mock<IBlobReferenceClient>();
+        blobs.Setup(b => b.GetAsync<List<InstanceIndexEntry>>(
+                "reference/journal-instance/index.json", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<InstanceIndexEntry>
+            {
+                new(
+                    Id: 1200,
+                    Name: "Liberation of Undermine",
+                    Modes: new[] { new InstanceIndexMode("NORMAL:25"), new InstanceIndexMode("HEROIC:25") },
+                    Expansion: "The War Within",
+                    PortraitUrl: "https://render.worldofwarcraft.com/tile.jpg"),
+            });
+        var repo = new InstancesRepository(blobs.Object);
+
+        var rows = await repo.ListAsync(CancellationToken.None);
+
+        Assert.Collection(rows,
+            r =>
+            {
+                Assert.Equal("1200:NORMAL:25", r.Id);
+                Assert.Equal("Liberation of Undermine", r.Name);
+                Assert.Equal("NORMAL:25", r.ModeKey);
+                Assert.Equal("The War Within", r.Expansion);
+                Assert.Equal("https://render.worldofwarcraft.com/tile.jpg", r.PortraitUrl);
+            },
+            r =>
+            {
+                Assert.Equal("1200:HEROIC:25", r.Id);
+                Assert.Equal("HEROIC:25", r.ModeKey);
+                Assert.Equal("https://render.worldofwarcraft.com/tile.jpg", r.PortraitUrl);
+            });
+
+        blobs.Verify(b => b.ListAsync<JournalInstanceBlob>(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ListAsync_manifest_row_with_no_modes_emits_unknown_sentinel()
+    {
+        var blobs = new Mock<IBlobReferenceClient>();
+        blobs.Setup(b => b.GetAsync<List<InstanceIndexEntry>>(
+                "reference/journal-instance/index.json", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<InstanceIndexEntry>
+            {
+                new(Id: 42, Name: "Solo Dungeon", Modes: null, Expansion: "Test", PortraitUrl: null),
+            });
+        var repo = new InstancesRepository(blobs.Object);
+
+        var rows = await repo.ListAsync(CancellationToken.None);
+
+        var row = Assert.Single(rows);
+        Assert.Equal("42:UNKNOWN:0", row.Id);
+        Assert.Equal("UNKNOWN:0", row.ModeKey);
+        Assert.Null(row.PortraitUrl);
+    }
+
+    // ── Fallback path (no manifest yet) ──────────────────────────────────────
+
+    [Fact]
+    public async Task ListAsync_falls_back_to_per_id_blobs_and_resolves_tile_portrait()
+    {
+        var blobs = new Mock<IBlobReferenceClient>();
+        blobs.Setup(b => b.GetAsync<List<InstanceIndexEntry>>(
+                "reference/journal-instance/index.json", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((List<InstanceIndexEntry>?)null);
+
+        blobs.Setup(b => b.ListAsync<JournalInstanceBlob>(
+                "reference/journal-instance/", It.IsAny<CancellationToken>()))
+            .Returns(AsAsync(new JournalInstanceBlob(
+                Id: 67,
+                Name: "The Stonecore",
+                Expansion: new JournalInstanceExpansionBlob("Cataclysm"),
+                Modes: new[]
+                {
+                    new JournalInstanceModeBlob(new JournalModeRefBlob("NORMAL"), 5),
+                })));
+
+        blobs.Setup(b => b.GetAsync<MediaAssetsBlob>(
+                "reference/journal-instance-media/67.json", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MediaAssetsBlob(new[]
+            {
+                new MediaAssetBlob("tile", "https://render.worldofwarcraft.com/stonecore-tile.jpg"),
+                new MediaAssetBlob("image", "https://render.worldofwarcraft.com/stonecore-image.jpg"),
+            }));
+
+        var repo = new InstancesRepository(blobs.Object);
+        var rows = await repo.ListAsync(CancellationToken.None);
+
+        var row = Assert.Single(rows);
+        Assert.Equal("67:NORMAL:5", row.Id);
+        Assert.Equal("The Stonecore", row.Name);
+        Assert.Equal("Cataclysm", row.Expansion);
+        Assert.Equal("https://render.worldofwarcraft.com/stonecore-tile.jpg", row.PortraitUrl);
+    }
+
+    [Fact]
+    public async Task ListAsync_falls_back_and_uses_image_when_tile_missing()
+    {
+        var blobs = new Mock<IBlobReferenceClient>();
+        blobs.Setup(b => b.GetAsync<List<InstanceIndexEntry>>(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((List<InstanceIndexEntry>?)null);
+        blobs.Setup(b => b.ListAsync<JournalInstanceBlob>(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(AsAsync(new JournalInstanceBlob(
+                Id: 67, Name: "X",
+                Modes: new[] { new JournalInstanceModeBlob(new JournalModeRefBlob("NORMAL"), 25) })));
+        blobs.Setup(b => b.GetAsync<MediaAssetsBlob>(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MediaAssetsBlob(new[]
+            {
+                new MediaAssetBlob("image", "https://render.worldofwarcraft.com/legacy.jpg"),
+            }));
+
+        var repo = new InstancesRepository(blobs.Object);
+        var rows = await repo.ListAsync(CancellationToken.None);
+
+        Assert.Equal("https://render.worldofwarcraft.com/legacy.jpg", Assert.Single(rows).PortraitUrl);
+    }
+
+    [Fact]
+    public async Task ListAsync_falls_back_and_returns_null_portrait_when_media_blob_missing()
+    {
+        var blobs = new Mock<IBlobReferenceClient>();
+        blobs.Setup(b => b.GetAsync<List<InstanceIndexEntry>>(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((List<InstanceIndexEntry>?)null);
+        blobs.Setup(b => b.ListAsync<JournalInstanceBlob>(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(AsAsync(new JournalInstanceBlob(
+                Id: 67, Name: "X",
+                Modes: new[] { new JournalInstanceModeBlob(new JournalModeRefBlob("NORMAL"), 25) })));
+        blobs.Setup(b => b.GetAsync<MediaAssetsBlob>(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MediaAssetsBlob?)null);
+
+        var repo = new InstancesRepository(blobs.Object);
+        var rows = await repo.ListAsync(CancellationToken.None);
+
+        Assert.Null(Assert.Single(rows).PortraitUrl);
+    }
+
+    [Fact]
+    public async Task ListAsync_falls_back_and_emits_unknown_sentinel_for_instance_with_no_modes()
+    {
+        var blobs = new Mock<IBlobReferenceClient>();
+        blobs.Setup(b => b.GetAsync<List<InstanceIndexEntry>>(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((List<InstanceIndexEntry>?)null);
+        blobs.Setup(b => b.ListAsync<JournalInstanceBlob>(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(AsAsync(new JournalInstanceBlob(Id: 42, Name: "Solo", Modes: null)));
+        blobs.Setup(b => b.GetAsync<MediaAssetsBlob>(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MediaAssetsBlob?)null);
+
+        var repo = new InstancesRepository(blobs.Object);
+        var rows = await repo.ListAsync(CancellationToken.None);
+
+        var row = Assert.Single(rows);
+        Assert.Equal("42:UNKNOWN:0", row.Id);
+        Assert.Equal("UNKNOWN:0", row.ModeKey);
+        Assert.Equal("", row.Expansion);
+    }
+}

--- a/tests/Lfm.Api.Tests/Serialization/LocalizedStringConverterTests.cs
+++ b/tests/Lfm.Api.Tests/Serialization/LocalizedStringConverterTests.cs
@@ -281,63 +281,48 @@ public class LocalizedStringConverterTests
     // ------------------------------------------------------------------
 
     [Fact]
-    public void InstanceDocument_deserializes_with_localized_name()
+    public void JournalInstanceBlob_deserializes_with_localized_name_and_expansion()
     {
+        // Shape of a verbatim TS-ingested journal-instance blob at
+        // reference/journal-instance/{id}.json. Blizzard's no-locale response
+        // stores both instance name and expansion.name as localized objects —
+        // the converter must handle both sites (fallback path in
+        // InstancesRepository reads both).
         var json = """
         {
-          "id": "67:NORMAL:25",
-          "instanceId": "67",
+          "id": 67,
           "name": { "en_US": "Icecrown Citadel", "de_DE": "Eiskronenzitadelle" },
-          "modeKey": "NORMAL:25",
-          "expansion": "WRATH_OF_THE_LICH_KING"
+          "expansion": {
+            "name": { "en_US": "Wrath of the Lich King", "de_DE": "Zorn des Lichkönigs" }
+          },
+          "modes": [{ "mode": { "type": "NORMAL" }, "players": 25 }]
         }
         """;
 
-        var doc = JsonConvert.DeserializeObject<InstanceDocument>(json, CosmosLikeSettings);
+        var blob = JsonConvert.DeserializeObject<JournalInstanceBlob>(json, CosmosLikeSettings);
 
-        Assert.Equal("Icecrown Citadel", doc!.Name);
+        Assert.Equal("Icecrown Citadel", blob!.Name);
+        Assert.Equal("Wrath of the Lich King", blob.Expansion?.Name);
     }
 
     [Fact]
-    public void InstanceListRow_deserializes_with_localized_name()
+    public void JournalInstanceBlob_deserializes_with_plain_string_name()
     {
-        // Shape of the row produced by InstancesRepository.ListAsync's projection:
-        //   SELECT c.instanceId AS id, c.name, c.modeKey, c.expansion FROM c
-        // Legacy documents store c.name as the no-locale object; projecting
-        // directly into InstanceDto (no converter) crashed every /api/instances
-        // call with JsonReaderException — same root cause as the 2026-04-20
-        // /api/guild incident, retriggered when editing a run.
+        // After Phase 3 ingestion with locale=en_US on the Blizzard call,
+        // the reader also must handle plain-string names.
         var json = """
         {
-          "id": "67",
-          "name": { "en_US": "Icecrown Citadel", "de_DE": "Eiskronenzitadelle" },
-          "modeKey": "NORMAL:25",
-          "expansion": "WRATH_OF_THE_LICH_KING"
-        }
-        """;
-
-        var row = JsonConvert.DeserializeObject<InstanceListRow>(json, CosmosLikeSettings);
-
-        Assert.Equal("Icecrown Citadel", row!.Name);
-    }
-
-    [Fact]
-    public void InstanceListRow_deserializes_with_plain_string_name()
-    {
-        // Newly-written documents use the plain-string shape via
-        // LocalizedStringConverter.WriteJson — must keep working.
-        var json = """
-        {
-          "id": "67",
+          "id": 67,
           "name": "Icecrown Citadel",
-          "modeKey": "NORMAL:25",
-          "expansion": "WRATH_OF_THE_LICH_KING"
+          "expansion": { "name": "Wrath of the Lich King" },
+          "modes": [{ "mode": { "type": "NORMAL" }, "players": 25 }]
         }
         """;
 
-        var row = JsonConvert.DeserializeObject<InstanceListRow>(json, CosmosLikeSettings);
+        var blob = JsonConvert.DeserializeObject<JournalInstanceBlob>(json, CosmosLikeSettings);
 
-        Assert.Equal("Icecrown Citadel", row!.Name);
+        Assert.Equal("Icecrown Citadel", blob!.Name);
+        Assert.Equal("Wrath of the Lich King", blob.Expansion?.Name);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes the `/api/instances` 500 in production. Root cause: `InstancesRepository.ListAsync` queried a Cosmos container (`instances`) that was never provisioned in Bicep. The reference data has lived in blob (`lfmstore/wow/reference/journal-instance/`) since the TS-era ingester, but the C# read path pointed at Cosmos. Follows the rule established in [docs/storage-architecture.md](docs/storage-architecture.md).

- `InstancesRepository.ListAsync` now reads from blob via `IBlobReferenceClient` (added in previous PR). Manifest fast path: reads `reference/journal-instance/index.json` when present. Fallback: enumerates `reference/journal-instance/*.json`, tolerantly fetches `reference/journal-instance-media/{id}.json` for portrait URLs, maps to one `InstanceDto` per (instance, mode) pair.
- `InstanceDto` gains `string? PortraitUrl = null`. Null-tolerant — pre-Phase-3, media blobs don't exist yet, so `PortraitUrl` will be `null` until the ingester runs.
- Drops the obsolete `InstanceDocument` type + `UpsertBatchAsync` method from `IInstancesRepository`.
- Stubs `ReferenceSync.SyncInstancesAsync` to `throw new NotImplementedException("... Phase 3 ...")`. The admin `POST /api/wow/update` reports `instances` as `failed:` with a clear forward-looking message until Phase 3 reimplements the writer as blob uploads. `IInstancesRepository` is dropped from `ReferenceSync`'s constructor since nothing calls it from there anymore.
- Retargets the instance-related `LocalizedStringConverter` tests from the removed `InstanceDocument` / `InstanceListRow` to the new `JournalInstanceBlob` — same coverage, correct type. Adds coverage for nested `expansion.name` localized-object shape (the fallback path reads both).
- New `InstancesRepositoryTests` mocks `IBlobReferenceClient` and covers manifest fast path, fallback path, both tile- and image-keyed media, missing media blob, and the no-modes UNKNOWN sentinel.
- Prunes `ReferenceSyncTests` of the (now-obsolete) instance-behavior tests; spec sync tests remain intact (commit C will handle specs).

## Env / schema changes

None. `StorageOptions` already has the blob config keys from the previous PR.

On first deploy, `/api/instances` will return rows with `portraitUrl: null` (the legacy TS ingester never wrote `journal-instance-media/` blobs). Phase 3 will backfill those on the first sync run.

## Test plan

- [x] `dotnet build lfm.sln -c Release` — green.
- [x] `dotnet test tests/Lfm.Api.Tests` — 386 passed.
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error` — clean.
- [ ] Post-deploy: `curl https://lfm-api.dinosauruskeksi.com/api/instances` returns 200 with a list of instances (rows have `portraitUrl: null` until Phase 3 runs).
- [ ] Edit-run page in the browser: instance dropdown populates instead of erroring.
