### PR TITLE
Phase 3 writer: blob ingester with manifest

### DIFF
--- a/api/Services/BlizzardGameDataClient.cs
+++ b/api/Services/BlizzardGameDataClient.cs
@@ -107,6 +107,11 @@ public sealed class BlizzardGameDataClient : IBlizzardGameDataClient
         => GetStaticJsonAsync<BlizzardJournalInstanceDetail>(
             $"data/wow/journal-instance/{instanceId}", accessToken, ct);
 
+    /// <inheritdoc/>
+    public Task<BlizzardMediaAssets> GetJournalInstanceMediaAsync(int instanceId, string accessToken, CancellationToken ct)
+        => GetStaticJsonAsync<BlizzardMediaAssets>(
+            $"data/wow/media/journal-instance/{instanceId}", accessToken, ct);
+
     // ---------------------------------------------------------------------------
     // Generic static-namespace fetch
     // ---------------------------------------------------------------------------

--- a/api/Services/BlobReferenceClient.cs
+++ b/api/Services/BlobReferenceClient.cs
@@ -67,6 +67,24 @@ public sealed class BlobReferenceClient(BlobContainerClient container) : IBlobRe
         }
     }
 
+    public async Task UploadAsync<T>(string blobName, T payload, CancellationToken ct)
+    {
+        var json = JsonConvert.SerializeObject(payload, JsonSettings);
+        var bytes = System.Text.Encoding.UTF8.GetBytes(json);
+        using var stream = new MemoryStream(bytes);
+        var blob = container.GetBlobClient(blobName);
+        await blob.UploadAsync(
+            stream,
+            new BlobUploadOptions
+            {
+                HttpHeaders = new BlobHttpHeaders
+                {
+                    ContentType = "application/json",
+                },
+            },
+            ct);
+    }
+
     private static bool IsManifestBlob(string blobName)
         => blobName.EndsWith("/index.json", StringComparison.Ordinal)
         || blobName.EndsWith("/meta.json", StringComparison.Ordinal);

--- a/api/Services/IBlizzardGameDataClient.cs
+++ b/api/Services/IBlizzardGameDataClient.cs
@@ -55,6 +55,11 @@ public interface IBlizzardGameDataClient
     /// Fetches a single journal-instance detail document.
     /// </summary>
     Task<BlizzardJournalInstanceDetail> GetJournalInstanceAsync(int instanceId, string accessToken, CancellationToken ct);
+
+    /// <summary>
+    /// Fetches the media (tile / image URLs) for a single journal-instance.
+    /// </summary>
+    Task<BlizzardMediaAssets> GetJournalInstanceMediaAsync(int instanceId, string accessToken, CancellationToken ct);
 }
 
 // ---------------------------------------------------------------------------

--- a/api/Services/IBlobReferenceClient.cs
+++ b/api/Services/IBlobReferenceClient.cs
@@ -26,4 +26,12 @@ public interface IBlobReferenceClient
     /// receive only per-id detail documents.
     /// </summary>
     IAsyncEnumerable<T> ListAsync<T>(string prefix, CancellationToken ct) where T : class;
+
+    /// <summary>
+    /// Serializes <paramref name="payload"/> with Newtonsoft and uploads it to the
+    /// container at <paramref name="blobName"/>, overwriting any existing blob.
+    /// Used by the ingester (<c>ReferenceSync</c>) to write per-id reference
+    /// documents and the list-endpoint manifest (<c>reference/{kind}/index.json</c>).
+    /// </summary>
+    Task UploadAsync<T>(string blobName, T payload, CancellationToken ct);
 }

--- a/api/Services/ReferenceSync.cs
+++ b/api/Services/ReferenceSync.cs
@@ -1,62 +1,228 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
+using Lfm.Api.Repositories;
 using Lfm.Contracts.Admin;
 using Microsoft.Extensions.Logging;
 
 namespace Lfm.Api.Services;
 
 /// <summary>
-/// Implements <see cref="IReferenceSync"/>.
+/// Syncs static Blizzard reference data (journal-instance, playable-specialization,
+/// plus their media blobs) from the Blizzard Game Data API into the
+/// <c>lfmstore/wow/reference/</c> blob container — see
+/// <c>docs/storage-architecture.md</c>.
 ///
