### PR TITLE
Persist Category, ExpansionId, and structured mode fields on instances

### DIFF
--- a/api/Repositories/InstancesRepository.cs
+++ b/api/Repositories/InstancesRepository.cs
@@ -14,14 +14,36 @@ namespace Lfm.Api.Repositories;
 /// this directly — one blob GET for the whole list endpoint. When absent (first
 /// deploy, pre-ingest), the reader falls back to enumerating per-id detail blobs.
 /// </summary>
+/// <summary>
+/// Manifest entry at <c>reference/journal-instance/index.json</c>.
+/// <para>
+/// Category / ExpansionId / per-mode Difficulty+Size are nullable because
+/// legacy manifests predating PR 3 of the create-run-page staging won't
+/// carry them. The reader populates the corresponding <see cref="InstanceDto"/>
+/// fields with sensible defaults when the manifest row is missing them; a
+/// post-deploy <c>POST /api/wow/reference/refresh</c> re-hydrates every row.
+/// </para>
+/// </summary>
 internal sealed record InstanceIndexEntry(
     int Id,
     string Name,
     IReadOnlyList<InstanceIndexMode>? Modes,
     string? Expansion,
-    string? PortraitUrl);
+    string? PortraitUrl,
+    string? Category = null,
+    int? ExpansionId = null);
 
-internal sealed record InstanceIndexMode(string ModeKey);
+/// <summary>
+/// Per-mode manifest entry. <c>ModeKey</c> is the legacy composite
+/// (<c>"{Difficulty}:{Size}"</c>) that pre-PR-3 manifests carried; the new
+/// <c>Difficulty</c> + <c>Size</c> fields are populated by the current
+/// ingester and preferred by new consumers. Both shapes round-trip so the
+/// transition is cross-compatible.
+/// </summary>
+internal sealed record InstanceIndexMode(
+    string ModeKey,
+    string? Difficulty = null,
+    int? Size = null);
 
 /// <summary>
 /// Verbatim Blizzard journal-instance detail as stored at
@@ -32,10 +54,14 @@ internal sealed record JournalInstanceBlob(
     int Id,
     [property: JsonConverter(typeof(LocalizedStringConverter))] string Name,
     JournalInstanceExpansionBlob? Expansion = null,
-    IReadOnlyList<JournalInstanceModeBlob>? Modes = null);
+    IReadOnlyList<JournalInstanceModeBlob>? Modes = null,
+    JournalInstanceCategoryBlob? Category = null);
 
 internal sealed record JournalInstanceExpansionBlob(
-    [property: JsonConverter(typeof(LocalizedStringConverter))] string? Name = null);
+    [property: JsonConverter(typeof(LocalizedStringConverter))] string? Name = null,
+    int? Id = null);
+
+internal sealed record JournalInstanceCategoryBlob(string? Type = null);
 
 internal sealed record JournalInstanceModeBlob(
     JournalModeRefBlob? Mode,
@@ -67,6 +93,8 @@ public sealed class InstancesRepository(IBlobReferenceClient blobs) : IInstances
         {
             var portraitUrl = await ResolvePortraitUrlAsync(detail.Id, ct);
             var expansion = detail.Expansion?.Name ?? "";
+            var expansionId = detail.Expansion?.Id;
+            var category = detail.Category?.Type;
             var instanceId = detail.Id.ToString();
 
             if (detail.Modes is null || detail.Modes.Count == 0)
@@ -77,6 +105,10 @@ public sealed class InstancesRepository(IBlobReferenceClient blobs) : IInstances
                     Name: detail.Name,
                     ModeKey: "UNKNOWN:0",
                     Expansion: expansion,
+                    Category: category,
+                    ExpansionId: expansionId,
+                    Difficulty: "UNKNOWN",
+                    Size: 0,
                     PortraitUrl: portraitUrl));
                 continue;
             }
@@ -84,13 +116,18 @@ public sealed class InstancesRepository(IBlobReferenceClient blobs) : IInstances
             foreach (var mode in detail.Modes)
             {
                 var modeType = mode.Mode?.Type ?? "UNKNOWN";
-                var modeKey = $"{modeType}:{mode.Players ?? 0}";
+                var size = mode.Players ?? 0;
+                var modeKey = $"{modeType}:{size}";
                 rows.Add(new InstanceDto(
                     Id: $"{instanceId}:{modeKey}",
                     InstanceNumericId: detail.Id,
                     Name: detail.Name,
                     ModeKey: modeKey,
                     Expansion: expansion,
+                    Category: category,
+                    ExpansionId: expansionId,
+                    Difficulty: modeType,
+                    Size: size,
                     PortraitUrl: portraitUrl));
             }
         }
