### PR TITLE
Set Storage__BlobServiceUri on Function App

### DIFF
--- a/infra/modules/functions.bicep
+++ b/infra/modules/functions.bicep
@@ -120,6 +120,12 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
         { name: 'Cors__AllowedOrigins__0', value: frontendOrigin }
         // StorageOptions (section: Storage)
         { name: 'Storage__DataProtectionBlobUri', value: dataProtectionBlobUri }
+        // Drives BlobReferenceClient (api/Program.cs) for the Phase 1
+        // blob-backed reference reads (`/api/instances`,
+        // `/api/reference/specializations`). Managed identity flows through
+        // DefaultAzureCredential — no shared key in app settings. Container
+        // name defaults to "wow" in StorageOptions.
+        { name: 'Storage__BlobServiceUri', value: storageAccountRef.properties.primaryEndpoints.blob }
         // Site
         { name: 'PRIVACY_EMAIL', value: privacyEmail }
       ]


### PR DESCRIPTION
## Summary

Phase 1 follow-up: wire the app setting `BlobReferenceClient` needs at startup. The Phase 1 commits shipped the client + repositories but never added the production config key, so the registered factory throws `InvalidOperationException: "Storage:BlobServiceUri or Storage:BlobConnectionString must be configured for reference-data reads."` at every request (confirmed in App Insights at 2026-04-21T13:50Z).

- `infra/modules/functions.bicep` — add the `Storage__BlobServiceUri` app setting under the existing `StorageOptions` section, sourced from the existing `storageAccountRef.properties.primaryEndpoints.blob`. Managed identity handles auth via the `Storage Blob Data Owner` role the MI already holds on `lfmstore` (no shared key, no Key Vault ref needed).
- No code change, no E2E change (E2E uses `Storage__BlobConnectionString` against Azurite, already wired in PR #78).

## Env / schema changes

Adds app setting `Storage__BlobServiceUri` on the production Function App. Value resolves to `https://lfmstore.blob.core.windows.net/` from the existing storage account reference. Redeploys the Function App — brief restart expected.

## Test plan

- [x] `az bicep build --file infra/main.bicep --stdout` — clean.
- [ ] Post-merge: `deploy-infra.yml` completes green; PSRule analyze gate passes.
- [ ] Post-deploy: `curl https://lfm-api.dinosauruskeksi.com/api/instances` returns 200 with a JSON list (first row "Liberation of Undermine", NORMAL:25, expansion "The War Within").
- [ ] Post-deploy: `curl https://lfm-api.dinosauruskeksi.com/api/reference/specializations` returns 200 with ~40 entries, each with a Blizzard render `iconUrl`.
- [ ] App Insights: `AppExceptions | where TimeGenerated > ago(5m) and OuterMessage has "BlobServiceUri"` returns zero rows.