-/// Phase 1 (2026-04-21) moved reference-data *reads* from Cosmos to blob — see
-/// <c>docs/storage-architecture.md</c>. The writer side (this class) will be
-/// re-implemented in Phase 3 to upload blobs instead of upserting Cosmos
-/// documents. In the meantime both entity stubs surface a clear "failed:"
-/// status through the admin <c>POST /api/wow/update</c> endpoint, while the
-/// respective repositories continue to serve the existing
-/// <c>lfmstore/wow/reference/</c> blobs ingested by the legacy TS job.
+/// For each entity the sync:
+/// 1. Fetches the Blizzard index and iterates entries.
+/// 2. Per entry: fetches the detail (with simple 429 retry) + media (best-effort).
+/// 3. Writes per-id detail + media blobs.
+/// 4. At the end, writes <c>reference/{kind}/index.json</c> — a self-contained
+///    list-endpoint manifest that the repositories read as a single blob GET.
 ///
-/// Per-entity failures are caught and recorded; the remaining entities are
-/// still attempted.
+/// Per-entity failures are caught by <see cref="SyncAllAsync"/>; the remaining
+/// entities are still attempted.
 /// </summary>
-public sealed class ReferenceSync(ILogger<ReferenceSync> logger) : IReferenceSync
+public sealed class ReferenceSync(
+    IBlizzardGameDataClient gameData,
+    IBlobReferenceClient blobs,
+    ILogger<ReferenceSync> logger) : IReferenceSync
 {
     /// <inheritdoc/>
-    public Task<WowUpdateResponse> SyncAllAsync(CancellationToken ct)
+    public async Task<WowUpdateResponse> SyncAllAsync(CancellationToken ct)
     {
         var results = new List<WowUpdateEntityResult>();
+        string? token = null;
 
-        foreach (var (name, sync) in Entities)
+        try
         {
+            token ??= await gameData.GetClientCredentialsTokenAsync(ct);
+            var count = await SyncInstancesAsync(token, ct);
+            results.Add(new WowUpdateEntityResult("instances", $"synced ({count} docs)"));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to sync instances");
+            results.Add(new WowUpdateEntityResult("instances", $"failed: {ex.Message}"));
+        }
+
+        try
+        {
+            token ??= await gameData.GetClientCredentialsTokenAsync(ct);
+            var count = await SyncSpecializationsAsync(token, ct);
+            results.Add(new WowUpdateEntityResult("specializations", $"synced ({count} docs)"));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to sync specializations");
+            results.Add(new WowUpdateEntityResult("specializations", $"failed: {ex.Message}"));
+        }
+
+        return new WowUpdateResponse(results);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Instance sync
+    // ---------------------------------------------------------------------------
+
+    private async Task<int> SyncInstancesAsync(string token, CancellationToken ct)
+    {
+        var index = await gameData.GetJournalInstanceIndexAsync(token, ct);
+        var manifest = new List<InstanceIndexEntry>();
+
+        foreach (var entry in index.Instances)
+        {
+            var detail = await FetchWithRetryAsync(
+                () => gameData.GetJournalInstanceAsync(entry.Id, token, ct),
+                $"instance {entry.Id}",
+                ct);
+            if (detail is null) continue;
+
+            BlizzardMediaAssets? media = null;
             try
             {
-                sync();
-                results.Add(new WowUpdateEntityResult(name, "synced"));
+                media = await gameData.GetJournalInstanceMediaAsync(entry.Id, token, ct);
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "Failed to sync {Entity}", name);
-                results.Add(new WowUpdateEntityResult(name, $"failed: {ex.Message}"));
+                logger.LogWarning(ex, "Could not fetch media for instance {Id}", entry.Id);
             }
+
+            var modeBlobs = detail.Modes?
+                .Select(m => new JournalInstanceModeBlob(new JournalModeRefBlob(m.Mode.Type), m.Players))
+                .ToList();
+            var detailBlob = new JournalInstanceBlob(
+                Id: detail.Id,
+                Name: detail.Name,
+                Expansion: detail.Expansion is null ? null : new JournalInstanceExpansionBlob(detail.Expansion.Name),
+                Modes: modeBlobs);
+            await blobs.UploadAsync($"reference/journal-instance/{detail.Id}.json", detailBlob, ct);
+
+            string? portraitUrl = null;
+            if (media?.Assets is not null)
+            {
+                var assetBlobs = media.Assets.Select(a => new MediaAssetBlob(a.Key, a.Value)).ToList();
+                await blobs.UploadAsync(
+                    $"reference/journal-instance-media/{detail.Id}.json",
+                    new MediaAssetsBlob(assetBlobs),
+                    ct);
+                portraitUrl = assetBlobs.FirstOrDefault(a => a.Key == "tile")?.Value
+                           ?? assetBlobs.FirstOrDefault(a => a.Key == "image")?.Value;
+            }
+
+            var manifestModes = (detail.Modes?.Count ?? 0) == 0
+                ? new List<InstanceIndexMode> { new("UNKNOWN:0") }
+                : detail.Modes!
+                    .Select(m => new InstanceIndexMode($"{m.Mode.Type}:{m.Players ?? 0}"))
+                    .ToList();
+
+            manifest.Add(new InstanceIndexEntry(
+                Id: detail.Id,
+                Name: detail.Name,
+                Modes: manifestModes,
+                Expansion: detail.Expansion?.Name ?? "",
+                PortraitUrl: portraitUrl));
         }
 
-        return Task.FromResult(new WowUpdateResponse(results));
+        await blobs.UploadAsync("reference/journal-instance/index.json", manifest, ct);
+        return manifest.Count;
     }
 
-    private static readonly (string Name, Action Sync)[] Entities =
-    [
-        ("instances", SyncInstancesAsync),
-        ("specializations", SyncSpecializationsAsync),
-    ];
+    // ---------------------------------------------------------------------------
+    // Specialization sync
+    // ---------------------------------------------------------------------------
 
-    private static void SyncInstancesAsync() =>
-        throw new NotImplementedException(
-            "Instance sync is being rewritten to write blobs in Phase 3. " +
-            "Existing lfmstore/wow/reference/journal-instance/ blobs remain readable via InstancesRepository.");
+    private async Task<int> SyncSpecializationsAsync(string token, CancellationToken ct)
+    {
+        var index = await gameData.GetPlayableSpecIndexAsync(token, ct);
+        var manifest = new List<SpecializationIndexEntry>();
 
-    private static void SyncSpecializationsAsync() =>
-        throw new NotImplementedException(
-            "Specialization sync is being rewritten to write blobs in Phase 3. " +
-            "Existing lfmstore/wow/reference/playable-specialization/ blobs remain readable via SpecializationsRepository.");
+        foreach (var entry in index.CharacterSpecializations)
+        {
+            var detail = await FetchWithRetryAsync(
+                () => gameData.GetPlayableSpecAsync(entry.Id, token, ct),
+                $"specialization {entry.Id}",
+                ct);
+            if (detail is null) continue;
+
+            BlizzardMediaAssets? media = null;
+            try
+            {
+                media = await gameData.GetPlayableSpecMediaAsync(entry.Id, token, ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Could not fetch media for spec {Id}", entry.Id);
+            }
+
+            var detailBlob = new PlayableSpecializationBlob(
+                Id: detail.Id,
+                Name: detail.Name,
+                PlayableClass: new PlayableClassRefBlob(detail.PlayableClass.Id),
+                Role: new PlayableSpecRoleRefBlob(detail.Role.Type));
+            await blobs.UploadAsync($"reference/playable-specialization/{detail.Id}.json", detailBlob, ct);
+
+            string? iconUrl = null;
+            if (media?.Assets is not null)
+            {
+                var assetBlobs = media.Assets.Select(a => new MediaAssetBlob(a.Key, a.Value)).ToList();
+                await blobs.UploadAsync(
+                    $"reference/playable-specialization-media/{detail.Id}.json",
+                    new MediaAssetsBlob(assetBlobs),
+                    ct);
+                iconUrl = assetBlobs.FirstOrDefault(a => a.Key == "icon")?.Value;
+            }
+
+            manifest.Add(new SpecializationIndexEntry(
+                Id: detail.Id,
+                Name: detail.Name,
+                ClassId: detail.PlayableClass.Id,
+                Role: ToRole(detail.Role.Type),
+                IconUrl: iconUrl));
+        }
+
+        await blobs.UploadAsync("reference/playable-specialization/index.json", manifest, ct);
+        return manifest.Count;
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    /// <summary>
+    /// Simple 429-retry wrapper: sleep 1s and retry on <c>HttpStatusCode.TooManyRequests</c>,
+    /// log + skip on any other error. The shared <c>BlizzardRateLimiter</c> gates
+    /// outbound traffic to ~80 req/s so genuine 429s from Blizzard are rare, but
+    /// the retry is kept for safety.
+    /// </summary>
+    private async Task<T?> FetchWithRetryAsync<T>(
+        Func<Task<T>> fetch,
+        string description,
+        CancellationToken ct) where T : class
+    {
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+            try
+            {
+                return await fetch();
+            }
+            catch (HttpRequestException ex) when ((int?)ex.StatusCode == 429)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1), ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Skipping {Description}: fetch failed", description);
+                return null;
+            }
+        }
+    }
+
+    private static string ToRole(string blizzardRoleType) => blizzardRoleType switch
+    {
+        "HEALER" => "HEALER",
+        "TANK" => "TANK",
+        _ => "DPS",
+    };
 }

