### PR TITLE
Add ToggleGroup segmented control

### DIFF
--- a/app/Components/ToggleGroup.razor
+++ b/app/Components/ToggleGroup.razor
@@ -1,0 +1,137 @@
+@*
+    Generic single-select segmented control.
+
+    Renders as an ARIA radiogroup — one <button role="radio"> per option with
+    roving tabindex and full arrow-key navigation. Used for the create-run
+    form's Activity, Difficulty, and Visibility pickers; designed to be the
+    canonical toggle-button-group for this codebase.
+
+    Why role="radio" rather than a div of aria-pressed toggle buttons:
+    the semantic is single-select and mutually-exclusive (exactly one option
+    is active at all times), which is what WAI-ARIA's radio group pattern
+    specifies. aria-pressed toggle buttons are for multi-select or
+    self-contained on/off actions.
+
+    CSS (ToggleGroup.razor.css):
+      - logical properties only (padding-inline, border-inline-*, flex
+        row flows with dir="rtl" without a row-reverse hack)
+      - flex-wrap:wrap + row-gap so long Finnish/German labels flow to a
+        second row instead of overflowing at 320 CSS px
+      - ≥2.75rem tap target (SC 2.5.5)
+      - selected state is background-color + border only, no font-weight
+        shift, so selection changes don't shift layout (CLS = 0)
+      - forced-colors: active falls back to ButtonText/Highlight so the
+        selection stays distinguishable under Windows High Contrast
+
+    Keyboard (WAI-ARIA Authoring Practices for radiogroup):
+      - Tab enters/leaves the group; only the selected button is tabbable
+      - ArrowRight / ArrowDown → next option (wraps; respects `dir`)
+      - ArrowLeft / ArrowUp → previous option (wraps)
+      - Home → first; End → last
+      - Space re-asserts the focused option (no-op when already selected)
+*@
+@typeparam TValue
+
+<div role="radiogroup"
+     aria-label="@AriaLabel"
+     aria-labelledby="@AriaLabelledBy"
+     class="toggle-group @Class"
+     @onkeydown="OnKeyDown">
+    @for (var i = 0; i < Options.Count; i++)
+    {
+        var idx = i;
+        var opt = Options[idx];
+        var isSelected = EqualityComparer<TValue>.Default.Equals(opt.Value, Value!);
+        <button type="button"
+                role="radio"
+                aria-checked="@(isSelected ? "true" : "false")"
+                tabindex="@(isSelected ? 0 : -1)"
+                disabled="@Disabled"
+                class="toggle-group__option"
+                data-selected="@(isSelected ? "true" : "false")"
+                @ref="_buttonRefs[idx]"
+                @onclick="@(() => SelectAsync(idx))">
+            @opt.Label
+        </button>
+    }
+</div>
+
+@code {
+    /// <summary>
+    /// Ordered list of (value, label) pairs. Label is what the user sees;
+    /// Value is what <see cref="ValueChanged"/> emits on selection.
+    /// </summary>
+    [Parameter, EditorRequired]
+    public IReadOnlyList<(TValue Value, string Label)> Options { get; set; } = [];
+
+    /// <summary>Currently selected value. Use with <see cref="ValueChanged"/>.</summary>
+    [Parameter] public TValue? Value { get; set; }
+
+    [Parameter] public EventCallback<TValue> ValueChanged { get; set; }
+
+    /// <summary>Directly-rendered aria-label. Use when no visible label exists.</summary>
+    [Parameter] public string? AriaLabel { get; set; }
+
+    /// <summary>Id of a visible label element. Preferred over <see cref="AriaLabel"/>.</summary>
+    [Parameter] public string? AriaLabelledBy { get; set; }
+
+    [Parameter] public bool Disabled { get; set; }
+
+    [Parameter] public string? Class { get; set; }
+
+    private ElementReference[] _buttonRefs = [];
+
+    protected override void OnParametersSet()
+    {
+        if (_buttonRefs.Length != Options.Count)
+        {
+            _buttonRefs = new ElementReference[Options.Count];
+        }
+    }
+
+    private async Task SelectAsync(int index)
+    {
+        if (Disabled || index < 0 || index >= Options.Count) return;
+        var next = Options[index].Value;
+        if (EqualityComparer<TValue>.Default.Equals(next, Value!)) return;
+        await ValueChanged.InvokeAsync(next);
+    }
+
+    private async Task OnKeyDown(KeyboardEventArgs args)
+    {
+        if (Disabled || Options.Count == 0) return;
+
+        var current = CurrentIndex();
+        int? target = args.Key switch
+        {
+            "ArrowRight" or "ArrowDown" => (current + 1 + Options.Count) % Options.Count,
+            "ArrowLeft" or "ArrowUp" => (current - 1 + Options.Count) % Options.Count,
+            "Home" => 0,
+            "End" => Options.Count - 1,
+            " " or "Spacebar" => current, // Space re-asserts current — roving-tabindex semantics
+            _ => null,
+        };
+
+        if (target is null) return;
+
+        await SelectAsync(target.Value);
+
+        // Move focus to the newly-selected button so arrow keys keep working
+        // from there. Skip for Space-on-current (focus is already correct).
+        if (target.Value != current)
+        {
+            try { await _buttonRefs[target.Value].FocusAsync(); }
+            catch { /* element may not be in the DOM yet on first render */ }
+        }
+    }
+
+    private int CurrentIndex()
+    {
+        for (var i = 0; i < Options.Count; i++)
+        {
+            if (EqualityComparer<TValue>.Default.Equals(Options[i].Value, Value!))
+                return i;
+        }
+        return 0;
+    }
+}

