### PR TITLE
Paginate runs-list: TOP 200 cap and continuation token

### DIFF
--- a/api/Functions/RunsListFunction.cs
+++ b/api/Functions/RunsListFunction.cs
@@ -27,6 +27,11 @@ namespace Lfm.Api.Functions;
 /// </summary>
 public class RunsListFunction(IRunsRepository repo, IRaidersRepository raidersRepo)
 {
+    // Hard cap on page size. Keeps per-request RU + payload bounded regardless
+    // of what the caller asks for.
+    internal const int DefaultTop = 200;
+    internal const int MaxTop = 200;
+
     [Function("runs-list")]
     [RequireAuth]
     public async Task<IActionResult> Run(
@@ -42,15 +47,35 @@ public class RunsListFunction(IRunsRepository repo, IRaidersRepository raidersRe
 
         var (guildId, _) = GuildResolver.FromRaider(raider);
 
-        IReadOnlyList<RunDocument> runs = guildId is not null
-            ? await repo.ListForGuildAsync(guildId, principal.BattleNetId, ct)
-            : await repo.ListForUserAsync(principal.BattleNetId, ct);
+        var top = ParseTop(req);
+        var continuationToken = ParseContinuationToken(req);
 
-        var dtos = runs
+        var page = guildId is not null
+            ? await repo.ListForGuildAsync(guildId, principal.BattleNetId, top, continuationToken, ct)
+            : await repo.ListForUserAsync(principal.BattleNetId, top, continuationToken, ct);
+
+        var dtos = page.Items
             .Select(r => Sanitize(r, principal.BattleNetId))
             .ToList();
 
-        return new OkObjectResult(dtos);
+        return new OkObjectResult(new RunsListResponse(dtos, page.ContinuationToken));
+    }
+
+    private static int ParseTop(HttpRequest req)
+    {
+        if (!req.Query.TryGetValue("top", out var raw) || raw.Count == 0)
+            return DefaultTop;
+        if (!int.TryParse(raw[0], out var parsed))
+            return DefaultTop;
+        return Math.Clamp(parsed, 1, MaxTop);
+    }
+
+    private static string? ParseContinuationToken(HttpRequest req)
+    {
+        if (!req.Query.TryGetValue("continuationToken", out var raw) || raw.Count == 0)
+            return null;
+        var value = raw[0];
+        return string.IsNullOrEmpty(value) ? null : value;
     }
 
     // ------------------------------------------------------------------

--- a/api/Repositories/IRunsRepository.cs
+++ b/api/Repositories/IRunsRepository.cs
@@ -46,6 +46,13 @@ public sealed record RunDocument(
     IReadOnlyList<RunCharacterEntry> RunCharacters,
     [property: System.Text.Json.Serialization.JsonPropertyName("_etag")] string? ETag = null);
 
+/// <summary>
+/// One page of runs returned by the list endpoints. <see cref="ContinuationToken"/>
+/// is the opaque Cosmos continuation token to pass back for the next page; a
+/// null value means the server has no more results.
+/// </summary>
+public sealed record RunsPage(IReadOnlyList<RunDocument> Items, string? ContinuationToken);
+
 public interface IRunsRepository
 {
     /// <summary>
@@ -59,23 +66,26 @@ public interface IRunsRepository
     Task ScrubRaiderAsync(string battleNetId, CancellationToken ct);
 
     /// <summary>
-    /// Returns all runs visible to a user who belongs to the given guild.
+    /// Returns one page of runs visible to a user who belongs to the given guild.
     /// Visibility rules (mirrors runs-list.ts):
     ///   - PUBLIC runs (visible to everyone)
     ///   - GUILD runs created by the same guild (creatorGuildId matches)
     ///   - runs created by the user themselves (creatorBattleNetId matches)
-    /// Ordered by startTime ascending.
+    /// Ordered by startTime ascending. Caps the page at <paramref name="top"/> items
+    /// via Cosmos <c>MaxItemCount</c>; returns a continuation token when more
+    /// pages are available.
     /// </summary>
-    Task<IReadOnlyList<RunDocument>> ListForGuildAsync(string guildId, string battleNetId, CancellationToken ct);
+    Task<RunsPage> ListForGuildAsync(string guildId, string battleNetId, int top, string? continuationToken, CancellationToken ct);
 
     /// <summary>
-    /// Returns all runs visible to a user who has no guild.
+    /// Returns one page of runs visible to a user who has no guild.
     /// Visibility rules:
     ///   - PUBLIC runs
     ///   - runs created by the user themselves
-    /// Ordered by startTime ascending.
+    /// Ordered by startTime ascending. Paginated the same way as
+    /// <see cref="ListForGuildAsync"/>.
     /// </summary>
-    Task<IReadOnlyList<RunDocument>> ListForUserAsync(string battleNetId, CancellationToken ct);
+    Task<RunsPage> ListForUserAsync(string battleNetId, int top, string? continuationToken, CancellationToken ct);
 
     /// <summary>
     /// Returns a single run by its document id, or null if it does not exist.

--- a/api/Repositories/RunsRepository.cs
+++ b/api/Repositories/RunsRepository.cs
@@ -12,14 +12,14 @@ public sealed class RunsRepository(CosmosClient client, IOptions<CosmosOptions> 
     private const string ContainerName = "runs";
     private readonly Container _container = client.GetContainer(cosmosOpts.Value.DatabaseName, ContainerName);
 
-    public async Task<IReadOnlyList<RunDocument>> ListForGuildAsync(
-        string guildId, string battleNetId, CancellationToken ct)
+    public async Task<RunsPage> ListForGuildAsync(
+        string guildId, string battleNetId, int top, string? continuationToken, CancellationToken ct)
     {
         // Mirrors the guild-scoped query in runs-list.ts:
         //   PUBLIC runs | runs created by this user | GUILD runs from the same guild
         //   Ordered by startTime ascending.
         if (!int.TryParse(guildId, out var numericGuildId))
-            return Array.Empty<RunDocument>();
+            return new RunsPage(Array.Empty<RunDocument>(), null);
 
         const string query = """
             SELECT * FROM c
@@ -29,15 +29,17 @@ public sealed class RunsRepository(CosmosClient client, IOptions<CosmosOptions> 
             ORDER BY c.startTime ASC
             """;
 
-        return await QueryRunsAsync(
+        return await QueryOnePageAsync(
             new QueryDefinition(query)
                 .WithParameter("@battleNetId", battleNetId)
                 .WithParameter("@guildId", numericGuildId),
+            top,
+            continuationToken,
             ct);
     }
 
-    public async Task<IReadOnlyList<RunDocument>> ListForUserAsync(
-        string battleNetId, CancellationToken ct)
+    public async Task<RunsPage> ListForUserAsync(
+        string battleNetId, int top, string? continuationToken, CancellationToken ct)
     {
         // Mirrors the no-guild branch in runs-list.ts:
         //   PUBLIC runs | runs created by this user
@@ -49,23 +51,30 @@ public sealed class RunsRepository(CosmosClient client, IOptions<CosmosOptions> 
             ORDER BY c.startTime ASC
             """;
 
-        return await QueryRunsAsync(
+        return await QueryOnePageAsync(
             new QueryDefinition(query)
                 .WithParameter("@battleNetId", battleNetId),
+            top,
+            continuationToken,
             ct);
     }
 
-    private async Task<IReadOnlyList<RunDocument>> QueryRunsAsync(
-        QueryDefinition queryDef, CancellationToken ct)
+    // Reads exactly one page (up to `top` items) from Cosmos and returns it
+    // alongside the continuation token. Does NOT drain the iterator — the caller
+    // re-invokes us with the returned token to fetch the next page.
+    private async Task<RunsPage> QueryOnePageAsync(
+        QueryDefinition queryDef, int top, string? continuationToken, CancellationToken ct)
     {
-        var feedIterator = _container.GetItemQueryIterator<RunDocument>(queryDef);
-        var results = new List<RunDocument>();
-        while (feedIterator.HasMoreResults)
-        {
-            var page = await feedIterator.ReadNextAsync(ct);
-            results.AddRange(page);
-        }
-        return results;
+        var options = new QueryRequestOptions { MaxItemCount = top };
+        var feedIterator = _container.GetItemQueryIterator<RunDocument>(
+            queryDef, continuationToken, options);
+
+        if (!feedIterator.HasMoreResults)
+            return new RunsPage(Array.Empty<RunDocument>(), null);
+
+        var response = await feedIterator.ReadNextAsync(ct);
+        var items = response.ToList();
+        return new RunsPage(items, response.ContinuationToken);
     }
 
     public async Task<RunDocument?> GetByIdAsync(string id, CancellationToken ct)

--- a/app/Lfm.App.Core/Services/RunsClient.cs
+++ b/app/Lfm.App.Core/Services/RunsClient.cs
@@ -10,9 +10,13 @@ public sealed class RunsClient(IHttpClientFactory factory) : IRunsClient
 {
     public async Task<IReadOnlyList<RunSummaryDto>> ListAsync(CancellationToken ct)
     {
+        // The server returns a RunsListResponse envelope capped at 200 items per
+        // page with a continuation token for further pages. The SPA currently
+        // consumes only the first page — a future "load more" feature will need
+        // a ListAsync overload that exposes ContinuationToken.
         var http = factory.CreateClient("api");
-        var items = await http.GetFromJsonAsync<List<RunSummaryDto>>("api/runs", ct);
-        return items ?? [];
+        var response = await http.GetFromJsonAsync<RunsListResponse>("api/runs", ct);
+        return response?.Items ?? [];
     }
 
     public async Task<RunDetailDto?> GetAsync(string id, CancellationToken ct)

--- a/shared/Lfm.Contracts/Runs/RunsListResponse.cs
+++ b/shared/Lfm.Contracts/Runs/RunsListResponse.cs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+namespace Lfm.Contracts.Runs;
+
+/// <summary>
+/// Paginated response for <c>GET /api/runs</c>. One page of visible runs plus
+/// an opaque continuation token the client hands back to fetch the next page.
+/// A null token means the server has no more results for this query. The
+/// server caps <c>Items.Count</c> at the service-defined maximum (currently
+/// 200); the client MUST NOT assume a full-page response implies no more data.
+/// </summary>
+public sealed record RunsListResponse(
+    IReadOnlyList<RunSummaryDto> Items,
+    string? ContinuationToken);

--- a/tests/Lfm.Api.Tests/RunsListFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RunsListFunctionTests.cs
@@ -111,8 +111,8 @@ public class RunsListFunctionTests
             runCharacters: [ownCharacter, otherCharacter]);
 
         var repo = new Mock<IRunsRepository>();
-        repo.Setup(r => r.ListForGuildAsync("12345", "bnet-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<RunDocument> { doc });
+        repo.Setup(r => r.ListForGuildAsync("12345", "bnet-1", It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunsPage(new List<RunDocument> { doc }, null));
 
         var raidersRepo = new Mock<IRaidersRepository>();
         raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-1", It.IsAny<CancellationToken>()))
@@ -124,10 +124,10 @@ public class RunsListFunctionTests
         var result = await fn.Run(new DefaultHttpContext().Request, ctx, CancellationToken.None);
 
         var ok = Assert.IsType<OkObjectResult>(result);
-        var runs = Assert.IsAssignableFrom<IReadOnlyList<RunSummaryDto>>(ok.Value);
-        Assert.Single(runs);
+        var response = Assert.IsType<RunsListResponse>(ok.Value);
+        Assert.Single(response.Items);
 
-        var run = runs[0];
+        var run = response.Items[0];
         Assert.Equal(doc.Id, run.Id);
         Assert.Equal(2, run.RunCharacters.Count);
 
@@ -177,8 +177,8 @@ public class RunsListFunctionTests
         var principal = MakePrincipal();
 
         var repo = new Mock<IRunsRepository>();
-        repo.Setup(r => r.ListForGuildAsync("12345", "bnet-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<RunDocument>());
+        repo.Setup(r => r.ListForGuildAsync("12345", "bnet-1", It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunsPage(new List<RunDocument>(), null));
 
         var raidersRepo = new Mock<IRaidersRepository>();
         raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-1", It.IsAny<CancellationToken>()))
@@ -190,8 +190,9 @@ public class RunsListFunctionTests
         var result = await fn.Run(new DefaultHttpContext().Request, ctx, CancellationToken.None);
 
         var ok = Assert.IsType<OkObjectResult>(result);
-        var runs = Assert.IsAssignableFrom<IReadOnlyList<RunSummaryDto>>(ok.Value);
-        Assert.Empty(runs);
+        var response = Assert.IsType<RunsListResponse>(ok.Value);
+        Assert.Empty(response.Items);
+        Assert.Null(response.ContinuationToken);
     }
 
     // ------------------------------------------------------------------
@@ -208,8 +209,8 @@ public class RunsListFunctionTests
         var doc = MakeRunDoc(runCharacters: [ownCharacter]);
 
         var repo = new Mock<IRunsRepository>();
-        repo.Setup(r => r.ListForUserAsync("bnet-loner", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<RunDocument> { doc });
+        repo.Setup(r => r.ListForUserAsync("bnet-loner", It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunsPage(new List<RunDocument> { doc }, null));
 
         var raidersRepo = new Mock<IRaidersRepository>();
         raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-loner", It.IsAny<CancellationToken>()))
@@ -221,14 +222,121 @@ public class RunsListFunctionTests
         var result = await fn.Run(new DefaultHttpContext().Request, ctx, CancellationToken.None);
 
         var ok = Assert.IsType<OkObjectResult>(result);
-        var runs = Assert.IsAssignableFrom<IReadOnlyList<RunSummaryDto>>(ok.Value);
-        Assert.Single(runs);
+        var response = Assert.IsType<RunsListResponse>(ok.Value);
+        Assert.Single(response.Items);
 
         // The guild query must not be called when the raider has no guild.
         repo.Verify(r => r.ListForGuildAsync(
-            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Never,
             "a raider with no guild must use ListForUserAsync, not ListForGuildAsync");
     }
 
+    // ------------------------------------------------------------------
+    // Pagination — request parsing and response envelope (W5)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task Run_passes_default_top_200_when_top_query_param_missing()
+    {
+        var principal = MakePrincipal(battleNetId: "bnet-1", guildId: "12345");
+
+        var repo = new Mock<IRunsRepository>();
+        repo.Setup(r => r.ListForGuildAsync("12345", "bnet-1", It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunsPage(new List<RunDocument>(), null));
+        var raidersRepo = new Mock<IRaidersRepository>();
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRaiderDoc("bnet-1", guildId: 12345));
+
+        var fn = new RunsListFunction(repo.Object, raidersRepo.Object);
+        await fn.Run(new DefaultHttpContext().Request, MakeFunctionContext(principal), CancellationToken.None);
+
+        repo.Verify(r => r.ListForGuildAsync("12345", "bnet-1", 200, null, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Run_clamps_over_max_top_to_200()
+    {
+        var principal = MakePrincipal(battleNetId: "bnet-1", guildId: "12345");
+
+        var repo = new Mock<IRunsRepository>();
+        repo.Setup(r => r.ListForGuildAsync("12345", "bnet-1", It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunsPage(new List<RunDocument>(), null));
+        var raidersRepo = new Mock<IRaidersRepository>();
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRaiderDoc("bnet-1", guildId: 12345));
+
+        var ctx = new DefaultHttpContext();
+        ctx.Request.QueryString = new Microsoft.AspNetCore.Http.QueryString("?top=5000");
+
+        var fn = new RunsListFunction(repo.Object, raidersRepo.Object);
+        await fn.Run(ctx.Request, MakeFunctionContext(principal), CancellationToken.None);
+
+        // Client-requested 5000 is clamped down to the service cap.
+        repo.Verify(r => r.ListForGuildAsync("12345", "bnet-1", 200, null, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Run_honours_top_query_param_within_range()
+    {
+        var principal = MakePrincipal(battleNetId: "bnet-1", guildId: "12345");
+
+        var repo = new Mock<IRunsRepository>();
+        repo.Setup(r => r.ListForGuildAsync("12345", "bnet-1", It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunsPage(new List<RunDocument>(), null));
+        var raidersRepo = new Mock<IRaidersRepository>();
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRaiderDoc("bnet-1", guildId: 12345));
+
+        var ctx = new DefaultHttpContext();
+        ctx.Request.QueryString = new Microsoft.AspNetCore.Http.QueryString("?top=25");
+
+        var fn = new RunsListFunction(repo.Object, raidersRepo.Object);
+        await fn.Run(ctx.Request, MakeFunctionContext(principal), CancellationToken.None);
+
+        repo.Verify(r => r.ListForGuildAsync("12345", "bnet-1", 25, null, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Run_passes_continuation_token_from_query_to_repo()
+    {
+        var principal = MakePrincipal(battleNetId: "bnet-1", guildId: "12345");
+
+        var repo = new Mock<IRunsRepository>();
+        repo.Setup(r => r.ListForGuildAsync("12345", "bnet-1", It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunsPage(new List<RunDocument>(), null));
+        var raidersRepo = new Mock<IRaidersRepository>();
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRaiderDoc("bnet-1", guildId: 12345));
+
+        var ctx = new DefaultHttpContext();
+        ctx.Request.QueryString = new Microsoft.AspNetCore.Http.QueryString("?continuationToken=abc123");
+
+        var fn = new RunsListFunction(repo.Object, raidersRepo.Object);
+        await fn.Run(ctx.Request, MakeFunctionContext(principal), CancellationToken.None);
+
+        repo.Verify(r => r.ListForGuildAsync("12345", "bnet-1", 200, "abc123", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Run_returns_repo_continuation_token_in_response_envelope()
+    {
+        var principal = MakePrincipal(battleNetId: "bnet-1", guildId: "12345");
+        var doc = MakeRunDoc();
+
+        var repo = new Mock<IRunsRepository>();
+        repo.Setup(r => r.ListForGuildAsync("12345", "bnet-1", It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunsPage(new List<RunDocument> { doc }, "next-page-token"));
+        var raidersRepo = new Mock<IRaidersRepository>();
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRaiderDoc("bnet-1", guildId: 12345));
+
+        var fn = new RunsListFunction(repo.Object, raidersRepo.Object);
+        var result = await fn.Run(new DefaultHttpContext().Request, MakeFunctionContext(principal), CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<RunsListResponse>(ok.Value);
+        Assert.Single(response.Items);
+        Assert.Equal("next-page-token", response.ContinuationToken);
+    }
 }

--- a/tests/Lfm.App.Core.Tests/Services/RunsClientTests.cs
+++ b/tests/Lfm.App.Core.Tests/Services/RunsClientTests.cs
@@ -75,11 +75,15 @@ public class RunsClientTests
             InstanceName: "Liberation of Undermine");
 
     [Fact]
-    public async Task ListAsync_deserializes_json_array_response()
+    public async Task ListAsync_deserializes_items_from_runs_list_response_envelope()
     {
-        var (client, handler) = MakeClient(StubHttpMessageHandler.Json(
-            HttpStatusCode.OK,
-            new[] { MakeSummary("run-a"), MakeSummary("run-b") }));
+        // Server now returns a RunsListResponse envelope ({ items, continuationToken })
+        // — the client must deserialize it and surface only the items through the
+        // existing IRunsClient.ListAsync signature.
+        var envelope = new RunsListResponse(
+            Items: [MakeSummary("run-a"), MakeSummary("run-b")],
+            ContinuationToken: "next-page");
+        var (client, handler) = MakeClient(StubHttpMessageHandler.Json(HttpStatusCode.OK, envelope));
 
         var result = await client.ListAsync(CancellationToken.None);
 
@@ -90,9 +94,10 @@ public class RunsClientTests
     }
 
     [Fact]
-    public async Task ListAsync_returns_empty_list_when_body_is_empty_array()
+    public async Task ListAsync_returns_empty_list_when_envelope_items_is_empty()
     {
-        var (client, _) = MakeClient(StubHttpMessageHandler.Json(HttpStatusCode.OK, Array.Empty<RunSummaryDto>()));
+        var envelope = new RunsListResponse(Items: [], ContinuationToken: null);
+        var (client, _) = MakeClient(StubHttpMessageHandler.Json(HttpStatusCode.OK, envelope));
 
         var result = await client.ListAsync(CancellationToken.None);
 


### PR DESCRIPTION
Branch 7 (final) of 7 from the route-level security review (W5).

## Summary

Before: `RunsRepository.ListFor{User,Guild}Async` drained the Cosmos `FeedIterator` in a while loop, returning every visible run in a single in-memory allocation. A prolific guild could force an arbitrarily large query cost (RU) and response payload on a single `GET /api/runs` call. Every list GET is authenticated (so there's no anonymous abuse), but the worst case is still unbounded RU + memory.

After:

- Repository issues ONE page via `GetItemQueryIterator(..., continuationToken, new QueryRequestOptions { MaxItemCount = top })` and returns a new `RunsPage { Items, ContinuationToken }` record.
- Function parses `?top=` (clamped to `[1, 200]`, default 200) and `?continuationToken=` and wraps the response in a new `RunsListResponse { Items, ContinuationToken }` contract.
- SPA's `IRunsClient.ListAsync` keeps its `IReadOnlyList<RunSummaryDto>` signature by extracting `.Items` from the envelope and dropping the token — a future "load more" feature will need a new overload that exposes it.

## Changes

- `shared/Lfm.Contracts/Runs/RunsListResponse.cs` (new) — response envelope.
- `api/Repositories/IRunsRepository.cs` — new `RunsPage` record; `ListForGuildAsync` / `ListForUserAsync` take `top` + `continuationToken` and return `RunsPage`.
- `api/Repositories/RunsRepository.cs` — `QueryOnePageAsync` reads exactly one page.
- `api/Functions/RunsListFunction.cs` — `?top` + `?continuationToken` parsing; returns envelope.
- `app/Lfm.App.Core/Services/RunsClient.cs` — deserializes envelope; preserves interface.
- `tests/Lfm.Api.Tests/RunsListFunctionTests.cs` — ported existing tests to the new repo shape; **four new tests** pin default-top, clamp-over-max, in-range-top, continuation-token forwarding, and the response envelope's `ContinuationToken` field.
- `tests/Lfm.App.Core.Tests/Services/RunsClientTests.cs` — updated two list-shape assertions to use the envelope.

## Env / schema changes

**Wire-contract change on GET /api/runs.** Old shape: `[RunSummaryDto, ...]`. New shape: `{ "items": [...], "continuationToken": "..." | null }`. The SPA is updated in the same commit to deserialize the new shape, so any mid-deploy cached old SPA would break on a call until refresh — acceptable for a hobby project with rolling main.

New optional query parameters:
- `?top=<int>` — clamped to `[1, 200]`, default 200.
- `?continuationToken=<opaque>` — pass back the token from the previous page's response.

## Test plan

- [ ] CI `verify` passes.
- [ ] Local full-suite: 423 API + 151 App + 129 App.Core all green.
- [ ] Over-budget commit noted — 7 files vs. the 5-file guideline. Atomic because the wire-contract migration can't be split without leaving the tree uncompilable between commits.

## Related

Plan `review-security-of-each-whimsical-hickey.md` — Branch 7 (W5). This closes the seven-branch sequence of the route-level security review.
