### PR TITLE
Pin Azurite image by digest in E2E StackFixture

### DIFF
--- a/tests/Lfm.E2E/Infrastructure/StackFixture.cs
+++ b/tests/Lfm.E2E/Infrastructure/StackFixture.cs
@@ -47,7 +47,15 @@ public class StackFixture : IAsyncLifetime
         })
         .Build();
 
-    private readonly AzuriteContainer _azurite = new AzuriteBuilder("mcr.microsoft.com/azure-storage/azurite:3.28.0")
+    // Version tag + manifest-list digest, matching the Cosmos pin above. The
+    // :3.28.0 tag documents which Azurite release the digest corresponds to;
+    // the @sha256: digest (on the multi-arch manifest list) guarantees the
+    // same bytes every run and still resolves to the correct platform
+    // manifest (linux/amd64 on CI, linux/arm64 on Apple-silicon dev). Bump
+    // both together when upgrading.
+    private readonly AzuriteContainer _azurite = new AzuriteBuilder(
+        "mcr.microsoft.com/azure-storage/azurite:3.28.0"
+        + "@sha256:b2edf4c05060390f368fef3dde4b82981b7125c763a3c6fdeb16e74b20094375")
         .WithPortBinding(10000, 10000)
         .WithPortBinding(10001, 10001)
         .WithPortBinding(10002, 10002)


### PR DESCRIPTION
## Summary

Pin the Azurite image in `tests/Lfm.E2E/Infrastructure/StackFixture.cs` to a `@sha256:` digest, matching the Cosmos emulator pin on the line above. Carries the same `docker.POS-1` (pinned dependency) signal the deleted `docker-compose.test.yml` used to hold, fixing a gap surfaced by the devsecops audit on PR #96.

**Before:**
```csharp
new AzuriteBuilder("mcr.microsoft.com/azure-storage/azurite:3.28.0")
```

**After:**
```csharp
new AzuriteBuilder(
    "mcr.microsoft.com/azure-storage/azurite:3.28.0"
    + "@sha256:b2edf4c05060390f368fef3dde4b82981b7125c763a3c6fdeb16e74b20094375")
```

The digest is the manifest-list (index) digest so it keeps multi-arch resolution (linux/amd64 on CI, linux/arm64 on Apple-silicon dev). The `:3.28.0` tag is kept for human readability; the digest overrides it for reproducibility.

Verified via `docker buildx imagetools inspect mcr.microsoft.com/azure-storage/azurite:3.28.0`:

```
Name:      mcr.microsoft.com/azure-storage/azurite:3.28.0
MediaType: application/vnd.docker.distribution.manifest.list.v2+json
Digest:    sha256:b2edf4c05060390f368fef3dde4b82981b7125c763a3c6fdeb16e74b20094375
Manifests:
  linux/amd64 → sha256:cef8b26e…
  linux/arm64 → sha256:802deb41…
```

## Context

From the devsecops audit of PR #96:

> `docker.POS-1` removed-alongside: `docker-compose.test.yml` — Cosmos digest matches in both code paths, but `StackFixture.cs:51` uses the `3.28.0` tag rather than a `@sha256:` digest. Pre-existing inconsistency, not introduced by that PR, but worth a follow-up.

This is that follow-up.

## Scope

- Single file, 1 insertion + 1 deletion (plus a comment block explaining the rationale).
- No behavioural change — Azurite at `3.28.0` is already the effective pin; this just removes the assumption that Microsoft never repushes the `:3.28.0` tag.
- `docker-compose.local.yml:22` still uses `latest@sha256:dae2a5f9…` — different image/version from the test stack by design (local dev tracks `latest`, tests pin a specific version). Not touched here.

## Test plan

- [x] `dotnet format lfm.sln` — no diff
- [x] `dotnet build lfm.sln -c Release` — clean
- [x] Digest verified against Microsoft Container Registry via `docker buildx imagetools inspect`
- [ ] CI: format check, build, secret scan
- [ ] Manual: next local E2E run will pull the pinned digest on first use (cached thereafter)
