### PR TITLE
Treat blob JSON parse failure as missing

### DIFF
--- a/api/Services/BlobReferenceClient.cs
+++ b/api/Services/BlobReferenceClient.cs
@@ -25,14 +25,30 @@ public sealed class BlobReferenceClient(BlobContainerClient container) : IBlobRe
     public async Task<T?> GetAsync<T>(string blobName, CancellationToken ct) where T : class
     {
         var blob = container.GetBlobClient(blobName);
+        string json;
         try
         {
             var response = await blob.DownloadContentAsync(ct);
-            var json = response.Value.Content.ToString();
-            return JsonConvert.DeserializeObject<T>(json, JsonSettings);
+            json = response.Value.Content.ToString();
         }
         catch (RequestFailedException ex) when (ex.Status == 404)
         {
+            return null;
+        }
+
+        try
+        {
+            return JsonConvert.DeserializeObject<T>(json, JsonSettings);
+        }
+        catch (JsonException)
+        {
+            // A blob whose JSON shape does not match T is treated the same as
+            // a missing blob. The legacy TS ingester wrote Blizzard's raw
+            // index response at reference/{kind}/index.json (an object with
+            // _links + an instances array) — not the Phase 3 manifest format
+            // (a flat List<IndexEntry>). Returning null lets InstancesRepository
+            // and SpecializationsRepository fall through to the per-id
+            // enumeration path instead of 500-ing the endpoint.
             return null;
         }
     }


### PR DESCRIPTION
## Summary

Second Phase 1 follow-up. With `Storage__BlobServiceUri` now set (PR #79), `BlobReferenceClient` successfully opens the wow container — but `/api/instances` now surfaces a different 500 (confirmed in App Insights):

```
Newtonsoft.Json.JsonSerializationException: Cannot deserialize the current JSON
object (e.g. {"name":"value"}) into type
'System.Collections.Generic.List`1[Lfm.Api.Repositories.InstanceIndexEntry]'
because the type requires a JSON array. Path '_links', line 2, position 11.
```

Root cause: the legacy TS ingester did write `reference/journal-instance/index.json` and `reference/playable-specialization/index.json` — but with **Blizzard's raw index response shape** (an object carrying `_links` plus a nested `instances` array), not the Phase 3 manifest shape (a flat `List<IndexEntry>`). My Phase 1 reader assumes the second; the first crashes the endpoint before the fallback ever runs.

- `BlobReferenceClient.GetAsync<T>` now catches `JsonException` and returns `null`, treating a malformed or wrong-shaped blob identically to a missing blob. This lets `InstancesRepository.ListAsync` and `SpecializationsRepository.ListAsync` cleanly fall through to per-id enumeration when the TS-era `index.json` is unreadable. Phase 3 will overwrite both `index.json` blobs with the manifest shape the reader expects.

## Behaviour change

Previously: a blob whose shape cannot be deserialized to the requested `T` crashed the request with a `JsonException`.

Now: returns `null`, same as a 404. Callers that want the data to load see `null` and handle accordingly (instances / specializations fall through to enumeration). A truly broken per-id detail blob is skipped by `ListAsync`, which is also the right behaviour — the alternative is one bad file bricking the entire list endpoint.

## Env / schema changes

None.

## Test plan

- [x] `dotnet build lfm.sln -c Release` — green.
- [x] `dotnet test tests/Lfm.Api.Tests` — 387 passing. The downstream repository-level tests (`InstancesRepositoryTests::ListAsync_falls_back_*`, `SpecializationsRepositoryTests::ListAsync_falls_back_*`) already prove the manifest-null → enumerate fallback wiring; this PR doesn't change that contract, only adds a new input that lands in the same fallback branch.
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error` — clean.
- [ ] Post-deploy: `curl https://lfm-api.dinosauruskeksi.com/api/instances` returns 200 with a non-empty JSON array. App Insights `AppExceptions | where Method startswith "Newtonsoft.Json"` quiet for 5 min after deploy.
- [ ] Same for `/api/reference/specializations`.

Skipped a dedicated `BlobReferenceClient` unit test for the new catch — `BlobContainerClient` / `BlobClient` mocking for `DownloadContentAsync` is disproportionate to a single `try/catch` on a documented `JsonException` type. Repository-level fallback tests cover the downstream contract. Worth revisiting if we introduce a second scenario (e.g. I/O retry) that would share the same test harness.
