### PR TITLE
Seed wow reference blobs into Azurite for E2E

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -39,6 +39,11 @@ services:
       COSMOS_KEY: ${COSMOS_KEY}
       COSMOS_DATABASE: ${COSMOS_DATABASE}
       AzureWebJobsStorage: ${AzureWebJobsStorage}
+      # Storage__BlobConnectionString drives BlobReferenceClient in
+      # api/Program.cs for the Phase-1 blob-backed reference-data reads.
+      # Inside the docker network Azurite is addressable as "azurite" on 10000.
+      Storage__BlobConnectionString: DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;
+      Storage__WowContainerName: wow
       BLOB_STORAGE_URL: ${BLOB_STORAGE_URL}
       PUBLIC_BLOB_STORAGE_URL: ${PUBLIC_BLOB_STORAGE_URL}
       APP_BASE_URL: ${APP_BASE_URL}

--- a/tests/Lfm.E2E/Infrastructure/SharedStack.cs
+++ b/tests/Lfm.E2E/Infrastructure/SharedStack.cs
@@ -21,6 +21,7 @@ public static class SharedStack
             var stack = new StackFixture();
             await stack.InitializeAsync();
             await DefaultSeed.SeedAsync(stack.CosmosClient, StackFixture.DatabaseName);
+            await WowReferenceSeed.SeedAsync(stack.BlobConnectionString);
             return stack;
         },
         LazyThreadSafetyMode.ExecutionAndPublication);

--- a/tests/Lfm.E2E/Infrastructure/StackFixture.cs
+++ b/tests/Lfm.E2E/Infrastructure/StackFixture.cs
@@ -58,6 +58,10 @@ public class StackFixture : IAsyncLifetime
     public CosmosClient CosmosClient { get; private set; } = null!;
     public string ApiBaseUrl => $"http://localhost:{_apiPort}";
     public string AppBaseUrl => $"http://localhost:{_appPort}";
+    // Azurite connection string used by E2E seeders and passed to the API as
+    // Storage__BlobConnectionString so BlobReferenceClient binds to the
+    // containerised Azurite instead of trying managed identity at startup.
+    public string BlobConnectionString => _azurite.GetConnectionString();
 
     /// <summary>
     /// Recent API process stdout/stderr for test failure diagnostics. The
@@ -143,6 +147,12 @@ public class StackFixture : IAsyncLifetime
                 ["Cosmos__ConnectionMode"] = "Gateway",
                 ["Cosmos__SkipCertValidation"] = "true",
                 ["AzureWebJobsStorage"] = "UseDevelopmentStorage=true",
+                // Storage__BlobConnectionString drives BlobReferenceClient in
+                // api/Program.cs. Must point at the same Azurite the seeder
+                // uploads reference fixtures into — otherwise /api/instances
+                // and /api/reference/specializations see an empty container.
+                ["Storage__BlobConnectionString"] = _azurite.GetConnectionString(),
+                ["Storage__WowContainerName"] = Seeds.WowReferenceSeed.ContainerName,
                 ["FUNCTIONS_WORKER_RUNTIME"] = "dotnet-isolated",
                 ["E2E_TEST_MODE"] = "true",
                 ["Auth__CookieName"] = "battlenet_token",

--- a/tests/Lfm.E2E/Lfm.E2E.csproj
+++ b/tests/Lfm.E2E/Lfm.E2E.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Testcontainers.Azurite" Version="4.11.0" />
     <PackageReference Include="Deque.AxeCore.Playwright" Version="4.11.2" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Lfm.E2E/Seeds/DefaultSeed.cs
+++ b/tests/Lfm.E2E/Seeds/DefaultSeed.cs
@@ -43,17 +43,9 @@ public static class DefaultSeed
 
         await SeedRunAsync(runsContainer);
 
-        // --- Instances container (partition key: /id) ---
-        var instancesContainer = (await RetryAsync(
-            () => db.CreateContainerIfNotExistsAsync(
-                new ContainerProperties("instances", "/id")))).Container;
-
-        await SeedInstancesAsync(instancesContainer);
-
-        // --- Specializations container (partition key: /id) ---
-        await RetryAsync(
-            () => db.CreateContainerIfNotExistsAsync(
-                new ContainerProperties("specializations", "/id")));
+        // Reference data (instances, specializations) lives in blob — see
+        // docs/storage-architecture.md. Seeded separately via WowReferenceSeed
+        // against the Azurite blob container.
     }
 
     private static async Task SeedPrimaryRaiderAsync(Container container)
