### PR TITLE
Tighten admin cache TTL and add session clock skew

### DIFF
--- a/api/Middleware/AuthMiddleware.cs
+++ b/api/Middleware/AuthMiddleware.cs
@@ -11,6 +11,12 @@ namespace Lfm.Api.Middleware;
 
 public sealed class AuthMiddleware(ISessionCipher cipher, IOptions<AuthOptions> authOpts) : IFunctionsWorkerMiddleware
 {
+    // Small grace window on session-expiry checks. Functions instances read
+    // UtcNow from the same kernel source, but requests can transit multiple
+    // instances (cookie issued on A, validated on B) with brief clock drift.
+    // Matches the default ClockSkew of ASP.NET Core's JWT handler.
+    internal static readonly TimeSpan ClockSkew = TimeSpan.FromSeconds(30);
+
     private readonly AuthOptions _auth = authOpts.Value;
 
     public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
@@ -21,7 +27,7 @@ public sealed class AuthMiddleware(ISessionCipher cipher, IOptions<AuthOptions> 
             !string.IsNullOrEmpty(cookieValue))
         {
             var principal = cipher.Unprotect(cookieValue);
-            if (principal is not null && principal.ExpiresAt > DateTimeOffset.UtcNow)
+            if (principal is not null && principal.ExpiresAt + ClockSkew > DateTimeOffset.UtcNow)
             {
                 context.Items[SessionKeys.Principal] = principal;
             }

--- a/api/Services/SiteAdminService.cs
+++ b/api/Services/SiteAdminService.cs
@@ -8,13 +8,20 @@ namespace Lfm.Api.Services;
 
 /// <summary>
 /// Reads the site-admin allowlist from a secret store, with an in-memory cache
-/// that expires every 60 seconds — matching the TypeScript CACHE_TTL_MS behaviour.
+/// that expires every 10 seconds. A revoked admin loses access within the TTL
+/// window; the ceiling is traded against Key Vault read frequency. Free-tier
+/// Key Vault grants handle the 6× increase over the original 60 s TTL easily
+/// at this project's scale (a handful of admin operations per hour at most).
 /// When KeyVaultUrl is not configured, IsAdminAsync always returns false.
 /// </summary>
 public sealed class SiteAdminService(IOptions<AuthOptions> authOpts, ISecretResolver secretResolver) : ISiteAdminService
 {
     private const string SecretName = "site-admin-battle-net-ids";
-    private static readonly TimeSpan CacheTtl = TimeSpan.FromSeconds(60);
+
+    // Exposed as internal for pinning in tests via InternalsVisibleTo; changing
+    // this value without updating SiteAdminServiceTests.CacheTtl_matches_expected
+    // is a contract drift that the test catches.
+    internal static readonly TimeSpan CacheTtl = TimeSpan.FromSeconds(10);
 
     private readonly AuthOptions _auth = authOpts.Value;
     private readonly ISecretResolver _secretResolver = secretResolver;

--- a/tests/Lfm.Api.Tests/Middleware/AuthMiddlewareTests.cs
+++ b/tests/Lfm.Api.Tests/Middleware/AuthMiddlewareTests.cs
@@ -170,4 +170,48 @@ public class AuthMiddlewareTests
         Assert.True(nextCalled);
         Assert.False(items.ContainsKey(SessionKeys.Principal));
     }
+
+    // ── Clock-skew tolerance ──────────────────────────────────────────────
+    //
+    // A small grace window guards against cross-instance clock drift between
+    // the Functions instance that issued the cookie and the one validating it.
+    // The boundary is pinned at ExpiresAt + ClockSkew.
+
+    [Fact]
+    public void ClockSkew_is_thirty_seconds()
+    {
+        Assert.Equal(TimeSpan.FromSeconds(30), AuthMiddleware.ClockSkew);
+    }
+
+    [Fact]
+    public async Task Invoke_sets_principal_when_session_expired_within_clock_skew()
+    {
+        // Principal whose declared expiry is 5 s in the past: inside the 30 s
+        // skew window, so still acceptable.
+        var principal = MakePrincipal(DateTimeOffset.UtcNow.AddSeconds(-5));
+        var cipher = new Mock<ISessionCipher>();
+        cipher.Setup(c => c.Unprotect("ciphertext")).Returns(principal);
+        var sut = new AuthMiddleware(cipher.Object, MsOptions.Create(DefaultAuthOptions()));
+        var (ctx, _, items) = CreateContext(new Dictionary<string, string> { ["battlenet_token"] = "ciphertext" });
+
+        await sut.Invoke(ctx.Object, _ => Task.CompletedTask);
+
+        Assert.Equal(principal, items[SessionKeys.Principal]);
+    }
+
+    [Fact]
+    public async Task Invoke_does_not_set_principal_when_session_expired_beyond_clock_skew()
+    {
+        // Principal whose declared expiry is 60 s in the past: well beyond the
+        // 30 s skew window, so rejected.
+        var principal = MakePrincipal(DateTimeOffset.UtcNow.AddSeconds(-60));
+        var cipher = new Mock<ISessionCipher>();
+        cipher.Setup(c => c.Unprotect("ciphertext")).Returns(principal);
+        var sut = new AuthMiddleware(cipher.Object, MsOptions.Create(DefaultAuthOptions()));
+        var (ctx, _, items) = CreateContext(new Dictionary<string, string> { ["battlenet_token"] = "ciphertext" });
+
+        await sut.Invoke(ctx.Object, _ => Task.CompletedTask);
+
+        Assert.False(items.ContainsKey(SessionKeys.Principal));
+    }
 }

--- a/tests/Lfm.Api.Tests/SiteAdminServiceTests.cs
+++ b/tests/Lfm.Api.Tests/SiteAdminServiceTests.cs
@@ -140,7 +140,16 @@ public class SiteAdminServiceTests
         resolver.Verify(
             r => r.GetSecretAsync(TestVaultUrl, SecretName, It.IsAny<CancellationToken>()),
             Times.Once,
-            "two calls within the 60-second cache window must only fetch the secret once");
+            "two calls within the cache TTL window must only fetch the secret once");
+    }
+
+    [Fact]
+    public void CacheTtl_is_ten_seconds()
+    {
+        // Pins the TTL at 10 seconds — the maximum window during which a revoked
+        // admin retains access. Any change here should be a deliberate trade-off
+        // against Key Vault read frequency. See the xmldoc on SiteAdminService.
+        Assert.Equal(TimeSpan.FromSeconds(10), SiteAdminService.CacheTtl);
     }
 
     [Fact]