@@ -131,21 +168,48 @@ public sealed class InstancesRepository(IBlobReferenceClient blobs) : IInstances
                     Name: entry.Name,
                     ModeKey: "UNKNOWN:0",
                     Expansion: expansion,
+                    Category: entry.Category,
+                    ExpansionId: entry.ExpansionId,
+                    Difficulty: "UNKNOWN",
+                    Size: 0,
                     PortraitUrl: entry.PortraitUrl));
                 continue;
             }
 
             foreach (var mode in entry.Modes)
             {
+                var (difficulty, size) = SplitModeKey(mode);
                 rows.Add(new InstanceDto(
                     Id: $"{instanceId}:{mode.ModeKey}",
                     InstanceNumericId: entry.Id,
                     Name: entry.Name,
                     ModeKey: mode.ModeKey,
                     Expansion: expansion,
+                    Category: entry.Category,
+                    ExpansionId: entry.ExpansionId,
+                    Difficulty: difficulty,
+                    Size: size,
                     PortraitUrl: entry.PortraitUrl));
             }
         }
         return rows;
+    }
+
+    /// <summary>
+    /// Prefer the new structured <see cref="InstanceIndexMode.Difficulty"/> +
+    /// <see cref="InstanceIndexMode.Size"/> fields the ingester now writes;
+    /// fall back to splitting the legacy composite <c>ModeKey</c> when reading
+    /// a pre-PR-3 manifest. Round-trippable — the ingester writes both so a
+    /// re-ingest converges the manifest onto the new shape.
+    /// </summary>
+    private static (string Difficulty, int Size) SplitModeKey(InstanceIndexMode mode)
+    {
+        if (!string.IsNullOrEmpty(mode.Difficulty) && mode.Size.HasValue)
+            return (mode.Difficulty, mode.Size.Value);
+
+        var parts = mode.ModeKey.Split(':', 2);
+        var difficulty = parts.Length > 0 && parts[0].Length > 0 ? parts[0] : "UNKNOWN";
+        var size = parts.Length > 1 && int.TryParse(parts[1], out var n) ? n : 0;
+        return (difficulty, size);
     }
 }

--- a/api/Services/ReferenceSync.cs
+++ b/api/Services/ReferenceSync.cs
@@ -106,8 +106,11 @@ public sealed class ReferenceSync(
             var detailBlob = new JournalInstanceBlob(
                 Id: detail.Id,
                 Name: detail.Name,
-                Expansion: detail.Expansion is null ? null : new JournalInstanceExpansionBlob(detail.Expansion.Name),
-                Modes: modeBlobs);
+                Expansion: detail.Expansion is null
+                    ? null
+                    : new JournalInstanceExpansionBlob(detail.Expansion.Name, detail.Expansion.Id),
+                Modes: modeBlobs,
+                Category: detail.Category is null ? null : new JournalInstanceCategoryBlob(detail.Category.Type));
             await blobs.UploadAsync($"reference/journal-instance/{detail.Id}.json", detailBlob, ct);
 
             string? portraitUrl = null;
@@ -122,10 +125,17 @@ public sealed class ReferenceSync(
                            ?? assetBlobs.FirstOrDefault(a => a.Key == "image")?.Value;
             }
 
+            // Write both the legacy composite ModeKey and the new structured
+            // Difficulty + Size on each manifest mode row. New consumers read
+            // Difficulty / Size; legacy readers continue to parse ModeKey.
             var manifestModes = (detail.Modes?.Count ?? 0) == 0
-                ? new List<InstanceIndexMode> { new("UNKNOWN:0") }
+                ? new List<InstanceIndexMode> { new("UNKNOWN:0", "UNKNOWN", 0) }
                 : detail.Modes!
