### PR TITLE
Trust X-Forwarded-For only from configured proxies; rate-limit GETs

### DIFF
--- a/api/Middleware/RateLimitMiddleware.cs
+++ b/api/Middleware/RateLimitMiddleware.cs
@@ -13,10 +13,10 @@ using Microsoft.Extensions.Options;
 namespace Lfm.Api.Middleware;
 
 /// <summary>
-/// Per-IP rate limiting for auth and write endpoints using sliding window limiters.
-/// GET and OPTIONS requests are not rate limited.
+/// Per-IP rate limiting for auth, write, and read endpoints using sliding
+/// window limiters. OPTIONS bypasses entirely (handled by CorsMiddleware).
 /// </summary>
-public sealed class RateLimitMiddleware(IOptions<RateLimitOptions> opts) : IFunctionsWorkerMiddleware
+public sealed class RateLimitMiddleware : IFunctionsWorkerMiddleware
 {
     private static readonly HashSet<string> AuthFunctions =
         new(["battlenet-login", "battlenet-callback"], StringComparer.OrdinalIgnoreCase);
@@ -26,9 +26,17 @@ public sealed class RateLimitMiddleware(IOptions<RateLimitOptions> opts) : IFunc
 
     private readonly ConcurrentDictionary<string, (SlidingWindowRateLimiter Limiter, DateTimeOffset LastAccessed)> _authLimiters = new();
     private readonly ConcurrentDictionary<string, (SlidingWindowRateLimiter Limiter, DateTimeOffset LastAccessed)> _writeLimiters = new();
+    private readonly ConcurrentDictionary<string, (SlidingWindowRateLimiter Limiter, DateTimeOffset LastAccessed)> _readLimiters = new();
 
     private long _callCount;
-    private readonly RateLimitOptions _options = opts.Value;
+    private readonly RateLimitOptions _options;
+    private readonly HashSet<string> _trustedProxies;
+
+    public RateLimitMiddleware(IOptions<RateLimitOptions> opts)
+    {
+        _options = opts.Value;
+        _trustedProxies = new HashSet<string>(_options.TrustedProxyAddresses, StringComparer.OrdinalIgnoreCase);
+    }
 
     public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
     {
@@ -47,9 +55,8 @@ public sealed class RateLimitMiddleware(IOptions<RateLimitOptions> opts) : IFunc
 
         var method = httpContext.Request.Method;
 
-        // OPTIONS and GET are never rate limited
-        if (string.Equals(method, HttpMethods.Options, StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(method, HttpMethods.Get, StringComparison.OrdinalIgnoreCase))
+        // OPTIONS bypasses — preflight is handled by CorsMiddleware.
+        if (string.Equals(method, HttpMethods.Options, StringComparison.OrdinalIgnoreCase))
         {
             await next(context);
             return;
@@ -58,8 +65,9 @@ public sealed class RateLimitMiddleware(IOptions<RateLimitOptions> opts) : IFunc
         var functionName = context.FunctionDefinition.Name;
         var isAuth = AuthFunctions.Contains(functionName);
         var isWrite = !isAuth && WriteMethods.Contains(method);
+        var isRead = !isAuth && !isWrite && string.Equals(method, HttpMethods.Get, StringComparison.OrdinalIgnoreCase);
 
-        if (!isAuth && !isWrite)
+        if (!isAuth && !isWrite && !isRead)
         {
             await next(context);
             return;
@@ -71,11 +79,16 @@ public sealed class RateLimitMiddleware(IOptions<RateLimitOptions> opts) : IFunc
         {
             EvictStaleEntries(_authLimiters);
             EvictStaleEntries(_writeLimiters);
+            EvictStaleEntries(_readLimiters);
         }
 
         var clientIp = GetClientIp(httpContext);
-        var limiters = isAuth ? _authLimiters : _writeLimiters;
-        var permitLimit = isAuth ? _options.AuthRequestsPerMinute : _options.WriteRequestsPerMinute;
+        var (limiters, permitLimit) = (isAuth, isWrite) switch
+        {
+            (true, _) => (_authLimiters, _options.AuthRequestsPerMinute),
+            (_, true) => (_writeLimiters, _options.WriteRequestsPerMinute),
+            _ => (_readLimiters, _options.ReadRequestsPerMinute),
+        };
 
         var entry = limiters.AddOrUpdate(
             clientIp,
@@ -96,20 +109,32 @@ public sealed class RateLimitMiddleware(IOptions<RateLimitOptions> opts) : IFunc
         await next(context);
     }
 
-    internal static string GetClientIp(HttpContext httpContext)
+    internal string GetClientIp(HttpContext httpContext)
     {
-        var forwarded = httpContext.Request.Headers["X-Forwarded-For"].ToString();
-        if (!string.IsNullOrEmpty(forwarded))
+        var remote = httpContext.Connection.RemoteIpAddress?.ToString();
+
+        // Only honour X-Forwarded-For when the TCP peer is a known, configured
+        // proxy. Otherwise a direct attacker can forge the header and spin up
+        // arbitrarily many fresh buckets, bypassing rate limits entirely.
+        if (remote is not null && _trustedProxies.Contains(remote))
         {
-            // Take the first entry (leftmost = original client)
-            var firstIp = forwarded.Split(',', StringSplitOptions.TrimEntries)[0];
-            if (!string.IsNullOrEmpty(firstIp))
+            var forwarded = httpContext.Request.Headers["X-Forwarded-For"].ToString();
+            if (!string.IsNullOrEmpty(forwarded))
             {
-                return firstIp;
+                // Take the rightmost entry: the proxy that added it is trusted,
+                // and any entries to its left could have been forged by the
+                // original client. The rightmost is the only hop the trusted
+                // proxy actually witnessed.
+                var parts = forwarded.Split(',', StringSplitOptions.TrimEntries);
+                var lastIp = parts[^1];
+                if (!string.IsNullOrEmpty(lastIp))
+                {
+                    return lastIp;
+                }
             }
         }
 
-        return httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        return remote ?? "unknown";
     }
 
     private static SlidingWindowRateLimiter CreateLimiter(int permitLimit)

--- a/api/Options/RateLimitOptions.cs
+++ b/api/Options/RateLimitOptions.cs
@@ -8,5 +8,17 @@ public sealed class RateLimitOptions
     public const string SectionName = "RateLimit";
     public int AuthRequestsPerMinute { get; set; } = 10;
     public int WriteRequestsPerMinute { get; set; } = 30;
+    public int ReadRequestsPerMinute { get; set; } = 120;
     public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// IPs that may legitimately set X-Forwarded-For on the way in. If the
+    /// request's TCP peer address appears here, the middleware trusts XFF and
+    /// uses the rightmost entry (the last proxy-recorded client hop) as the
+    /// rate-limit bucket key. Otherwise XFF is ignored and the bucket key is
+    /// the TCP peer itself — a direct attacker cannot forge a new bucket.
+    /// Configure via RateLimit:TrustedProxyAddresses:0, ...:1, ... — typically
+    /// the Azure Front Door / SWA egress IPs. Empty by default.
+    /// </summary>
+    public IReadOnlyList<string> TrustedProxyAddresses { get; set; } = [];
 }

--- a/tests/Lfm.Api.Tests/Middleware/RateLimitMiddlewareTests.cs
+++ b/tests/Lfm.Api.Tests/Middleware/RateLimitMiddlewareTests.cs
@@ -343,6 +343,36 @@ public class RateLimitMiddlewareTests
     }
 
     [Fact]
+    public async Task Xff_different_rightmost_entries_from_trusted_proxy_get_separate_buckets()
+    {
+        // Covers the mutant where the proxy IP is used as the bucket key
+        // (ignoring XFF) or where a constant is used (collapsing all clients
+        // behind one proxy). Two requests with *different* rightmost entries
+        // through the same trusted proxy must land in separate buckets.
+        var options = DefaultOptions(trustedProxies: ["10.0.0.1"]);
+        options.WriteRequestsPerMinute = 1;
+        var opts = MsOptions.Create(options);
+        var middleware = new RateLimitMiddleware(opts);
+
+        // Client A exhausts their bucket.
+        var (ctx1, _) = CreateContext("runs-create", "POST",
+            clientIp: "10.0.0.1",
+            xForwardedFor: "203.0.113.10");
+        await middleware.Invoke(ctx1.Object, _ => Task.CompletedTask);
+
+        // Client B via the same trusted proxy must have its own permit.
+        var (ctx2, httpCtx2) = CreateContext("runs-create", "POST",
+            clientIp: "10.0.0.1",
+            xForwardedFor: "203.0.113.20");
+        var nextCalled = false;
+
+        await middleware.Invoke(ctx2.Object, _ => { nextCalled = true; return Task.CompletedTask; });
+
+        Assert.True(nextCalled);
+        Assert.NotEqual(429, httpCtx2.Response.StatusCode);
+    }
+
+    [Fact]
     public async Task Xff_trims_whitespace_around_addresses()
     {
         var options = DefaultOptions(trustedProxies: ["10.0.0.1"]);
@@ -369,6 +399,7 @@ public class RateLimitMiddlewareTests
     [Fact]
     public async Task Empty_xff_from_trusted_remote_falls_back_to_remote_ip()
     {
+        // Empty-string XFF header must resolve to the remote-IP bucket.
         var options = DefaultOptions(trustedProxies: ["10.0.0.5"]);
         options.WriteRequestsPerMinute = 1;
         var opts = MsOptions.Create(options);
@@ -379,15 +410,41 @@ public class RateLimitMiddlewareTests
             xForwardedFor: "");
         await middleware.Invoke(ctx1.Object, _ => Task.CompletedTask);
 
+        // Second request with a distinct but still-empty XFF input proves the
+        // bucket is keyed on the TCP peer, not on the XFF literal.
         var (ctx2, httpCtx2) = CreateContext("runs-create", "POST",
             clientIp: "10.0.0.5",
+            xForwardedFor: "");
+        httpCtx2.Response.Body = new MemoryStream();
+
+        await middleware.Invoke(ctx2.Object, _ => Task.CompletedTask);
+
+        Assert.Equal(429, httpCtx2.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Missing_xff_from_trusted_remote_falls_back_to_remote_ip()
+    {
+        // Separate from the empty-string case: an absent XFF header is a
+        // different input path (no Request.Headers entry at all), so it gets
+        // its own test to isolate failure modes.
+        var options = DefaultOptions(trustedProxies: ["10.0.0.6"]);
+        options.WriteRequestsPerMinute = 1;
+        var opts = MsOptions.Create(options);
+        var middleware = new RateLimitMiddleware(opts);
+
+        var (ctx1, _) = CreateContext("runs-create", "POST",
+            clientIp: "10.0.0.6",
+            xForwardedFor: null);
+        await middleware.Invoke(ctx1.Object, _ => Task.CompletedTask);
+
+        var (ctx2, httpCtx2) = CreateContext("runs-create", "POST",
+            clientIp: "10.0.0.6",
             xForwardedFor: null);
         httpCtx2.Response.Body = new MemoryStream();
 
         await middleware.Invoke(ctx2.Object, _ => Task.CompletedTask);
 
-        // Both requests share the RemoteIpAddress bucket (no XFF → no
-        // forwarded client identity), so the second must be blocked.
         Assert.Equal(429, httpCtx2.Response.StatusCode);
     }
 

--- a/tests/Lfm.Api.Tests/Middleware/RateLimitMiddlewareTests.cs
+++ b/tests/Lfm.Api.Tests/Middleware/RateLimitMiddlewareTests.cs
@@ -18,12 +18,16 @@ public class RateLimitMiddlewareTests
     // See: Azure/azure-functions-dotnet-worker Constants.HttpContextKey
     private const string HttpContextKey = "HttpRequestContext";
 
-    private static RateLimitOptions DefaultOptions(bool enabled = true) => new()
-    {
-        AuthRequestsPerMinute = 10,
-        WriteRequestsPerMinute = 30,
-        Enabled = enabled,
-    };
+    private static RateLimitOptions DefaultOptions(
+        bool enabled = true,
+        IReadOnlyList<string>? trustedProxies = null) => new()
+        {
+            AuthRequestsPerMinute = 10,
+            WriteRequestsPerMinute = 30,
+            ReadRequestsPerMinute = 120,
+            Enabled = enabled,
+            TrustedProxyAddresses = trustedProxies ?? [],
+        };
 
     private static (Mock<FunctionContext> Context, DefaultHttpContext HttpContext) CreateContext(
         string functionName,
@@ -57,6 +61,8 @@ public class RateLimitMiddlewareTests
         return (funcContext, httpContext);
     }
 
+    // ── Write-bucket behaviour ────────────────────────────────────────────
+
     [Fact]
     public async Task Request_under_limit_passes_through()
     {
@@ -79,14 +85,12 @@ public class RateLimitMiddlewareTests
         var opts = MsOptions.Create(options);
         var middleware = new RateLimitMiddleware(opts);
 
-        // Exhaust the limit
         for (var i = 0; i < 2; i++)
         {
             var (ctx, _) = CreateContext("runs-create", "POST");
             await middleware.Invoke(ctx.Object, _ => Task.CompletedTask);
         }
 
-        // Next request should be blocked
         var (blockedCtx, blockedHttpCtx) = CreateContext("runs-create", "POST");
         blockedHttpCtx.Response.Body = new MemoryStream();
         var nextCalled = false;
@@ -106,11 +110,9 @@ public class RateLimitMiddlewareTests
         var opts = MsOptions.Create(options);
         var middleware = new RateLimitMiddleware(opts);
 
-        // IP 1 uses its permit
         var (ctx1, _) = CreateContext("runs-create", "POST", clientIp: "10.0.0.1");
         await middleware.Invoke(ctx1.Object, _ => Task.CompletedTask);
 
-        // IP 2 should still have its own permit
         var (ctx2, httpCtx2) = CreateContext("runs-create", "POST", clientIp: "10.0.0.2");
         var nextCalled = false;
 
@@ -129,11 +131,9 @@ public class RateLimitMiddlewareTests
         var opts = MsOptions.Create(options);
         var middleware = new RateLimitMiddleware(opts);
 
-        // Exhaust auth limit with a POST to battlenet-callback
         var (authCtx1, _) = CreateContext("battlenet-callback", "POST");
         await middleware.Invoke(authCtx1.Object, _ => Task.CompletedTask);
 
-        // Auth limit exhausted — next auth POST should be blocked
         var (authCtx2, authHttp2) = CreateContext("battlenet-callback", "POST");
         authHttp2.Response.Body = new MemoryStream();
         var authNextCalled = false;
@@ -143,7 +143,6 @@ public class RateLimitMiddlewareTests
         Assert.False(authNextCalled);
         Assert.Equal(429, authHttp2.Response.StatusCode);
 
-        // Write endpoint should still work (separate bucket with 100 limit)
         var (writeCtx, writeHttp) = CreateContext("runs-create", "POST");
         var writeNextCalled = false;
 
@@ -161,11 +160,9 @@ public class RateLimitMiddlewareTests
         var opts = MsOptions.Create(options);
         var middleware = new RateLimitMiddleware(opts);
 
-        // Exhaust write limit with a POST
         var (ctx1, _) = CreateContext("runs-create", "POST");
         await middleware.Invoke(ctx1.Object, _ => Task.CompletedTask);
 
-        // Next write (PUT) should be blocked — same IP, same write bucket
         var (ctx2, httpCtx2) = CreateContext("runs-update", "PUT");
         httpCtx2.Response.Body = new MemoryStream();
         var nextCalled = false;
@@ -176,17 +173,17 @@ public class RateLimitMiddlewareTests
         Assert.Equal(429, httpCtx2.Response.StatusCode);
     }
 
+    // ── Read bucket (NEW in W3) ───────────────────────────────────────────
+
     [Fact]
-    public async Task Get_request_is_not_rate_limited()
+    public async Task Get_request_under_read_limit_passes_through()
     {
         var options = DefaultOptions();
-        options.WriteRequestsPerMinute = 1;
-        options.AuthRequestsPerMinute = 1;
+        options.ReadRequestsPerMinute = 3;
         var opts = MsOptions.Create(options);
         var middleware = new RateLimitMiddleware(opts);
 
-        // Make many GET requests — none should be blocked
-        for (var i = 0; i < 50; i++)
+        for (var i = 0; i < 3; i++)
         {
             var (ctx, httpCtx) = CreateContext("runs-list", "GET");
             var nextCalled = false;
@@ -199,53 +196,89 @@ public class RateLimitMiddlewareTests
     }
 
     [Fact]
-    public async Task Forwarded_for_header_overrides_remote_ip_for_bucketing()
+    public async Task Get_request_at_read_limit_returns_429()
     {
-        // When the X-Forwarded-For header is present, the leftmost address must be
-        // used as the bucket key — otherwise a proxy in front of the function would
-        // collapse all client traffic into one bucket.
         var options = DefaultOptions();
-        options.WriteRequestsPerMinute = 1;
+        options.ReadRequestsPerMinute = 2;
         var opts = MsOptions.Create(options);
         var middleware = new RateLimitMiddleware(opts);
 
-        // First request: forwarded client A behind proxy 10.0.0.1
-        var (ctx1, _) = CreateContext("runs-create", "POST",
-            clientIp: "10.0.0.1",
-            xForwardedFor: "203.0.113.1, 10.0.0.1");
-        await middleware.Invoke(ctx1.Object, _ => Task.CompletedTask);
+        for (var i = 0; i < 2; i++)
+        {
+            var (ctx, _) = CreateContext("runs-list", "GET");
+            await middleware.Invoke(ctx.Object, _ => Task.CompletedTask);
+        }
 
-        // Second request: same proxy, different forwarded client B → must get its own bucket
-        var (ctx2, httpCtx2) = CreateContext("runs-create", "POST",
-            clientIp: "10.0.0.1",
-            xForwardedFor: "203.0.113.2, 10.0.0.1");
+        var (blockedCtx, blockedHttpCtx) = CreateContext("runs-list", "GET");
+        blockedHttpCtx.Response.Body = new MemoryStream();
         var nextCalled = false;
 
-        await middleware.Invoke(ctx2.Object, _ => { nextCalled = true; return Task.CompletedTask; });
+        await middleware.Invoke(blockedCtx.Object, _ => { nextCalled = true; return Task.CompletedTask; });
 
-        Assert.True(nextCalled);
-        Assert.NotEqual(429, httpCtx2.Response.StatusCode);
+        Assert.False(nextCalled);
+        Assert.Equal(429, blockedHttpCtx.Response.StatusCode);
     }
 
     [Fact]
-    public async Task Forwarded_for_with_single_address_uses_it_as_bucket_key()
+    public async Task Read_bucket_is_separate_from_write_bucket()
     {
+        // Exhausting the read budget on /runs (GET) must not block a POST to /runs.
         var options = DefaultOptions();
+        options.ReadRequestsPerMinute = 1;
         options.WriteRequestsPerMinute = 1;
         var opts = MsOptions.Create(options);
         var middleware = new RateLimitMiddleware(opts);
 
-        // Burn the limit for forwarded client A
+        var (readCtx, _) = CreateContext("runs-list", "GET");
+        await middleware.Invoke(readCtx.Object, _ => Task.CompletedTask);
+
+        var (readCtx2, readHttp2) = CreateContext("runs-list", "GET");
+        readHttp2.Response.Body = new MemoryStream();
+        await middleware.Invoke(readCtx2.Object, _ => Task.CompletedTask);
+        Assert.Equal(429, readHttp2.Response.StatusCode);
+
+        // Write bucket must still have a fresh permit.
+        var (writeCtx, writeHttp) = CreateContext("runs-create", "POST");
+        var writeNextCalled = false;
+
+        await middleware.Invoke(writeCtx.Object, _ => { writeNextCalled = true; return Task.CompletedTask; });
+
+        Assert.True(writeNextCalled);
+        Assert.NotEqual(429, writeHttp.Response.StatusCode);
+    }
+
+    // ── X-Forwarded-For trust (W2) ────────────────────────────────────────
+    //
+    // The contract after W2: X-Forwarded-For is only honoured when the TCP
+    // peer (`Connection.RemoteIpAddress`) appears in
+    // `RateLimitOptions.TrustedProxyAddresses`. When honoured, the RIGHTMOST
+    // entry is used as the bucket key — the only hop the trusted proxy
+    // actually witnessed. When not honoured, XFF is ignored entirely and the
+    // bucket key is the TCP peer.
+
+    [Fact]
+    public async Task Xff_from_untrusted_remote_is_ignored_for_bucketing()
+    {
+        // A direct attacker setting X-Forwarded-For to forge a fresh bucket
+        // must fall into their real-IP bucket. Without this, they can bypass
+        // rate limits indefinitely by rotating XFF values.
+        var options = DefaultOptions();
+        options.WriteRequestsPerMinute = 1;
+        // No trusted proxies configured — every request is treated as direct.
+        var opts = MsOptions.Create(options);
+        var middleware = new RateLimitMiddleware(opts);
+
+        // Attacker at 198.51.100.1 forges XFF pointing at a different IP.
         var (ctx1, _) = CreateContext("runs-create", "POST",
-            clientIp: "10.0.0.1",
-            xForwardedFor: "203.0.113.10");
+            clientIp: "198.51.100.1",
+            xForwardedFor: "203.0.113.1");
         await middleware.Invoke(ctx1.Object, _ => Task.CompletedTask);
 
-        // Second request from same forwarded client must be 429 — proves the
-        // bucket key was the forwarded IP, not the proxy IP.
+        // Same attacker, different forged XFF — must hit the same bucket
+        // (keyed on 198.51.100.1) and be blocked.
         var (ctx2, httpCtx2) = CreateContext("runs-create", "POST",
-            clientIp: "10.0.0.1",
-            xForwardedFor: "203.0.113.10");
+            clientIp: "198.51.100.1",
+            xForwardedFor: "203.0.113.2");
         httpCtx2.Response.Body = new MemoryStream();
 
         await middleware.Invoke(ctx2.Object, _ => Task.CompletedTask);
@@ -254,24 +287,25 @@ public class RateLimitMiddlewareTests
     }
 
     [Fact]
-    public async Task Forwarded_for_trims_whitespace_around_addresses()
+    public async Task Xff_from_trusted_remote_is_used_rightmost_for_bucketing()
     {
-        // X-Forwarded-For commonly has spaces after commas — the parser must
-        // trim them so the leftmost address is matched correctly.
-        var options = DefaultOptions();
+        // The request arrives from a configured proxy; the rightmost XFF
+        // entry identifies the last hop the proxy witnessed.
+        var options = DefaultOptions(trustedProxies: ["10.0.0.1"]);
         options.WriteRequestsPerMinute = 1;
         var opts = MsOptions.Create(options);
         var middleware = new RateLimitMiddleware(opts);
 
+        // Proxy forwards a single hop. Bucket key = rightmost = 203.0.113.50.
         var (ctx1, _) = CreateContext("runs-create", "POST",
             clientIp: "10.0.0.1",
-            xForwardedFor: "203.0.113.50,   10.0.0.1");
+            xForwardedFor: "203.0.113.50");
         await middleware.Invoke(ctx1.Object, _ => Task.CompletedTask);
 
+        // Same client via the trusted proxy → same bucket → blocked.
         var (ctx2, httpCtx2) = CreateContext("runs-create", "POST",
             clientIp: "10.0.0.1",
-            // Same client, no whitespace this time — must hit the same bucket
-            xForwardedFor: "203.0.113.50,10.0.0.1");
+            xForwardedFor: "203.0.113.50");
         httpCtx2.Response.Body = new MemoryStream();
 
         await middleware.Invoke(ctx2.Object, _ => Task.CompletedTask);
@@ -280,9 +314,62 @@ public class RateLimitMiddlewareTests
     }
 
     [Fact]
-    public async Task Empty_forwarded_for_falls_back_to_remote_ip()
+    public async Task Xff_from_trusted_remote_takes_rightmost_not_leftmost()
     {
-        var options = DefaultOptions();
+        // When the XFF chain has multiple entries, the rightmost is the one
+        // the trusted proxy actually recorded. Any earlier entries could
+        // have been forged by the original client.
+        var options = DefaultOptions(trustedProxies: ["10.0.0.1"]);
+        options.WriteRequestsPerMinute = 1;
+        var opts = MsOptions.Create(options);
+        var middleware = new RateLimitMiddleware(opts);
+
+        // First request: client A (spoofed leftmost) + witnessed hop 203.0.113.99
+        var (ctx1, _) = CreateContext("runs-create", "POST",
+            clientIp: "10.0.0.1",
+            xForwardedFor: "198.51.100.77, 203.0.113.99");
+        await middleware.Invoke(ctx1.Object, _ => Task.CompletedTask);
+
+        // Second request: different forged leftmost, same witnessed rightmost.
+        // Bucket must be shared — keyed on the rightmost entry.
+        var (ctx2, httpCtx2) = CreateContext("runs-create", "POST",
+            clientIp: "10.0.0.1",
+            xForwardedFor: "198.51.100.88, 203.0.113.99");
+        httpCtx2.Response.Body = new MemoryStream();
+
+        await middleware.Invoke(ctx2.Object, _ => Task.CompletedTask);
+
+        Assert.Equal(429, httpCtx2.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Xff_trims_whitespace_around_addresses()
+    {
+        var options = DefaultOptions(trustedProxies: ["10.0.0.1"]);
+        options.WriteRequestsPerMinute = 1;
+        var opts = MsOptions.Create(options);
+        var middleware = new RateLimitMiddleware(opts);
+
+        var (ctx1, _) = CreateContext("runs-create", "POST",
+            clientIp: "10.0.0.1",
+            xForwardedFor: "198.51.100.1,   203.0.113.50");
+        await middleware.Invoke(ctx1.Object, _ => Task.CompletedTask);
+
+        // Same rightmost entry without extra whitespace must hit the same bucket.
+        var (ctx2, httpCtx2) = CreateContext("runs-create", "POST",
+            clientIp: "10.0.0.1",
+            xForwardedFor: "198.51.100.1,203.0.113.50");
+        httpCtx2.Response.Body = new MemoryStream();
+
+        await middleware.Invoke(ctx2.Object, _ => Task.CompletedTask);
+
+        Assert.Equal(429, httpCtx2.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Empty_xff_from_trusted_remote_falls_back_to_remote_ip()
+    {
+        var options = DefaultOptions(trustedProxies: ["10.0.0.5"]);
         options.WriteRequestsPerMinute = 1;
         var opts = MsOptions.Create(options);
         var middleware = new RateLimitMiddleware(opts);
@@ -299,8 +386,12 @@ public class RateLimitMiddlewareTests
 
         await middleware.Invoke(ctx2.Object, _ => Task.CompletedTask);
 
+        // Both requests share the RemoteIpAddress bucket (no XFF → no
+        // forwarded client identity), so the second must be blocked.
         Assert.Equal(429, httpCtx2.Response.StatusCode);
     }
+
+    // ── Misc ──────────────────────────────────────────────────────────────
 
     [Fact]
     public async Task Disabled_rate_limiting_passes_all_requests()
@@ -310,10 +401,32 @@ public class RateLimitMiddlewareTests
         var opts = MsOptions.Create(options);
         var middleware = new RateLimitMiddleware(opts);
 
-        // Even after exceeding the notional limit, requests pass through
         for (var i = 0; i < 5; i++)
         {
             var (ctx, httpCtx) = CreateContext("runs-create", "POST");
+            var nextCalled = false;
+
+            await middleware.Invoke(ctx.Object, _ => { nextCalled = true; return Task.CompletedTask; });
+
+            Assert.True(nextCalled);
+            Assert.NotEqual(429, httpCtx.Response.StatusCode);
+        }
+    }
+
+    [Fact]
+    public async Task Options_request_bypasses_rate_limit_entirely()
+    {
+        // CorsMiddleware handles preflight; RateLimit must not count OPTIONS.
+        var options = DefaultOptions();
+        options.WriteRequestsPerMinute = 1;
+        options.ReadRequestsPerMinute = 1;
+        options.AuthRequestsPerMinute = 1;
+        var opts = MsOptions.Create(options);
+        var middleware = new RateLimitMiddleware(opts);
+
+        for (var i = 0; i < 20; i++)
+        {
+            var (ctx, httpCtx) = CreateContext("cors-preflight", "OPTIONS");
             var nextCalled = false;
 
             await middleware.Invoke(ctx.Object, _ => { nextCalled = true; return Task.CompletedTask; });


### PR DESCRIPTION
Branch 4 of 7 from the route-level security review (W2 + W3).

## Summary

**W2 — XFF forgery closed.** Previously any client could set `X-Forwarded-For: <random>` to occupy a fresh rate-limit bucket per request, fully bypassing the 10 /min auth limit and 30 /min write limit. Now XFF is honoured only when `Connection.RemoteIpAddress` appears in `RateLimit:TrustedProxyAddresses` (empty by default). When honoured, the **rightmost** entry is used as the bucket key — the one the trusted proxy actually recorded. A direct attacker's forged XFF is ignored; they fall into their real-IP bucket.

**W3 — GET rate-limit bucket added.** A third tier (`ReadRequestsPerMinute`, default 120) now meters GETs. `/runs`, `/me`, `/battlenet/characters`, `/guild`, reference endpoints, and other reads can no longer be scraped without a limit. OPTIONS still bypasses — preflight is handled by CorsMiddleware.

## Changes

- `api/Options/RateLimitOptions.cs` — added `ReadRequestsPerMinute = 120`, `TrustedProxyAddresses` (empty default list of IPs).
- `api/Middleware/RateLimitMiddleware.cs` — added `_readLimiters` bucket; `GetClientIp` now gates XFF parsing on the TCP peer being a trusted proxy and takes the rightmost entry when trusted.
- `tests/Lfm.Api.Tests/Middleware/RateLimitMiddlewareTests.cs` — 15 tests (previously 11). Replaced the old "XFF leftmost overrides remote" tests with the new contract. Added tests for: read-bucket under/at-limit, read bucket ≠ write bucket, XFF ignored from untrusted remote (forgery defence), XFF honoured from trusted remote with rightmost semantics, empty XFF falls back to remote.

## Env / schema changes

**New optional config.** Operators can configure trusted ingress proxies (typically the Azure Front Door / SWA egress IPs):

```
RateLimit__TrustedProxyAddresses__0=<front-door-ip-1>
RateLimit__TrustedProxyAddresses__1=<front-door-ip-2>
...
```

Unconfigured deployments are strictly safer than before: XFF is simply ignored and every request goes into its real-TCP-peer bucket.

`RateLimit__ReadRequestsPerMinute` is also new; default 120 is used if unset.

## Test plan

- [ ] CI `verify` passes.
- [ ] 15 rate-limit tests pass locally (`--filter "FullyQualifiedName~RateLimitMiddlewareTests"`).
- [ ] Full API suite still passes (420 locally).
- [ ] Full App suite still passes (150 locally).

## Related

Plan `review-security-of-each-whimsical-hickey.md` — Branch 4 (W2 + W3). Next: Branch 5a (W9 — rename reference routes to `wow/reference/*`).

The anonymous-read vs authenticated-read split is deferred — distinguishing requires running RateLimit after AuthMiddleware (which currently runs after). The single 120/min ceiling meaningfully blocks naive scraping; the split can be added later if abuse warrants it.
