### PR TITLE
Stop leaking exception detail from API error responses

### DIFF
--- a/api/Functions/HealthFunction.cs
+++ b/api/Functions/HealthFunction.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Lfm.Api.Options;
 using Lfm.Contracts.Health;
@@ -18,7 +19,7 @@ namespace Lfm.Api.Functions;
 //                       because Cosmos is down would take the entire app offline.
 //   /api/health/ready — readiness. Validates Cosmos connectivity. Consumed by external
 //                       monitors / deploy smoke tests, not by App Service Health Check.
-public class HealthFunction(CosmosClient cosmos, IOptions<CosmosOptions> cosmosOpts)
+public class HealthFunction(CosmosClient cosmos, IOptions<CosmosOptions> cosmosOpts, ILogger<HealthFunction> logger)
 {
     [Function("health")]
     public IActionResult Live(
@@ -31,9 +32,10 @@ public class HealthFunction(CosmosClient cosmos, IOptions<CosmosOptions> cosmosO
     /// Readiness probe — validates that this instance can talk to Cosmos.
     /// Response contract:
     ///   - 200 OK with <see cref="HealthResponse"/> (status="ready") on success.
-    ///   - 503 Service Unavailable with anonymous-object body { status: "unready", error: string } on failure.
-    /// The <c>error</c> field is the runtime exception type name (e.g. "CosmosException"). It is intended
-    /// for operator log triage only — clients must rely on the HTTP status code, not the error string.
+    ///   - 503 Service Unavailable with anonymous-object body { status: "unready" } on failure.
+    /// The exception is logged server-side (including type + message + stack) for
+    /// operator triage. Nothing about the failure is exposed to the caller beyond
+    /// the HTTP status code — clients must key off status, not a response string.
     /// </summary>
     [Function("health-ready")]
     public async Task<IActionResult> Ready(
@@ -48,7 +50,8 @@ public class HealthFunction(CosmosClient cosmos, IOptions<CosmosOptions> cosmosO
         }
         catch (Exception ex)
         {
-            return new ObjectResult(new { status = "unready", error = ex.GetType().Name })
+            logger.LogError(ex, "Readiness probe failed");
+            return new ObjectResult(new { status = "unready" })
             {
                 StatusCode = 503
             };

--- a/api/Functions/RaiderCharacterFunction.cs
+++ b/api/Functions/RaiderCharacterFunction.cs
@@ -4,7 +4,9 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
 using Lfm.Api.Auth;
+using Lfm.Api.Helpers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
 using Lfm.Contracts.Raiders;
@@ -27,7 +29,7 @@ namespace Lfm.Api.Functions;
 /// Mirrors the character-selection part of <c>handler</c> in
 /// <c>functions/src/functions/raider-character.ts</c>.
 /// </summary>
-public class RaiderCharacterFunction(IRaidersRepository repo)
+public class RaiderCharacterFunction(IRaidersRepository repo, ILogger<RaiderCharacterFunction> logger)
 {
     [Function("raider-character")]
     [RequireAuth]
@@ -60,8 +62,7 @@ public class RaiderCharacterFunction(IRaidersRepository repo)
         }
         catch (Exception ex)
         {
-            return new ObjectResult(new { error = ex.Message, type = ex.GetType().Name })
-            { StatusCode = 500 };
+            return InternalErrorResult.Create(logger, ctx, ex, "raider-character select");
         }
 
         // 4. Return updated selection.

--- a/api/Functions/RunsSignupFunction.cs
+++ b/api/Functions/RunsSignupFunction.cs
@@ -66,9 +66,12 @@ public class RunsSignupFunction(
             if (body is null)
                 return new BadRequestObjectResult(new { error = "Invalid request body" });
         }
-        catch (JsonException ex)
+        catch (JsonException)
         {
-            return new BadRequestObjectResult(new { error = ex.Message });
+            // Never echo JsonException.Message — it can disclose offset/line/path
+            // detail from the caller's payload that is not useful to the user and
+            // inconsistent with how other handlers report parse failures.
+            return new BadRequestObjectResult(new { error = "Invalid request body" });
         }
 
         var validator = new SignupRequestValidator();

--- a/api/Helpers/InternalErrorResult.cs
+++ b/api/Helpers/InternalErrorResult.cs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace Lfm.Api.Helpers;
+
+/// <summary>
+/// Builds a generic 500 response that logs the full exception server-side and
+/// exposes only the Functions invocation id as a correlation token to the
+/// client. Use in catch-all blocks where the exception source (Cosmos, DPAPI,
+/// network clients) could otherwise leak infrastructure details through
+/// <c>ex.Message</c> or <c>ex.GetType().Name</c>.
+///
+/// Response body: <c>{ "error": "internal error", "correlationId": "&lt;invocation-id&gt;" }</c>.
+/// </summary>
+public static class InternalErrorResult
+{
+    public static IActionResult Create(ILogger logger, FunctionContext ctx, Exception ex, string operation)
+    {
+        logger.LogError(
+            ex,
+            "Unhandled exception in {Operation} (invocation {InvocationId})",
+            operation,
+            ctx.InvocationId);
+
+        return new ObjectResult(new { error = "internal error", correlationId = ctx.InvocationId })
+        {
+            StatusCode = 500,
+        };
+    }
+}

--- a/tests/Lfm.Api.Tests/HealthFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/HealthFunctionTests.cs
@@ -59,7 +59,7 @@ public class HealthFunctionTests
             DatabaseName = "test-db",
         });
 
-        return (new HealthFunction(mockClient.Object, opts), mockDb);
+        return (new HealthFunction(mockClient.Object, opts, new TestLogger<HealthFunction>()), mockDb);
     }
 
     [Fact]
@@ -86,9 +86,8 @@ public class HealthFunctionTests
     [Fact]
     public async Task Ready_returns_503_with_unready_status_when_cosmos_throws()
     {
-        // Per HealthFunction.Ready xmldoc: failure must surface as 503 with status="unready".
-        // The `error` field carries the exception type name for operator triage but is not
-        // part of the client contract — clients must key off the HTTP status code only.
+        // Per HealthFunction.Ready xmldoc: failure must surface as 503 with status="unready"
+        // and nothing else. The exception is logged server-side; clients key off status only.
         var (fn, mockDb) = CreateReadyFunction();
         mockDb.Setup(d => d.ReadAsync(It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new CosmosException("Service unavailable", System.Net.HttpStatusCode.ServiceUnavailable, 0, "", 0));
@@ -99,6 +98,7 @@ public class HealthFunctionTests
         Assert.Equal(503, obj.StatusCode);
         var statusProp = obj.Value!.GetType().GetProperty("status")!.GetValue(obj.Value);
         Assert.Equal("unready", statusProp);
+        Assert.Null(obj.Value!.GetType().GetProperty("error"));
     }
 
     [Fact]
@@ -122,9 +122,9 @@ public class HealthFunctionTests
     // `HealthEndpoint_NoSensitiveInfo`, which exercised the full Docker
     // stack to prove the same property at much higher cost. Asserts on
     // the JSON-serialized form of every health response shape (live,
-    // ready-success, ready-cosmos-error, ready-unexpected-error) since
-    // a future refactor that swaps `ex.GetType().Name` for `ex.ToString()`
-    // would be a real regression.
+    // ready-success, ready-cosmos-error, ready-unexpected-error) since a
+    // future refactor that re-adds a response field carrying `ex.Message`
+    // or `ex.ToString()` would be a real regression.
     // ------------------------------------------------------------------
 
     private static readonly string[] SensitiveSubstrings =
@@ -175,10 +175,11 @@ public class HealthFunctionTests
     public async Task Ready_failure_response_body_does_not_leak_sensitive_configuration()
     {
         // CosmosException messages typically contain the account endpoint and
-        // diagnostic JSON. The contract is that we expose only the exception
-        // *type name*, not the message. Pin it: a refactor that swaps
-        // `ex.GetType().Name` for `ex.ToString()` or `ex.Message` would
-        // surface AccountEndpoint and request diagnostics to clients.
+        // diagnostic JSON. The contract is that the readiness response body
+        // carries only { status: "unready" } — no exception type, message, or
+        // any derived string. Pin it: a refactor that re-adds an `error` field
+        // (or anything else derived from the exception) would surface
+        // AccountEndpoint and request diagnostics to clients.
         var (fn, mockDb) = CreateReadyFunction();
         mockDb.Setup(d => d.ReadAsync(It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new CosmosException(
@@ -190,5 +191,7 @@ public class HealthFunctionTests
         var obj = Assert.IsType<ObjectResult>(result);
         var json = JsonSerializer.Serialize(obj.Value);
         AssertNoSensitiveSubstrings(json, "/api/health/ready (failure)");
+        Assert.DoesNotContain("CosmosException", json);
+        Assert.DoesNotContain("Service unavailable", json);
     }
 }

--- a/tests/Lfm.Api.Tests/RaiderCharacterFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RaiderCharacterFunctionTests.cs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
+using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Functions.Worker;
 using Moq;
 using Lfm.Api.Auth;
@@ -19,11 +21,14 @@ public class RaiderCharacterFunctionTests
     // Helpers
     // ------------------------------------------------------------------
 
+    private const string FakeInvocationId = "00000000-0000-0000-0000-000000000001";
+
     private static FunctionContext MakeFunctionContext(SessionPrincipal principal)
     {
         var items = new Dictionary<object, object> { [SessionKeys.Principal] = principal };
         var ctx = new Mock<FunctionContext>();
         ctx.Setup(c => c.Items).Returns(items);
+        ctx.Setup(c => c.InvocationId).Returns(FakeInvocationId);
         return ctx.Object;
     }
 
@@ -76,7 +81,7 @@ public class RaiderCharacterFunctionTests
         repo.Setup(r => r.UpsertAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        var fn = new RaiderCharacterFunction(repo.Object);
+        var fn = new RaiderCharacterFunction(repo.Object, new TestLogger<RaiderCharacterFunction>());
         var result = await fn.Run(MakePutRequest(), "eu-silvermoon-aelrin", MakeFunctionContext(principal), CancellationToken.None);
 
         var ok = Assert.IsType<OkObjectResult>(result);
@@ -102,7 +107,7 @@ public class RaiderCharacterFunctionTests
         repo.Setup(r => r.GetByBattleNetIdAsync("bnet-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(raider);
 
-        var fn = new RaiderCharacterFunction(repo.Object);
+        var fn = new RaiderCharacterFunction(repo.Object, new TestLogger<RaiderCharacterFunction>());
         var result = await fn.Run(MakePutRequest(), "eu-silvermoon-unknownchar", MakeFunctionContext(principal), CancellationToken.None);
 
         var objectResult = Assert.IsType<ObjectResult>(result);
@@ -111,4 +116,41 @@ public class RaiderCharacterFunctionTests
         repo.Verify(r => r.UpsertAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    // ------------------------------------------------------------------
+    // Test 3: Upsert failure — 500 with no exception detail in the body
+    // ------------------------------------------------------------------
+    //
+    // Pin the contract that the 500 path never echoes `ex.Message` or
+    // `ex.GetType().Name` to the caller. CosmosException messages typically
+    // embed AccountEndpoint / diagnostic JSON; a refactor that stops routing
+    // through `InternalErrorResult.Create` would re-leak them.
+
+    [Fact]
+    public async Task Run_returns_generic_500_without_exception_detail_when_upsert_throws()
+    {
+        var principal = MakePrincipal();
+        var raider = MakeRaiderDoc();
+
+        var repo = new Mock<IRaidersRepository>();
+        repo.Setup(r => r.GetByBattleNetIdAsync("bnet-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(raider);
+        repo.Setup(r => r.UpsertAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new CosmosException(
+                "ProvisioningRU exhausted. AccountEndpoint=https://secret.documents.azure.com; AccountKey=topsecret",
+                System.Net.HttpStatusCode.TooManyRequests, 0, "", 0));
+
+        var fn = new RaiderCharacterFunction(repo.Object, new TestLogger<RaiderCharacterFunction>());
+        var result = await fn.Run(MakePutRequest(), "eu-silvermoon-aelrin", MakeFunctionContext(principal), CancellationToken.None);
+
+        var obj = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(500, obj.StatusCode);
+
+        var json = JsonSerializer.Serialize(obj.Value);
+        Assert.DoesNotContain("ProvisioningRU", json);
+        Assert.DoesNotContain("AccountEndpoint", json);
+        Assert.DoesNotContain("AccountKey", json);
+        Assert.DoesNotContain("CosmosException", json);
+        Assert.Contains("internal error", json);
+        Assert.Contains(FakeInvocationId, json);
+    }
 }

--- a/tests/Lfm.Api.Tests/RunsSignupFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RunsSignupFunctionTests.cs
@@ -382,4 +382,44 @@ public class RunsSignupFunctionTests
         var objectResult = Assert.IsType<ObjectResult>(result);
         Assert.Equal(409, objectResult.StatusCode);
     }
+
+    // ------------------------------------------------------------------
+    // Invalid JSON body — generic 400 with no parser detail
+    // ------------------------------------------------------------------
+    //
+    // Pin the contract that a JsonException never flows to the client. The
+    // message typically contains byte offsets, line numbers, and fragments
+    // of the caller's payload — none of it is useful over the wire, and it
+    // drifts between System.Text.Json versions.
+
+    [Fact]
+    public async Task Run_returns_generic_400_when_body_is_invalid_json()
+    {
+        var principal = MakePrincipal();
+        var runsRepo = new Mock<IRunsRepository>();
+        var raidersRepo = new Mock<IRaidersRepository>();
+        var permissions = new Mock<IGuildPermissions>();
+        var fn = MakeFunction(runsRepo, raidersRepo, permissions);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes("{ not valid json at all"));
+        httpContext.Request.ContentType = "application/json";
+
+        var result = await fn.Run(httpContext.Request, "run-1", MakeFunctionContext(principal), CancellationToken.None);
+
+        var bad = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal(400, bad.StatusCode);
+
+        var json = JsonSerializer.Serialize(bad.Value);
+        Assert.DoesNotContain("line", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("byte", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("path:", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("position", json, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Invalid request body", json);
+
+        // Repos must not have been touched for a parse failure.
+        runsRepo.VerifyNoOtherCalls();
+        raidersRepo.VerifyNoOtherCalls();
+        permissions.VerifyNoOtherCalls();
+    }
 }


### PR DESCRIPTION
Branch 1 of 7 from the route-level security review (W1 + I2).

## Summary

Three leak sites returned exception detail directly to callers. Each is closed independently:

- **`PUT /api/raider/characters/{id}`** — the 500 catch-all returned `{ error: ex.Message, type: ex.GetType().Name }`. A new `InternalErrorResult` helper now logs the full exception server-side and returns `{ error: "internal error", correlationId: <invocationId> }`. Handler tests assert that a forced `CosmosException` carrying `AccountEndpoint=…` / `AccountKey=…` leaks nothing through the response body.
- **`POST /api/runs/{id}/signup`** — the `JsonException` catch echoed `ex.Message`, which carries byte offsets, line numbers, and payload fragments and drifts between `System.Text.Json` versions. Replaced with a plain "Invalid request body" 400. Tests pin the absence of any parser-positional vocabulary.
- **`GET /api/health/ready`** — the 503 body exposed `ex.GetType().Name` ("for operator triage"), but reached anonymous callers unchanged. The exception is now logged server-side and the body is just `{ status: "unready" }`. Tests pin that no exception-derived field can reappear.

## Changes

- **New** `api/Helpers/InternalErrorResult.cs` — generic 500 shape with a correlation id sourced from `FunctionContext.InvocationId`.
- **Modified** `api/Functions/RaiderCharacterFunction.cs`, `api/Functions/RunsSignupFunction.cs`, `api/Functions/HealthFunction.cs`, plus their test files.

## Env / schema changes

None. Response shape tightens on three endpoints (no new fields, some fields removed).

## Test plan

- [ ] Full `dotnet test` across `Lfm.Api.Tests`, `Lfm.App.Tests`, `Lfm.App.Core.Tests` passes locally (402 / 150 / 129).
- [ ] Full `dotnet build lfm.sln -c Release` passes with 0 warnings, 0 errors.
- [ ] `dotnet format lfm.sln --verify-no-changes` produces no output.
- [ ] CI required checks go green.

## Related

Plan: `review-security-of-each-whimsical-hickey.md` — Branch 1 (W1 + I2). Remaining branches (Branch 2 input-caps, Branch 3 admin+skew, Branch 4 ratelimit-trust, Branch 5a/5b rename+lockdown, Branch 6 privacy, Branch 7 pagination) land in separate PRs.