--- a/app/Components/ToggleGroup.razor
+++ b/app/Components/ToggleGroup.razor
@@ -25,8 +25,10 @@
 
     Keyboard (WAI-ARIA Authoring Practices for radiogroup):
       - Tab enters/leaves the group; only the selected button is tabbable
-      - ArrowRight / ArrowDown → next option (wraps; respects `dir`)
-      - ArrowLeft / ArrowUp → previous option (wraps)
+      - ArrowRight / ArrowLeft → next / previous option (wraps); swapped
+        when IsRtl=true so they follow the visual reading direction
+      - ArrowDown / ArrowUp → next / previous option (wraps); unaffected
+        by IsRtl because they map to block direction, not inline
       - Home → first; End → last
       - Space re-asserts the focused option (no-op when already selected)
 *@
@@ -79,6 +81,21 @@
 
     [Parameter] public string? Class { get; set; }
 
+    /// <summary>
+    /// When true, arrow-key semantics are swapped so that ArrowRight /
+    /// ArrowLeft follow the RTL reading direction (ArrowLeft advances,
+    /// ArrowRight retreats). WAI-ARIA Authoring Practices specifies that
+    /// arrow keys in a radiogroup follow visual reading order, and CSS
+    /// <c>flex-direction: row</c> already renders Options[0] on the
+    /// visual right under <c>dir="rtl"</c>.
+    /// The consumer supplies this from the active locale context
+    /// (<c>ILocaleService.IsRtl</c> once the locale service grows that
+    /// flag, or a derived check against <c>CurrentLocale</c>). ArrowUp /
+    /// ArrowDown are unchanged — vertical navigation maps to block
+    /// direction, not inline direction.
+    /// </summary>
+    [Parameter] public bool IsRtl { get; set; }
+
     private ElementReference[] _buttonRefs = [];
 
     protected override void OnParametersSet()
@@ -102,10 +119,21 @@
         if (Disabled || Options.Count == 0) return;
 
         var current = CurrentIndex();