@@ -401,22 +393,6 @@ public static class DefaultSeed
 
         await RetryAsync(
             () => container.UpsertItemAsync(run, new PartitionKey(TestRunId)));
-    }
-
-    private static async Task SeedInstancesAsync(Container container)
-    {
-        // Matches InstanceDocument schema: id = "{instanceId}:{modeKey}", partition key = /id
-        var instance = new Dictionary<string, object?>
-        {
-            ["id"] = "67:NORMAL:25",
-            ["instanceId"] = "67",
-            ["name"] = "Liberation of Undermine",
-            ["modeKey"] = "NORMAL:25",
-            ["expansion"] = "The War Within",
-        };
-
-        await RetryAsync(
-            () => container.UpsertItemAsync(instance, new PartitionKey("67:NORMAL:25")));
     }
 
     private static async Task<T> RetryAsync<T>(Func<Task<T>> action, int maxRetries = 5)

--- a/tests/Lfm.E2E/Seeds/WowReferenceSeed.cs
+++ b/tests/Lfm.E2E/Seeds/WowReferenceSeed.cs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Text;
+using System.Text.Json;
+using Azure.Storage.Blobs;
+
+namespace Lfm.E2E.Seeds;
+
+/// <summary>
+/// Seeds the <c>wow</c> container in Azurite with enough static Blizzard
+/// reference data for the Phase-1 blob-backed read paths (<c>/api/instances</c>
+/// and <c>/api/reference/specializations</c>) to return meaningful rows during
+/// E2E. Mirrors the on-disk layout defined in <c>docs/storage-architecture.md</c>
+/// — fixtures are intentionally minimal but shaped like the verbatim Blizzard
+/// responses the legacy TS ingester wrote (localized-object names included so
+/// the <see cref="Lfm.Api.Serialization.LocalizedStringConverter"/> is exercised).
+/// </summary>
+public static class WowReferenceSeed
+{
+    public const string ContainerName = "wow";
+
+    public static async Task SeedAsync(string blobConnectionString)
+    {
+        var service = new BlobServiceClient(blobConnectionString);
+        var container = service.GetBlobContainerClient(ContainerName);
+        await container.CreateIfNotExistsAsync();
+
+        // --- Journal instances ---
+        // Seeds just the instance referenced by DefaultSeed's test run
+        // (instanceId 67, "Liberation of Undermine", NORMAL:25). Uses the
+        // localized-object name shape on purpose — exercises the converter.
+        await UploadJsonAsync(container, "reference/journal-instance/67.json", new
+        {
+            id = 67,
+            name = new
+            {
+                en_US = "Liberation of Undermine",
+                de_DE = "Befreiung von Schattenmark",
+            },
+            expansion = new { name = "The War Within" },
+            modes = new[]
+            {
+                new { mode = new { type = "NORMAL" }, players = 25 },
+            },
+        });
+
+        // --- Playable specializations ---
+        // Specs referenced by the raiders seeded in DefaultSeed: 62 Arcane,
+        // 65 Holy, 71 Arms. Kept to three so the dropdown has meaningful rows
+        // without pretending to be a full spec index.
+        await UploadSpecAsync(container, specId: 62, name: "Arcane", classId: 8, roleType: "DAMAGE");
+        await UploadSpecAsync(container, specId: 65, name: "Holy", classId: 5, roleType: "HEALER");
+        await UploadSpecAsync(container, specId: 71, name: "Arms", classId: 1, roleType: "DAMAGE");
+    }
+
+    private static async Task UploadSpecAsync(
+        BlobContainerClient container, int specId, string name, int classId, string roleType)
+    {
+        await UploadJsonAsync(container, $"reference/playable-specialization/{specId}.json", new
+        {
+            id = specId,
+            // Localized-object shape verifies the converter path.
+            name = new Dictionary<string, string> { ["en_US"] = name },
+            playable_class = new { id = classId },
+            role = new { type = roleType },
+        });
+
+        await UploadJsonAsync(container, $"reference/playable-specialization-media/{specId}.json", new
+        {
+            assets = new[]
+            {
+                new { key = "icon", value = $"https://render.worldofwarcraft.com/e2e/spec-{specId}.jpg" },
+            },
+        });
+    }
+
+    private static async Task UploadJsonAsync(BlobContainerClient container, string blobName, object payload)
+    {
+        var json = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+        {
+            // Blizzard field convention — keep snake_case keys verbatim so the
+            // reader (Newtonsoft + [JsonProperty]) picks them up exactly as in prod.
+            PropertyNamingPolicy = null,
+            WriteIndented = false,
+        });
+        var bytes = Encoding.UTF8.GetBytes(json);
+        var blob = container.GetBlobClient(blobName);
+        using var ms = new MemoryStream(bytes);
+        await blob.UploadAsync(ms, overwrite: true);
+    }
+}

