### PR TITLE
Move specializations read to blob with icon URL

### DIFF
--- a/api/Repositories/ISpecializationsRepository.cs
+++ b/api/Repositories/ISpecializationsRepository.cs
@@ -1,32 +1,19 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
-using Newtonsoft.Json;
-using Lfm.Api.Serialization;
 using Lfm.Contracts.Specializations;
 
 namespace Lfm.Api.Repositories;
 
 /// <summary>
-/// Cosmos document stored in the "specializations" container.
-/// Partition key: /id  (string representation of the numeric spec id).
+/// Reads the static Blizzard playable-specialization reference data set.
+///
+/// Source: blob container <c>lfmstore/wow/reference/playable-specialization/</c>
+/// plus <c>.../playable-specialization-media/</c> for icon URLs — see
+/// <c>docs/storage-architecture.md</c>. The ingester that populates this is
+/// <c>WowUpdateFunction</c> / <c>WowUpdateTimerFunction</c> (Phase 3).
 /// </summary>
-public sealed record SpecializationDocument(
-    /// <summary>Cosmos document id and partition key: string form of the numeric spec id.</summary>
-    string Id,
-    int SpecId,
-    [property: JsonConverter(typeof(LocalizedStringConverter))] string Name,
-    int ClassId,
-    string Role,
-    string? IconUrl);
-
 public interface ISpecializationsRepository
 {
     Task<IReadOnlyList<SpecializationDto>> ListAsync(CancellationToken ct);
-
-    /// <summary>
-    /// Upserts a batch of specialization documents.
-    /// Existing documents with the same id are replaced.
-    /// </summary>
-    Task UpsertBatchAsync(IEnumerable<SpecializationDocument> documents, CancellationToken ct);
 }

--- a/api/Repositories/SpecializationsRepository.cs
+++ b/api/Repositories/SpecializationsRepository.cs
@@ -1,59 +1,91 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
-using Microsoft.Azure.Cosmos;
-using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
-using Lfm.Api.Options;
 using Lfm.Api.Serialization;
+using Lfm.Api.Services;
 using Lfm.Contracts.Specializations;
+using Newtonsoft.Json;
 
 namespace Lfm.Api.Repositories;
 
 /// <summary>
-/// Projection row for <see cref="SpecializationsRepository.ListAsync"/>.
-///
-/// Mirrors <c>InstanceListRow</c>: we cannot project Cosmos directly into
-/// <see cref="SpecializationDto"/> because legacy documents store <c>c.name</c>
-/// as Blizzard's localized-object shape, and <see cref="SpecializationDto"/>
-/// has no converter. Same root cause as the 2026-04-20 /api/guild and
-/// /api/instances incidents.
+/// Manifest entry emitted by the ingester (Phase 3) at
+/// <c>reference/playable-specialization/index.json</c>. When present, the reader
+/// returns this directly — one blob GET for the whole list endpoint. When absent
+/// (first deploy, pre-ingest), the reader falls back to enumerating per-id
+/// detail blobs plus per-id media blobs for icon URLs.
 /// </summary>
