### PR TITLE
Tighten SWA CSP by removing unused blob origin

### DIFF
--- a/.github/workflows/deploy-app-build.yml
+++ b/.github/workflows/deploy-app-build.yml
@@ -62,7 +62,6 @@ jobs:
           FRONTEND_HOSTNAME: ${{ vars.FRONTEND_HOSTNAME }}
           SECURITY_POLICY_URL: ${{ vars.SECURITY_POLICY_URL }}
           API_HOSTNAME: ${{ vars.API_HOSTNAME }}
-          STORAGE_ACCOUNT_NAME: ${{ vars.STORAGE_ACCOUNT_NAME }}
         run: dotnet publish app/Lfm.App.csproj -c Release -o ./publish/app --no-build
 
       - name: Install brotli

--- a/app/Lfm.App.csproj
+++ b/app/Lfm.App.csproj
@@ -57,8 +57,6 @@
       <SecurityPolicyUrl Condition="'$(SecurityPolicyUrl)' == ''">https://example.com/SECURITY.md</SecurityPolicyUrl>
       <ApiHostname Condition="'$(ApiHostname)' == ''">$(API_HOSTNAME)</ApiHostname>
       <ApiHostname Condition="'$(ApiHostname)' == ''">api.localhost</ApiHostname>
-      <StorageAccountName Condition="'$(StorageAccountName)' == ''">$(STORAGE_ACCOUNT_NAME)</StorageAccountName>
-      <StorageAccountName Condition="'$(StorageAccountName)' == ''">examplestore</StorageAccountName>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -82,7 +80,6 @@
 
     <Exec Command="bash -c &quot;sed \
         -e 's|{{API_HOSTNAME}}|$(ApiHostname)|g' \
-        -e 's|{{STORAGE_ACCOUNT_NAME}}|$(StorageAccountName)|g' \
         '$(SwaConfigSource)' &gt; '$(SwaConfigDest)'&quot;"
           Condition="Exists('$(SwaConfigSource)')" />
 

--- a/app/wwwroot/staticwebapp.config.json.template
+++ b/app/wwwroot/staticwebapp.config.json.template
@@ -43,7 +43,7 @@
     "X-Frame-Options": "DENY",
     "Referrer-Policy": "strict-origin-when-cross-origin",
     "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
-    "Content-Security-Policy": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://{{API_HOSTNAME}} https://{{STORAGE_ACCOUNT_NAME}}.blob.core.windows.net; img-src 'self' https://{{API_HOSTNAME}} https://render.worldofwarcraft.com https://{{STORAGE_ACCOUNT_NAME}}.blob.core.windows.net",
+    "Content-Security-Policy": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://{{API_HOSTNAME}}; img-src 'self' https://{{API_HOSTNAME}} https://render.worldofwarcraft.com",
     "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
   }
 }


### PR DESCRIPTION
## Summary

Phase 4 of the storage-consolidation plan. Removes the `{STORAGE_ACCOUNT_NAME}.blob.core.windows.net` entries from the Blazor SPA's CSP and the build-time plumbing that existed only to populate them. Confirmed via grep + architecture: the Blazor client never fetches from blob directly — all reference data flows through `/api/*` (proxy origin) and portraits load from `render.worldofwarcraft.com` (already CSP-allowed). Follows [docs/storage-architecture.md](docs/storage-architecture.md).

- `app/wwwroot/staticwebapp.config.json.template` — drop `https://{{STORAGE_ACCOUNT_NAME}}.blob.core.windows.net` from both `connect-src` and `img-src`.
- `app/Lfm.App.csproj` — remove the now-dead `StorageAccountName` MSBuild property + the matching `sed -e '{{STORAGE_ACCOUNT_NAME}}'` substitution in the SWA-config generation `Exec`.
- `.github/workflows/deploy-app-build.yml` — drop `STORAGE_ACCOUNT_NAME: ${{ vars.STORAGE_ACCOUNT_NAME }}` from the `Publish App` step's env (only consumer was the MSBuild property removed above). The infra workflow keeps its `vars.STORAGE_ACCOUNT_NAME` reference — Bicep still needs the storage account name as input.
- Contract-pin test `StaticWebAppConfigContractTests` doesn't assert the blob origin, so it continues to pass. `default-src 'self'`, `script-src` `wasm-unsafe-eval` runtime directive, and `connect-src` containing the API hostname are all preserved.

Paired with the Phase 4 manual step: `az storage container delete --account-name lfmstore --name github-actions-deploy --auth-mode login --yes`. Container holds TS-era `Functionapp_*.zip` deploy artifacts from 2026-03-22 that the current `deploy-app.yml` path doesn't touch.

## Env / schema changes

- GitHub repo variable `STORAGE_ACCOUNT_NAME` keeps its value; the app-build step no longer reads it but the infra workflow still does. Nothing to change in repo settings.
- CSP is narrower on the production response after deploy — fewer allowed origins, strictly a hardening.
- If byte-caching of Blizzard art ever gets picked up (the escape-hatch flagged in the plan's image-caching section), reverting this PR is the minimal re-enable.

## Test plan

- [x] `dotnet build lfm.sln -c Release` — green.
- [x] Generated `app/wwwroot/staticwebapp.config.json` after publish contains `connect-src 'self' https://api.localhost; img-src 'self' https://api.localhost https://render.worldofwarcraft.com` (no `blob.core`, no unsubstituted `{{STORAGE_ACCOUNT_NAME}}`).
- [x] `StaticWebAppConfigContractTests` — 4 passing.
- [x] Full non-E2E suite — 129 + 150 + 400 passing.
- [x] `dotnet format lfm.sln --verify-no-changes` — clean.
- [ ] Post-deploy: `curl -sSI https://lfm.dinosauruskeksi.com/ | grep content-security-policy` shows the tightened CSP (no `blob.core.windows.net`).
- [ ] Post-deploy smoke: edit-run page loads instances + specs; characters page renders portraits from `render.worldofwarcraft.com` without CSP console errors.
- [ ] Post-merge manual cleanup of the `github-actions-deploy` blob container (see Summary).
