### PR TITLE
Drop unused Cosmos migrations container

### DIFF
--- a/infra/modules/cosmos.bicep
+++ b/infra/modules/cosmos.bicep
@@ -120,24 +120,6 @@ resource guildsContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/con
   }
 }
 
-resource migrationsContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-05-15' = {
-  parent: database
-  name: 'migrations'
-  properties: {
-    resource: {
-      id: 'migrations'
-      partitionKey: { paths: ['/id'], kind: 'Hash' }
-      // Point-read only (by partition key). Exclude all secondary indexes to save write RU.
-      indexingPolicy: {
-        automatic: true
-        indexingMode: 'consistent'
-        includedPaths: []
-        excludedPaths: [{ path: '/*' }]
-      }
-    }
-  }
-}
-
 resource cosmosLock 'Microsoft.Authorization/locks@2020-05-01' = {
   name: '${accountName}-lock'
   scope: cosmosAccount


### PR DESCRIPTION
## Summary

Phase 2 of the storage-consolidation plan. The `migrations` Cosmos container is a TS-era remnant — no C# code references it (`grep -r 'migrations' api --include='*.cs'` returns zero hits), there is no `api/Migrations/` folder, and CLAUDE.md's `## Storage Architecture` section already describes the new state ("no DB migration runner"). The container has been empty on production since this codebase shipped.

- Remove the `migrationsContainer` resource block from `infra/modules/cosmos.bicep`. The `cosmosLock` (`CanNotDelete`) stays — it protects the Cosmos account and its remaining three containers (`raiders`, `runs`, `guilds`) as before.
- Post-merge: manual `az cosmosdb sql container delete -g lfm -a lfm-cosmos -d lfm -n migrations --yes` to remove the container from the live account. User confirmed 2026-04-21 that there's no real production data yet, so an unconditional drop is safe.

## Env / schema changes

Removes Cosmos container `migrations` from the production `lfm-cosmos/lfm` database. No code change required — no C# repository binds to it. The account-level RU/s pool (1000 RU/s shared) now has one fewer idle container but the same free-tier envelope.

## Test plan

- [x] `az bicep build --file infra/main.bicep --stdout` — clean.
- [ ] PSRule analyze gate green on PR.
- [ ] Post-merge: `deploy-infra.yml` completes green.
- [ ] Post-deploy: `az cosmosdb sql container delete -g lfm -a lfm-cosmos -d lfm -n migrations --yes` followed by `az cosmosdb sql container list -g lfm -a lfm-cosmos -d lfm --query "[].name" -o tsv` returns exactly `guilds`, `raiders`, `runs`.
- [ ] Smoke: `/api/health`, `/api/instances`, `/api/reference/specializations` all remain 200 post-deploy (none touch `migrations`).
