### PR TITLE
Add journal-expansion reference kind

### DIFF
--- a/api/Functions/WowReferenceExpansionsFunction.cs
+++ b/api/Functions/WowReferenceExpansionsFunction.cs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Lfm.Api.Auth;
+using Lfm.Api.Repositories;
+
+namespace Lfm.Api.Functions;
+
+public class WowReferenceExpansionsFunction(IExpansionsRepository repo)
+{
+    [Function("wow-reference-expansions")]
+    [RequireAuth]
+    public async Task<IActionResult> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "wow/reference/expansions")] HttpRequest req,
+        CancellationToken ct)
+    {
+        var items = await repo.ListAsync(ct);
+        return new OkObjectResult(items);
+    }
+}

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -126,6 +126,7 @@ builder.Services.AddSingleton<BlobContainerClient>(sp =>
 builder.Services.AddSingleton<Lfm.Api.Services.IBlobReferenceClient, Lfm.Api.Services.BlobReferenceClient>();
 
 builder.Services.AddScoped<Lfm.Api.Repositories.IInstancesRepository, Lfm.Api.Repositories.InstancesRepository>();
+builder.Services.AddScoped<Lfm.Api.Repositories.IExpansionsRepository, Lfm.Api.Repositories.ExpansionsRepository>();
 builder.Services.AddScoped<Lfm.Api.Repositories.ISpecializationsRepository, Lfm.Api.Repositories.SpecializationsRepository>();
 builder.Services.AddScoped<Lfm.Api.Repositories.IRaidersRepository, Lfm.Api.Repositories.RaidersRepository>();
 builder.Services.AddScoped<Lfm.Api.Repositories.IRunsRepository, Lfm.Api.Repositories.RunsRepository>();

--- a/api/Repositories/ExpansionsRepository.cs
+++ b/api/Repositories/ExpansionsRepository.cs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Services;
+using Lfm.Contracts.Expansions;
+
+namespace Lfm.Api.Repositories;
+
+/// <summary>
+/// Manifest entry emitted by the ingester at
+/// <c>reference/journal-expansion/index.json</c>. Name mirrors the Blizzard
+/// tier name verbatim.
+/// </summary>
+internal sealed record ExpansionIndexEntry(int Id, string Name);
+
+public sealed class ExpansionsRepository(IBlobReferenceClient blobs) : IExpansionsRepository
+{
+    private const string ManifestName = "reference/journal-expansion/index.json";
+
+    public async Task<IReadOnlyList<ExpansionDto>> ListAsync(CancellationToken ct)
+    {
+        var manifest = await blobs.GetAsync<List<ExpansionIndexEntry>>(ManifestName, ct);
+        if (manifest is null) return [];
+        return manifest
+            .Select(e => new ExpansionDto(e.Id, e.Name))
+            .ToList();
+    }
+}

--- a/api/Repositories/IExpansionsRepository.cs
+++ b/api/Repositories/IExpansionsRepository.cs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Contracts.Expansions;
+
+namespace Lfm.Api.Repositories;
+
+/// <summary>
+/// Reads the journal-expansion manifest written by <c>ReferenceSync</c>
+/// at <c>reference/journal-expansion/index.json</c>.
+/// </summary>
+public interface IExpansionsRepository
+{
+    /// <summary>
+    /// Returns every WoW expansion known to the Blizzard Game Data API, in
+    /// the canonical order Blizzard returns. Empty list if the manifest
+    /// blob is absent (pre-ingest).
+    /// </summary>
+    Task<IReadOnlyList<ExpansionDto>> ListAsync(CancellationToken ct);
+}

--- a/api/Services/BlizzardGameDataClient.cs
+++ b/api/Services/BlizzardGameDataClient.cs
@@ -98,6 +98,11 @@ public sealed class BlizzardGameDataClient : IBlizzardGameDataClient
             $"data/wow/media/playable-specialization/{specId}", accessToken, ct);
 
     /// <inheritdoc/>
+    public Task<BlizzardJournalExpansionIndex> GetJournalExpansionIndexAsync(string accessToken, CancellationToken ct)
+        => GetStaticJsonAsync<BlizzardJournalExpansionIndex>(
+            "data/wow/journal-expansion/index", accessToken, ct);
+
+    /// <inheritdoc/>
     public Task<BlizzardJournalInstanceIndex> GetJournalInstanceIndexAsync(string accessToken, CancellationToken ct)
         => GetStaticJsonAsync<BlizzardJournalInstanceIndex>(
             "data/wow/journal-instance/index", accessToken, ct);