-                    .Select(m => new InstanceIndexMode($"{m.Mode.Type}:{m.Players ?? 0}"))
+                    .Select(m =>
+                    {
+                        var size = m.Players ?? 0;
+                        return new InstanceIndexMode($"{m.Mode.Type}:{size}", m.Mode.Type, size);
+                    })
                     .ToList();
 
             manifest.Add(new InstanceIndexEntry(
@@ -133,7 +143,9 @@ public sealed class ReferenceSync(
                 Name: detail.Name,
                 Modes: manifestModes,
                 Expansion: detail.Expansion?.Name ?? "",
-                PortraitUrl: portraitUrl));
+                PortraitUrl: portraitUrl,
+                Category: detail.Category?.Type,
+                ExpansionId: detail.Expansion?.Id));
         }
 
         await blobs.UploadAsync("reference/journal-instance/index.json", manifest, ct);

--- a/shared/Lfm.Contracts/Instances/InstanceDto.cs
+++ b/shared/Lfm.Contracts/Instances/InstanceDto.cs
@@ -12,6 +12,38 @@ namespace Lfm.Contracts.Instances;
 /// Numeric Blizzard journal-instance id. Used wherever the wire / Cosmos
 /// schema wants an <c>int</c> (e.g. <c>CreateRunRequest.InstanceId</c>).
 /// </param>
+/// <param name="ModeKey">
+/// Legacy composite mode key (<c>"{Difficulty}:{Size}"</c>) retained for
+/// cross-compatibility during the create-run page reshape — remove once all
+/// consumers switch to <paramref name="Difficulty"/> + <paramref name="Size"/>.
+/// </param>
+/// <param name="Category">
+/// Blizzard journal-instance category type — <c>"RAID"</c> or <c>"DUNGEON"</c>.
+/// Null on legacy manifests that predate PR 3 of the staged create-run page
+/// refactor; a manual reference-refresh repopulates. Planned consumer: the
+/// activity segmented control on the create-run form (tracked under the
+/// wire-payload-contract "planned near-term feature reservation" exception —
+/// see docs/wire-payload-contract.md).
+/// </param>
+/// <param name="ExpansionId">
+/// Blizzard expansion id for this instance. Null on legacy manifests; a
+/// manual reference-refresh repopulates. Planned consumer: the expansion
+/// selector on the create-run form (same reservation exception as
+/// <paramref name="Category"/>).
+/// </param>
+/// <param name="Difficulty">
+/// Blizzard mode-type enum — <c>"NORMAL"</c>, <c>"HEROIC"</c>, <c>"MYTHIC"</c>,
+/// <c>"LFR"</c>, <c>"MYTHIC_KEYSTONE"</c>, etc. Empty string on legacy
+/// manifests predating PR 3; a manual reference-refresh repopulates. Planned
+/// consumer: the difficulty segmented control on the create-run form (same
+/// reservation exception as <paramref name="Category"/>).
+/// </param>
+/// <param name="Size">
+/// Player count Blizzard returns for this mode. 0 on legacy manifests
+/// predating PR 3; a manual reference-refresh repopulates. Planned consumer:
+/// the difficulty display label on the create-run form (same reservation
+/// exception as <paramref name="Category"/>).
+/// </param>
 /// <param name="PortraitUrl">
 /// Reserved for the in-flight instance-portrait UI. No app consumer today.
 /// Tracked by the wire-payload-contract "planned near-term feature reservation"
@@ -24,4 +56,8 @@ public sealed record InstanceDto(
     string Name,
     string ModeKey,
     string Expansion,
+    string? Category = null,
+    int? ExpansionId = null,
+    string Difficulty = "",
+    int Size = 0,
     string? PortraitUrl = null);

--- a/tests/Lfm.Api.Tests/ReferenceSyncTests.cs
+++ b/tests/Lfm.Api.Tests/ReferenceSyncTests.cs
@@ -163,6 +163,43 @@ public class ReferenceSyncTests
     }
 
     [Fact]
