### PR TITLE
Document wire-payload contract for shared DTOs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,10 @@ See [docs/storage-architecture.md](docs/storage-architecture.md) for the full da
 
 There is no DB migration runner. Reference data refresh is handled by `WowReferenceRefreshFunction` (admin-only `POST /api/wow/reference/refresh`) and `WowReferenceRefreshTimerFunction` (weekly), both writing to blob.
 
+## API Wire Contracts
+
+Every property on a `shared/Lfm.Contracts/` record must have a live consumer in `app/` markup or `app/Lfm.App.Core/`. Test-only usage does not qualify. Server-internal state (Cosmos `Ttl`, audit timestamps, other users' Battle.net ids, raw Blizzard pass-through payloads) never goes on the wire — project to a Lfm-owned DTO at the `api/Functions/` boundary. Two narrow exceptions (peer permission fields, planned near-term feature reservations) require an XML doc-comment naming the reason. See [docs/wire-payload-contract.md](docs/wire-payload-contract.md).
+
 ## Documentation Separation
 
 `CLAUDE.md` and `docs/` are Claude-facing: guidance, workflow rules, architectural decisions. User-facing content belongs in `README.md` or `docs/user/`. Plans and specs: `docs/superpowers/plans/` and `docs/superpowers/specs/`.

--- a/docs/wire-payload-contract.md
+++ b/docs/wire-payload-contract.md
@@ -1,0 +1,71 @@
+# Wire Payload Contract
+
+This document is the rule for what fields are allowed on the JSON the API sends to the Blazor app. When adding a property to a record under `shared/Lfm.Contracts/`, when reviewing a change that touches a wire DTO, or when auditing the API surface, measure the change against the rule below.
+
+## The rule
+
+Every property on a `shared/Lfm.Contracts/` record must have a live consumer in the Blazor app — either bound in Razor markup (`app/`) or read in code-behind / `app/Lfm.App.Core/` services. Test-only usage does not count: if the only place a field is referenced is `tests/`, the field doesn't earn its place on the wire.
+
+The wire is the public contract between API and app. Storage shape (Cosmos documents, blob JSON) is separate — see [storage-architecture.md](storage-architecture.md). Server-internal state must stop at the API boundary.
+
+## What must never appear on the wire
+
+| Category | Examples | Why |
+|---|---|---|
+| Cosmos container internals | `Ttl`, partition keys, `_etag`, `_rid` | Storage concept, not a domain concept. Leaking it ossifies the wire to a specific persistence layer. |
+| Audit timestamps | `CreatedAt`, `UpdatedAt`, `DeletedAt` | The app does not surface them. If the UI needs "X minutes ago", add the field then — until then, it's just bytes. |
+| Other users' Battle.net ids | A run's `CreatorBattleNetId`, a roster member's `RaiderBattleNetId` | PII. Replace with a derived boolean (`IsCurrentUser`) or a non-identifying display string (`CreatorGuild`). The pattern in `RunCharacterDto.IsCurrentUser` is the reference. |
+| Internal document ids the route doesn't expose | A nested-entry `Id` that no PUT/DELETE route accepts | If you can't act on the id from the client, sending it is just confusion. |
+| Raw Blizzard pass-through payloads | The full `account-profile`, `journal-instance`, `playable-class` JSON | Always project to a Lfm-owned DTO. The mapping layer is the place to drop fields the app doesn't render. |
+
+## Exceptions
+
+Two — and only these two — narrow exceptions are allowed. Both must be marked in the code so the next audit recognises them.
+
+### Peer permission fields
+
+When a permission tuple is rendered together (e.g. `CanCreateGuildRuns` / `CanSignupGuildRuns` / `CanDeleteGuildRuns`), keep the unused peer for semantic completeness even when the UI only surfaces some members today. Rationale: shipping the permission set partial-by-partial creates a fragmented API surface where adding a UI hint requires a wire change.
+
+Mark with an XML doc-comment naming the peer set, e.g.:
+
+```csharp
+/// <summary>
+/// Kept for peer-permission symmetry with CanCreateGuildRuns/CanSignupGuildRuns,
+/// even though no UI surfaces it today.
+/// </summary>
+public bool CanDeleteGuildRuns { get; }
+```
+
+### Planned near-term feature reservation
+
+A field with no current consumer is allowed if a feature already in flight will read it within the next handful of changes. Annotate with an XML doc-comment naming the pending feature so the next audit knows why it's there. If the feature stalls or gets dropped, the field gets trimmed at the next audit — the reservation is not permanent.
+
+Example today: `InstanceDto.PortraitUrl`. The portrait surface is in design; the field stays so the API ingester (`WowReferenceRefreshFunction`) doesn't need a re-shape when the UI lands.
+
+## How to verify a new field
+
+Before adding a property to a `shared/Lfm.Contracts/` record:
+
+```bash
+grep -rn "\.NewField" app/
+```
+
+At least one non-test hit must exist (or be in the same diff). If the only hits are under `tests/`, do not add the field — change the test or wait for the consumer.
+
+## How to audit the contract
+
+Run periodically (and after large refactors). The audit reads every property of every record under `shared/Lfm.Contracts/` and grep-checks `app/` for a non-test consumer. Fields with zero non-test consumers are candidates for trimming; verify each by hand against the two exceptions above before removing.
+
+```bash
+# List PascalCase property/parameter names declared in shared/Lfm.Contracts records.
+# Cross-reference each against app/ (excluding tests/) for a real consumer.
+git grep -hE '^\s*(public\s+\S+\s+|[A-Z]\w+\??\s)\s*[A-Z]\w+\s*[,;\)\{=]' shared/Lfm.Contracts/
+```
+
+The exact command is intentionally rough — the audit is human-driven, not automated. The point is to force a deliberate look at every wire field on a regular cadence, not to gate CI.
+
+## Cross-references
+
+- [storage-architecture.md](storage-architecture.md) — where the data lives at rest. The wire is *not* the storage shape; mapping in `api/Functions/` is what bridges them.
+- `api/Functions/RunsListFunction.cs`, `api/Functions/GuildMapper.cs` — reference projection sites that show the storage-document → wire-DTO mapping pattern.
+- `RunCharacterDto.IsCurrentUser` — the reference pattern for replacing an other-user identifier with a derived boolean.

--- a/shared/Lfm.Contracts/Instances/InstanceDto.cs
+++ b/shared/Lfm.Contracts/Instances/InstanceDto.cs
@@ -3,6 +3,12 @@
 
 namespace Lfm.Contracts.Instances;
 
+/// <param name="PortraitUrl">
+/// Reserved for the in-flight instance-portrait UI. No app consumer today.
+/// Tracked by the wire-payload-contract "planned near-term feature reservation"
+/// exception — see docs/wire-payload-contract.md. If the portrait surface is
+/// dropped, trim this field at the next audit.
+/// </param>
 public sealed record InstanceDto(
     string Id,
     string Name,


### PR DESCRIPTION
## Summary

- Adds [`docs/wire-payload-contract.md`](docs/wire-payload-contract.md) — the rule that every property on a `shared/Lfm.Contracts/` record must have a live consumer in `app/` markup or `app/Lfm.App.Core/`. Test-only usage doesn't qualify. Server-internal state (Cosmos `Ttl`, audit timestamps, other users' Battle.net ids, raw Blizzard pass-through payloads) never goes on the wire.
- Two narrow exceptions documented: peer permission fields, and planned near-term feature reservations — both require an XML doc-comment naming the reason.
- `CLAUDE.md` gains a brief "API Wire Contracts" section pointing at the new doc.
- `InstanceDto.PortraitUrl` gains an XML `<param>` doc-comment marking it as the canonical reservation example (in-flight portrait UI).

This is the docs-first branch in a four-branch payload-trim sequence. The follow-up branches (`claude/payload-trim-runs`, `claude/payload-trim-guild`) cite this doc when removing fields.

## Test plan

- [x] `dotnet build lfm.sln -c Release` — clean
- [x] `dotnet format lfm.sln` — no diff
- [ ] CI: format check, build, secret scan, infra analyze