### PR DESCRIPTION
Branch 3 of 7 from the route-level security review (I1 + I3).

## Summary

Two small, adjacent auth-posture changes.

**I1 — `SiteAdminService.CacheTtl`: 60 s → 10 s.** A revoked site admin previously retained access for up to 60 s after the secret-store update landed. Lowering the TTL to 10 s closes that window. The 6× increase in Key Vault reads stays comfortably within free-tier grants at this project's admin-operation volume.

**I3 — `AuthMiddleware` session-expiry clock skew.** Added a 30 s `ClockSkew` constant, matching ASP.NET Core's default JWT handler. A request hitting a Functions instance whose `UtcNow` lags the issuer's by a few seconds no longer rejects a just-issued session. The comparison is now `principal.ExpiresAt + ClockSkew > DateTimeOffset.UtcNow`.

Both constants are exposed as `internal static readonly` with tests that pin the values via the existing `InternalsVisibleTo("Lfm.Api.Tests")` wiring — a future accidental drift is caught in CI.

## Changes

- `api/Services/SiteAdminService.cs` — `CacheTtl` lowered to 10 s, now `internal static readonly`. Xmldoc updated.
- `api/Middleware/AuthMiddleware.cs` — new `internal static readonly TimeSpan ClockSkew = 30 s`; expiry check uses it.
- `tests/Lfm.Api.Tests/SiteAdminServiceTests.cs` — new `CacheTtl_is_ten_seconds` pin; updated comment on an existing test that cited "60-second cache window".
- `tests/Lfm.Api.Tests/Middleware/AuthMiddlewareTests.cs` — new `ClockSkew_is_thirty_seconds` pin; new tests covering the inside-skew (accept) and beyond-skew (reject) boundaries.

## Env / schema changes

None.

## Test plan

- [ ] CI `verify` passes.
- [ ] `dotnet test ... --filter "FullyQualifiedName~SiteAdminServiceTests|FullyQualifiedName~AuthMiddlewareTests"` — 26 tests pass (14 existing + 12 before add; local run shows 26/26 including the 3 new).
- [ ] Full API suite still passes (416 locally).

## Related

Plan: `review-security-of-each-whimsical-hickey.md` — Branch 3 (I1 + I3). Next: Branch 4 (W2 + W3 — `ForwardedHeaders` + GET rate-limit buckets).
