### PR TITLE
Add weekly timer trigger for wow reference sync

### DIFF
--- a/api/Functions/WowUpdateTimerFunction.cs
+++ b/api/Functions/WowUpdateTimerFunction.cs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Services;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace Lfm.Api.Functions;
+
+/// <summary>
+/// Timer-triggered weekly refresh of the static Blizzard reference blobs — see
+/// <c>docs/storage-architecture.md</c>. Runs <see cref="IReferenceSync.SyncAllAsync"/>
+/// to fetch the latest <c>journal-instance</c> + <c>playable-specialization</c>
+/// indices from Blizzard, upload per-id detail + media blobs, and emit the
+/// list-endpoint manifests at <c>reference/{kind}/index.json</c>.
+///
+/// Schedule: Sunday 04:00 UTC. Chosen to co-exist with <see cref="RaiderCleanupFunction"/>
+/// (daily 04:00 UTC) without clashing on any one minute — Functions handles
+/// multiple timer triggers at the same second fine, but staggering is cheap
+/// insurance against observability noise. Blizzard reference data changes at
+/// patch cadence (weeks to months); weekly is more than enough.
+///
+/// The same <see cref="IReferenceSync"/> code path serves both this timer and
+/// the admin-only <see cref="WowUpdateFunction"/> HTTP endpoint, so behaviour
+/// is identical between scheduled and ad-hoc invocations.
+///
+/// Ad-hoc invocation for a backfill (e.g. the first run after this ships) is
+/// via the Functions host admin endpoint — timer triggers bypass the HTTP
+/// <c>AuthPolicyMiddleware</c> entirely, so a Function App master key is
+/// sufficient:
+/// <code>
+/// MASTER=$(az functionapp keys list -g lfm -n lfm-functions --query masterKey -o tsv)
+/// curl -X POST -H "x-functions-key: $MASTER" \
+///     https://lfm-functions.azurewebsites.net/admin/functions/wow-update-timer \
+///     -H "Content-Type: application/json" -d '{}'
+/// </code>
+/// </summary>
+public class WowUpdateTimerFunction(
+    IReferenceSync referenceSync,
+    ILogger<WowUpdateTimerFunction> logger)
+{
+    [Function("wow-update-timer")]
+    public async Task Run(
+        [TimerTrigger("0 0 4 * * SUN")] TimerInfo timer,
+        CancellationToken ct)
+    {
+        logger.LogInformation("Starting weekly WoW reference sync");
+        var response = await referenceSync.SyncAllAsync(ct);
+        foreach (var result in response.Results)
+        {
+            logger.LogInformation(
+                "WoW reference sync — {Entity}: {Status}",
+                result.Name, result.Status);
+        }
+    }
+}

--- a/tests/Lfm.Api.Tests/WowUpdateTimerFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/WowUpdateTimerFunctionTests.cs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Functions;
+using Lfm.Api.Services;
+using Lfm.Contracts.Admin;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Lfm.Api.Tests;
+
+/// <summary>
+/// Covers the weekly-timer entry point. The heavy lifting is in
+/// <see cref="IReferenceSync"/>, which has its own tests; this file only
+/// verifies that the timer invokes the sync and logs each entity's result.
+/// </summary>
+public class WowUpdateTimerFunctionTests
+{
+    [Fact]
+    public async Task Run_invokes_reference_sync_and_logs_each_entity_result()
+    {
+        var sync = new Mock<IReferenceSync>();
+        sync.Setup(s => s.SyncAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new WowUpdateResponse(new[]
+            {
+                new WowUpdateEntityResult("instances", "synced (211 docs)"),
+                new WowUpdateEntityResult("specializations", "synced (40 docs)"),
+            }));
+        var logger = new TestLogger<WowUpdateTimerFunction>();
+        var sut = new WowUpdateTimerFunction(sync.Object, logger);
+
+        await sut.Run(new TimerInfo(), CancellationToken.None);
+
+        sync.Verify(s => s.SyncAllAsync(It.IsAny<CancellationToken>()), Times.Once);
+        Assert.Contains(logger.Entries, e =>
+            e.Level == LogLevel.Information &&
+            (e.Message ?? "").Contains("Starting weekly"));
+        Assert.Contains(logger.Entries, e =>
+            e.Level == LogLevel.Information &&
+            (e.Message ?? "").Contains("instances") &&
+            (e.Message ?? "").Contains("synced (211 docs)"));
+        Assert.Contains(logger.Entries, e =>
+            e.Level == LogLevel.Information &&
+            (e.Message ?? "").Contains("specializations") &&
+            (e.Message ?? "").Contains("synced (40 docs)"));
+    }
+}


### PR DESCRIPTION
## Summary

Phase 3 commit 2 — the weekly scheduled refresh that complements the admin-only `POST /api/wow/update`. Shares the exact same `IReferenceSync.SyncAllAsync` code path (tested in the preceding PR), so behaviour is identical between scheduled and ad-hoc invocations.

- `api/Functions/WowUpdateTimerFunction.cs` *(new)* — `[TimerTrigger("0 0 4 * * SUN")]` (Sunday 04:00 UTC). Staggered against the existing `RaiderCleanupFunction` (daily 04:00 UTC) only at the observability-noise level; Functions handles concurrent timers fine.
- `tests/Lfm.Api.Tests/WowUpdateTimerFunctionTests.cs` *(new)* — one test: `Run` invokes `IReferenceSync.SyncAllAsync` and logs the two per-entity results. The heavy behaviour is already covered by `ReferenceSyncTests` (`b9ba05e`).

Timer triggers bypass HTTP middleware entirely — `AuthPolicyMiddleware` only short-circuits when `context.GetHttpContext()` is non-null — so this function is invocable via the Functions host admin endpoint with a master key from `az functionapp keys list`. The XML-doc on the function body documents the exact command for ad-hoc invocation (needed for the first-time backfill after this PR lands, and for any future rush refresh).

## Env / schema changes

None. Same `Storage__BlobServiceUri` app setting the admin endpoint already uses. No new RBAC — the Function App managed identity already has `Storage Blob Data Owner` on `lfmstore`.

## Test plan

- [x] `dotnet build lfm.sln -c Release` — green.
- [x] `dotnet test --filter WowUpdateTimerFunctionTests` — 1 passing.
- [x] `dotnet format lfm.sln --verify-no-changes` — clean.
- [ ] Post-deploy backfill (first real sync against Blizzard):
  ```
  MASTER=$(az functionapp keys list -g lfm -n lfm-functions --query masterKey -o tsv)
  curl -X POST -H "x-functions-key: $MASTER" -H "Content-Type: application/json" -d '{}' \
      --max-time 180 \
      https://lfm-functions.azurewebsites.net/admin/functions/wow-update-timer
  ```
  Expect a 202 with no body; `az monitor log-analytics query` for `AppTraces | where Message has "WoW reference sync"` should show one "Starting weekly" entry followed by two per-entity "synced (N docs)" entries.
- [ ] Post-backfill smoke: `/api/instances` TTFB drops to <500 ms (manifest fast path), returned rows have non-null `portraitUrl` from Blizzard render CDN. `az storage blob exists ... reference/journal-instance-media/67.json` returns True.
- [ ] Next Sunday 04:00 UTC: observe the scheduled run in App Insights.

Phase 3 is substantially complete after this PR + backfill. Phase 4 (legacy cleanup — `github-actions-deploy` blob container + CSP tighten) remains.