+    public async Task SyncInstancesAsync_persists_category_expansionId_and_structured_mode_fields()
+    {
+        var (sut, blizzard, blobs, _) = MakeSut();
+        blizzard.Setup(b => b.GetJournalInstanceIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeJournalIndex((1200, "Liberation of Undermine")));
+        blizzard.Setup(b => b.GetJournalInstanceAsync(1200, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeInstanceDetail(
+                1200,
+                "Liberation of Undermine",
+                expansionName: "The War Within",
+                modes: ("HEROIC", 25)));
+
+        await sut.SyncAllAsync(CancellationToken.None);
+
+        // Per-id detail blob carries Category + expansion Id (plus Name).
+        blobs.Verify(b => b.UploadAsync(
+            "reference/journal-instance/1200.json",
+            It.Is<JournalInstanceBlob>(d =>
+                d.Category!.Type == "RAID" &&
+                d.Expansion!.Id == 11 &&
+                d.Expansion.Name == "The War Within"),
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        // Manifest row carries Category + ExpansionId top-level plus
+        // Difficulty + Size on every mode entry.
+        blobs.Verify(b => b.UploadAsync(
+            "reference/journal-instance/index.json",
+            It.Is<List<InstanceIndexEntry>>(ix =>
+                ix.Single().Category == "RAID" &&
+                ix.Single().ExpansionId == 11 &&
+                ix.Single().Modes!.Single().ModeKey == "HEROIC:25" &&
+                ix.Single().Modes!.Single().Difficulty == "HEROIC" &&
+                ix.Single().Modes!.Single().Size == 25),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public async Task SyncInstancesAsync_emits_one_mode_entry_per_blizzard_mode()
     {
         var (sut, blizzard, blobs, _) = MakeSut();

--- a/tests/Lfm.Api.Tests/Repositories/InstancesRepositoryTests.cs
+++ b/tests/Lfm.Api.Tests/Repositories/InstancesRepositoryTests.cs
@@ -44,9 +44,15 @@ public class InstancesRepositoryTests
                 new(
                     Id: 1200,
                     Name: "Liberation of Undermine",
-                    Modes: new[] { new InstanceIndexMode("NORMAL:25"), new InstanceIndexMode("HEROIC:25") },
+                    Modes: new[]
+                    {
+                        new InstanceIndexMode("NORMAL:25", "NORMAL", 25),
+                        new InstanceIndexMode("HEROIC:25", "HEROIC", 25),
+                    },
                     Expansion: "The War Within",
-                    PortraitUrl: "https://render.worldofwarcraft.com/tile.jpg"),
+                    PortraitUrl: "https://render.worldofwarcraft.com/tile.jpg",
+                    Category: "RAID",
+                    ExpansionId: 505),
             });
         var repo = new InstancesRepository(blobs.Object);
 
@@ -60,6 +66,10 @@ public class InstancesRepositoryTests
                 Assert.Equal("Liberation of Undermine", r.Name);
                 Assert.Equal("NORMAL:25", r.ModeKey);
                 Assert.Equal("The War Within", r.Expansion);
+                Assert.Equal("RAID", r.Category);
+                Assert.Equal(505, r.ExpansionId);
+                Assert.Equal("NORMAL", r.Difficulty);
+                Assert.Equal(25, r.Size);
                 Assert.Equal("https://render.worldofwarcraft.com/tile.jpg", r.PortraitUrl);
             },
             r =>
@@ -67,11 +77,43 @@ public class InstancesRepositoryTests
                 Assert.Equal("1200:HEROIC:25", r.Id);
                 Assert.Equal(1200, r.InstanceNumericId);
                 Assert.Equal("HEROIC:25", r.ModeKey);
+                Assert.Equal("HEROIC", r.Difficulty);
+                Assert.Equal(25, r.Size);
                 Assert.Equal("https://render.worldofwarcraft.com/tile.jpg", r.PortraitUrl);
             });
 
         blobs.Verify(b => b.ListAsync<JournalInstanceBlob>(It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    [Fact]
+    public async Task ListAsync_parses_legacy_manifest_without_structured_mode_fields()
+    {
+        // Pre-PR-3 manifests only carried ModeKey. The reader splits the
+        // composite to populate Difficulty + Size so consumers can switch to
+        // the new fields immediately — the manifest converges on the next
+        // re-ingest.
+        var blobs = new Mock<IBlobReferenceClient>();
+        blobs.Setup(b => b.GetAsync<List<InstanceIndexEntry>>(
+                "reference/journal-instance/index.json", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<InstanceIndexEntry>
+            {
+                new(
+                    Id: 1200,
+                    Name: "Legacy",
+                    Modes: new[] { new InstanceIndexMode("MYTHIC:20") },
+                    Expansion: "X",
+                    PortraitUrl: null),
+            });
+        var repo = new InstancesRepository(blobs.Object);
+
+        var row = Assert.Single(await repo.ListAsync(CancellationToken.None));
+
+        Assert.Equal("MYTHIC:20", row.ModeKey);
+        Assert.Equal("MYTHIC", row.Difficulty);
+        Assert.Equal(20, row.Size);
+        Assert.Null(row.Category);
+        Assert.Null(row.ExpansionId);
     }
 
     [Fact]
@@ -109,11 +151,12 @@ public class InstancesRepositoryTests
             .Returns(AsAsync(new JournalInstanceBlob(
                 Id: 67,
                 Name: "The Stonecore",
-                Expansion: new JournalInstanceExpansionBlob("Cataclysm"),
+                Expansion: new JournalInstanceExpansionBlob("Cataclysm", 3),
                 Modes: new[]
                 {
                     new JournalInstanceModeBlob(new JournalModeRefBlob("NORMAL"), 5),
-                })));
+                },
+                Category: new JournalInstanceCategoryBlob("DUNGEON"))));
 
         blobs.Setup(b => b.GetAsync<MediaAssetsBlob>(
                 "reference/journal-instance-media/67.json", It.IsAny<CancellationToken>()))