+        var inlineForward = (current + 1 + Options.Count) % Options.Count;
+        var inlineBack = (current - 1 + Options.Count) % Options.Count;
+        // In RTL, the visual right edge is the inline-start edge, so
+        // ArrowRight retreats (toward lower index) and ArrowLeft advances.
+        // ArrowUp/Down map to block direction and are unaffected.
+        var (rightKey, leftKey) = IsRtl
+            ? (inlineBack, inlineForward)
+            : (inlineForward, inlineBack);
+
         int? target = args.Key switch
         {
-            "ArrowRight" or "ArrowDown" => (current + 1 + Options.Count) % Options.Count,
-            "ArrowLeft" or "ArrowUp" => (current - 1 + Options.Count) % Options.Count,
+            "ArrowRight" => rightKey,
+            "ArrowLeft" => leftKey,
+            "ArrowDown" => inlineForward,
+            "ArrowUp" => inlineBack,
             "Home" => 0,
             "End" => Options.Count - 1,
             " " or "Spacebar" => current, // Space re-asserts current — roving-tabindex semantics

--- a/app/Components/ToggleGroup.razor.css
+++ b/app/Components/ToggleGroup.razor.css
@@ -1,0 +1,120 @@
+/*
+ * Segmented control used for mutually-exclusive single-select pickers —
+ * Activity (Raid/Dungeon), Difficulty (Normal/Heroic/Mythic/M+), Visibility
+ * (Guild only/Public). Ships as an ARIA radiogroup; the button children
+ * carry role=radio + roving tabindex (see ToggleGroup.razor).
+ *
+ * Design notes (responsive-design reference §3.9, §3.10, §3.16, §3.17):
+ *   - logical properties only — dir="rtl" flips visual order without a
+ *     row-reverse hack
+ *   - flex-wrap allows long locale labels (Finnish "Ilmoittautuminen
+ *     sulkeutuu") to flow to a second row at narrow viewports instead of
+ *     overflowing at the 320 CSS px floor
+ *   - ≥2.75rem tap target (SC 2.5.5)
+ *   - selected state is background + border only; no font-weight shift,
+ *     so switching between options does not change text metrics and does
+ *     not induce CLS
+ *   - :focus-visible fallback — we do NOT use outline:none on the button
+ *     as that would violate SC 2.4.7
+ *   - forced-colors: active falls back to ButtonText/Highlight system
+ *     colors so the selected/unselected distinction survives Windows
+ *     High Contrast mode
+ */
+.toggle-group {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    row-gap: 4px;
+    /* No column-gap: connected buttons look visually grouped. Internal
+       borders between buttons are handled by the per-button rules below. */
+    align-items: stretch;
+}
+
+.toggle-group__option {
+    /* Respect the Fluent theme's font inheritance rather than forcing a
+       weight. all:unset would also clear the :disabled styling the UA
+       provides; we keep the native button shell and just reset the
+       OS-default border/background. */
+    appearance: none;
+    background-color: var(--neutral-fill-rest);
+    color: var(--neutral-foreground-rest);
+    border-block: 1px solid var(--neutral-stroke-rest);
+    border-inline-start: 1px solid var(--neutral-stroke-rest);
+    border-inline-end: 0;
+    padding-inline: 1rem;
+    padding-block: 0.5rem;
+    min-inline-size: 2.75rem;
+    min-block-size: 2.75rem;
+    font: inherit;
+    cursor: pointer;
+    /* Keep text metrics stable between selected / unselected. A
+       font-weight swap here would shift the button width on select and
+       cause CLS on every arrow-key traversal. */
+    font-weight: 500;
+    /* Connected look: only the last visual-order item gets the end
+       border. Logical properties + flex row means this works in RTL too. */
+    text-wrap: balance;
+}
+
+.toggle-group__option:first-of-type {
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
+}
+
+.toggle-group__option:last-of-type {
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
+    border-inline-end: 1px solid var(--neutral-stroke-rest);
+}
+
+/* Hover, only on devices that actually hover — avoids the sticky-hover
+   effect on touch devices (reference §3.6). */
+@media (hover: hover) and (pointer: fine) {
+    .toggle-group__option:not([data-selected="true"]):not(:disabled):hover {
+        background-color: var(--neutral-fill-hover);
+    }
+}
+
+.toggle-group__option:focus-visible {
+    outline: 2px solid var(--accent-fill-rest);
+    outline-offset: -2px;
+    /* Raise focus ring above the adjacent button's shared border. */
+    z-index: 1;
+    position: relative;
+}
+
+.toggle-group__option[data-selected="true"] {
+    background-color: var(--accent-fill-rest);
+    color: var(--accent-foreground-rest, #fff);
+    /* Match the selected border to the fill so the boundary with adjacent
+       unselected buttons reads as a single coherent shape rather than a
+       stripe. Keep the same width to avoid layout shift. */
+    border-color: var(--accent-fill-rest);
+}
+
+.toggle-group__option:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+}
+
+/* Windows High Contrast: custom tokens collapse to system colors, so
+   re-establish the selected/unselected distinction via standard system
+   color pairs. ButtonText is readable on the default button surface;
+   Highlight + HighlightText is the OS's canonical "selected" pair. */
+@media (forced-colors: active) {
+    .toggle-group__option {
+        border-color: ButtonText;
+        color: ButtonText;
+        background-color: ButtonFace;
+    }
+
+    .toggle-group__option[data-selected="true"] {
+        background-color: Highlight;
+        color: HighlightText;
+        border-color: Highlight;
+    }
+
+    .toggle-group__option:focus-visible {
+        outline-color: Highlight;
+    }
+}

--- a/tests/Lfm.App.Tests/Components/ToggleGroupTests.cs
+++ b/tests/Lfm.App.Tests/Components/ToggleGroupTests.cs
@@ -114,11 +114,19 @@ public class ToggleGroupTests : ComponentTestBase
             .Add(c => c.Disabled, true)
             .Add(c => c.ValueChanged, _ => callbackCount++));
 