--- a/api/Services/IBlizzardGameDataClient.cs
+++ b/api/Services/IBlizzardGameDataClient.cs
@@ -47,6 +47,15 @@ public interface IBlizzardGameDataClient
     Task<BlizzardMediaAssets> GetPlayableSpecMediaAsync(int specId, string accessToken, CancellationToken ct);
 
     /// <summary>
+    /// Fetches the journal-expansion index — the canonical ordered list of
+    /// WoW expansions. Used to populate the expansion selector on the
+    /// create-run form. Each entry carries only <c>Id</c> and <c>Name</c>;
+    /// we never fetch per-expansion detail because the dungeon / raid
+    /// membership is already carried on each journal-instance row.
+    /// </summary>
+    Task<BlizzardJournalExpansionIndex> GetJournalExpansionIndexAsync(string accessToken, CancellationToken ct);
+
+    /// <summary>
     /// Fetches the journal-instance index.
     /// </summary>
     Task<BlizzardJournalInstanceIndex> GetJournalInstanceIndexAsync(string accessToken, CancellationToken ct);
@@ -92,6 +101,12 @@ public sealed record BlizzardPlayableSpecDetail(
 public sealed record BlizzardMediaAsset(string Key, string Value);
 
 public sealed record BlizzardMediaAssets(IReadOnlyList<BlizzardMediaAsset>? Assets);
+
+/// <summary>Blizzard journal-expansion index response. The wire field is
+/// <c>tiers</c>, not <c>expansions</c>.</summary>
+public sealed record BlizzardJournalExpansionIndex(
+    [property: JsonPropertyName("tiers")]
+    IReadOnlyList<BlizzardIndexEntry> Tiers);
 
 public sealed record BlizzardJournalInstanceIndex(IReadOnlyList<BlizzardIndexEntry> Instances);
 

--- a/api/Services/ReferenceSync.cs
+++ b/api/Services/ReferenceSync.cs
@@ -58,6 +58,18 @@ public sealed class ReferenceSync(
             results.Add(new WowReferenceRefreshEntityResult("specializations", $"failed: {ex.Message}"));
         }
 
+        try
+        {
+            token ??= await gameData.GetClientCredentialsTokenAsync(ct);
+            var count = await SyncExpansionsAsync(token, ct);
+            results.Add(new WowReferenceRefreshEntityResult("expansions", $"synced ({count} docs)"));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to sync expansions");
+            results.Add(new WowReferenceRefreshEntityResult("expansions", $"failed: {ex.Message}"));
+        }
+
         return new WowReferenceRefreshResponse(results);
     }
 
@@ -182,6 +194,21 @@ public sealed class ReferenceSync(
         }
 
         await blobs.UploadAsync("reference/playable-specialization/index.json", manifest, ct);
+        return manifest.Count;
+    }
+
+    // ---------------------------------------------------------------------------
+    // Expansion sync
+    // ---------------------------------------------------------------------------
+
+    private async Task<int> SyncExpansionsAsync(string token, CancellationToken ct)
+    {
+        var index = await gameData.GetJournalExpansionIndexAsync(token, ct);
+        var manifest = index.Tiers
+            .Select(t => new ExpansionIndexEntry(Id: t.Id, Name: t.Name))
+            .ToList();
+
+        await blobs.UploadAsync("reference/journal-expansion/index.json", manifest, ct);
         return manifest.Count;
     }
 

--- a/app/Lfm.App.Core/Services/ExpansionsClient.cs
+++ b/app/Lfm.App.Core/Services/ExpansionsClient.cs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Net.Http.Json;
+using Lfm.Contracts.Expansions;
+
+namespace Lfm.App.Services;
+
+public sealed class ExpansionsClient(IHttpClientFactory factory) : IExpansionsClient
+{
+    public async Task<IReadOnlyList<ExpansionDto>> ListAsync(CancellationToken ct)
+    {
+        var http = factory.CreateClient("api");
+        var items = await http.GetFromJsonAsync<List<ExpansionDto>>("api/wow/reference/expansions", ct);
+        return items ?? [];
+    }
+}

--- a/app/Lfm.App.Core/Services/IExpansionsClient.cs
+++ b/app/Lfm.App.Core/Services/IExpansionsClient.cs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Contracts.Expansions;
+
+namespace Lfm.App.Services;
+
+public interface IExpansionsClient
+{
+    Task<IReadOnlyList<ExpansionDto>> ListAsync(CancellationToken ct);
+}

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -37,6 +37,7 @@ builder.Services.AddHttpClient("api", client =>
 }).AddHttpMessageHandler<CredentialsHandler>();
 
 builder.Services.AddScoped<IInstancesClient, InstancesClient>();