--- a/tests/Lfm.Api.Tests/ReferenceSyncTests.cs
+++ b/tests/Lfm.Api.Tests/ReferenceSyncTests.cs
@@ -1,43 +1,328 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
+using Lfm.Api.Repositories;
 using Lfm.Api.Services;
 using Microsoft.Extensions.Logging;
+using Moq;
 using Xunit;
 
 namespace Lfm.Api.Tests;
 
 /// <summary>
-/// Phase 1 stub coverage. Both reference-sync entity writers throw
-/// <see cref="NotImplementedException"/> until Phase 3 rewires them to upload
-/// blobs instead of upserting Cosmos. The writer contract we defend here is
-/// exactly that: the admin endpoint surfaces a clear per-entity "failed:"
-/// status rather than aborting the whole call, and each failure is logged at
-/// Error level.
+/// Phase 3 writer coverage. <see cref="ReferenceSync"/> fetches the Blizzard
+/// index + details + media, uploads per-id detail and media blobs to the wow
+/// container, and emits <c>reference/{kind}/index.json</c> — the list-endpoint
+/// manifest the repositories read as a single blob GET.
 /// </summary>
 public class ReferenceSyncTests
 {
-    [Fact]
-    public async Task SyncAllAsync_reports_both_entities_as_failed_pending_phase_3_blob_writer()
+    private const string FakeToken = "fake-bnet-token";
+
+    // ── Fixture builders ─────────────────────────────────────────────────────
+
+    private static BlizzardJournalInstanceIndex MakeJournalIndex(params (int Id, string Name)[] entries) =>
+        new(entries.Select(e => new BlizzardIndexEntry(e.Id, e.Name)).ToList());
+
+    private static BlizzardJournalInstanceDetail MakeInstanceDetail(
+        int id,
+        string name,
+        string? expansionName = "The War Within",
+        params (string ModeType, int Players)[] modes) =>
+        new(
+            Id: id,
+            Name: name,
+            Category: new BlizzardJournalInstanceCategory("RAID"),
+            Expansion: expansionName is null ? null : new BlizzardJournalExpansion(11, expansionName),
+            MinimumLevel: 80,
+            Modes: modes
+                .Select(m => new BlizzardJournalInstanceMode(
+                    Mode: new BlizzardJournalModeRef(m.ModeType, m.ModeType),
+                    Players: m.Players,
+                    IsTracked: true))
+                .ToList(),
+            Media: null);
+
+    private static BlizzardPlayableSpecIndex MakeSpecIndex(params (int Id, string Name)[] entries) =>
+        new(entries.Select(e => new BlizzardIndexEntry(e.Id, e.Name)).ToList());
+
+    private static BlizzardPlayableSpecDetail MakeSpecDetail(
+        int id, string name, int classId, string roleType) =>
+        new(
+            Id: id,
+            Name: name,
+            PlayableClass: new BlizzardPlayableSpecClassRef(classId, "Priest"),
+            Role: new BlizzardPlayableSpecRoleRef(roleType, roleType));
+
+    private static (
+        ReferenceSync sut,
+        Mock<IBlizzardGameDataClient> blizzard,
+        Mock<IBlobReferenceClient> blobs,
+        TestLogger<ReferenceSync> logger) MakeSut()
     {
+        var blizzard = new Mock<IBlizzardGameDataClient>();
+        blizzard.Setup(b => b.GetClientCredentialsTokenAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FakeToken);
+        blizzard.Setup(b => b.GetJournalInstanceIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeJournalIndex());
+        blizzard.Setup(b => b.GetPlayableSpecIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeSpecIndex());
+
+        var blobs = new Mock<IBlobReferenceClient>();
         var logger = new TestLogger<ReferenceSync>();
-        var sut = new ReferenceSync(logger);
+        var sut = new ReferenceSync(blizzard.Object, blobs.Object, logger);
+        return (sut, blizzard, blobs, logger);
+    }
+
+    // ── Happy path ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SyncAllAsync_uploads_detail_media_and_manifest_for_each_entity()
+    {
+        var (sut, blizzard, blobs, _) = MakeSut();
+        blizzard.Setup(b => b.GetJournalInstanceIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeJournalIndex((10, "Undermine")));
+        blizzard.Setup(b => b.GetJournalInstanceAsync(10, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeInstanceDetail(10, "Undermine", modes: ("HEROIC", 25)));
+        blizzard.Setup(b => b.GetJournalInstanceMediaAsync(10, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BlizzardMediaAssets(new[]
+            {
+                new BlizzardMediaAsset("tile", "https://render.example/tile-10.jpg"),
+            }));
+        blizzard.Setup(b => b.GetPlayableSpecIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeSpecIndex((257, "Holy")));
+        blizzard.Setup(b => b.GetPlayableSpecAsync(257, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeSpecDetail(257, "Holy", classId: 5, roleType: "HEALER"));
+        blizzard.Setup(b => b.GetPlayableSpecMediaAsync(257, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BlizzardMediaAssets(new[]
+            {
+                new BlizzardMediaAsset("icon", "https://render.example/icon-257.jpg"),
+            }));
 
         var response = await sut.SyncAllAsync(CancellationToken.None);
 
-        Assert.Collection(response.Results,
-            first =>
+        Assert.StartsWith("synced", response.Results[0].Status);
+        Assert.StartsWith("synced", response.Results[1].Status);
+
+        blobs.Verify(b => b.UploadAsync(
+            "reference/journal-instance/10.json",
+            It.Is<JournalInstanceBlob>(d => d.Id == 10 && d.Name == "Undermine"),
+            It.IsAny<CancellationToken>()), Times.Once);
+        blobs.Verify(b => b.UploadAsync(
+            "reference/journal-instance-media/10.json",
+            It.Is<MediaAssetsBlob>(m => m.Assets!.Single().Value == "https://render.example/tile-10.jpg"),
+            It.IsAny<CancellationToken>()), Times.Once);
+        blobs.Verify(b => b.UploadAsync(
+            "reference/journal-instance/index.json",
+            It.Is<List<InstanceIndexEntry>>(ix =>
+                ix.Count == 1 &&
+                ix[0].Id == 10 &&
+                ix[0].Modes!.Single().ModeKey == "HEROIC:25" &&
+                ix[0].PortraitUrl == "https://render.example/tile-10.jpg"),
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        blobs.Verify(b => b.UploadAsync(
+            "reference/playable-specialization/257.json",
+            It.Is<PlayableSpecializationBlob>(d => d.Id == 257 && d.PlayableClass!.Id == 5),
+            It.IsAny<CancellationToken>()), Times.Once);
+        blobs.Verify(b => b.UploadAsync(
+            "reference/playable-specialization-media/257.json",
+            It.IsAny<MediaAssetsBlob>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+        blobs.Verify(b => b.UploadAsync(
+            "reference/playable-specialization/index.json",
+            It.Is<List<SpecializationIndexEntry>>(ix =>
+                ix.Count == 1 &&
+                ix[0].Id == 257 &&
+                ix[0].Role == "HEALER" &&
+                ix[0].IconUrl == "https://render.example/icon-257.jpg"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SyncInstancesAsync_emits_unknown_sentinel_mode_when_detail_has_no_modes()
+    {
+        var (sut, blizzard, blobs, _) = MakeSut();
+        blizzard.Setup(b => b.GetJournalInstanceIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeJournalIndex((42, "Solo")));
+        blizzard.Setup(b => b.GetJournalInstanceAsync(42, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeInstanceDetail(42, "Solo", modes: Array.Empty<(string, int)>()));
+
+        await sut.SyncAllAsync(CancellationToken.None);
+
+        blobs.Verify(b => b.UploadAsync(
+            "reference/journal-instance/index.json",
+            It.Is<List<InstanceIndexEntry>>(ix =>
+                ix.Single().Modes!.Single().ModeKey == "UNKNOWN:0"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SyncInstancesAsync_emits_one_mode_entry_per_blizzard_mode()
+    {
+        var (sut, blizzard, blobs, _) = MakeSut();
+        blizzard.Setup(b => b.GetJournalInstanceIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeJournalIndex((10, "Multi")));
+        blizzard.Setup(b => b.GetJournalInstanceAsync(10, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeInstanceDetail(10, "Multi", modes: new[]
             {
-                Assert.Equal("instances", first.Name);
-                Assert.StartsWith("failed:", first.Status);
-            },
-            second =>
+                ("NORMAL", 25),
+                ("HEROIC", 25),
+                ("MYTHIC", 20),
+            }));
+
+        await sut.SyncAllAsync(CancellationToken.None);
+
+        blobs.Verify(b => b.UploadAsync(
+            "reference/journal-instance/index.json",
+            It.Is<List<InstanceIndexEntry>>(ix =>
+                ix.Single().Modes!.Count == 3 &&
+                ix.Single().Modes!.Any(m => m.ModeKey == "HEROIC:25")),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ── Resilience ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SyncAllAsync_records_failure_for_instances_but_still_syncs_specializations()
+    {
+        var (sut, blizzard, blobs, logger) = MakeSut();
+        blizzard.Setup(b => b.GetJournalInstanceIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("blizzard 503"));
+        blizzard.Setup(b => b.GetPlayableSpecIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeSpecIndex((257, "Holy")));
+        blizzard.Setup(b => b.GetPlayableSpecAsync(257, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeSpecDetail(257, "Holy", 5, "HEALER"));
+        blizzard.Setup(b => b.GetPlayableSpecMediaAsync(257, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BlizzardMediaAssets(null));
+
+        var response = await sut.SyncAllAsync(CancellationToken.None);
+
+        Assert.StartsWith("failed:", response.Results[0].Status);
+        Assert.StartsWith("synced", response.Results[1].Status);
+        blobs.Verify(b => b.UploadAsync(
+            It.Is<string>(n => n.StartsWith("reference/journal-instance/")),
+            It.IsAny<object>(), It.IsAny<CancellationToken>()), Times.Never);
+        blobs.Verify(b => b.UploadAsync(
+            "reference/playable-specialization/index.json",
+            It.IsAny<List<SpecializationIndexEntry>>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Error && (e.Message ?? "").Contains("instances"));
+    }
+
+    [Fact]
+    public async Task SyncInstancesAsync_skips_instance_when_detail_fetch_fails_but_continues_index()
+    {
+        var (sut, blizzard, blobs, logger) = MakeSut();
+        blizzard.Setup(b => b.GetJournalInstanceIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeJournalIndex((1, "Skipped"), (2, "Worked")));
+        blizzard.Setup(b => b.GetJournalInstanceAsync(1, FakeToken, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("404"));
+        blizzard.Setup(b => b.GetJournalInstanceAsync(2, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeInstanceDetail(2, "Worked", modes: ("HEROIC", 25)));
+
+        await sut.SyncAllAsync(CancellationToken.None);
+
+        blobs.Verify(b => b.UploadAsync(
+            "reference/journal-instance/index.json",
+            It.Is<List<InstanceIndexEntry>>(ix => ix.Single().Id == 2 && ix.Single().Name == "Worked"),
+            It.IsAny<CancellationToken>()), Times.Once);
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Warning && (e.Message ?? "").Contains("Skipping"));
+    }
+
+    [Fact]
+    public async Task SyncInstancesAsync_continues_when_media_fetch_fails_with_null_portrait_url()
+    {
+        var (sut, blizzard, blobs, logger) = MakeSut();
+        blizzard.Setup(b => b.GetJournalInstanceIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeJournalIndex((10, "Undermine")));
+        blizzard.Setup(b => b.GetJournalInstanceAsync(10, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeInstanceDetail(10, "Undermine", modes: ("NORMAL", 25)));
+        blizzard.Setup(b => b.GetJournalInstanceMediaAsync(10, FakeToken, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("media 404"));
+
+        await sut.SyncAllAsync(CancellationToken.None);
+
+        blobs.Verify(b => b.UploadAsync(
+            "reference/journal-instance-media/10.json",
+            It.IsAny<MediaAssetsBlob>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+        blobs.Verify(b => b.UploadAsync(
+            "reference/journal-instance/index.json",
+            It.Is<List<InstanceIndexEntry>>(ix => ix.Single().PortraitUrl == null),
+            It.IsAny<CancellationToken>()), Times.Once);
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Warning);
+    }
+
+    [Fact]
+    public async Task SyncSpecializationsAsync_continues_when_spec_media_fetch_fails_with_null_icon_url()
+    {
+        var (sut, blizzard, blobs, logger) = MakeSut();
+        blizzard.Setup(b => b.GetPlayableSpecIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeSpecIndex((257, "Holy")));
+        blizzard.Setup(b => b.GetPlayableSpecAsync(257, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeSpecDetail(257, "Holy", 5, "HEALER"));
+        blizzard.Setup(b => b.GetPlayableSpecMediaAsync(257, FakeToken, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("media 404"));
+
+        await sut.SyncAllAsync(CancellationToken.None);
+
+        blobs.Verify(b => b.UploadAsync(
+            "reference/playable-specialization/index.json",
+            It.Is<List<SpecializationIndexEntry>>(ix => ix.Single().IconUrl == null && ix.Single().Role == "HEALER"),
+            It.IsAny<CancellationToken>()), Times.Once);
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Warning);
+    }
+
+    [Fact]
+    public async Task SyncInstancesAsync_retries_after_429_and_still_writes_manifest_entry()
+    {
+        var (sut, blizzard, blobs, _) = MakeSut();
+        blizzard.Setup(b => b.GetJournalInstanceIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeJournalIndex((10, "Retrying")));
+        var callCount = 0;
+        blizzard.Setup(b => b.GetJournalInstanceAsync(10, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
             {
-                Assert.Equal("specializations", second.Name);
-                Assert.StartsWith("failed:", second.Status);
+                callCount++;
+                if (callCount == 1)
+                    throw new HttpRequestException("rate limited", null, System.Net.HttpStatusCode.TooManyRequests);
+                return MakeInstanceDetail(10, "Retrying", modes: ("HEROIC", 25));
             });
 
-        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Error && (e.Message ?? "").Contains("instances"));
-        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Error && (e.Message ?? "").Contains("specializations"));
+        await sut.SyncAllAsync(CancellationToken.None);
+
+        Assert.Equal(2, callCount);
+        blobs.Verify(b => b.UploadAsync(
+            "reference/journal-instance/index.json",
+            It.Is<List<InstanceIndexEntry>>(ix => ix.Single().Id == 10),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ── Role mapping ────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("HEALER", "HEALER")]
+    [InlineData("TANK", "TANK")]
+    [InlineData("DAMAGE", "DPS")]
+    [InlineData("anything else", "DPS")]
+    [InlineData("", "DPS")]
+    public async Task SyncSpecializationsAsync_maps_blizzard_role_type_to_DPS_when_not_HEALER_or_TANK(
+        string blizzardRoleType, string expectedRole)
+    {
+        var (sut, blizzard, blobs, _) = MakeSut();
+        blizzard.Setup(b => b.GetPlayableSpecIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeSpecIndex((1, "X")));
+        blizzard.Setup(b => b.GetPlayableSpecAsync(1, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeSpecDetail(1, "X", 5, blizzardRoleType));
+        blizzard.Setup(b => b.GetPlayableSpecMediaAsync(1, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BlizzardMediaAssets(null));
+
+        await sut.SyncAllAsync(CancellationToken.None);
+
+        blobs.Verify(b => b.UploadAsync(
+            "reference/playable-specialization/index.json",
+            It.Is<List<SpecializationIndexEntry>>(ix => ix.Single().Role == expectedRole),
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 }


### PR DESCRIPTION
## Summary

Phase 3 writer commit — flips `ReferenceSync` from a Phase-1 stub back to a real ingester, this time writing blobs instead of the long-retired Cosmos upsert. After this PR lands and an admin hits `POST /api/wow/update` once, `/api/instances` + `/api/reference/specializations` collapse from ~422 blob GETs per call (Phase 1 fallback) to one GET of a freshly-emitted `index.json` manifest, and `InstanceDto.PortraitUrl` stops being null because the ingester now writes `reference/journal-instance-media/` blobs that the legacy TS pipeline never did. Follows [docs/storage-architecture.md](docs/storage-architecture.md).

Split into two commits for reviewability:

- **`adb3122` — Add blob upload and journal-instance media client methods.** Foundation: adds `IBlobReferenceClient.UploadAsync<T>` + implementation (Newtonsoft serialize → overwriting `BlobClient.UploadAsync` with `application/json` content-type) and `IBlizzardGameDataClient.GetJournalInstanceMediaAsync` + implementation (the one Blizzard game-data endpoint previously unused — `/data/wow/media/journal-instance/{id}`). 4 files, +36 / -0 — runtime-neutral on its own.

- **`4dee74a` — Write reference sync output to blob with manifest.** `ReferenceSync` is rewritten to take `IBlizzardGameDataClient` + `IBlobReferenceClient` + `ILogger`, remove the two Phase-1 NotImplementedException stubs, fetch the Blizzard index per entity, iterate entries with the same 429-retry + skip-on-failure semantics the original had, upload per-id detail (`reference/{kind}/{id}.json`) and per-id media (`reference/{kind}-media/{id}.json` — best-effort, missing is fine), and finally emit the list-endpoint manifest (`reference/{kind}/index.json`) containing every field the repositories need for their fast path. `SyncAllAsync` still catches per-entity failures so one broken entity doesn't take out the other. Tests rewritten against a `Mock<IBlobReferenceClient>` — verifies per-blob-name uploads, manifest shape, UNKNOWN sentinel for empty modes, one row per mode for multi-mode instances, 429 retry, null-portrait/icon when media fails, role mapping (× 5 theory).

## Env / schema changes

None. `Storage__BlobServiceUri` was set in the Phase 1 hotfix and is already authenticated via the Function App's existing `Storage Blob Data Owner` role.

Post-merge operational step: one admin `POST /api/wow/update` to backfill manifests + media blobs. The weekly timer lands in the next PR.

## Test plan

- [x] `dotnet build lfm.sln -c Release` — green.
- [x] `dotnet test tests/Lfm.Api.Tests` — 399 passing (was 387 before; +12 for new ReferenceSync coverage).
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error` — clean.
- [ ] Post-deploy: `curl -X POST -H "Authorization: Bearer $LFM_DEV_ACCESS_TOKEN" https://lfm-api.dinosauruskeksi.com/api/wow/update` returns `{results:[{name:"instances",status:"synced (~211 docs)"},{name:"specializations",status:"synced (~40 docs)"}]}`. Completes in <~1min given the shared 80 req/s `BlizzardRateLimiter`.
- [ ] Post-sync: `/api/instances` TTFB drops from ~8s (fallback path) to <500ms (manifest path); every returned row has `portraitUrl` populated from Blizzard render CDN.
- [ ] Post-sync: `az storage blob exists --account-name lfmstore --container-name wow --name 'reference/journal-instance-media/67.json' --auth-mode login` returns True (didn't exist before Phase 3).