--- a/tests/Lfm.E2E/packages.lock.json
+++ b/tests/Lfm.E2E/packages.lock.json
@@ -2,6 +2,16 @@
   "version": 1,
   "dependencies": {
     "net10.0": {
+      "Azure.Storage.Blobs": {
+        "type": "Direct",
+        "requested": "[12.27.0, )",
+        "resolved": "12.27.0",
+        "contentHash": "zI5rg1tTtnA8T2g2/21l+1iIUdDjpEQQ0FI1BabJVEQJ1JUyTQKrc41eNabAHs0SBHprl6pu/6OqIMK9Ve+4tQ==",
+        "dependencies": {
+          "Azure.Core": "1.50.0",
+          "Azure.Storage.Common": "12.26.0"
+        }
+      },
       "Deque.AxeCore.Playwright": {
         "type": "Direct",
         "requested": "[4.11.2, )",
@@ -112,12 +122,21 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.44.1",
-        "contentHash": "YyznXLQZCregzHvioip07/BkzjuWNXogJEVz9T5W6TwjNr17ax41YGzYMptlo2G10oLCuVPoyva62y0SIRDixg==",
+        "resolved": "1.50.0",
+        "contentHash": "GBNKZEhdIbTXxedvD3R7I/yDVFX9jJJEz02kCziFSJxspSQ5RMHc3GktulJ1s7+ffXaXD7kMgrtdQTaggyInLw==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
-          "System.ClientModel": "1.1.0",
-          "System.Memory.Data": "6.0.0"
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "System.ClientModel": "1.8.0",
+          "System.Memory.Data": "8.0.1"
+        }
+      },
+      "Azure.Storage.Common": {
+        "type": "Transitive",
+        "resolved": "12.26.0",
+        "contentHash": "XaT6CDcSshZb7KaCTwc6m4EouZbLBg7ciOEpsJSdJCvkNsZJQCvPKw7V5TtXno19AA1NpwtsZriYque8mzbQVg==",
+        "dependencies": {
+          "Azure.Core": "1.50.0",
+          "System.IO.Hashing": "10.0.1"
         }
       },
       "BouncyCastle.Cryptography": {
@@ -752,8 +771,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+        "resolved": "8.0.0",
+        "contentHash": "3WA9q9yVqJp222P3x1wYIGDAkpjAku0TMUaaQV22g6L67AI0LdOIrVS7Ht2vJfLHGSPVuqN94vIr15qn+HEkHw=="
       },
       "Microsoft.Bcl.HashCode": {
         "type": "Transitive",
@@ -1007,10 +1026,10 @@
       },
       "System.ClientModel": {
         "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "UocOlCkxLZrG2CKMAAImPcldJTxeesHnHGHwhJ0pNlZEvEXcWKuQvVOER2/NiOkJGRJk978SNdw3j6/7O9H1lg==",
+        "resolved": "1.8.0",
+        "contentHash": "AqRzhn0v29GGGLj/Z6gKq4lGNtvPHT4nHdG5PDJh9IfVjv/nYUVmX11hwwws1vDFeIAzrvmn0dPu8IjLtu6fAw==",
         "dependencies": {
-          "System.Memory.Data": "1.0.2"
+          "System.Memory.Data": "8.0.1"
         }
       },
       "System.ComponentModel.Annotations": {
@@ -1049,10 +1068,15 @@
         "resolved": "17.0.24",
         "contentHash": "hA7bacntMiZv1Yf9xtjwl/GP3GT1mG84QxhAk7ijAUD0pJhJaVVwXScE13vMpXnNtlaRDW6SeyZdWg2j2qrh4w=="
       },
+      "System.IO.Hashing": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "Dy6ULPb2S0GmNndjKrEIpfibNsc8+FTOoZnqygtFDuyun8vWboQbfMpQtKUXpgTxokR5E4zFHETpNnGfeWY6NA=="
+      },
       "System.Memory.Data": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "ntFHArH3I4Lpjf5m4DCXQHJuGwWPNVJPaAvM95Jy/u+2Yzt2ryiyIN04LAogkjP9DeRcEOiviAjQotfmPq/FrQ=="