+builder.Services.AddScoped<IExpansionsClient, ExpansionsClient>();
 builder.Services.AddScoped<IMeClient, MeClient>();
 builder.Services.AddScoped<IGuildClient, GuildClient>();
 builder.Services.AddScoped<IRunsClient, RunsClient>();

--- a/shared/Lfm.Contracts/Expansions/ExpansionDto.cs
+++ b/shared/Lfm.Contracts/Expansions/ExpansionDto.cs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+namespace Lfm.Contracts.Expansions;
+
+/// <summary>
+/// One row in the journal-expansion manifest. Carries the Blizzard expansion
+/// id and display name only — everything else (icon, minimum level, raid /
+/// dungeon membership) lives on the individual journal-instance rows via
+/// <c>InstanceDto.ExpansionId</c> and is joined client-side.
+///
+/// Both properties are planned consumers of the create-run expansion selector
+/// that ships in a follow-up PR. Tracked under the wire-payload-contract
+/// "planned near-term feature reservation" exception — see
+/// <c>docs/wire-payload-contract.md</c>. If the expansion selector is dropped,
+/// remove this DTO (and the <c>/api/wow/reference/expansions</c> endpoint that
+/// produces it) at the next audit.
+/// </summary>
+public sealed record ExpansionDto(int Id, string Name);

--- a/tests/Lfm.Api.Tests/ReferenceSyncTests.cs
+++ b/tests/Lfm.Api.Tests/ReferenceSyncTests.cs
@@ -46,6 +46,9 @@ public class ReferenceSyncTests
     private static BlizzardPlayableSpecIndex MakeSpecIndex(params (int Id, string Name)[] entries) =>
         new(entries.Select(e => new BlizzardIndexEntry(e.Id, e.Name)).ToList());
 