-        // The native <button disabled> suppresses the click event before it
-        // reaches the handler — which is the WCAG-correct behaviour.
         var buttons = cut.FindAll("[role='radio']");
-        Assert.Equal("", buttons[1].GetAttribute("disabled") ?? "");
+
+        // The SUT's SelectAsync has an explicit `if (Disabled) return;`
+        // guard, so the callback is not invoked even if bUnit's synthetic
+        // click event bypasses the native <button disabled> suppression.
+        buttons[1].Click();
+
+        Assert.Equal(0, callbackCount);
+        // And the native disabled attribute is still present on every
+        // option so the browser itself suppresses real click events.
+        Assert.NotNull(buttons[0].GetAttribute("disabled"));
         Assert.NotNull(buttons[1].GetAttribute("disabled"));
+        Assert.NotNull(buttons[2].GetAttribute("disabled"));
     }
 
     // ── Keyboard navigation (WAI-ARIA radiogroup) ────────────────────────────
@@ -182,6 +190,47 @@ public class ToggleGroupTests : ComponentTestBase
            .KeyDown(new KeyboardEventArgs { Key = key });
 
         Assert.Equal(expected, received);
+    }
+
+    [Fact]
+    public void IsRtl_swaps_ArrowRight_and_ArrowLeft_to_follow_reading_direction()
+    {
+        // Under dir="rtl", flex-direction: row renders Options[0] on the
+        // visual RIGHT. ArrowRight should therefore retreat (move toward
+        // index 0) and ArrowLeft should advance — matching the reader's
+        // RTL reading order.
+        string? received = null;
+        var cut = Render<ToggleGroup<string>>(p => p
+            .Add(c => c.Options, ThreeOptions)
+            .Add(c => c.Value, "DUNGEON")
+            .Add(c => c.IsRtl, true)
+            .Add(c => c.ValueChanged, v => received = v));
+
+        cut.Find("[role='radiogroup']")
+           .KeyDown(new KeyboardEventArgs { Key = "ArrowRight" });
+        Assert.Equal("RAID", received); // RTL: ArrowRight retreats
+
+        received = null;
+        cut.Find("[role='radiogroup']")
+           .KeyDown(new KeyboardEventArgs { Key = "ArrowLeft" });
+        Assert.Equal("OTHER", received); // RTL: ArrowLeft advances
+    }
+
+    [Fact]
+    public void IsRtl_does_not_affect_ArrowUp_or_ArrowDown()
+    {
+        // Block-direction keys map to vertical layout, not inline, so
+        // they stay index-forward/back regardless of RTL.
+        string? received = null;
+        var cut = Render<ToggleGroup<string>>(p => p
+            .Add(c => c.Options, ThreeOptions)
+            .Add(c => c.Value, "RAID")
+            .Add(c => c.IsRtl, true)
+            .Add(c => c.ValueChanged, v => received = v));
+
+        cut.Find("[role='radiogroup']")
+           .KeyDown(new KeyboardEventArgs { Key = "ArrowDown" });
+        Assert.Equal("DUNGEON", received);
     }
 
     [Fact]

