### PR TITLE
Trim Guild wire DTOs to fields the app reads

### DIFF
--- a/api/Functions/GuildMapper.cs
+++ b/api/Functions/GuildMapper.cs
@@ -19,17 +19,14 @@ internal static class GuildMapper
                 IsInitialized: false,
                 RequiresSetup: true,
                 RankDataFresh: false,
-                RankDataFetchedAt: null,
                 Timezone: "UTC",
                 Locale: "en"),
             Settings: null,
-            Editor: new GuildEditorDto(CanEdit: false, Mode: "member"),
+            Editor: new GuildEditorDto(CanEdit: false),
             MemberPermissions: new GuildMemberPermissionsDto(
-                MatchedRank: null,
                 CanCreateGuildRuns: false,
                 CanSignupGuildRuns: false,
-                CanDeleteGuildRuns: false,
-                RankDataFresh: false));
+                CanDeleteGuildRuns: false));
 
     internal static GuildDto MapToDto(GuildDocument doc)
     {
@@ -47,12 +44,9 @@ internal static class GuildMapper
                 Id: doc.GuildId,
                 Name: profile.Name,
                 Slogan: doc.Slogan,
-                RealmSlug: doc.RealmSlug,
                 RealmName: profile.Realm.Name ?? doc.RealmSlug,
                 FactionName: profile.Faction?.Name,
                 MemberCount: profile.MemberCount,
-                AchievementPoints: profile.AchievementPoints,
-                SyncedMemberCount: rosterMembers?.Count,
                 RankCount: rankCount,
                 CrestEmblemUrl: doc.CrestEmblemUrl,
                 CrestBorderUrl: doc.CrestBorderUrl);
@@ -62,18 +56,15 @@ internal static class GuildMapper
             IsInitialized: doc.Setup?.InitializedAt is not null,
             RequiresSetup: false,
             RankDataFresh: IsRosterFresh(doc),
-            RankDataFetchedAt: doc.BlizzardRosterFetchedAt,
             Timezone: doc.Setup?.Timezone ?? "Europe/Helsinki",
             Locale: doc.Setup?.Locale ?? "fi");
 