+        "resolved": "8.0.1",
+        "contentHash": "BVYuec3jV23EMRDeR7Dr1/qhx7369dZzJ9IWy2xylvb4YfXsrUxspWc4UWYid/tj4zZK58uGZqn2WQiaDMhmAg=="
       },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Transitive",


### PR DESCRIPTION
## Summary

Finishes Phase 1 of the storage-consolidation plan by moving E2E's reference-data seeding from Cosmos to the Azurite `wow` blob container, so the blob-backed `/api/instances` and `/api/reference/specializations` reads have something to return in the test stack. Follows [docs/storage-architecture.md](docs/storage-architecture.md).

- New `WowReferenceSeed` uploads minimal fixtures to `lfmstore/wow/reference/` in Azurite: one journal-instance (id 67, "Liberation of Undermine", NORMAL:25) matching the seeded test run, plus three playable-specializations (62 Arcane, 65 Holy, 71 Arms) matching the raider characters DefaultSeed creates. Each fixture uses Blizzard's localized-object `name` shape on purpose so the `LocalizedStringConverter` is exercised at the seam.
- `DefaultSeed` drops the Cosmos `instances` container creation + seed and the empty `specializations` container creation — both stores are retired.
- `StackFixture` exposes `BlobConnectionString` (derived from the Testcontainers Azurite instance) and threads it into the API env as `Storage__BlobConnectionString` + `Storage__WowContainerName` so `BlobReferenceClient` binds correctly at startup.
- `SharedStack` invokes `WowReferenceSeed.SeedAsync` after `DefaultSeed` so fixtures are in place before any test hits the API.
- `docker-compose.test.yml` gains the same two env vars (for the alternate containerised E2E path); uses Azurite's well-known shared-key connection string with the `azurite` hostname that resolves inside the compose network.
- `Lfm.E2E.csproj` gains `Azure.Storage.Blobs` 12.27.0 (matching the pin in `api/Lfm.Api.csproj`); `packages.lock.json` regenerated.

## Env / schema changes

New env vars for the E2E API process / functions container:

- `Storage__BlobConnectionString` — Azurite connection string (Testcontainers in the in-process path, the compose-network variant in docker-compose).
- `Storage__WowContainerName` — `wow`.

No production change; these are E2E-only.

## Test plan

- [x] `dotnet build lfm.sln -c Release` — green.
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error` — clean.
- [x] `dotnet test tests/Lfm.Api.Tests` — still 387 passing (unit tests unaffected by E2E-only wiring).
- [ ] Manual E2E run (workflow_dispatch on the `E2E` workflow): `/api/instances` returns "Liberation of Undermine"; EditRun page instance dropdown populates; raider character detail pages resolve spec names.
- [ ] Post-merge production smoke: `/api/instances` returns 200 (no behaviour change in prod — this PR only touches E2E seeding and the docker-compose file that isn't used by the deploy pipeline).

## Phase 1 status

This merges the last of the four commits in the Phase 1 plan:

1. `e5da846` Add BlobReferenceClient for wow container reads
2. `930f6fe` Move instances read to blob with portrait URL
3. `1cd6f43` Move specializations read to blob with icon URL
4. this PR — E2E Azurite seed

After this lands, `/api/instances` and `/api/reference/specializations` are both blob-backed end-to-end, the local E2E stack matches, and Phase 2 (delete the unused Cosmos `migrations` container) is ready to start.