--- a/tests/Lfm.App.Tests/Components/ToggleGroupTests.cs
+++ b/tests/Lfm.App.Tests/Components/ToggleGroupTests.cs
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Bunit;
+using Lfm.App.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Xunit;
+
+namespace Lfm.App.Tests.Components;
+
+/// <summary>
+/// bUnit coverage for the generic ToggleGroup segmented control.
+/// Keyboard spec follows WAI-ARIA Authoring Practices for the radiogroup
+/// pattern; every assertion pins a WCAG 2.2 AA-relevant behaviour.
+/// </summary>
+public class ToggleGroupTests : ComponentTestBase
+{
+    private static readonly (string Value, string Label)[] ThreeOptions = new[]
+    {
+        ("RAID", "Raid"),
+        ("DUNGEON", "Dungeon"),
+        ("OTHER", "Other"),
+    };
+
+    // ── Rendering ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Renders_one_radio_button_per_option_inside_a_radiogroup()
+    {
+        var cut = Render<ToggleGroup<string>>(p => p
+            .Add(c => c.Options, ThreeOptions)
+            .Add(c => c.Value, "RAID")
+            .Add(c => c.AriaLabel, "Activity"));
+
+        var group = cut.Find("[role='radiogroup']");
+        Assert.Equal("Activity", group.GetAttribute("aria-label"));
+
+        var buttons = cut.FindAll("[role='radio']");
+        Assert.Equal(3, buttons.Count);
+        Assert.Equal("Raid", buttons[0].TextContent.Trim());
+        Assert.Equal("Dungeon", buttons[1].TextContent.Trim());
+        Assert.Equal("Other", buttons[2].TextContent.Trim());
+    }
+
+    [Fact]
+    public void Selected_button_has_aria_checked_true_and_tabindex_0()
+    {
+        var cut = Render<ToggleGroup<string>>(p => p
+            .Add(c => c.Options, ThreeOptions)
+            .Add(c => c.Value, "DUNGEON")
+            .Add(c => c.AriaLabel, "Activity"));
+
+        var buttons = cut.FindAll("[role='radio']");
+        Assert.Equal("false", buttons[0].GetAttribute("aria-checked"));
+        Assert.Equal("true", buttons[1].GetAttribute("aria-checked"));
+        Assert.Equal("false", buttons[2].GetAttribute("aria-checked"));
+        Assert.Equal("-1", buttons[0].GetAttribute("tabindex"));
+        Assert.Equal("0", buttons[1].GetAttribute("tabindex"));
+        Assert.Equal("-1", buttons[2].GetAttribute("tabindex"));
+    }
+
+    [Fact]
+    public void AriaLabelledBy_is_preferred_over_AriaLabel_when_both_provided()
+    {
+        var cut = Render<ToggleGroup<string>>(p => p
+            .Add(c => c.Options, ThreeOptions)
+            .Add(c => c.Value, "RAID")
+            .Add(c => c.AriaLabel, "fallback")
+            .Add(c => c.AriaLabelledBy, "visible-label-id"));
+
+        var group = cut.Find("[role='radiogroup']");
+        Assert.Equal("visible-label-id", group.GetAttribute("aria-labelledby"));
+        // Both attributes render; AT will prefer labelledby over label per ARIA.
+        Assert.Equal("fallback", group.GetAttribute("aria-label"));
+    }
+
+    // ── Click selection ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void Clicking_an_unselected_option_fires_ValueChanged_with_its_value()
+    {
+        string? received = null;
+        var cut = Render<ToggleGroup<string>>(p => p
+            .Add(c => c.Options, ThreeOptions)
+            .Add(c => c.Value, "RAID")
+            .Add(c => c.ValueChanged, v => received = v));
+
+        cut.FindAll("[role='radio']")[1].Click();
+
+        Assert.Equal("DUNGEON", received);
+    }
+
+    [Fact]
+    public void Clicking_the_already_selected_option_does_not_fire_ValueChanged()
+    {
+        var callbackCount = 0;
+        var cut = Render<ToggleGroup<string>>(p => p
+            .Add(c => c.Options, ThreeOptions)
+            .Add(c => c.Value, "RAID")
+            .Add(c => c.ValueChanged, _ => callbackCount++));
+
+        cut.FindAll("[role='radio']")[0].Click();
+
+        Assert.Equal(0, callbackCount);
+    }
+
+    [Fact]
+    public void Disabled_group_does_not_fire_ValueChanged_on_click()
+    {
+        var callbackCount = 0;
+        var cut = Render<ToggleGroup<string>>(p => p
+            .Add(c => c.Options, ThreeOptions)
+            .Add(c => c.Value, "RAID")
+            .Add(c => c.Disabled, true)
+            .Add(c => c.ValueChanged, _ => callbackCount++));
+
+        // The native <button disabled> suppresses the click event before it
+        // reaches the handler — which is the WCAG-correct behaviour.
+        var buttons = cut.FindAll("[role='radio']");
+        Assert.Equal("", buttons[1].GetAttribute("disabled") ?? "");
+        Assert.NotNull(buttons[1].GetAttribute("disabled"));
+    }
+
+    // ── Keyboard navigation (WAI-ARIA radiogroup) ────────────────────────────
+
+    [Fact]
+    public void ArrowRight_moves_selection_to_next()
+    {
+        string? received = null;
+        var cut = Render<ToggleGroup<string>>(p => p
+            .Add(c => c.Options, ThreeOptions)
+            .Add(c => c.Value, "DUNGEON")
+            .Add(c => c.ValueChanged, v => received = v));
+
+        cut.Find("[role='radiogroup']")
+           .KeyDown(new KeyboardEventArgs { Key = "ArrowRight" });
+
+        Assert.Equal("OTHER", received);
+    }
+
+    [Fact]
+    public void ArrowRight_wraps_from_last_to_first()
+    {
+        string? received = null;
+        var cut = Render<ToggleGroup<string>>(p => p
+            .Add(c => c.Options, ThreeOptions)
+            .Add(c => c.Value, "OTHER")
+            .Add(c => c.ValueChanged, v => received = v));
+
+        cut.Find("[role='radiogroup']")
+           .KeyDown(new KeyboardEventArgs { Key = "ArrowRight" });
+
+        Assert.Equal("RAID", received);
+    }
+
+    [Fact]
+    public void ArrowLeft_moves_selection_to_previous_and_wraps_at_start()
+    {
+        string? received = null;
+        var cut = Render<ToggleGroup<string>>(p => p
+            .Add(c => c.Options, ThreeOptions)
+            .Add(c => c.Value, "RAID")
+            .Add(c => c.ValueChanged, v => received = v));
+
+        cut.Find("[role='radiogroup']")
+           .KeyDown(new KeyboardEventArgs { Key = "ArrowLeft" });
+        Assert.Equal("OTHER", received); // wrapped
+    }
+
+    [Theory]
+    [InlineData("ArrowDown", "DUNGEON")]
+    [InlineData("ArrowUp", "OTHER")]
+    public void ArrowDown_and_ArrowUp_behave_like_Right_and_Left(string key, string expected)
+    {
+        string? received = null;
+        var cut = Render<ToggleGroup<string>>(p => p
+            .Add(c => c.Options, ThreeOptions)
+            .Add(c => c.Value, "RAID")
+            .Add(c => c.ValueChanged, v => received = v));
+
+        cut.Find("[role='radiogroup']")
+           .KeyDown(new KeyboardEventArgs { Key = key });
+
+        Assert.Equal(expected, received);
+    }
+
+    [Fact]
+    public void Home_jumps_to_first_option()
+    {
+        string? received = null;
+        var cut = Render<ToggleGroup<string>>(p => p
+            .Add(c => c.Options, ThreeOptions)
+            .Add(c => c.Value, "OTHER")
+            .Add(c => c.ValueChanged, v => received = v));
+
+        cut.Find("[role='radiogroup']")
+           .KeyDown(new KeyboardEventArgs { Key = "Home" });
+
+        Assert.Equal("RAID", received);
+    }
+
+    [Fact]
+    public void End_jumps_to_last_option()
+    {
+        string? received = null;
+        var cut = Render<ToggleGroup<string>>(p => p
+            .Add(c => c.Options, ThreeOptions)
+            .Add(c => c.Value, "RAID")
+            .Add(c => c.ValueChanged, v => received = v));
+
+        cut.Find("[role='radiogroup']")
+           .KeyDown(new KeyboardEventArgs { Key = "End" });
+
+        Assert.Equal("OTHER", received);
+    }
+
+    [Fact]
+    public void Space_on_already_selected_option_is_a_no_op()
+    {
+        var callbackCount = 0;
+        var cut = Render<ToggleGroup<string>>(p => p
+            .Add(c => c.Options, ThreeOptions)
+            .Add(c => c.Value, "RAID")
+            .Add(c => c.ValueChanged, _ => callbackCount++));
+
+        cut.Find("[role='radiogroup']")
+           .KeyDown(new KeyboardEventArgs { Key = " " });
+
+        Assert.Equal(0, callbackCount);
+    }
+
+    [Fact]
+    public void Unrelated_keys_do_not_fire_ValueChanged()
+    {
+        var callbackCount = 0;
+        var cut = Render<ToggleGroup<string>>(p => p
+            .Add(c => c.Options, ThreeOptions)
+            .Add(c => c.Value, "RAID")
+            .Add(c => c.ValueChanged, _ => callbackCount++));
+
+        foreach (var key in new[] { "Enter", "a", "Tab", "Escape" })
+        {
+            cut.Find("[role='radiogroup']")
+               .KeyDown(new KeyboardEventArgs { Key = key });
+        }
+
+        Assert.Equal(0, callbackCount);
+    }
+
+    // ── CSS hook for the selected state (drives forced-colors CSS too) ───────
+
+    [Fact]
+    public void Selected_option_carries_data_selected_true_for_CSS_targeting()
+    {
+        var cut = Render<ToggleGroup<string>>(p => p
+            .Add(c => c.Options, ThreeOptions)
+            .Add(c => c.Value, "DUNGEON"));
+
+        var buttons = cut.FindAll("[role='radio']");
+        Assert.Equal("false", buttons[0].GetAttribute("data-selected"));
+        Assert.Equal("true", buttons[1].GetAttribute("data-selected"));
+        Assert.Equal("false", buttons[2].GetAttribute("data-selected"));
+    }
+
+    // ── Empty options — renders nothing but doesn't throw ────────────────────
+
+    [Fact]
+    public void Empty_Options_renders_an_empty_radiogroup()
+    {
+        var cut = Render<ToggleGroup<string>>(p => p
+            .Add(c => c.Options, Array.Empty<(string, string)>())
+            .Add(c => c.Value, "RAID")
+            .Add(c => c.AriaLabel, "Empty"));
+
+        var group = cut.Find("[role='radiogroup']");
+        Assert.Empty(cut.FindAll("[role='radio']"));
+        Assert.Equal("Empty", group.GetAttribute("aria-label"));
+    }
+}