@@ -131,6 +174,10 @@ public class InstancesRepositoryTests
         Assert.Equal(67, row.InstanceNumericId);
         Assert.Equal("The Stonecore", row.Name);
         Assert.Equal("Cataclysm", row.Expansion);
+        Assert.Equal("DUNGEON", row.Category);
+        Assert.Equal(3, row.ExpansionId);
+        Assert.Equal("NORMAL", row.Difficulty);
+        Assert.Equal(5, row.Size);
         Assert.Equal("https://render.worldofwarcraft.com/stonecore-tile.jpg", row.PortraitUrl);
     }
 


### PR DESCRIPTION
## Summary

Stops dropping three pieces of data Blizzard's `journal-instance` endpoint already returns:

1. **`category.type`** (`"RAID"` / `"DUNGEON"`) — used by the upcoming activity segmented control to split the instance dropdown by raid vs dungeon.
2. **`expansion.id`** — used by the upcoming expansion selector to filter instances by expansion without string-matching names.
3. **Per-mode `Difficulty` + `Size`** — structured form of the legacy composite `ModeKey` (`"HEROIC:25"` → `Difficulty="HEROIC"`, `Size=25`) so consumers join on typed fields.

All three flow from the Blizzard detail fetch → per-id blob → manifest → `InstanceDto`. No wire consumer today (PR 6 in the staged plan lights them up); each new property on `InstanceDto` carries an XML doc-comment citing the wire-payload-contract "planned near-term feature reservation" exception with a pointer to the retirement criterion.

## Schema / env changes

- **Blob shape (additive):**
  - `reference/journal-instance/{id}.json` now carries `Category.Type` and `Expansion.Id` (in addition to the existing `Expansion.Name`).
  - `reference/journal-instance/index.json` gains top-level `Category` + `ExpansionId` per entry and per-mode `Difficulty` + `Size` alongside the existing `ModeKey`.
- **Legacy blobs still parse.** `JournalInstanceExpansionBlob.Id`, `JournalInstanceCategoryBlob`, `InstanceIndexEntry.{Category,ExpansionId}`, and `InstanceIndexMode.{Difficulty,Size}` are all optional/nullable with defaults. The reader splits the legacy composite `ModeKey` to populate `Difficulty` + `Size` when the structured fields are missing — no data loss on pre-PR-3 manifests; a manual `POST /api/wow/reference/refresh` converges on the new shape.
- **`InstanceDto` (additive):** four new fields (`Category`, `ExpansionId`, `Difficulty`, `Size`). `ModeKey` retained for cross-compatibility; removal is queued for PR 5 after consumers switch.
- **No Cosmos, Bicep, workflow, Dockerfile, or auth changes.**
- **Post-deploy:** run `POST /api/wow/reference/refresh` once (site-admin) so the new detail blobs and manifest lines land; the weekly timer will pick it up on Sunday otherwise.

## Test plan

- [x] `dotnet build lfm.sln -c Release` clean.
- [x] `dotnet format lfm.sln --verify-no-changes` clean.
- [x] `Lfm.Api.Tests` — 436 pass (+2 new: `SyncInstancesAsync_persists_category_expansionId_and_structured_mode_fields` + `ListAsync_parses_legacy_manifest_without_structured_mode_fields`; existing tests updated to assert the new DTO fields).
- [x] `Lfm.App.Tests` — 151 pass.
- [x] `Lfm.App.Core.Tests` — 132 pass.
- [ ] Post-deploy: run the refresh and inspect one blob to confirm the new fields land.