+    private static BlizzardJournalExpansionIndex MakeExpansionIndex(params (int Id, string Name)[] entries) =>
+        new(entries.Select(e => new BlizzardIndexEntry(e.Id, e.Name)).ToList());
+
     private static BlizzardPlayableSpecDetail MakeSpecDetail(
         int id, string name, int classId, string roleType) =>
         new(
@@ -67,6 +70,8 @@ public class ReferenceSyncTests
             .ReturnsAsync(MakeJournalIndex());
         blizzard.Setup(b => b.GetPlayableSpecIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
             .ReturnsAsync(MakeSpecIndex());
+        blizzard.Setup(b => b.GetJournalExpansionIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeExpansionIndex());
 
         var blobs = new Mock<IBlobReferenceClient>();
         var logger = new TestLogger<ReferenceSync>();
@@ -297,6 +302,67 @@ public class ReferenceSyncTests
             "reference/journal-instance/index.json",
             It.Is<List<InstanceIndexEntry>>(ix => ix.Single().Id == 10),
             It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ── Role mapping ────────────────────────────────────────────────────────
+
+    // ── Expansion sync ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SyncExpansionsAsync_uploads_manifest_in_blizzard_order()
+    {
+        var (sut, blizzard, blobs, _) = MakeSut();
+        blizzard.Setup(b => b.GetJournalExpansionIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeExpansionIndex(
+                (68, "Classic"),
+                (67, "The Burning Crusade"),
+                (505, "The War Within")));
+
+        var response = await sut.SyncAllAsync(CancellationToken.None);
+
+        var expansionsResult = response.Results.Single(r => r.Name == "expansions");
+        Assert.Equal("synced (3 docs)", expansionsResult.Status);
+
+        blobs.Verify(b => b.UploadAsync(
+            "reference/journal-expansion/index.json",
+            It.Is<List<ExpansionIndexEntry>>(ix =>
+                ix.Count == 3 &&
+                ix[0].Id == 68 && ix[0].Name == "Classic" &&
+                ix[2].Id == 505 && ix[2].Name == "The War Within"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SyncExpansionsAsync_writes_empty_manifest_when_index_empty()
+    {
+        var (sut, blizzard, blobs, _) = MakeSut();
+        // default setup already returns an empty expansion index
+
+        var response = await sut.SyncAllAsync(CancellationToken.None);
+
+        var expansionsResult = response.Results.Single(r => r.Name == "expansions");
+        Assert.Equal("synced (0 docs)", expansionsResult.Status);
+        blobs.Verify(b => b.UploadAsync(
+            "reference/journal-expansion/index.json",
+            It.Is<List<ExpansionIndexEntry>>(ix => ix.Count == 0),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SyncAllAsync_records_failure_for_expansions_but_still_syncs_others()
+    {
+        var (sut, blizzard, _, logger) = MakeSut();
+        blizzard.Setup(b => b.GetJournalExpansionIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("blizzard 503"));
+
+        var response = await sut.SyncAllAsync(CancellationToken.None);
+
+        var expansionsResult = response.Results.Single(r => r.Name == "expansions");
+        Assert.StartsWith("failed:", expansionsResult.Status);
+        // instances + specializations should still have succeeded (empty indexes)
+        Assert.StartsWith("synced", response.Results.Single(r => r.Name == "instances").Status);
+        Assert.StartsWith("synced", response.Results.Single(r => r.Name == "specializations").Status);
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Error && (e.Message ?? "").Contains("expansions"));
     }
 
     // ── Role mapping ────────────────────────────────────────────────────────

--- a/tests/Lfm.Api.Tests/Repositories/ExpansionsRepositoryTests.cs
+++ b/tests/Lfm.Api.Tests/Repositories/ExpansionsRepositoryTests.cs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Repositories;
+using Lfm.Api.Services;
+using Moq;
+using Xunit;
+
+namespace Lfm.Api.Tests.Repositories;
+
+public class ExpansionsRepositoryTests
+{
+    [Fact]
+    public async Task ListAsync_returns_manifest_rows_in_blizzard_order()
+    {
+        var blobs = new Mock<IBlobReferenceClient>();
+        blobs.Setup(b => b.GetAsync<List<ExpansionIndexEntry>>(
+                "reference/journal-expansion/index.json", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ExpansionIndexEntry>
+            {
+                new(Id: 68, Name: "Classic"),
+                new(Id: 67, Name: "The Burning Crusade"),
+                new(Id: 505, Name: "The War Within"),
+            });
+
+        var repo = new ExpansionsRepository(blobs.Object);
+        var rows = await repo.ListAsync(CancellationToken.None);
+
+        Assert.Collection(rows,
+            r => { Assert.Equal(68, r.Id); Assert.Equal("Classic", r.Name); },
+            r => { Assert.Equal(67, r.Id); Assert.Equal("The Burning Crusade", r.Name); },
+            r => { Assert.Equal(505, r.Id); Assert.Equal("The War Within", r.Name); });
+    }
+
+    [Fact]
+    public async Task ListAsync_returns_empty_list_when_manifest_missing()
+    {
+        // First deploy: manifest blob hasn't been written yet. Repository
+        // should return an empty list rather than throw.
+        var blobs = new Mock<IBlobReferenceClient>();
+        blobs.Setup(b => b.GetAsync<List<ExpansionIndexEntry>>(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((List<ExpansionIndexEntry>?)null);
+
+        var repo = new ExpansionsRepository(blobs.Object);
+        var rows = await repo.ListAsync(CancellationToken.None);
+
+        Assert.Empty(rows);
+    }
+}

--- a/tests/Lfm.Api.Tests/WowReferenceExpansionsFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/WowReferenceExpansionsFunctionTests.cs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Lfm.Api.Functions;
+using Lfm.Api.Repositories;
+using Lfm.Contracts.Expansions;
+using Xunit;
+
+namespace Lfm.Api.Tests;
+
+public class WowReferenceExpansionsFunctionTests
+{
+    private static List<ExpansionDto> RepositoryFixture() => new()
+    {
+        new(68, "Classic"),
+        new(505, "The War Within"),
+    };
+
+    [Fact]
+    public async Task Returns_expansions_from_repository_unchanged()
+    {
+        var fixture = RepositoryFixture();
+        var repo = new Mock<IExpansionsRepository>();
+        repo.Setup(r => r.ListAsync(It.IsAny<CancellationToken>())).ReturnsAsync(fixture);
+        var fn = new WowReferenceExpansionsFunction(repo.Object);
+
+        var result = await fn.Run(new DefaultHttpContext().Request, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var list = Assert.IsAssignableFrom<IReadOnlyList<ExpansionDto>>(ok.Value);
+        Assert.Equal(fixture, list);
+    }
+
+    [Fact]
+    public async Task Returns_empty_list_when_repository_is_empty()
+    {
+        var repo = new Mock<IExpansionsRepository>();
+        repo.Setup(r => r.ListAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new List<ExpansionDto>());
+        var fn = new WowReferenceExpansionsFunction(repo.Object);
+
+        var result = await fn.Run(new DefaultHttpContext().Request, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var list = Assert.IsAssignableFrom<IReadOnlyList<ExpansionDto>>(ok.Value);
+        Assert.Empty(list);
+    }
+}

--- a/tests/Lfm.App.Core.Tests/Services/ExpansionsClientTests.cs
+++ b/tests/Lfm.App.Core.Tests/Services/ExpansionsClientTests.cs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Net;
+using Lfm.App.Services;
+using Lfm.Contracts.Expansions;
+using Moq;
+using Xunit;
+
+namespace Lfm.App.Core.Tests.Services;
+
+public class ExpansionsClientTests
+{
+    private static (ExpansionsClient client, StubHttpMessageHandler handler) MakeClient(StubHttpMessageHandler handler)
+    {
+        var http = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:7071/") };
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient("api")).Returns(http);
+        return (new ExpansionsClient(factory.Object), handler);
+    }
+
+    [Fact]
+    public async Task ListAsync_returns_expansions_on_success()
+    {
+        var expansions = new[]
+        {
+            new ExpansionDto(68, "Classic"),
+            new ExpansionDto(505, "The War Within"),
+        };
+        var (client, handler) = MakeClient(StubHttpMessageHandler.Json(HttpStatusCode.OK, expansions));
+
+        var result = await client.ListAsync(CancellationToken.None);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(68, result[0].Id);
+        Assert.Equal("The War Within", result[1].Name);
+        Assert.Equal(HttpMethod.Get, handler.LastRequest!.Method);
+        Assert.Equal("/api/wow/reference/expansions", handler.LastRequest.RequestUri!.PathAndQuery);
+    }
+
+    [Fact]
+    public async Task ListAsync_returns_empty_when_body_is_null()
+    {
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("null", System.Text.Encoding.UTF8, "application/json"),
+        });
+        var (client, _) = MakeClient(handler);
+
+        var result = await client.ListAsync(CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task ListAsync_throws_HttpRequestException_on_5xx()
+    {
+        var (client, _) = MakeClient(new StubHttpMessageHandler(HttpStatusCode.ServiceUnavailable));
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => client.ListAsync(CancellationToken.None));
+    }
+}


### PR DESCRIPTION
## Summary

Introduces the canonical WoW expansion list as a new Blizzard reference kind, served via `GET /api/wow/reference/expansions`. Mirrors the existing `journal-instance` / `playable-specialization` ingest pattern — Blizzard Game Data fetch → blob manifest → repository → function → typed app client.

This is additive: nothing on the create/edit run page consumes it yet. The expansion selector that surfaces it lands in a follow-up PR as part of the plan's staged reshape (see `docs/superpowers/plans/…` — plan tracks PR 6).

## Schema / env changes

- **New blob path:** `lfmstore/wow/reference/journal-expansion/index.json` — written by `ReferenceSync.SyncExpansionsAsync` on every scheduled / admin-triggered refresh. Contents: `List<{ Id, Name }>` preserving Blizzard's canonical order.
- **New wire endpoint:** `GET /api/wow/reference/expansions` → `IReadOnlyList<ExpansionDto(int Id, string Name)>`. Requires auth (matches `/api/wow/reference/instances`).
- **`ExpansionDto`** ships with no page-level consumer today; the XML doc-comment cites the wire-payload-contract "planned near-term feature reservation" exception. PR 6 wires it into the create-run expansion selector.
- **No Cosmos changes. No Bicep changes. No auth or CORS changes.**
- After merge + deploy: run `POST /api/wow/reference/refresh` once (site-admin) so the new manifest lands in blob; the weekly timer will also pick it up on Sunday.

## Test plan

- [x] `dotnet build lfm.sln -c Release` clean.
- [x] `dotnet format lfm.sln --verify-no-changes` clean.
- [x] `Lfm.Api.Tests` — 434 pass (+8 new: `ReferenceSyncTests` expansion cases + `ExpansionsRepositoryTests` + `WowReferenceExpansionsFunctionTests`).
- [x] `Lfm.App.Tests` — 151 pass.
- [x] `Lfm.App.Core.Tests` — 132 pass (+3 new: `ExpansionsClientTests`).
- [ ] Post-deploy: `POST /api/wow/reference/refresh` as site-admin, then `GET /api/wow/reference/expansions` returns the canonical expansion list.