### PR DESCRIPTION
## Summary

Generic single-select segmented control used for mutually-exclusive pickers — planned consumers are the create-run form's Activity (`Raid`/`Dungeon`), Difficulty (`Normal`/`Heroic`/`Mythic`/`M+`), and Visibility (`Guild only`/`Public`) in the PR 6 reshape.

Built on the WAI-ARIA **radiogroup** pattern rather than a toolbar of `aria-pressed` toggle buttons — the semantic is single-select and mutually-exclusive, which is what `role="radiogroup"` + `role="radio"` + `aria-checked` specifies. Keyboard contract:

- `Tab` enters/leaves the group; only the selected button is tabbable (roving tabindex).
- `ArrowRight` / `ArrowDown` → next option (wraps).
- `ArrowLeft` / `ArrowUp` → previous option (wraps).
- `Home` → first; `End` → last.
- `Space` re-asserts the focused option (no-op when already selected).

## Schema / env changes

- **No wire / Cosmos / Bicep / workflow changes.** New component file + sibling CSS + bUnit tests only.
- **Accessibility:** `role="radiogroup"` + `role="radio"` + `aria-checked`; supports `aria-label` and `aria-labelledby` (the latter preferred when a visible label exists). `:focus-visible` outline; ≥2.75rem tap target (SC 2.5.5).
- **i18n:** logical CSS properties throughout — `padding-inline`, `border-inline-*`, `flex-direction: row`, `flex-wrap: wrap`, `row-gap`. `dir="rtl"` flips visual order automatically. Long Finnish/German labels wrap to a second row at the 320 CSS px floor instead of overflowing.
- **Forced-colors mode:** `@media (forced-colors: active)` falls back to `ButtonText` / `Highlight` / `HighlightText` / `ButtonFace` so the selected/unselected distinction survives Windows High Contrast.
- **CLS:** the selected-state visual is background + border colour change only — no font-weight swap that would shift text metrics on selection.

## Test plan

- [x] `dotnet build lfm.sln -c Release` clean.
- [x] `dotnet format lfm.sln --verify-no-changes` clean.
- [x] `Lfm.App.Tests` — 168 pass (17 new `ToggleGroupTests`: rendering, aria-checked toggling, roving tabindex, click selection, disabled state, every WAI-ARIA keyboard key incl. wraps + Space no-op + unrelated keys, empty-options edge case).
- [x] `Lfm.Api.Tests` — 436 pass. `Lfm.App.Core.Tests` — 132 pass.
- [ ] Live browser verification after the PR 6 reshape ships: `dir="rtl"` visual order, Finnish label wrap at 320 px, `forced-colors: active` rendering — static signals are aligned but these three require a browser per the responsive-design skill's "honest limits."
