### PR TITLE
Fix net_http_request_timedout on /admin/reference refresh

### DIFF
--- a/app/Lfm.App.Core/Services/WowReferenceAdminClient.cs
+++ b/app/Lfm.App.Core/Services/WowReferenceAdminClient.cs
@@ -10,7 +10,12 @@ public sealed class WowReferenceAdminClient(IHttpClientFactory factory) : IWowRe
 {
     public async Task<WowReferenceRefreshResponse> RefreshAsync(CancellationToken ct)
     {
-        var http = factory.CreateClient("api");
+        // Use the long-timeout "api-admin" client: a cold-cache Blizzard
+        // refresh takes minutes (one HTTP call per journal-instance and
+        // playable-specialization, rate-limited at ~80 rps). The regular
+        // "api" client's 10 s ceiling is fine for the GET endpoints but
+        // would kill this POST mid-sync.
+        var http = factory.CreateClient("api-admin");
         var response = await http.PostAsync("api/wow/reference/refresh", content: null, ct);
         response.EnsureSuccessStatusCode();
         var body = await response.Content.ReadFromJsonAsync<WowReferenceRefreshResponse>(cancellationToken: ct);

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -36,6 +36,18 @@ builder.Services.AddHttpClient("api", client =>
     client.Timeout = TimeSpan.FromSeconds(10);
 }).AddHttpMessageHandler<CredentialsHandler>();
 
+// Long-running admin operations. POST /api/wow/reference/refresh iterates
+// every Blizzard journal-instance + playable-specialization + journal-expansion
+// sequentially with ~80 rps rate-limiting — a cold-cache run takes minutes,
+// well past the 10 s default the regular "api" client uses. Shares the same
+// credentials handler; just relaxes the per-request ceiling.
+builder.Services.AddHttpClient("api-admin", client =>
+{
+    client.BaseAddress = new Uri(apiBaseUrl);
+    client.DefaultRequestHeaders.Add("Accept", "application/json");
+    client.Timeout = TimeSpan.FromMinutes(5);
+}).AddHttpMessageHandler<CredentialsHandler>();
+
 builder.Services.AddScoped<IInstancesClient, InstancesClient>();
 builder.Services.AddScoped<IExpansionsClient, ExpansionsClient>();
 builder.Services.AddScoped<IWowReferenceAdminClient, WowReferenceAdminClient>();


### PR DESCRIPTION
## Summary

Clicking **Refresh now** on `/admin/reference` (PR #105) failed with `net_http_request_timedout, 10` because the shared `"api"` HttpClient in [app/Program.cs:36](app/Program.cs#L36) has `Timeout = 10s`. A cold-cache `POST /api/wow/reference/refresh` iterates every Blizzard `journal-instance` + `playable-specialization` + `journal-expansion` sequentially with ~80 rps rate-limiting, which takes 1–2 minutes, not 10 seconds.

Registers a second named HttpClient `"api-admin"` with `Timeout = 5 minutes` (and the same `CredentialsHandler` as `"api"`), and routes `WowReferenceAdminClient` through it. Every other consumer of `"api"` keeps the fast 10 s ceiling unchanged.

## Schema / env changes

- **No server changes.** The Functions-side refresh is untouched — it was finishing fine; only the browser was hanging up early.
- **Client-side:** one new named HttpClient registration in `app/Program.cs`. Default timeout of the normal `"api"` client is untouched.
- **No auth / Bicep / workflow / locale changes.**

## Test plan

- [x] `dotnet build lfm.sln -c Release` clean.
- [x] `dotnet format lfm.sln --verify-no-changes` clean.
- [x] `Lfm.App.Tests.AdminReferenceRefreshPageTests` — 5/5 pass (unchanged; the tests mock `IWowReferenceAdminClient` directly, so the HttpClient timeout is transparent to them).
- [ ] Post-deploy: sign in as site admin → `/admin/reference` → Refresh now → confirm the result table renders after ~1–2 min rather than a 10 s timeout.