-        var editor = new GuildEditorDto(CanEdit: false, Mode: "member");
+        var editor = new GuildEditorDto(CanEdit: false);
 
         var memberPermissions = new GuildMemberPermissionsDto(
-            MatchedRank: null,
             CanCreateGuildRuns: false,
             CanSignupGuildRuns: false,
-            CanDeleteGuildRuns: false,
-            RankDataFresh: IsRosterFresh(doc));
+            CanDeleteGuildRuns: false);
 
         return new GuildDto(
             Guild: guildInfo,

--- a/shared/Lfm.Contracts/Guild/GuildDto.cs
+++ b/shared/Lfm.Contracts/Guild/GuildDto.cs
@@ -6,37 +6,35 @@ namespace Lfm.Contracts.Guild;
 /// <summary>
 /// Guild info nested inside GuildDto; null when the user is not in a guild
 /// or the guild document has not been bootstrapped yet.
-/// Mirrors the <c>guild</c> field in the TypeScript <c>GuildHomeView</c>.
+/// Wire-only shape per docs/wire-payload-contract.md — fields the app does
+/// not render (RealmSlug, AchievementPoints, SyncedMemberCount) are omitted.
 /// </summary>
 public sealed record GuildInfoDto(
     int Id,
     string Name,
     string? Slogan,
-    string RealmSlug,
     string RealmName,
     string? FactionName,
     int? MemberCount,
-    int? AchievementPoints,
-    int? SyncedMemberCount,
     int? RankCount,
     string? CrestEmblemUrl,
     string? CrestBorderUrl);
 
 /// <summary>
 /// Setup / initialisation status of the guild.
-/// Mirrors the <c>setup</c> field in the TypeScript <c>GuildHomeView</c>.
+/// Wire-only shape per docs/wire-payload-contract.md — RankDataFetchedAt is
+/// omitted; the app reads RankDataFresh (the derived boolean), not the
+/// raw timestamp.
 /// </summary>
 public sealed record GuildSetupDto(
     bool IsInitialized,
     bool RequiresSetup,
     bool RankDataFresh,
-    string? RankDataFetchedAt,
     string Timezone,
     string Locale);
 
 /// <summary>
 /// Per-rank permission entry.
-/// Mirrors the <c>rankPermissions</c> entries in the TypeScript <c>GuildHomeView</c>.
 /// </summary>
 public sealed record GuildRankPermissionDto(
     int Rank,
@@ -55,23 +53,25 @@ public sealed record GuildSettingsDto(
 /// Guild editor context.
 /// </summary>
 public sealed record GuildEditorDto(
-    bool CanEdit,
-    string Mode);
+    bool CanEdit);
 
+/// <param name="CanDeleteGuildRuns">
+/// Kept for peer-permission symmetry with CanCreateGuildRuns / CanSignupGuildRuns
+/// (the wire-payload-contract peer-permission exception — see
+/// docs/wire-payload-contract.md), even though no UI surfaces it today.
+/// </param>
 /// <summary>
 /// Effective permission set for the current raider within the guild.
-/// Mirrors the <c>memberPermissions</c> field in the TypeScript <c>GuildHomeView</c>.
+/// Wire-only shape per docs/wire-payload-contract.md — MatchedRank is
+/// omitted (not rendered) and RankDataFresh is read from GuildSetupDto.
 /// </summary>
 public sealed record GuildMemberPermissionsDto(
-    int? MatchedRank,
     bool CanCreateGuildRuns,
     bool CanSignupGuildRuns,
-    bool CanDeleteGuildRuns,
-    bool RankDataFresh);
+    bool CanDeleteGuildRuns);
 
 /// <summary>
 /// Response body for GET /api/guild.
-/// Mirrors the TypeScript <c>GuildHomeView</c> returned by <c>loadCurrentGuildHome</c>.
 /// </summary>
 public sealed record GuildDto(
     GuildInfoDto? Guild,

--- a/tests/Lfm.App.Core.Tests/Services/GuildClientTests.cs
+++ b/tests/Lfm.App.Core.Tests/Services/GuildClientTests.cs
@@ -25,12 +25,9 @@ public class GuildClientTests
                 Id: 1,
                 Name: name,
                 Slogan: "We ride the storm",
-                RealmSlug: "silvermoon",
                 RealmName: "Silvermoon",
                 FactionName: "Alliance",
                 MemberCount: 120,
-                AchievementPoints: 5000,
-                SyncedMemberCount: 100,
                 RankCount: 10,
                 CrestEmblemUrl: null,
                 CrestBorderUrl: null),
@@ -38,17 +35,14 @@ public class GuildClientTests
                 IsInitialized: true,
                 RequiresSetup: false,
                 RankDataFresh: true,
-                RankDataFetchedAt: null,
                 Timezone: "Europe/Helsinki",
                 Locale: "fi"),
             Settings: null,
-            Editor: new GuildEditorDto(CanEdit: false, Mode: "member"),
+            Editor: new GuildEditorDto(CanEdit: false),
             MemberPermissions: new GuildMemberPermissionsDto(
-                MatchedRank: 3,
                 CanCreateGuildRuns: true,
                 CanSignupGuildRuns: true,
-                CanDeleteGuildRuns: false,
-                RankDataFresh: true));
+                CanDeleteGuildRuns: false));
 
     // ── GetAsync ─────────────────────────────────────────────────────────────
 

--- a/tests/Lfm.App.Tests/GuildPagesTests.cs
+++ b/tests/Lfm.App.Tests/GuildPagesTests.cs
@@ -34,10 +34,10 @@ public class GuildPagesTests : ComponentTestBase
         var client = new Mock<IGuildClient>();
         var dto = new GuildDto(
             Guild: null,
-            Setup: new GuildSetupDto(false, true, false, null, "Europe/Helsinki", "fi"),
+            Setup: new GuildSetupDto(false, true, false, "Europe/Helsinki", "fi"),
             Settings: null,
-            Editor: new GuildEditorDto(false, "member"),
-            MemberPermissions: new GuildMemberPermissionsDto(null, false, false, false, false));
+            Editor: new GuildEditorDto(false),
+            MemberPermissions: new GuildMemberPermissionsDto(false, false, false));
         client.Setup(c => c.GetAsync(It.IsAny<CancellationToken>())).ReturnsAsync(dto);
         Services.AddSingleton(client.Object);
 
