### PR TITLE
Fix two pre-existing RunsUpdateFunction issues

### DIFF
--- a/api/Functions/RunsUpdateFunction.cs
+++ b/api/Functions/RunsUpdateFunction.cs
@@ -103,9 +103,12 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
             if (body is null)
                 return new BadRequestObjectResult(new { error = "Invalid request body" });
         }
-        catch (JsonException ex)
+        catch (JsonException)
         {
-            return new BadRequestObjectResult(new { error = ex.Message });
+            // Never echo JsonException.Message — it can disclose offset/line/path
+            // detail from the caller's payload that is not useful to the user and
+            // inconsistent with how other handlers report parse failures.
+            return new BadRequestObjectResult(new { error = "Invalid request body" });
         }
 
         var validator = new UpdateRunRequestValidator();
@@ -190,14 +193,14 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
 
         AuditLog.Emit(logger, new AuditEvent("run.update", principal.BattleNetId, id, "success", null));
 
-        return new OkObjectResult(MapToDto(persisted));
+        return new OkObjectResult(MapToDto(persisted, principal.BattleNetId));
     }
 
     // ------------------------------------------------------------------
     // Mapping helper — projects the stored RunDocument to its wire DTO.
     // ------------------------------------------------------------------
 
-    private static RunDetailDto MapToDto(RunDocument doc) =>
+    private static RunDetailDto MapToDto(RunDocument doc, string currentBattleNetId) =>
         new(
             Id: doc.Id,
             StartTime: doc.StartTime,
@@ -218,6 +221,6 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
                     ReviewedAttendance: c.ReviewedAttendance,
                     SpecName: c.SpecName,
                     Role: c.Role,
-                    IsCurrentUser: false))
+                    IsCurrentUser: c.RaiderBattleNetId == currentBattleNetId))
                 .ToList());
 }

--- a/tests/Lfm.Api.Tests/RunsUpdateFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RunsUpdateFunctionTests.cs
@@ -345,4 +345,123 @@ public class RunsUpdateFunctionTests
             actorId: "bnet-creator",
             result: "success"));
     }
+
+    // ------------------------------------------------------------------
+    // Test 6: Malformed JSON returns 400 with a static error string,
+    // never echoing the JsonException message (which can leak the
+    // caller's payload offset/line/path).
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task Run_returns_400_with_static_message_on_malformed_json()
+    {
+        var principal = MakePrincipal(battleNetId: "bnet-creator");
+        var existing = MakeOpenRunDoc(creatorBattleNetId: "bnet-creator");
+
+        var repo = new Mock<IRunsRepository>();
+        repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+
+        var permissions = new Mock<IGuildPermissions>();
+        var instancesRepo = new Mock<IInstancesRepository>();
+        var raidersRepo = MakeRaidersRepoFor(MakeRaiderDoc("bnet-creator"));
+
+        var fn = MakeFunction(repo, permissions, instancesRepo, raidersRepo);
+        var ctx = MakeFunctionContext(principal);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes("{not valid json"));
+        httpContext.Request.ContentType = "application/json";
+
+        var result = await fn.Run(httpContext.Request, "run-1", ctx, CancellationToken.None);
+
+        var bad = Assert.IsType<BadRequestObjectResult>(result);
+        var errorProp = bad.Value!.GetType().GetProperty("error");
+        Assert.NotNull(errorProp);
+        Assert.Equal("Invalid request body", errorProp!.GetValue(bad.Value));
+
+        repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 7: After a successful update, IsCurrentUser is true on the
+    // caller's own roster row (mirrors the sanitization in the other 5
+    // run handlers; was previously hardcoded false).
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task Run_returns_dto_with_IsCurrentUser_true_for_callers_own_roster_row()
+    {
+        var principal = MakePrincipal(battleNetId: "bnet-creator");
+
+        // Run with two roster entries: one belongs to the caller, one to a peer.
+        var existing = MakeOpenRunDoc(creatorBattleNetId: "bnet-creator") with
+        {
+            RunCharacters =
+            [
+                new RunCharacterEntry(
+                    Id: "rc-1",
+                    CharacterId: "char-self",
+                    CharacterName: "Selfwarrior",
+                    CharacterRealm: "silvermoon",
+                    CharacterLevel: 80,
+                    CharacterClassId: 1,
+                    CharacterClassName: "Warrior",
+                    CharacterRaceId: 1,
+                    CharacterRaceName: "Human",
+                    RaiderBattleNetId: "bnet-creator",
+                    DesiredAttendance: "IN",
+                    ReviewedAttendance: "IN",
+                    SpecId: 71,
+                    SpecName: "Arms",
+                    Role: "DPS"),
+                new RunCharacterEntry(
+                    Id: "rc-2",
+                    CharacterId: "char-peer",
+                    CharacterName: "Peerpriest",
+                    CharacterRealm: "silvermoon",
+                    CharacterLevel: 80,
+                    CharacterClassId: 5,
+                    CharacterClassName: "Priest",
+                    CharacterRaceId: 1,
+                    CharacterRaceName: "Human",
+                    RaiderBattleNetId: "bnet-someone-else",
+                    DesiredAttendance: "IN",
+                    ReviewedAttendance: "IN",
+                    SpecId: 257,
+                    SpecName: "Holy",
+                    Role: "HEALER"),
+            ],
+        };
+
+        // Update only the description so the locked-fields guard doesn't fire.
+        var updated = existing with { Description = "Updated description" };
+
+        var repo = new Mock<IRunsRepository>();
+        repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        repo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(updated);
+
+        var permissions = new Mock<IGuildPermissions>();
+        var instancesRepo = new Mock<IInstancesRepository>();
+        instancesRepo.Setup(r => r.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeInstances());
+
+        var raidersRepo = MakeRaidersRepoFor(MakeRaiderDoc("bnet-creator"));
+
+        var fn = MakeFunction(repo, permissions, instancesRepo, raidersRepo);
+        var ctx = MakeFunctionContext(principal);
+
+        var result = await fn.Run(MakePutRequest(new { description = "Updated description" }), "run-1", ctx, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var dto = Assert.IsType<RunDetailDto>(ok.Value);
+        Assert.Equal(2, dto.RunCharacters.Count);
+
+        var ownRow = dto.RunCharacters.Single(c => c.CharacterName == "Selfwarrior");
+        var peerRow = dto.RunCharacters.Single(c => c.CharacterName == "Peerpriest");
+        Assert.True(ownRow.IsCurrentUser);
+        Assert.False(peerRow.IsCurrentUser);
+    }
 }