-internal sealed record SpecializationListRow(
+internal sealed record SpecializationIndexEntry(
     int Id,
-    [property: JsonConverter(typeof(LocalizedStringConverter))] string Name,
+    string Name,
     int ClassId,
     string Role,
     string? IconUrl);
 
-public sealed class SpecializationsRepository(CosmosClient client, IOptions<CosmosOptions> cosmosOpts) : ISpecializationsRepository
+/// <summary>
+/// Verbatim Blizzard playable-specialization detail as stored at
+/// <c>reference/playable-specialization/{id}.json</c>. Legacy TS-ingested blobs
+/// carry localized-object names; the converter handles both shapes.
+/// </summary>
+internal sealed record PlayableSpecializationBlob(
+    int Id,
+    [property: JsonConverter(typeof(LocalizedStringConverter))] string Name,
+    [property: JsonProperty("playable_class")] PlayableClassRefBlob? PlayableClass = null,
+    PlayableSpecRoleRefBlob? Role = null);
+
+internal sealed record PlayableClassRefBlob(int Id);
+
+internal sealed record PlayableSpecRoleRefBlob(string Type);
+
+public sealed class SpecializationsRepository(IBlobReferenceClient blobs) : ISpecializationsRepository
 {
-    private const string ContainerName = "specializations";
-    private readonly Container _container = client.GetContainer(cosmosOpts.Value.DatabaseName, ContainerName);
+    private const string Prefix = "reference/playable-specialization/";
+    private const string MediaPrefix = "reference/playable-specialization-media/";
+    private const string ManifestName = "reference/playable-specialization/index.json";
 
     public async Task<IReadOnlyList<SpecializationDto>> ListAsync(CancellationToken ct)
     {
-        // Project specId → id so that the projection row's Id (int) receives the numeric
-        // spec id rather than the Cosmos string document id.
-        var query = new QueryDefinition("SELECT c.specId AS id, c.name, c.classId, c.role, c.iconUrl FROM c");
-        var results = new List<SpecializationDto>();
-        using var iterator = _container.GetItemQueryIterator<SpecializationListRow>(query);
-        while (iterator.HasMoreResults)
+        // Fast path: single GET of the manifest produced by the ingester (Phase 3).
+        var manifest = await blobs.GetAsync<List<SpecializationIndexEntry>>(ManifestName, ct);
+        if (manifest is not null)
         {
-            var page = await iterator.ReadNextAsync(ct);
-            foreach (var row in page)
-            {
-                results.Add(new SpecializationDto(row.Id, row.Name, row.ClassId, row.Role, row.IconUrl));
-            }
+            return manifest
+                .Select(e => new SpecializationDto(e.Id, e.Name, e.ClassId, e.Role, e.IconUrl))
+                .ToList();
         }
-        return results;
+
+        // Fallback: enumerate per-id detail blobs + tolerantly fetch media for icons.
+        // Runs on the first deploy before the ingester has emitted a manifest.
+        var rows = new List<SpecializationDto>();
+        await foreach (var detail in blobs.ListAsync<PlayableSpecializationBlob>(Prefix, ct))
+        {
+            var iconUrl = await ResolveIconUrlAsync(detail.Id, ct);
+            var role = ToRole(detail.Role?.Type ?? "");
+            var classId = detail.PlayableClass?.Id ?? 0;
+            rows.Add(new SpecializationDto(detail.Id, detail.Name, classId, role, iconUrl));
+        }
+        return rows;
     }
 
-    public async Task UpsertBatchAsync(IEnumerable<SpecializationDocument> documents, CancellationToken ct)
+    private async Task<string?> ResolveIconUrlAsync(int specId, CancellationToken ct)
     {
-        foreach (var doc in documents)
+        var media = await blobs.GetAsync<MediaAssetsBlob>($"{MediaPrefix}{specId}.json", ct);
+        if (media?.Assets is null) return null;
+
+        foreach (var asset in media.Assets)
         {
-            await _container.UpsertItemAsync(doc, new Microsoft.Azure.Cosmos.PartitionKey(doc.Id), cancellationToken: ct);
+            if (asset.Key == "icon" && !string.IsNullOrEmpty(asset.Value))
+                return asset.Value;
         }
+        return null;
     }
+
+    // Mirrors ReferenceSync.ToRole: Blizzard's role.type ("DAMAGE", "HEALER", "TANK", ...)
+    // collapses to the three game roles the frontend renders.
+    private static string ToRole(string blizzardRoleType) => blizzardRoleType switch
+    {
+        "HEALER" => "HEALER",
+        "TANK" => "TANK",
+        _ => "DPS",
+    };
 }

--- a/api/Services/ReferenceSync.cs
+++ b/api/Services/ReferenceSync.cs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
-using Lfm.Api.Repositories;
 using Lfm.Contracts.Admin;
 using Microsoft.Extensions.Logging;
 
@@ -10,136 +9,54 @@ namespace Lfm.Api.Services;
 /// <summary>
 /// Implements <see cref="IReferenceSync"/>.
 ///
-/// Syncs two entity types in order:
-///   1. instances       — journal-instance index + details → instances Cosmos container
-///   2. specializations — playable-specialization index + details + media → specializations container
+/// Phase 1 (2026-04-21) moved reference-data *reads* from Cosmos to blob — see
+/// <c>docs/storage-architecture.md</c>. The writer side (this class) will be
+/// re-implemented in Phase 3 to upload blobs instead of upserting Cosmos
+/// documents. In the meantime both entity stubs surface a clear "failed:"
+/// status through the admin <c>POST /api/wow/update</c> endpoint, while the
+/// respective repositories continue to serve the existing
+/// <c>lfmstore/wow/reference/</c> blobs ingested by the legacy TS job.
 ///
-/// Per-entity failures are caught and recorded; the remaining entities are still attempted.
-/// Mirrors the resilient loop in syncReferenceEntities (reference-sync-live.ts).
-///
-/// TODO: add classes and races syncs once those containers are added to the C# stack.
+/// Per-entity failures are caught and recorded; the remaining entities are
+/// still attempted.
 /// </summary>
-public sealed class ReferenceSync(
-    IBlizzardGameDataClient gameData,
-    ISpecializationsRepository specsRepo,
-    ILogger<ReferenceSync> logger) : IReferenceSync
+public sealed class ReferenceSync(ILogger<ReferenceSync> logger) : IReferenceSync
 {
     /// <inheritdoc/>
-    public async Task<WowUpdateResponse> SyncAllAsync(CancellationToken ct)
+    public Task<WowUpdateResponse> SyncAllAsync(CancellationToken ct)
     {
-        string? token = null;
         var results = new List<WowUpdateEntityResult>();
 
-        // --- instances ---
-        try
+        foreach (var (name, sync) in Entities)
         {
-            token ??= await gameData.GetClientCredentialsTokenAsync(ct);
-            var docs = await SyncInstancesAsync(token, ct);
-            results.Add(new WowUpdateEntityResult("instances", $"synced ({docs} docs)"));
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to sync instances");
-            results.Add(new WowUpdateEntityResult("instances", $"failed: {ex.Message}"));
-        }
-
-        // --- specializations ---
-        try
-        {
-            token ??= await gameData.GetClientCredentialsTokenAsync(ct);
-            var docs = await SyncSpecializationsAsync(token, ct);
-            results.Add(new WowUpdateEntityResult("specializations", $"synced ({docs} docs)"));
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to sync specializations");
-            results.Add(new WowUpdateEntityResult("specializations", $"failed: {ex.Message}"));
-        }
-
-        return new WowUpdateResponse(results);
-    }
-
-    // ---------------------------------------------------------------------------
-    // Instance sync
-    // ---------------------------------------------------------------------------
-
-    private static Task<int> SyncInstancesAsync(string token, CancellationToken ct)
-        // Reference data moved from Cosmos to blob — see docs/storage-architecture.md.
-        // Phase 1 rewired the reader (InstancesRepository now reads lfmstore/wow/reference/
-        // journal-instance/). Phase 3 will re-implement this sync writing to blob. Until
-        // then admin POST /api/wow/update reports "instances" as "failed:"; production
-        // blobs remain as ingested by the legacy TS job (2026-03-30) and the reader
-        // serves those.
-        => throw new NotImplementedException(
-            "Instance sync is being rewritten to write blobs in Phase 3. " +
-            "Existing lfmstore/wow/reference/journal-instance/ blobs remain readable via InstancesRepository.");
-
-    // ---------------------------------------------------------------------------
-    // Specialization sync
-    // ---------------------------------------------------------------------------
-
-    private async Task<int> SyncSpecializationsAsync(string token, CancellationToken ct)
-    {
-        var index = await gameData.GetPlayableSpecIndexAsync(token, ct);
-        var documents = new List<SpecializationDocument>();
-
-        foreach (var entry in index.CharacterSpecializations)
-        {
-            BlizzardPlayableSpecDetail detail;
-            while (true)
-            {
-                try
-                {
-                    detail = await gameData.GetPlayableSpecAsync(entry.Id, token, ct);
-                    break;
-                }
-                catch (HttpRequestException ex) when ((int?)ex.StatusCode == 429)
-                {
-                    await Task.Delay(TimeSpan.FromSeconds(1), ct);
-                }
-                catch (Exception ex)
-                {
-                    logger.LogWarning(ex, "Skipping specialization {Id}: detail fetch failed", entry.Id);
-                    detail = null!;
-                    break;
-                }
-            }
-            if (detail is null) continue;
-
-            // Media (icon URL) — keep the existing best-effort try/catch; no retry on 429.
-            string? iconUrl = null;
             try
             {
-                var media = await gameData.GetPlayableSpecMediaAsync(entry.Id, token, ct);
-                iconUrl = media.Assets?.FirstOrDefault(a => a.Key == "icon")?.Value;
+                sync();
+                results.Add(new WowUpdateEntityResult(name, "synced"));
             }
             catch (Exception ex)
             {
-                logger.LogWarning(ex, "Could not fetch media for spec {Id}", entry.Id);
+                logger.LogError(ex, "Failed to sync {Entity}", name);
+                results.Add(new WowUpdateEntityResult(name, $"failed: {ex.Message}"));
             }
-
-            var role = ToRole(detail.Role.Type);
-            documents.Add(new SpecializationDocument(
-                Id: entry.Id.ToString(),
-                SpecId: entry.Id,
-                Name: detail.Name,
-                ClassId: detail.PlayableClass.Id,
-                Role: role,
-                IconUrl: iconUrl));
         }
 
-        await specsRepo.UpsertBatchAsync(documents, ct);
-        return documents.Count;
+        return Task.FromResult(new WowUpdateResponse(results));
     }
 
-    // ---------------------------------------------------------------------------
-    // Helpers
-    // ---------------------------------------------------------------------------
+    private static readonly (string Name, Action Sync)[] Entities =
+    [
+        ("instances", SyncInstancesAsync),
+        ("specializations", SyncSpecializationsAsync),
+    ];
 
-    private static string ToRole(string blizzardRoleType) => blizzardRoleType switch
-    {
-        "HEALER" => "HEALER",
-        "TANK" => "TANK",
-        _ => "DPS",
-    };
+    private static void SyncInstancesAsync() =>
+        throw new NotImplementedException(
+            "Instance sync is being rewritten to write blobs in Phase 3. " +
+            "Existing lfmstore/wow/reference/journal-instance/ blobs remain readable via InstancesRepository.");
+
+    private static void SyncSpecializationsAsync() =>
+        throw new NotImplementedException(
+            "Specialization sync is being rewritten to write blobs in Phase 3. " +
+            "Existing lfmstore/wow/reference/playable-specialization/ blobs remain readable via SpecializationsRepository.");
 }

--- a/tests/Lfm.Api.Tests/ReferenceSyncTests.cs
+++ b/tests/Lfm.Api.Tests/ReferenceSyncTests.cs
@@ -1,161 +1,43 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
-using Lfm.Api.Repositories;
 using Lfm.Api.Services;
 using Microsoft.Extensions.Logging;
-using Moq;
 using Xunit;
 
 namespace Lfm.Api.Tests;
 
+/// <summary>
+/// Phase 1 stub coverage. Both reference-sync entity writers throw
+/// <see cref="NotImplementedException"/> until Phase 3 rewires them to upload
+/// blobs instead of upserting Cosmos. The writer contract we defend here is
+/// exactly that: the admin endpoint surfaces a clear per-entity "failed:"
+/// status rather than aborting the whole call, and each failure is logged at
+/// Error level.
+/// </summary>
 public class ReferenceSyncTests
 {
-    // ── Fixture builders ─────────────────────────────────────────────────────
-
-    private const string FakeToken = "fake-bnet-token";
-
-    private static BlizzardPlayableSpecIndex MakeSpecIndex(params (int Id, string Name)[] entries) =>
-        new(entries.Select(e => new BlizzardIndexEntry(e.Id, e.Name)).ToList());
-
-    private static BlizzardPlayableSpecDetail MakeSpecDetail(
-        int id,
-        string name,
-        int classId,
-        string roleType) =>
-        new(
-            Id: id,
-            Name: name,
-            PlayableClass: new BlizzardPlayableSpecClassRef(classId, "Priest"),
-            Role: new BlizzardPlayableSpecRoleRef(roleType, roleType));
-
-    private static (
-        ReferenceSync sut,
-        Mock<IBlizzardGameDataClient> blizzard,
-        Mock<ISpecializationsRepository> specs,
-        TestLogger<ReferenceSync> logger) MakeSut()
+    [Fact]
+    public async Task SyncAllAsync_reports_both_entities_as_failed_pending_phase_3_blob_writer()
     {
-        var blizzard = new Mock<IBlizzardGameDataClient>();
-        blizzard.Setup(b => b.GetClientCredentialsTokenAsync(It.IsAny<CancellationToken>())).ReturnsAsync(FakeToken);
-        blizzard.Setup(b => b.GetPlayableSpecIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeSpecIndex());
-
-        var specs = new Mock<ISpecializationsRepository>();
-        specs.Setup(r => r.UpsertBatchAsync(It.IsAny<IEnumerable<SpecializationDocument>>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
-
         var logger = new TestLogger<ReferenceSync>();
-        var sut = new ReferenceSync(blizzard.Object, specs.Object, logger);
-
-        return (sut, blizzard, specs, logger);
-    }
-
-    // ── Instance sync: stubbed (Phase 1 moved reads to blob; Phase 3 rewrites the writer) ─
-
-    [Fact]
-    public async Task SyncAllAsync_reports_instances_as_failed_pending_phase_3_blob_writer()
-    {
-        // Phase 1: SyncInstancesAsync throws NotImplementedException so the admin
-        // endpoint surfaces a clear "failed: ..." message, while the reader in
-        // InstancesRepository continues to serve the existing blob data. Spec sync
-        // (still Cosmos-backed in commit B) runs to completion.
-        var (sut, blizzard, specs, logger) = MakeSut();
-        blizzard.Setup(b => b.GetPlayableSpecIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeSpecIndex((257, "Holy")));
-        blizzard.Setup(b => b.GetPlayableSpecAsync(257, FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeSpecDetail(257, "Holy", 5, "HEALER"));
-        blizzard.Setup(b => b.GetPlayableSpecMediaAsync(257, FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BlizzardMediaAssets(null));
+        var sut = new ReferenceSync(logger);
 
         var response = await sut.SyncAllAsync(CancellationToken.None);
 
-        Assert.Equal(2, response.Results.Count);
-        Assert.Equal("instances", response.Results[0].Name);
-        Assert.StartsWith("failed:", response.Results[0].Status);
-        Assert.Contains("Phase 3", response.Results[0].Status);
-        Assert.Equal("specializations", response.Results[1].Name);
-        Assert.StartsWith("synced", response.Results[1].Status);
-
-        specs.Verify(r => r.UpsertBatchAsync(It.IsAny<IEnumerable<SpecializationDocument>>(), It.IsAny<CancellationToken>()), Times.Once);
-        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Error && (e.Message ?? "").Contains("instances"));
-    }
-
-    // ── Spec sync: still Cosmos-backed in commit B ───────────────────────────
-
-    [Fact]
-    public async Task SyncAllAsync_continues_when_spec_media_fetch_fails_with_null_icon_url()
-    {
-        var (sut, blizzard, specs, logger) = MakeSut();
-        blizzard.Setup(b => b.GetPlayableSpecIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeSpecIndex((257, "Holy")));
-        blizzard.Setup(b => b.GetPlayableSpecAsync(257, FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeSpecDetail(257, "Holy", 5, "HEALER"));
-        blizzard.Setup(b => b.GetPlayableSpecMediaAsync(257, FakeToken, It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new HttpRequestException("media 404"));
-
-        var response = await sut.SyncAllAsync(CancellationToken.None);
-
-        Assert.StartsWith("synced", response.Results[1].Status);
-        specs.Verify(r => r.UpsertBatchAsync(
-            It.Is<IEnumerable<SpecializationDocument>>(docs =>
-                docs.Single().IconUrl == null
-                && docs.Single().Role == "HEALER"),
-            It.IsAny<CancellationToken>()), Times.Once);
-        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Warning);
-    }
-
-    [Fact]
-    public async Task SyncAllAsync_retries_specialization_after_429_and_still_writes_document()
-    {
-        var (sut, blizzard, specs, _) = MakeSut();
-        blizzard.Setup(b => b.GetPlayableSpecIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeSpecIndex((257, "Holy")));
-        blizzard.Setup(b => b.GetPlayableSpecMediaAsync(257, FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BlizzardMediaAssets(null));
-
-        var callCount = 0;
-        blizzard
-            .Setup(b => b.GetPlayableSpecAsync(257, FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(() =>
+        Assert.Collection(response.Results,
+            first =>
             {
-                callCount++;
-                if (callCount == 1)
-                    throw new HttpRequestException("rate limited", null, System.Net.HttpStatusCode.TooManyRequests);
-                return MakeSpecDetail(257, "Holy", classId: 5, roleType: "HEALER");
+                Assert.Equal("instances", first.Name);
+                Assert.StartsWith("failed:", first.Status);
+            },
+            second =>
+            {
+                Assert.Equal("specializations", second.Name);
+                Assert.StartsWith("failed:", second.Status);
             });
 
-        var response = await sut.SyncAllAsync(CancellationToken.None);
-
-        Assert.StartsWith("synced", response.Results[1].Status);
-        Assert.Equal(2, callCount);
-        specs.Verify(r => r.UpsertBatchAsync(
-            It.Is<IEnumerable<SpecializationDocument>>(docs => docs.Count() == 1),
-            It.IsAny<CancellationToken>()), Times.Once);
-    }
-
-    // ── Role mapping ────────────────────────────────────────────────────────
-
-    [Theory]
-    [InlineData("HEALER", "HEALER")]
-    [InlineData("TANK", "TANK")]
-    [InlineData("DAMAGE", "DPS")]
-    [InlineData("anything else", "DPS")]
-    [InlineData("", "DPS")]
-    public async Task SyncAllAsync_maps_blizzard_role_type_to_DPS_when_not_HEALER_or_TANK(
-        string blizzardRoleType, string expectedRole)
-    {
-        var (sut, blizzard, specs, _) = MakeSut();
-        blizzard.Setup(b => b.GetPlayableSpecIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeSpecIndex((1, "X")));
-        blizzard.Setup(b => b.GetPlayableSpecAsync(1, FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeSpecDetail(1, "X", 5, blizzardRoleType));
-        blizzard.Setup(b => b.GetPlayableSpecMediaAsync(1, FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BlizzardMediaAssets(null));
-
-        await sut.SyncAllAsync(CancellationToken.None);
-
-        specs.Verify(r => r.UpsertBatchAsync(
-            It.Is<IEnumerable<SpecializationDocument>>(docs => docs.Single().Role == expectedRole),
-            It.IsAny<CancellationToken>()), Times.Once);
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Error && (e.Message ?? "").Contains("instances"));
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Error && (e.Message ?? "").Contains("specializations"));
     }
 }

--- a/tests/Lfm.Api.Tests/Repositories/SpecializationsRepositoryTests.cs
+++ b/tests/Lfm.Api.Tests/Repositories/SpecializationsRepositoryTests.cs
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Runtime.CompilerServices;
+using Lfm.Api.Repositories;
+using Lfm.Api.Services;
+using Moq;
+using Xunit;
+
+namespace Lfm.Api.Tests.Repositories;
+
+/// <summary>
+/// Covers <see cref="SpecializationsRepository.ListAsync"/> against a mocked
+/// <see cref="IBlobReferenceClient"/>: the manifest fast path, the per-id
+/// detail fallback, icon-media resolution, and the role-type mapping.
+/// </summary>
+public class SpecializationsRepositoryTests
+{
+    private static IAsyncEnumerable<T> AsAsync<T>(params T[] items) => AsAsyncImpl(items);
+
+    private static async IAsyncEnumerable<T> AsAsyncImpl<T>(
+        T[] items,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        foreach (var item in items)
+        {
+            ct.ThrowIfCancellationRequested();
+            yield return item;
+            await Task.Yield();
+        }
+    }
+
+    // ── Manifest fast path ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ListAsync_returns_manifest_rows_with_icon_url()
+    {
+        var blobs = new Mock<IBlobReferenceClient>();
+        blobs.Setup(b => b.GetAsync<List<SpecializationIndexEntry>>(
+                "reference/playable-specialization/index.json", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SpecializationIndexEntry>
+            {
+                new(Id: 262, Name: "Elemental", ClassId: 7, Role: "DPS",
+                    IconUrl: "https://render.worldofwarcraft.com/elemental.jpg"),
+            });
+
+        var repo = new SpecializationsRepository(blobs.Object);
+        var rows = await repo.ListAsync(CancellationToken.None);
+
+        var row = Assert.Single(rows);
+        Assert.Equal(262, row.Id);
+        Assert.Equal("Elemental", row.Name);
+        Assert.Equal(7, row.ClassId);
+        Assert.Equal("DPS", row.Role);
+        Assert.Equal("https://render.worldofwarcraft.com/elemental.jpg", row.IconUrl);
+
+        blobs.Verify(b => b.ListAsync<PlayableSpecializationBlob>(
+            It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ── Fallback path (no manifest yet) ──────────────────────────────────────
+
+    [Fact]
+    public async Task ListAsync_falls_back_to_per_id_blobs_and_resolves_icon()
+    {
+        var blobs = new Mock<IBlobReferenceClient>();
+        blobs.Setup(b => b.GetAsync<List<SpecializationIndexEntry>>(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((List<SpecializationIndexEntry>?)null);
+        blobs.Setup(b => b.ListAsync<PlayableSpecializationBlob>(
+                "reference/playable-specialization/", It.IsAny<CancellationToken>()))
+            .Returns(AsAsync(new PlayableSpecializationBlob(
+                Id: 262,
+                Name: "Elemental",
+                PlayableClass: new PlayableClassRefBlob(7),
+                Role: new PlayableSpecRoleRefBlob("DAMAGE"))));
+        blobs.Setup(b => b.GetAsync<MediaAssetsBlob>(
+                "reference/playable-specialization-media/262.json", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MediaAssetsBlob(new[]
+            {
+                new MediaAssetBlob("icon", "https://render.worldofwarcraft.com/elemental.jpg"),
+            }));
+
+        var repo = new SpecializationsRepository(blobs.Object);
+        var rows = await repo.ListAsync(CancellationToken.None);
+
+        var row = Assert.Single(rows);
+        Assert.Equal(262, row.Id);
+        Assert.Equal("Elemental", row.Name);
+        Assert.Equal(7, row.ClassId);
+        Assert.Equal("DPS", row.Role);
+        Assert.Equal("https://render.worldofwarcraft.com/elemental.jpg", row.IconUrl);
+    }
+
+    [Fact]
+    public async Task ListAsync_falls_back_and_returns_null_icon_when_media_missing()
+    {
+        var blobs = new Mock<IBlobReferenceClient>();
+        blobs.Setup(b => b.GetAsync<List<SpecializationIndexEntry>>(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((List<SpecializationIndexEntry>?)null);
+        blobs.Setup(b => b.ListAsync<PlayableSpecializationBlob>(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(AsAsync(new PlayableSpecializationBlob(
+                Id: 257, Name: "Holy",
+                PlayableClass: new PlayableClassRefBlob(5),
+                Role: new PlayableSpecRoleRefBlob("HEALER"))));
+        blobs.Setup(b => b.GetAsync<MediaAssetsBlob>(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MediaAssetsBlob?)null);
+
+        var repo = new SpecializationsRepository(blobs.Object);
+        var rows = await repo.ListAsync(CancellationToken.None);
+
+        var row = Assert.Single(rows);
+        Assert.Null(row.IconUrl);
+        Assert.Equal("HEALER", row.Role);
+    }
+
+    // ── Role mapping (fallback path) ─────────────────────────────────────────
+
+    [Theory]
+    [InlineData("HEALER", "HEALER")]
+    [InlineData("TANK", "TANK")]
+    [InlineData("DAMAGE", "DPS")]
+    [InlineData("anything else", "DPS")]
+    [InlineData("", "DPS")]
+    public async Task ListAsync_maps_blizzard_role_type_to_DPS_when_not_HEALER_or_TANK(
+        string blizzardRoleType, string expectedRole)
+    {
+        var blobs = new Mock<IBlobReferenceClient>();
+        blobs.Setup(b => b.GetAsync<List<SpecializationIndexEntry>>(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((List<SpecializationIndexEntry>?)null);
+        blobs.Setup(b => b.ListAsync<PlayableSpecializationBlob>(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(AsAsync(new PlayableSpecializationBlob(
+                Id: 1, Name: "X",
+                PlayableClass: new PlayableClassRefBlob(5),
+                Role: new PlayableSpecRoleRefBlob(blizzardRoleType))));
+        blobs.Setup(b => b.GetAsync<MediaAssetsBlob>(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MediaAssetsBlob?)null);
+
+        var repo = new SpecializationsRepository(blobs.Object);
+        var rows = await repo.ListAsync(CancellationToken.None);
+
+        Assert.Equal(expectedRole, Assert.Single(rows).Role);
+    }
+
+    [Fact]
+    public async Task ListAsync_falls_back_and_defaults_classId_zero_when_playable_class_missing()
+    {
+        // Guards the `detail.PlayableClass?.Id ?? 0` path when a blob is
+        // malformed (missing playable_class entirely).
+        var blobs = new Mock<IBlobReferenceClient>();
+        blobs.Setup(b => b.GetAsync<List<SpecializationIndexEntry>>(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((List<SpecializationIndexEntry>?)null);
+        blobs.Setup(b => b.ListAsync<PlayableSpecializationBlob>(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(AsAsync(new PlayableSpecializationBlob(
+                Id: 99, Name: "Orphan", PlayableClass: null, Role: null)));
+        blobs.Setup(b => b.GetAsync<MediaAssetsBlob>(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MediaAssetsBlob?)null);
+
+        var repo = new SpecializationsRepository(blobs.Object);
+        var rows = await repo.ListAsync(CancellationToken.None);
+
+        var row = Assert.Single(rows);
+        Assert.Equal(0, row.ClassId);
+        Assert.Equal("DPS", row.Role);
+    }
+}

--- a/tests/Lfm.Api.Tests/Serialization/LocalizedStringConverterTests.cs
+++ b/tests/Lfm.Api.Tests/Serialization/LocalizedStringConverterTests.cs
@@ -326,63 +326,42 @@ public class LocalizedStringConverterTests
     }
 
     [Fact]
-    public void SpecializationDocument_deserializes_with_localized_name()
+    public void PlayableSpecializationBlob_deserializes_with_localized_name()
     {
-        var json = """
-        {
-          "id": "262",
-          "specId": 262,
-          "name": { "en_US": "Elemental", "de_DE": "Elementar" },
-          "classId": 7,
-          "role": "DAMAGE",
-          "iconUrl": null
-        }
-        """;
-
-        var doc = JsonConvert.DeserializeObject<SpecializationDocument>(json, CosmosLikeSettings);
-
-        Assert.Equal("Elemental", doc!.Name);
-    }
-
-    [Fact]
-    public void SpecializationListRow_deserializes_with_localized_name()
-    {
-        // Shape of the row produced by SpecializationsRepository.ListAsync's
-        // projection: SELECT c.specId AS id, c.name, c.classId, c.role, c.iconUrl FROM c.
-        // Same root cause as InstanceListRow / /api/guild: legacy documents
-        // store c.name as Blizzard's no-locale object, and SpecializationDto
-        // (in Lfm.Contracts, no converter) cannot accept that shape.
+        // Shape of a verbatim TS-ingested playable-specialization blob at
+        // reference/playable-specialization/{id}.json. Blizzard's no-locale
+        // response stores name as a localized object.
         var json = """
         {
           "id": 262,
           "name": { "en_US": "Elemental", "de_DE": "Elementar" },
-          "classId": 7,
-          "role": "DAMAGE",
-          "iconUrl": null
+          "playable_class": { "id": 7 },
+          "role": { "type": "DAMAGE" }
         }
         """;
 
-        var row = JsonConvert.DeserializeObject<SpecializationListRow>(json, CosmosLikeSettings);
+        var blob = JsonConvert.DeserializeObject<PlayableSpecializationBlob>(json, CosmosLikeSettings);
 
-        Assert.Equal("Elemental", row!.Name);
+        Assert.Equal("Elemental", blob!.Name);
     }
 
     [Fact]
-    public void SpecializationListRow_deserializes_with_plain_string_name()
+    public void PlayableSpecializationBlob_deserializes_with_plain_string_name()
     {
+        // After Phase 3 ingestion with locale=en_US on the Blizzard call,
+        // the reader also must handle plain-string names.
         var json = """
         {
           "id": 262,
           "name": "Elemental",
-          "classId": 7,
-          "role": "DAMAGE",
-          "iconUrl": null
+          "playable_class": { "id": 7 },
+          "role": { "type": "DAMAGE" }
         }
         """;
 
-        var row = JsonConvert.DeserializeObject<SpecializationListRow>(json, CosmosLikeSettings);
+        var blob = JsonConvert.DeserializeObject<PlayableSpecializationBlob>(json, CosmosLikeSettings);
 
-        Assert.Equal("Elemental", row!.Name);
+        Assert.Equal("Elemental", blob!.Name);
     }
 
     // Record used only by the converter unit tests above.


### PR DESCRIPTION
## Summary

Fixes the `/api/reference/specializations` 500 in production, same root cause and pattern as the preceding instances PR: the Cosmos-backed read path pointed at a container (`specializations`) that was never provisioned in Bicep; the reference data has lived in blob (`lfmstore/wow/reference/playable-specialization/` + `.../playable-specialization-media/`) since the TS-era ingester. Follows [docs/storage-architecture.md](docs/storage-architecture.md).

- `SpecializationsRepository.ListAsync` now reads from blob via `IBlobReferenceClient`. Manifest fast path: `reference/playable-specialization/index.json` when present. Fallback: enumerates `reference/playable-specialization/*.json`, tolerantly fetches `reference/playable-specialization-media/{id}.json` for icon URLs, maps to `SpecializationDto`.
- Drops `SpecializationDocument` + `UpsertBatchAsync` from `ISpecializationsRepository`.
- With both reference entities now blob-read-only, `ReferenceSync` collapses to two stubs wrapped in the existing per-entity failure-reporting loop — Phase 3 reimplements both as blob writers. `ReferenceSync`'s `IBlizzardGameDataClient` and `ISpecializationsRepository` constructor deps are dropped (nothing uses them anymore).
- Retargets the specialization `LocalizedStringConverter` tests from the removed `SpecializationDocument` / `SpecializationListRow` to the new `PlayableSpecializationBlob`. Adds `[JsonProperty("playable_class")]` on that record because Blizzard's reference response is snake_case and Newtonsoft won't cross the underscore.
- `ReferenceSyncTests` now covers just the stub contract: `SyncAllAsync` reports both entities as `failed:` with per-entity Error-level logs. The old Blizzard-call happy path / retry / media-failure tests are obsolete and removed; they'll come back against the blob-writer in Phase 3.
- New `SpecializationsRepositoryTests` covers manifest fast path, fallback path, icon resolution, null-media tolerance, role mapping (theory × 5), and missing-playable-class defaulting to classId 0.

## Env / schema changes

None. Same `StorageOptions` keys from Commit A.

On first deploy, `/api/reference/specializations` will return real data — the legacy TS ingester already wrote `reference/playable-specialization/` + `-media/` blobs (dated 2026-03-30).

## Test plan

- [x] `dotnet build lfm.sln -c Release` — green.
- [x] `dotnet test tests/Lfm.Api.Tests` — 387 passed (was 386; net +1 as expected).
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error` — clean.
- [ ] Post-deploy: `curl https://lfm-api.dinosauruskeksi.com/api/reference/specializations` returns 200 with a list of 40-odd spec DTOs, each with `iconUrl` populated from the existing media blobs.
- [ ] Edit-run page in the browser: spec dropdown populates instead of erroring.