@@ -52,12 +52,12 @@ public class GuildPagesTests : ComponentTestBase
     {
         var client = new Mock<IGuildClient>();
         var dto = new GuildDto(
-            Guild: new GuildInfoDto(1, "Stormchasers", "We ride the storm", "silvermoon", "Silvermoon", "Alliance",
-                120, 5000, 100, 10, null, null),
-            Setup: new GuildSetupDto(true, false, true, null, "Europe/Helsinki", "fi"),
+            Guild: new GuildInfoDto(1, "Stormchasers", "We ride the storm", "Silvermoon", "Alliance",
+                120, 10, null, null),
+            Setup: new GuildSetupDto(true, false, true, "Europe/Helsinki", "fi"),
             Settings: null,
-            Editor: new GuildEditorDto(false, "member"),
-            MemberPermissions: new GuildMemberPermissionsDto(3, true, true, false, true));
+            Editor: new GuildEditorDto(false),
+            MemberPermissions: new GuildMemberPermissionsDto(true, true, false));
         client.Setup(c => c.GetAsync(It.IsAny<CancellationToken>())).ReturnsAsync(dto);
         Services.AddSingleton(client.Object);
 


### PR DESCRIPTION
## Summary

Applies the [wire-payload contract](docs/wire-payload-contract.md) to the Guild DTOs. -15 net lines.

**Removed (verified zero non-test consumers in `app/`):**

| DTO | Field | Why dropped |
|---|---|---|
| `GuildInfoDto` | `RealmSlug` | App renders `RealmName`, not the slug |
| `GuildInfoDto` | `AchievementPoints` | Not surfaced |
| `GuildInfoDto` | `SyncedMemberCount` | Not surfaced |
| `GuildSetupDto` | `RankDataFetchedAt` | App reads `RankDataFresh` (the derived bool), not the raw timestamp |
| `GuildMemberPermissionsDto` | `MatchedRank` | Not surfaced |
| `GuildMemberPermissionsDto` | `RankDataFresh` | Duplicate — `Setup.RankDataFresh` is the one bound at `GuildAdminPage.razor:46` and `GuildSettingsEditor.razor` |
| `GuildEditorDto` | `Mode` | Only `.CanEdit` is read at `GuildPage.razor:104`; record left single-field with room to grow |

**Kept under documented exception:** `GuildMemberPermissionsDto.CanDeleteGuildRuns` retained with an XML doc-comment under the peer-permission exception in [docs/wire-payload-contract.md](docs/wire-payload-contract.md). The other two members of the permission tuple (`CanCreateGuildRuns`, `CanSignupGuildRuns`) are surfaced together at `GuildPage.razor:109-110`; trimming `CanDelete` alone would be surprising.

**Storage shape unchanged** — `GuildDocument`, `BlizzardGuildProfileRaw`, `BlizzardGuildRosterRaw` keep all fields; only `api/Functions/GuildMapper.cs` (the `MapToDto` and `NoGuildDto` projections) was updated.

## Test plan

- [x] `dotnet build lfm.sln -c Release` — clean
- [x] `dotnet test tests/Lfm.Api.Tests` — 423/423
- [x] `dotnet test tests/Lfm.App.Tests` — 151/151
- [x] `dotnet test tests/Lfm.App.Core.Tests` — 129/129
- [x] `dotnet format lfm.sln` — no diff
- [ ] CI: format check, build, secret scan
- [ ] Manual smoke after merge: GuildPage renders name/realm/member count/rank count; GuildAdminPage rank-permissions editor works
