### PR TITLE
Run schema: add typed Difficulty/Size/KeystoneLevel + nullable InstanceId

### DIFF
--- a/api/Functions/RunsCancelSignupFunction.cs
+++ b/api/Functions/RunsCancelSignupFunction.cs
@@ -107,8 +107,10 @@ public class RunsCancelSignupFunction(
     // functions/src/lib/runResponseSanitizer.ts
     // ------------------------------------------------------------------
 
-    private static RunDetailDto Sanitize(RunDocument run, string currentBattleNetId) =>
-        new(
+    private static RunDetailDto Sanitize(RunDocument run, string currentBattleNetId)
+    {
+        var (difficulty, size) = Helpers.RunModeResolver.Resolve(run.Difficulty, run.Size, run.ModeKey);
+        return new RunDetailDto(
             Id: run.Id,
             StartTime: run.StartTime,
             SignupCloseTime: run.SignupCloseTime,
@@ -118,6 +120,9 @@ public class RunsCancelSignupFunction(
             CreatorGuild: run.CreatorGuild,
             InstanceId: run.InstanceId,
             InstanceName: run.InstanceName,
+            Difficulty: difficulty,
+            Size: size,
+            KeystoneLevel: run.KeystoneLevel,
             RunCharacters: run.RunCharacters
                 .Select(c => new RunCharacterDto(
                     CharacterName: c.CharacterName,
@@ -130,4 +135,5 @@ public class RunsCancelSignupFunction(
                     Role: c.Role,
                     IsCurrentUser: c.RaiderBattleNetId == currentBattleNetId))
                 .ToList());
+    }
 }

--- a/api/Functions/RunsCreateFunction.cs
+++ b/api/Functions/RunsCreateFunction.cs
@@ -8,6 +8,7 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 using Lfm.Api.Audit;
 using Lfm.Api.Auth;
+using Lfm.Api.Helpers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;
@@ -130,29 +131,44 @@ public class RunsCreateFunction(IRunsRepository repo, IRaidersRepository raiders
             ? gid
             : null;
 
+        // Resolve the typed mode fields: prefer what the client sent, fall
+        // back to parsing the legacy ModeKey composite. Persist ModeKey too,
+        // deriving "{Difficulty}:{Size}" when the client only sent the new
+        // fields — keeps legacy readers on the write side happy for one
+        // migration cycle.
+        var (difficulty, size) = RunModeResolver.Resolve(body.Difficulty, body.Size ?? 0, body.ModeKey);
+        var modeKey = !string.IsNullOrWhiteSpace(body.ModeKey)
+            ? body.ModeKey!
+            : $"{difficulty}:{size}";
+
         return new RunDocument(
             Id: id,
             StartTime: body.StartTime!,
             SignupCloseTime: body.SignupCloseTime ?? "",
             Description: body.Description ?? "",
-            ModeKey: body.ModeKey!,
+            ModeKey: modeKey,
             Visibility: body.Visibility!,
             CreatorGuild: guildName ?? "",
             CreatorGuildId: creatorGuildId,
-            InstanceId: body.InstanceId!.Value,
-            InstanceName: body.InstanceName ?? "",
+            InstanceId: body.InstanceId,
+            InstanceName: body.InstanceName,
             CreatorBattleNetId: principal.BattleNetId,
             CreatedAt: createdAt,
             Ttl: ttl,
-            RunCharacters: []);
+            RunCharacters: [],
+            Difficulty: difficulty,
+            Size: size,
+            KeystoneLevel: body.KeystoneLevel);
     }
 
     // ------------------------------------------------------------------
     // Mapping helper — projects the stored RunDocument to its wire DTO.
     // ------------------------------------------------------------------
 
-    private static RunDetailDto MapToDto(RunDocument doc) =>
-        new(
+    private static RunDetailDto MapToDto(RunDocument doc)
+    {
+        var (difficulty, size) = RunModeResolver.Resolve(doc.Difficulty, doc.Size, doc.ModeKey);
+        return new RunDetailDto(
             Id: doc.Id,
             StartTime: doc.StartTime,
             SignupCloseTime: doc.SignupCloseTime,
@@ -162,5 +178,9 @@ public class RunsCreateFunction(IRunsRepository repo, IRaidersRepository raiders
             CreatorGuild: doc.CreatorGuild,
             InstanceId: doc.InstanceId,
             InstanceName: doc.InstanceName,
-            RunCharacters: []);
+            RunCharacters: [],
+            Difficulty: difficulty,
+            Size: size,
+            KeystoneLevel: doc.KeystoneLevel);
+    }
 }

--- a/api/Functions/RunsDetailFunction.cs
+++ b/api/Functions/RunsDetailFunction.cs
@@ -73,8 +73,10 @@ public class RunsDetailFunction(IRunsRepository repo, IRaidersRepository raiders
     // functions/src/lib/runResponseSanitizer.ts
     // ------------------------------------------------------------------
 
-    private static RunDetailDto Sanitize(RunDocument run, string currentBattleNetId) =>
-        new RunDetailDto(
+    private static RunDetailDto Sanitize(RunDocument run, string currentBattleNetId)
+    {
+        var (difficulty, size) = Helpers.RunModeResolver.Resolve(run.Difficulty, run.Size, run.ModeKey);
+        return new RunDetailDto(
             Id: run.Id,
             StartTime: run.StartTime,
             SignupCloseTime: run.SignupCloseTime,
@@ -84,9 +86,13 @@ public class RunsDetailFunction(IRunsRepository repo, IRaidersRepository raiders
             CreatorGuild: run.CreatorGuild,
             InstanceId: run.InstanceId,
             InstanceName: run.InstanceName,
+            Difficulty: difficulty,
+            Size: size,
+            KeystoneLevel: run.KeystoneLevel,
             RunCharacters: run.RunCharacters
                 .Select(c => SanitizeCharacter(c, currentBattleNetId))
                 .ToList());
+    }
 
     private static RunCharacterDto SanitizeCharacter(
         RunCharacterEntry character, string currentBattleNetId) =>

--- a/api/Functions/RunsListFunction.cs
+++ b/api/Functions/RunsListFunction.cs
@@ -83,8 +83,10 @@ public class RunsListFunction(IRunsRepository repo, IRaidersRepository raidersRe
     // functions/src/lib/runResponseSanitizer.ts
     // ------------------------------------------------------------------
 
-    private static RunSummaryDto Sanitize(RunDocument run, string currentBattleNetId) =>
-        new RunSummaryDto(
+    private static RunSummaryDto Sanitize(RunDocument run, string currentBattleNetId)
+    {
+        var (difficulty, size) = Helpers.RunModeResolver.Resolve(run.Difficulty, run.Size, run.ModeKey);
+        return new RunSummaryDto(
             Id: run.Id,
             StartTime: run.StartTime,
             SignupCloseTime: run.SignupCloseTime,
@@ -94,9 +96,13 @@ public class RunsListFunction(IRunsRepository repo, IRaidersRepository raidersRe
             CreatorGuild: run.CreatorGuild,
             InstanceId: run.InstanceId,
             InstanceName: run.InstanceName,
+            Difficulty: difficulty,
+            Size: size,
+            KeystoneLevel: run.KeystoneLevel,
             RunCharacters: run.RunCharacters
                 .Select(c => SanitizeCharacter(c, currentBattleNetId))
                 .ToList());
+    }
 
     private static RunCharacterDto SanitizeCharacter(
         RunCharacterEntry character, string currentBattleNetId) =>

--- a/api/Functions/RunsMigrateSchemaFunction.cs
+++ b/api/Functions/RunsMigrateSchemaFunction.cs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+using Lfm.Api.Audit;
+using Lfm.Api.Auth;
+using Lfm.Api.Middleware;
+using Lfm.Api.Repositories;
+using Lfm.Api.Services;
+
+namespace Lfm.Api.Functions;
+
+/// <summary>
+/// Serves <c>POST /api/admin/runs/migrate-schema</c> (site-admin only).
+///
+/// Backfills <c>Difficulty</c> / <c>Size</c> / <c>KeystoneLevel</c> on every
+/// existing <see cref="RunDocument"/> by parsing the legacy composite
+/// <c>ModeKey</c>. Idempotent: documents whose typed fields are already
+/// populated are skipped. Supports a <c>?dryRun=true</c> query parameter
+/// that reports the would-migrate count without writing anything.
+///
+/// Ships as part of PR 5 of the create-run-page-improvements plan; intended
+/// to be invoked once post-deploy and then left alone. Not wired into the
+/// admin UI yet — a curl call from an admin session is the expected path.
+/// </summary>
+public class RunsMigrateSchemaFunction(
+    ISiteAdminService siteAdmin,
+    IRunsRepository runs,
+    ILogger<RunsMigrateSchemaFunction> logger)
+{
+    [Function("runs-migrate-schema")]
+    [RequireAuth]
+    public async Task<IActionResult> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "admin/runs/migrate-schema")] HttpRequest req,
+        FunctionContext ctx,
+        CancellationToken ct)
+    {
+        var principal = ctx.GetPrincipal();
+
+        if (!await siteAdmin.IsAdminAsync(principal.BattleNetId, ct))
+            return new ObjectResult(new { error = "Forbidden" }) { StatusCode = 403 };
+
+        var dryRun = string.Equals(
+            req.Query["dryRun"].ToString(),
+            "true",
+            StringComparison.OrdinalIgnoreCase);
+
+        var result = await runs.MigrateSchemaAsync(dryRun, ct);
+
+        AuditLog.Emit(logger, new AuditEvent(
+            "runs.migrate-schema",
+            principal.BattleNetId,
+            null,
+            "success",
+            $"scanned={result.Scanned} migrated={result.Migrated} dryRun={result.DryRun}"));
+
+        return new OkObjectResult(result);
+    }
+}

--- a/api/Functions/RunsSignupFunction.cs
+++ b/api/Functions/RunsSignupFunction.cs
@@ -217,8 +217,10 @@ public class RunsSignupFunction(
     // functions/src/lib/runResponseSanitizer.ts
     // ------------------------------------------------------------------
 
-    private static RunDetailDto Sanitize(RunDocument run, string currentBattleNetId) =>
-        new(
+    private static RunDetailDto Sanitize(RunDocument run, string currentBattleNetId)
+    {
+        var (difficulty, size) = Helpers.RunModeResolver.Resolve(run.Difficulty, run.Size, run.ModeKey);
+        return new RunDetailDto(
             Id: run.Id,
             StartTime: run.StartTime,
             SignupCloseTime: run.SignupCloseTime,
@@ -228,6 +230,9 @@ public class RunsSignupFunction(
             CreatorGuild: run.CreatorGuild,
             InstanceId: run.InstanceId,
             InstanceName: run.InstanceName,
+            Difficulty: difficulty,
+            Size: size,
+            KeystoneLevel: run.KeystoneLevel,
             RunCharacters: run.RunCharacters
                 .Select(c => new RunCharacterDto(
                     CharacterName: c.CharacterName,
@@ -240,4 +245,5 @@ public class RunsSignupFunction(
                     Role: c.Role,
                     IsCurrentUser: c.RaiderBattleNetId == currentBattleNetId))
                 .ToList());
+    }
 }

--- a/api/Functions/RunsUpdateFunction.cs
+++ b/api/Functions/RunsUpdateFunction.cs
@@ -157,20 +157,37 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
         // 7. Resolve effective instanceId + modeKey and look up the instance name.
         var effectiveInstanceId = body.InstanceId ?? existing.InstanceId;
         var effectiveModeKey = body.ModeKey ?? existing.ModeKey;
+        var (effectiveDifficulty, effectiveSize) = RunModeResolver.Resolve(
+            body.Difficulty ?? existing.Difficulty,
+            body.Size ?? existing.Size,
+            effectiveModeKey);
+        var effectiveKeystoneLevel = body.KeystoneLevel ?? existing.KeystoneLevel;
 
         // Load instances to validate the (instanceId, modeKey) combination and obtain
         // the canonical instance name. Each InstanceDto row in the container represents
         // one (instance, mode) pair: InstanceNumericId == Blizzard instance id,
         // ModeKey == "TYPE:players". Id is a composite "{instanceId}:{modeKey}" —
         // never parse it as an int (see InstanceDto doc-comment).
-        var instances = await instancesRepo.ListAsync(ct);
-        if (instances.Count == 0)
-            return new ObjectResult(new { error = "Instance data not available" }) { StatusCode = 503 };
+        //
+        // A dungeon-agnostic Mythic+ run (effectiveInstanceId is null) skips
+        // this validation — there is no specific instance to match.
+        string? effectiveInstanceName = existing.InstanceName;
+        if (effectiveInstanceId.HasValue)
+        {
+            var instances = await instancesRepo.ListAsync(ct);
+            if (instances.Count == 0)
+                return new ObjectResult(new { error = "Instance data not available" }) { StatusCode = 503 };
 
-        var matchedInstance = instances.FirstOrDefault(
-            i => i.InstanceNumericId == effectiveInstanceId && i.ModeKey == effectiveModeKey);
-        if (matchedInstance is null)
-            return new BadRequestObjectResult(new { error = "Invalid modeKey for instance" });
+            var matchedInstance = instances.FirstOrDefault(
+                i => i.InstanceNumericId == effectiveInstanceId.Value && i.ModeKey == effectiveModeKey);
+            if (matchedInstance is null)
+                return new BadRequestObjectResult(new { error = "Invalid modeKey for instance" });
+            effectiveInstanceName = matchedInstance.Name;
+        }
+        else
+        {
+            effectiveInstanceName = null;
+        }
 
         // 8. Apply changes — mirrors applyRunUpdate in runs-update.ts.
         var updated = existing with
@@ -179,9 +196,12 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
             SignupCloseTime = body.SignupCloseTime ?? existing.SignupCloseTime,
             Description = body.Description ?? existing.Description,
             ModeKey = effectiveModeKey,
+            Difficulty = effectiveDifficulty,
+            Size = effectiveSize,
+            KeystoneLevel = effectiveKeystoneLevel,
             Visibility = body.Visibility ?? existing.Visibility,
             InstanceId = effectiveInstanceId,
-            InstanceName = matchedInstance.Name,
+            InstanceName = effectiveInstanceName,
             CreatorGuild = isGuildPromotion
                 ? (guildName ?? "")
                 : existing.CreatorGuild,
@@ -202,8 +222,10 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
     // Mapping helper — projects the stored RunDocument to its wire DTO.
     // ------------------------------------------------------------------
 
-    private static RunDetailDto MapToDto(RunDocument doc, string currentBattleNetId) =>
-        new(
+    private static RunDetailDto MapToDto(RunDocument doc, string currentBattleNetId)
+    {
+        var (difficulty, size) = RunModeResolver.Resolve(doc.Difficulty, doc.Size, doc.ModeKey);
+        return new RunDetailDto(
             Id: doc.Id,
             StartTime: doc.StartTime,
             SignupCloseTime: doc.SignupCloseTime,
@@ -213,6 +235,9 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
             CreatorGuild: doc.CreatorGuild,
             InstanceId: doc.InstanceId,
             InstanceName: doc.InstanceName,
+            Difficulty: difficulty,
+            Size: size,
+            KeystoneLevel: doc.KeystoneLevel,
             RunCharacters: doc.RunCharacters
                 .Select(c => new RunCharacterDto(
                     CharacterName: c.CharacterName,
@@ -225,4 +250,5 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
                     Role: c.Role,
                     IsCurrentUser: c.RaiderBattleNetId == currentBattleNetId))
                 .ToList());
+    }
 }

--- a/api/Helpers/RunModeResolver.cs
+++ b/api/Helpers/RunModeResolver.cs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Repositories;
+using Lfm.Contracts.Runs;
+
+namespace Lfm.Api.Helpers;
+
+/// <summary>
+/// Resolves the canonical typed mode fields (<c>Difficulty</c>, <c>Size</c>) for
+/// a run, preferring the explicitly-set typed fields and falling back to
+/// parsing the legacy composite <c>ModeKey</c> when they are empty. Used by
+/// every handler that projects a <c>RunDocument</c> onto a wire DTO so
+/// consumers always see populated structured fields — even on Cosmos documents
+/// that predate the PR 5 schema migration.
+/// </summary>
+internal static class RunModeResolver
+{
+    internal static (string Difficulty, int Size) Resolve(string? difficulty, int size, string? modeKey)
+    {
+        if (!string.IsNullOrEmpty(difficulty) && size > 0)
+            return (difficulty, size);
+
+        var parsed = RunMode.Parse(modeKey);
+        return (
+            !string.IsNullOrEmpty(difficulty) ? difficulty : parsed.Difficulty,
+            size > 0 ? size : parsed.Size);
+    }
+
+    /// <summary>
+    /// Ensures a persisted <see cref="RunDocument"/> has the typed mode
+    /// fields populated, deriving them from <see cref="RunDocument.ModeKey"/>
+    /// when they are missing (legacy documents). Returns the same instance
+    /// when nothing needs to change.
+    /// </summary>
+    internal static RunDocument EnsurePopulated(RunDocument doc)
+    {
+        if (!string.IsNullOrEmpty(doc.Difficulty) && doc.Size > 0)
+            return doc;
+
+        var (difficulty, size) = Resolve(doc.Difficulty, doc.Size, doc.ModeKey);
+        return doc with { Difficulty = difficulty, Size = size };
+    }
+}

--- a/api/Repositories/IRunsRepository.cs
+++ b/api/Repositories/IRunsRepository.cs
@@ -135,4 +135,16 @@ public interface IRunsRepository
     /// Mirrors <c>getRunsContainer().item(id, id).delete()</c> in runs-delete.ts.
     /// </summary>
     Task DeleteAsync(string id, CancellationToken ct);
+
+    /// <summary>
+    /// Backfills <c>Difficulty</c> / <c>Size</c> / <c>KeystoneLevel</c> on every
+    /// <see cref="RunDocument"/> that predates the PR 5 schema. Idempotent —
+    /// documents whose typed fields are already populated are left untouched.
+    /// When <paramref name="dryRun"/> is true, returns the would-migrate count
+    /// without writing anything. Admin-only; callers must gate on
+    /// <see cref="Services.ISiteAdminService"/>.
+    /// </summary>
+    Task<RunMigrationResult> MigrateSchemaAsync(bool dryRun, CancellationToken ct);
 }
+
+public sealed record RunMigrationResult(int Scanned, int Migrated, bool DryRun);

--- a/api/Repositories/IRunsRepository.cs
+++ b/api/Repositories/IRunsRepository.cs
@@ -29,6 +29,24 @@ public sealed record RunCharacterEntry(
     [property: JsonConverter(typeof(LocalizedStringConverter))] string? SpecName,
     string? Role);
 
+/// <summary>
+/// Run document in the Cosmos "runs" container. Partition key: /id.
+///
+/// <para>
+/// <b>Mode schema.</b> <see cref="Difficulty"/> + <see cref="Size"/> + <see cref="KeystoneLevel"/>
+/// are the canonical typed mode fields; <see cref="ModeKey"/> is the legacy
+/// composite (<c>"{Difficulty}:{Size}"</c>) retained for one cycle for
+/// cross-compatibility while the migration populates the new fields on
+/// existing Cosmos documents. New writes populate both; consumers prefer
+/// the typed fields and fall back to parsing <see cref="ModeKey"/> when
+/// the new fields are empty.
+/// </para>
+/// <para>
+/// <b>Instance id/name.</b> Both are nullable: a Mythic+ "any dungeon"
+/// session has no specific instance. All other run kinds require an
+/// instance, which validators enforce on the request DTOs.
+/// </para>
+/// </summary>
 public sealed record RunDocument(
     string Id,
     string StartTime,
@@ -38,12 +56,15 @@ public sealed record RunDocument(
     string Visibility,
     string CreatorGuild,
     int? CreatorGuildId,
-    int InstanceId,
-    [property: JsonConverter(typeof(LocalizedStringConverter))] string InstanceName,
+    int? InstanceId,
+    [property: JsonConverter(typeof(LocalizedStringConverter))] string? InstanceName,
     string? CreatorBattleNetId,
     string CreatedAt,
     int Ttl,
     IReadOnlyList<RunCharacterEntry> RunCharacters,
+    string Difficulty = "",
+    int Size = 0,
+    int? KeystoneLevel = null,
     [property: System.Text.Json.Serialization.JsonPropertyName("_etag")] string? ETag = null);
 
 /// <summary>

--- a/api/Repositories/RunsRepository.cs
+++ b/api/Repositories/RunsRepository.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Options;
+using Lfm.Api.Helpers;
 using Lfm.Api.Options;
 
 namespace Lfm.Api.Repositories;
@@ -172,6 +173,37 @@ public sealed class RunsRepository(CosmosClient client, IOptions<CosmosOptions> 
                     cancellationToken: ct);
             }
         }
+    }
+
+    public async Task<RunMigrationResult> MigrateSchemaAsync(bool dryRun, CancellationToken ct)
+    {
+        // Iterate every run document. The set is small (hobby scale), and
+        // unlike ScrubRaiderAsync we don't have a cheap WHERE predicate —
+        // every legacy doc needs inspection.
+        var feedIterator = _container.GetItemQueryIterator<RunDocument>("SELECT * FROM c");
+
+        var scanned = 0;
+        var migrated = 0;
+        while (feedIterator.HasMoreResults)
+        {
+            var page = await feedIterator.ReadNextAsync(ct);
+            foreach (var run in page)
+            {
+                scanned++;
+                var populated = RunModeResolver.EnsurePopulated(run);
+                if (ReferenceEquals(populated, run)) continue;
+                migrated++;
+                if (!dryRun)
+                {
+                    await _container.ReplaceItemAsync(
+                        populated,
+                        run.Id,
+                        new PartitionKey(run.Id),
+                        cancellationToken: ct);
+                }
+            }
+        }
+        return new RunMigrationResult(scanned, migrated, dryRun);
     }
 
     /// <summary>

--- a/app/Components/RunListItem.razor
+++ b/app/Components/RunListItem.razor
@@ -61,7 +61,7 @@
         _isMe = RunVisualization.IsCurrentUserSignedUp(Run.RunCharacters);
         _isCurrentUserClass = _isMe ? "true" : "false";
         _counts = RunVisualization.CountRoles(Run.RunCharacters, Run.ModeKey);
-        _ariaLabel = Loc["runs.listItemAriaLabel", Run.InstanceName, FormatDate(Run.StartTime)].Value;
+        _ariaLabel = Loc["runs.listItemAriaLabel", Run.InstanceName ?? "", FormatDate(Run.StartTime)].Value;
         _compositionAria = Loc["runs.compositionAria",
             _counts.Tank.Attending, _counts.Healer.Attending, _counts.Dps.Attending].Value;
     }

--- a/shared/Lfm.Contracts/Runs/CreateRunRequest.cs
+++ b/shared/Lfm.Contracts/Runs/CreateRunRequest.cs
@@ -17,12 +17,23 @@ public sealed record CreateRunRequest(
     string? ModeKey,
     string? Visibility,
     int? InstanceId,
-    string? InstanceName);
+    string? InstanceName,
+    string? Difficulty = null,
+    int? Size = null,
+    int? KeystoneLevel = null);
 
 public sealed class CreateRunRequestValidator : AbstractValidator<CreateRunRequest>
 {
     private static readonly HashSet<string> ValidVisibilities =
         new(StringComparer.Ordinal) { "PUBLIC", "GUILD" };
+
+    internal static readonly HashSet<string> ValidDifficulties =
+        new(StringComparer.Ordinal)
+        {
+            "LFR", "NORMAL", "HEROIC", "MYTHIC", "MYTHIC_KEYSTONE",
+        };
+
+    internal const string MythicKeystone = "MYTHIC_KEYSTONE";
 
     public CreateRunRequestValidator()
     {
@@ -33,17 +44,47 @@ public sealed class CreateRunRequestValidator : AbstractValidator<CreateRunReque
         RuleFor(x => x.SignupCloseTime)
             .MaximumLength(64).WithMessage("signupCloseTime must be at most 64 characters");
 
+        // Accept either the legacy ModeKey (for pre-PR-5 clients) or the new
+        // structured Difficulty + Size — at least one must be present.
+        RuleFor(x => x)
+            .Must(x => !string.IsNullOrWhiteSpace(x.ModeKey)
+                      || (!string.IsNullOrEmpty(x.Difficulty) && x.Size is > 0))
+            .WithMessage("modeKey or (difficulty + size) is required");
+
         RuleFor(x => x.ModeKey)
-            .NotEmpty().WithMessage("modeKey is required")
             .MaximumLength(64).WithMessage("modeKey must be at most 64 characters");
+
+        RuleFor(x => x.Difficulty)
+            .Must(d => d is null || ValidDifficulties.Contains(d))
+            .WithMessage("difficulty must be one of LFR, NORMAL, HEROIC, MYTHIC, MYTHIC_KEYSTONE");
+
+        RuleFor(x => x.Size)
+            .InclusiveBetween(1, 40).When(x => x.Size.HasValue)
+            .WithMessage("size must be between 1 and 40");
 
         RuleFor(x => x.Visibility)
             .NotEmpty().WithMessage("visibility is required")
             .Must(v => v is not null && ValidVisibilities.Contains(v))
             .WithMessage("visibility must be PUBLIC or GUILD");
 
-        RuleFor(x => x.InstanceId)
-            .NotNull().WithMessage("instanceId is required");
+        // InstanceId is required unless the run is a Mythic+ session — M+
+        // runs may be dungeon-agnostic ("Any dungeon").
+        RuleFor(x => x)
+            .Must(x => x.InstanceId.HasValue || x.Difficulty == MythicKeystone)
+            .WithMessage("instanceId is required for non-Mythic+ runs");
+
+        // KeystoneLevel is only valid on Mythic+ runs, and it becomes required
+        // when no specific instance is selected — a dungeon-less M+ run needs
+        // the level to mean anything.
+        RuleFor(x => x.KeystoneLevel)
+            .InclusiveBetween(2, 30).When(x => x.KeystoneLevel.HasValue)
+            .WithMessage("keystoneLevel must be between 2 and 30");
+        RuleFor(x => x)
+            .Must(x => x.Difficulty == MythicKeystone || x.KeystoneLevel is null)
+            .WithMessage("keystoneLevel is only valid for Mythic+ runs");
+        RuleFor(x => x)
+            .Must(x => x.Difficulty != MythicKeystone || x.InstanceId.HasValue || x.KeystoneLevel.HasValue)
+            .WithMessage("keystoneLevel is required when no specific dungeon is selected");
 
         RuleFor(x => x.InstanceName)
             .MaximumLength(128).WithMessage("instanceName must be at most 128 characters");

--- a/shared/Lfm.Contracts/Runs/RunDetailDto.cs
+++ b/shared/Lfm.Contracts/Runs/RunDetailDto.cs
@@ -8,6 +8,15 @@ namespace Lfm.Contracts.Runs;
 /// Contains the same fields as RunSummaryDto; defined as a distinct type so
 /// that detail-specific fields can be added later without breaking the list
 /// endpoint contract. Wire-only shape per docs/wire-payload-contract.md.
+///
+/// <para>
+/// <b>Mode fields.</b> <see cref="Difficulty"/>, <see cref="Size"/>, and
+/// <see cref="KeystoneLevel"/> are the typed fields consumers should prefer;
+/// <see cref="ModeKey"/> is the legacy composite (<c>"{Difficulty}:{Size}"</c>)
+/// kept for one cycle during the schema migration. <see cref="InstanceId"/>
+/// and <see cref="InstanceName"/> are nullable because a Mythic+ "any dungeon"
+/// session has no specific instance.
+/// </para>
 /// </summary>
 public sealed record RunDetailDto(
     string Id,
@@ -17,6 +26,9 @@ public sealed record RunDetailDto(
     string ModeKey,
     string Visibility,
     string CreatorGuild,
-    int InstanceId,
-    string InstanceName,
-    IReadOnlyList<RunCharacterDto> RunCharacters);
+    int? InstanceId,
+    string? InstanceName,
+    IReadOnlyList<RunCharacterDto> RunCharacters,
+    string Difficulty = "",
+    int Size = 0,
+    int? KeystoneLevel = null);

--- a/shared/Lfm.Contracts/Runs/RunSummaryDto.cs
+++ b/shared/Lfm.Contracts/Runs/RunSummaryDto.cs
@@ -8,6 +8,15 @@ namespace Lfm.Contracts.Runs;
 /// Wire-only shape per docs/wire-payload-contract.md — omits storage-internal
 /// fields (Ttl, CreatedAt) and audit identifiers the app does not render
 /// (CreatorGuildId, CreatorBattleNetId).
+///
+/// <para>
+/// <b>Mode fields.</b> <see cref="Difficulty"/>, <see cref="Size"/>, and
+/// <see cref="KeystoneLevel"/> are the typed fields consumers should prefer;
+/// <see cref="ModeKey"/> is the legacy composite kept for one cycle during
+/// the schema migration. <see cref="InstanceId"/> and <see cref="InstanceName"/>
+/// are nullable because a Mythic+ "any dungeon" session has no specific
+/// instance.
+/// </para>
 /// </summary>
 public sealed record RunSummaryDto(
     string Id,
@@ -17,6 +26,9 @@ public sealed record RunSummaryDto(
     string ModeKey,
     string Visibility,
     string CreatorGuild,
-    int InstanceId,
-    string InstanceName,
-    IReadOnlyList<RunCharacterDto> RunCharacters);
+    int? InstanceId,
+    string? InstanceName,
+    IReadOnlyList<RunCharacterDto> RunCharacters,
+    string Difficulty = "",
+    int Size = 0,
+    int? KeystoneLevel = null);

--- a/shared/Lfm.Contracts/Runs/UpdateRunRequest.cs
+++ b/shared/Lfm.Contracts/Runs/UpdateRunRequest.cs
@@ -17,7 +17,10 @@ public sealed record UpdateRunRequest(
     string? ModeKey,
     string? Visibility,
     int? InstanceId,
-    string? InstanceName);
+    string? InstanceName,
+    string? Difficulty = null,
+    int? Size = null,
+    int? KeystoneLevel = null);
 
 public sealed class UpdateRunRequestValidator : AbstractValidator<UpdateRunRequest>
 {
@@ -39,6 +42,18 @@ public sealed class UpdateRunRequestValidator : AbstractValidator<UpdateRunReque
 
         RuleFor(x => x.ModeKey)
             .MaximumLength(64).WithMessage("modeKey must be at most 64 characters");
+
+        RuleFor(x => x.Difficulty)
+            .Must(d => d is null || CreateRunRequestValidator.ValidDifficulties.Contains(d))
+            .WithMessage("difficulty must be one of LFR, NORMAL, HEROIC, MYTHIC, MYTHIC_KEYSTONE");
+
+        RuleFor(x => x.Size)
+            .InclusiveBetween(1, 40).When(x => x.Size.HasValue)
+            .WithMessage("size must be between 1 and 40");
+
+        RuleFor(x => x.KeystoneLevel)
+            .InclusiveBetween(2, 30).When(x => x.KeystoneLevel.HasValue)
+            .WithMessage("keystoneLevel must be between 2 and 30");
 
         RuleFor(x => x.InstanceName)
             .MaximumLength(128).WithMessage("instanceName must be at most 128 characters");

--- a/tests/Lfm.Api.Tests/Helpers/RunModeResolverTests.cs
+++ b/tests/Lfm.Api.Tests/Helpers/RunModeResolverTests.cs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Helpers;
+using Lfm.Api.Repositories;
+using Xunit;
+
+namespace Lfm.Api.Tests.Helpers;
+
+public class RunModeResolverTests
+{
+    // ── Resolve ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Resolve_returns_structured_fields_when_both_present()
+    {
+        var (difficulty, size) = RunModeResolver.Resolve("HEROIC", 25, modeKey: "NORMAL:10");
+        Assert.Equal("HEROIC", difficulty);
+        Assert.Equal(25, size);
+    }
+
+    [Fact]
+    public void Resolve_falls_back_to_ModeKey_when_structured_fields_empty()
+    {
+        var (difficulty, size) = RunModeResolver.Resolve(null, 0, "MYTHIC:20");
+        Assert.Equal("MYTHIC", difficulty);
+        Assert.Equal(20, size);
+    }
+
+    [Fact]
+    public void Resolve_fills_only_missing_piece_when_other_present()
+    {
+        // Size missing, Difficulty present → use parsed Size but retain typed Difficulty.
+        var (d1, s1) = RunModeResolver.Resolve("HEROIC", 0, "MYTHIC:20");
+        Assert.Equal("HEROIC", d1);
+        Assert.Equal(20, s1);
+
+        // Difficulty missing, Size present → use parsed Difficulty but retain typed Size.
+        var (d2, s2) = RunModeResolver.Resolve(null, 25, "NORMAL:10");
+        Assert.Equal("NORMAL", d2);
+        Assert.Equal(25, s2);
+    }
+
+    [Fact]
+    public void Resolve_returns_defaults_when_everything_missing()
+    {
+        var (difficulty, size) = RunModeResolver.Resolve(null, 0, null);
+        Assert.Equal("", difficulty);
+        Assert.Equal(0, size);
+    }
+
+    // ── EnsurePopulated ─────────────────────────────────────────────────────
+
+    private static RunDocument MakeDoc(string modeKey, string difficulty, int size) =>
+        new(
+            Id: "run-1",
+            StartTime: "2026-05-01T20:00:00Z",
+            SignupCloseTime: "",
+            Description: "",
+            ModeKey: modeKey,
+            Visibility: "PUBLIC",
+            CreatorGuild: "",
+            CreatorGuildId: null,
+            InstanceId: 1200,
+            InstanceName: "Undermine",
+            CreatorBattleNetId: "bnet-1",
+            CreatedAt: "2026-04-01T00:00:00Z",
+            Ttl: 604800,
+            RunCharacters: [],
+            Difficulty: difficulty,
+            Size: size);
+
+    [Fact]
+    public void EnsurePopulated_returns_same_instance_when_fields_already_set()
+    {
+        var doc = MakeDoc(modeKey: "HEROIC:25", difficulty: "HEROIC", size: 25);
+        var result = RunModeResolver.EnsurePopulated(doc);
+        Assert.Same(doc, result);
+    }
+
+    [Fact]
+    public void EnsurePopulated_backfills_from_ModeKey_when_fields_empty()
+    {
+        var legacy = MakeDoc(modeKey: "MYTHIC:20", difficulty: "", size: 0);
+        var result = RunModeResolver.EnsurePopulated(legacy);
+        Assert.NotSame(legacy, result);
+        Assert.Equal("MYTHIC", result.Difficulty);
+        Assert.Equal(20, result.Size);
+        Assert.Equal("MYTHIC:20", result.ModeKey); // legacy field untouched
+    }
+}

--- a/tests/Lfm.Api.Tests/Runs/CreateRunRequestValidatorTests.cs
+++ b/tests/Lfm.Api.Tests/Runs/CreateRunRequestValidatorTests.cs
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Contracts.Runs;
+using Xunit;
+
+namespace Lfm.Api.Tests.Runs;
+
+/// <summary>
+/// Pins the new Mythic+ validation rules added in PR 5:
+///   - Legacy ModeKey or the new (Difficulty, Size) pair must be present.
+///   - InstanceId is required unless Difficulty == MYTHIC_KEYSTONE.
+///   - KeystoneLevel is only valid on Mythic+ and must be present when the
+///     run is dungeon-less.
+/// </summary>
+public class CreateRunRequestValidatorTests
+{
+    private const string ValidStart = "2026-05-01T20:00:00Z";
+    private static readonly CreateRunRequestValidator Sut = new();
+
+    private static CreateRunRequest Valid() =>
+        new(StartTime: ValidStart,
+            SignupCloseTime: null,
+            Description: null,
+            ModeKey: null,
+            Visibility: "PUBLIC",
+            InstanceId: 1200,
+            InstanceName: "Liberation of Undermine",
+            Difficulty: "HEROIC",
+            Size: 25,
+            KeystoneLevel: null);
+
+    [Fact]
+    public void Accepts_structured_Difficulty_Size_without_ModeKey()
+    {
+        var result = Sut.Validate(Valid());
+        Assert.True(result.IsValid, string.Join("; ", result.Errors.Select(e => e.ErrorMessage)));
+    }
+
+    [Fact]
+    public void Accepts_legacy_ModeKey_without_structured_fields()
+    {
+        var req = Valid() with { ModeKey = "HEROIC:25", Difficulty = null, Size = null };
+        var result = Sut.Validate(req);
+        Assert.True(result.IsValid, string.Join("; ", result.Errors.Select(e => e.ErrorMessage)));
+    }
+
+    [Fact]
+    public void Rejects_when_both_ModeKey_and_structured_fields_missing()
+    {
+        var req = Valid() with { ModeKey = null, Difficulty = null, Size = null };
+        var result = Sut.Validate(req);
+        Assert.Contains(result.Errors, e => e.ErrorMessage.Contains("modeKey or (difficulty + size) is required"));
+    }
+
+    [Fact]
+    public void Rejects_unknown_difficulty()
+    {
+        var req = Valid() with { Difficulty = "BRUTAL" };
+        var result = Sut.Validate(req);
+        Assert.Contains(result.Errors, e => e.ErrorMessage.Contains("difficulty must be one of"));
+    }
+
+    [Fact]
+    public void Rejects_size_out_of_range()
+    {
+        var result = Sut.Validate(Valid() with { Size = 50 });
+        Assert.Contains(result.Errors, e => e.ErrorMessage.Contains("size must be between 1 and 40"));
+    }
+
+    [Fact]
+    public void Rejects_missing_InstanceId_for_non_MythicPlus()
+    {
+        var req = Valid() with { InstanceId = null };
+        var result = Sut.Validate(req);
+        Assert.Contains(result.Errors, e => e.ErrorMessage.Contains("instanceId is required for non-Mythic+"));
+    }
+
+    [Fact]
+    public void Accepts_MythicPlus_with_specific_instance()
+    {
+        var req = Valid() with
+        {
+            Difficulty = "MYTHIC_KEYSTONE",
+            Size = 5,
+            InstanceId = 500,
+            InstanceName = "Ara-Kara, City of Echoes",
+            KeystoneLevel = 15,
+        };
+        var result = Sut.Validate(req);
+        Assert.True(result.IsValid, string.Join("; ", result.Errors.Select(e => e.ErrorMessage)));
+    }
+
+    [Fact]
+    public void Accepts_MythicPlus_any_dungeon_when_keystone_level_is_specified()
+    {
+        var req = Valid() with
+        {
+            Difficulty = "MYTHIC_KEYSTONE",
+            Size = 5,
+            InstanceId = null,
+            InstanceName = null,
+            KeystoneLevel = 10,
+        };
+        var result = Sut.Validate(req);
+        Assert.True(result.IsValid, string.Join("; ", result.Errors.Select(e => e.ErrorMessage)));
+    }
+
+    [Fact]
+    public void Rejects_MythicPlus_when_both_instance_and_keystone_level_are_missing()
+    {
+        // "Any dungeon, any level" is nonsense — one of them must be specific.
+        var req = Valid() with
+        {
+            Difficulty = "MYTHIC_KEYSTONE",
+            Size = 5,
+            InstanceId = null,
+            InstanceName = null,
+            KeystoneLevel = null,
+        };
+        var result = Sut.Validate(req);
+        Assert.Contains(result.Errors, e => e.ErrorMessage.Contains("keystoneLevel is required when no specific dungeon is selected"));
+    }
+
+    [Fact]
+    public void Rejects_KeystoneLevel_on_non_MythicPlus_run()
+    {
+        var req = Valid() with { KeystoneLevel = 15 };
+        var result = Sut.Validate(req);
+        Assert.Contains(result.Errors, e => e.ErrorMessage.Contains("keystoneLevel is only valid for Mythic+"));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(31)]
+    public void Rejects_KeystoneLevel_out_of_range(int level)
+    {
+        var req = Valid() with
+        {
+            Difficulty = "MYTHIC_KEYSTONE",
+            Size = 5,
+            InstanceId = null,
+            InstanceName = null,
+            KeystoneLevel = level,
+        };
+        var result = Sut.Validate(req);
+        Assert.Contains(result.Errors, e => e.ErrorMessage.Contains("keystoneLevel must be between 2 and 30"));
+    }
+}

--- a/tests/Lfm.Api.Tests/RunsMigrateSchemaFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RunsMigrateSchemaFunctionTests.cs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Lfm.Api.Auth;
+using Lfm.Api.Functions;
+using Lfm.Api.Repositories;
+using Lfm.Api.Services;
+using Xunit;
+
+namespace Lfm.Api.Tests;
+
+public class RunsMigrateSchemaFunctionTests
+{
+    private static FunctionContext MakeFunctionContext(SessionPrincipal principal)
+    {
+        var items = new Dictionary<object, object> { [SessionKeys.Principal] = principal };
+        var ctx = new Mock<FunctionContext>();
+        ctx.Setup(c => c.Items).Returns(items);
+        return ctx.Object;
+    }
+
+    private static SessionPrincipal MakePrincipal(string battleNetId = "admin-1") =>
+        new(
+            BattleNetId: battleNetId,
+            BattleTag: "Admin#0001",
+            GuildId: "42",
+            GuildName: "Test Guild",
+            IssuedAt: DateTimeOffset.UtcNow,
+            ExpiresAt: DateTimeOffset.UtcNow.AddHours(1));
+
+    [Fact]
+    public async Task Returns_200_with_migration_result_for_site_admin()
+    {
+        var siteAdmin = new Mock<ISiteAdminService>();
+        siteAdmin.Setup(s => s.IsAdminAsync("admin-1", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        var runs = new Mock<IRunsRepository>();
+        runs.Setup(r => r.MigrateSchemaAsync(false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunMigrationResult(Scanned: 12, Migrated: 7, DryRun: false));
+
+        var fn = new RunsMigrateSchemaFunction(siteAdmin.Object, runs.Object, NullLogger<RunsMigrateSchemaFunction>.Instance);
+        var result = await fn.Run(new DefaultHttpContext().Request, MakeFunctionContext(MakePrincipal()), CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var body = Assert.IsType<RunMigrationResult>(ok.Value);
+        Assert.Equal(12, body.Scanned);
+        Assert.Equal(7, body.Migrated);
+        Assert.False(body.DryRun);
+    }
+
+    [Fact]
+    public async Task Returns_403_for_non_admin_and_does_not_call_repository()
+    {
+        var siteAdmin = new Mock<ISiteAdminService>();
+        siteAdmin.Setup(s => s.IsAdminAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
+        var runs = new Mock<IRunsRepository>();
+
+        var fn = new RunsMigrateSchemaFunction(siteAdmin.Object, runs.Object, NullLogger<RunsMigrateSchemaFunction>.Instance);
+        var result = await fn.Run(new DefaultHttpContext().Request, MakeFunctionContext(MakePrincipal("raider-1")), CancellationToken.None);
+
+        var forbidden = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(403, forbidden.StatusCode);
+        runs.Verify(r => r.MigrateSchemaAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DryRun_query_flag_propagates_to_repository()
+    {
+        var siteAdmin = new Mock<ISiteAdminService>();
+        siteAdmin.Setup(s => s.IsAdminAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        var runs = new Mock<IRunsRepository>();
+        runs.Setup(r => r.MigrateSchemaAsync(true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunMigrationResult(Scanned: 12, Migrated: 7, DryRun: true));
+
+        var fn = new RunsMigrateSchemaFunction(siteAdmin.Object, runs.Object, NullLogger<RunsMigrateSchemaFunction>.Instance);
+
+        var req = new DefaultHttpContext().Request;
+        req.QueryString = new QueryString("?dryRun=true");
+        var result = await fn.Run(req, MakeFunctionContext(MakePrincipal()), CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var body = Assert.IsType<RunMigrationResult>(ok.Value);
+        Assert.True(body.DryRun);
+        runs.Verify(r => r.MigrateSchemaAsync(true, It.IsAny<CancellationToken>()), Times.Once);
+        runs.Verify(r => r.MigrateSchemaAsync(false, It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -104,7 +104,7 @@ public class RunsPagesTests : ComponentTestBase
             // get, without reaching into the page object's private helpers.
             var formattedDate = DateTimeOffset.Parse(summary.StartTime, System.Globalization.CultureInfo.InvariantCulture)
                 .ToString("yyyy-MM-dd HH:mm", System.Globalization.CultureInfo.InvariantCulture);
-            var expected = Loc("runs.listItemAriaLabel", summary.InstanceName, formattedDate);
+            var expected = Loc("runs.listItemAriaLabel", summary.InstanceName ?? "", formattedDate);
             Assert.Equal(expected, ariaLabel);
         });
     }


### PR DESCRIPTION
## Summary

Promotes the run's mode from a stringly-typed `ModeKey` composite (`"HEROIC:25"`, `"MYTHIC_KEYSTONE:5"`, …) to three typed fields — `Difficulty`, `Size`, `KeystoneLevel` — on `RunDocument` and all four run wire DTOs. Widens `RunDocument.InstanceId` and `InstanceName` to nullable so the upcoming Mythic+ "any dungeon" session can be expressed without a sentinel. Adds an admin-only migration endpoint so existing Cosmos documents pick up the new fields without a redeploy.

`ModeKey` stays on the wire and in storage for this cycle — writers emit both shapes, readers prefer the typed fields and fall back to parsing `ModeKey`. A follow-up cleanup PR can remove `ModeKey` once the migration has run. This PR is designed so nothing breaks if that cleanup never happens.

Client consumers (`DifficultyPill`, run-list, run-detail) still read `ModeKey` in this PR. They switch to the typed fields as part of the page reshape in PR 6, so the two changes land together.

## Schema / env changes

- **`RunDocument`** (Cosmos): nullable `InstanceId` / `InstanceName`; new `Difficulty`, `Size`, `KeystoneLevel` fields; `ModeKey` retained. Legacy documents still deserialise because the new fields have sensible defaults.
- **Wire DTOs** (`CreateRunRequest`, `UpdateRunRequest`, `RunDetailDto`, `RunSummaryDto`): same new fields, same ModeKey retention. `InstanceId` / `InstanceName` become nullable on `RunDetailDto` / `RunSummaryDto`.
- **`CreateRunRequestValidator`** new rules:
  - Either `ModeKey` or (`Difficulty` + `Size`) must be present.
  - `Difficulty` ∈ {`LFR`, `NORMAL`, `HEROIC`, `MYTHIC`, `MYTHIC_KEYSTONE`}; `Size` ∈ [1, 40]; `KeystoneLevel` ∈ [2, 30].
  - `InstanceId` required unless `Difficulty == MYTHIC_KEYSTONE`.
  - `KeystoneLevel` only valid on Mythic+; required when M+ is dungeon-less.
- **New endpoint**: `POST /api/admin/runs/migrate-schema` (site-admin only). Backfills the typed fields from legacy `ModeKey` on every existing run document. Supports `?dryRun=true` for a count-only dry run. Idempotent.
- No Bicep, workflow, CORS, or auth-surface changes.
- **Post-deploy action**: run `POST /api/admin/runs/migrate-schema?dryRun=true` first, verify the count, then run without the flag.

## Test plan

- [x] `dotnet build lfm.sln -c Release` clean.
- [x] `dotnet format lfm.sln --verify-no-changes` clean.
- [x] `Lfm.Api.Tests` — 458 pass (+22 new: `CreateRunRequestValidatorTests` covering every new rule, `RunModeResolverTests` covering the prefer-typed-fall-back-to-ModeKey semantics, `RunsMigrateSchemaFunctionTests` covering admin gate + dry-run propagation).
- [x] `Lfm.App.Tests` — 170 pass.
- [x] `Lfm.App.Core.Tests` — 132 pass.
- [ ] Post-deploy smoke: dry-run the migration, inspect the count; run it, confirm a randomly-picked doc now carries `Difficulty` + `Size`. `GET /api/runs/{id}` should return both the legacy `modeKey` and the new typed fields.
