### PR TITLE
Require auth on WoW reference GETs

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -53,8 +53,6 @@ Endpoints that are intentionally unauthenticated and may be called by any client
 - `GET /api/battlenet/login` — initiates OAuth flow
 - `GET /api/battlenet/callback` — receives OAuth callback
 - `GET /api/health/ready` — liveness probe
-- `GET /api/wow/reference/instances` — static reference data (WoW instances)
-- `GET /api/wow/reference/specializations` — static reference data (WoW specs)
 - `GET /api/privacy-contact/email` — privacy contact email
 
 All other endpoints require a valid session cookie enforced by `AuthPolicyMiddleware`.

--- a/api/Functions/WowReferenceInstancesFunction.cs
+++ b/api/Functions/WowReferenceInstancesFunction.cs
@@ -4,6 +4,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
+using Lfm.Api.Auth;
 using Lfm.Api.Repositories;
 
 namespace Lfm.Api.Functions;
@@ -11,6 +12,7 @@ namespace Lfm.Api.Functions;
 public class WowReferenceInstancesFunction(IInstancesRepository repo)
 {
     [Function("wow-reference-instances")]
+    [RequireAuth]
     public async Task<IActionResult> Run(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "wow/reference/instances")] HttpRequest req,
         CancellationToken ct)

--- a/api/Functions/WowReferenceSpecializationsFunction.cs
+++ b/api/Functions/WowReferenceSpecializationsFunction.cs
@@ -4,6 +4,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
+using Lfm.Api.Auth;
 using Lfm.Api.Repositories;
 
 namespace Lfm.Api.Functions;
@@ -11,6 +12,7 @@ namespace Lfm.Api.Functions;
 public class WowReferenceSpecializationsFunction(ISpecializationsRepository repo)
 {
     [Function("wow-reference-specializations")]
+    [RequireAuth]
     public async Task<IActionResult> Run(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "wow/reference/specializations")] HttpRequest req,
         CancellationToken ct)

--- a/tests/Lfm.Api.Tests/FunctionAuthorizationContractTests.cs
+++ b/tests/Lfm.Api.Tests/FunctionAuthorizationContractTests.cs
@@ -37,9 +37,6 @@ public class FunctionAuthorizationContractTests
         // Health probes — App Service Health Check / external monitors.
         "health",
         "health-ready",
-        // Static reference data — anonymous read endpoints with no PII.
-        "wow-reference-instances",
-        "wow-reference-specializations",
         // Public privacy contact — anonymous form submission.
         "privacy-email",
         "privacy-contact",


### PR DESCRIPTION
Branch 5b of 7 from the route-level security review (W6).

## Summary

The two WoW reference-data reads — `GET /api/wow/reference/instances` and `GET /api/wow/reference/specializations` — were documented in SECURITY.md as intentionally anonymous, but they are only called from pages that the SPA only shows after the user has signed in (`InstancesPage.razor`, `CreateRunPage.razor`, `EditRunPage.razor`). No legitimate anonymous use case exists. Leaving them open:

- Handed scrapers a free, uncapped surface.
- Compounded with W3 (GET rate-limit bucket, landed in Branch 4).
- Broke the project-wide posture that every data-serving endpoint runs behind `AuthPolicyMiddleware`.

Add `[RequireAuth]` to both functions, drop them from the `FunctionAuthorizationContractTests` anonymous-allow list, and remove the matching bullets from SECURITY.md's Public Endpoints list.

## Changes

- `api/Functions/WowReferenceInstancesFunction.cs` — added `[RequireAuth]` and `using Lfm.Api.Auth;`.
- `api/Functions/WowReferenceSpecializationsFunction.cs` — same.
- `tests/Lfm.Api.Tests/FunctionAuthorizationContractTests.cs` — removed the two function ids + comment line from the allow-list.
- `SECURITY.md` — removed the two bullets from § Public Endpoints.

## Ratchet

`FunctionAuthorizationContractTests` pins the new shape via two theories:
1. `Every_function_either_has_require_auth_or_is_in_anonymous_allow_list` — would fail if `[RequireAuth]` were ever removed from either function without re-adding an allow-list entry.
2. `Anonymous_allow_list_is_a_subset_of_known_function_names` — would fail if an entry were re-added for a renamed/removed function.

## Env / schema changes

None. Runtime behaviour: an anonymous caller now receives 401 instead of 200. The SPA already holds a session cookie by the time either page renders post-auth, so the change is invisible to signed-in users.

## Test plan

- [ ] CI `verify` passes.
- [ ] Local full-suite: 422 API + 150 App + 129 App.Core all green.
- [ ] Manual (post-merge, pre-deploy): open `/instances` and `/create-run` logged-out; pages either redirect to login or render empty — not a 200 leak.

## Related

Plan `review-security-of-each-whimsical-hickey.md` — Branch 5b (W6). Next: Branch 6 (W7 + W8 — privacy-page click-gate + DOM obfuscation + `<meta robots>`; delete dead `privacy/contact` POST).