### PR DESCRIPTION
## Summary

Two pre-existing items surfaced by the DevSecOps audit on the wire-payload trim PR (#94). Both fixed here with regression tests.

### 1. `JsonException.Message` echoed in 400 response

[`RunsUpdateFunction.cs:106-109`](api/Functions/RunsUpdateFunction.cs#L106) used to return `ex.Message` from a malformed-body parse failure. That string can disclose the byte offset, line number, and JSON path of the bad token in the caller's payload — useful to nobody, mildly informative to an attacker probing the parser. Replaced with the same static `"Invalid request body"` pattern (and explanatory comment) already used at [`RunsSignupFunction.cs:69-75`](api/Functions/RunsSignupFunction.cs#L69).

### 2. `IsCurrentUser: false` hardcoded in `MapToDto`

[`RunsUpdateFunction.cs:200`](api/Functions/RunsUpdateFunction.cs#L200) built every roster `RunCharacterDto` with `IsCurrentUser: false`. The five sibling sanitizers (`RunsList`, `RunsDetail`, `RunsSignup`, `RunsCancelSignup`, plus the pattern in the audit reference) compare `RaiderBattleNetId` against the principal's `BattleNetId`. After a successful PUT, the caller's own roster row would not get the highlight the UI expects. `MapToDto` now takes `currentBattleNetId` as a second arg and derives the boolean correctly.

## Tests added

- `Run_returns_400_with_static_message_on_malformed_json` — sends `{not valid json` as the request body, asserts response is `BadRequestObjectResult` with `error == "Invalid request body"` and that no `UpdateAsync` call happened.
- `Run_returns_dto_with_IsCurrentUser_true_for_callers_own_roster_row` — sets up a run with two roster entries (one whose `RaiderBattleNetId` matches the principal, one that doesn't), updates the run, asserts the caller's row has `IsCurrentUser == true` and the peer's has `false`.

## Test plan

- [x] `dotnet build lfm.sln -c Release` — clean
- [x] `dotnet test tests/Lfm.Api.Tests` — 425/425 (was 423; +2 from this PR)
- [x] `dotnet test tests/Lfm.App.Tests` — 151/151
- [x] `dotnet test tests/Lfm.App.Core.Tests` — 129/129
- [x] `dotnet format lfm.sln` — no diff
- [ ] CI: format check, build, secret scan
