### PR TITLE
Reshape CreateRunPage and EditRunPage around the raid leader's task flow

### DIFF
--- a/app/Pages/CreateRunPage.razor
+++ b/app/Pages/CreateRunPage.razor
@@ -49,12 +49,12 @@
 
                 @* ── Activity (Raid / Dungeon) ──────────────────────────── *@
                 <div>
-                    <label for="activity-toggle" class="field__label">@Loc["createRun.activity"]</label>
+                    <span id="createRun-activity-label" class="field__label">@Loc["createRun.activity"]</span>
                     <ToggleGroup TValue="ActivityKind"
                                  Options="_activityOptions"
                                  Value="_activity"
                                  ValueChanged="OnActivityChanged"
-                                 AriaLabel="@Loc["createRun.activity"]"
+                                 AriaLabelledBy="createRun-activity-label"
                                  Disabled="@_submitting" />
                 </div>
 
@@ -62,12 +62,12 @@
                 @if (_activity == ActivityKind.Dungeon && _difficulty == "MYTHIC_KEYSTONE")
                 {
                     <div>
-                        <label for="dungeonScope-toggle" class="field__label">@Loc["createRun.dungeonScope"]</label>
+                        <span id="createRun-dungeonScope-label" class="field__label">@Loc["createRun.dungeonScope"]</span>
                         <ToggleGroup TValue="bool"
                                      Options="_dungeonScopeOptions"
                                      Value="_anyDungeon"
                                      ValueChanged="OnDungeonScopeChanged"
-                                     AriaLabel="@Loc["createRun.dungeonScope"]"
+                                     AriaLabelledBy="createRun-dungeonScope-label"
                                      Disabled="@_submitting" />
                     </div>
                 }
@@ -93,12 +93,12 @@
                 @if (ShowDifficultyToggle && _difficultyOptions.Count > 1)
                 {
                     <div>
-                        <label for="difficulty-toggle" class="field__label">@Loc["createRun.difficulty"]</label>
+                        <span id="createRun-difficulty-label" class="field__label">@Loc["createRun.difficulty"]</span>
                         <ToggleGroup TValue="string"
                                      Options="_difficultyOptions"
                                      Value="_difficulty"
                                      ValueChanged="OnDifficultyChanged"
-                                     AriaLabel="@Loc["createRun.difficulty"]"
+                                     AriaLabelledBy="createRun-difficulty-label"
                                      Disabled="@_submitting" />
                     </div>
                 }
@@ -170,12 +170,12 @@
                 @if (_canShowGuildOption)
                 {
                     <div>
-                        <label for="visibility-toggle" class="field__label">@Loc["createRun.visibility"]</label>
+                        <span id="createRun-visibility-label" class="field__label">@Loc["createRun.visibility"]</span>
                         <ToggleGroup TValue="string"
                                      Options="_visibilityOptions"
                                      Value="_visibility"
                                      ValueChanged="@(v => _visibility = v)"
-                                     AriaLabel="@Loc["createRun.visibility"]"
+                                     AriaLabelledBy="createRun-visibility-label"
                                      Disabled="@_submitting" />
                         @if (!_canCreateGuildRuns)
                         {

--- a/app/Pages/CreateRunPage.razor
+++ b/app/Pages/CreateRunPage.razor
@@ -1,25 +1,31 @@
 @page "/runs/new"
 @attribute [Authorize]
+@using Lfm.App.Components
+@using Lfm.App.Runs
 @using Lfm.App.Services
+@using Lfm.Contracts.Expansions
+@using Lfm.Contracts.Guild
 @using Lfm.Contracts.Instances
 @using Lfm.Contracts.Runs
+@using RunError = Lfm.App.Runs.RunError
 @inject IInstancesClient InstancesClient
+@inject IExpansionsClient ExpansionsClient
+@inject IGuildClient GuildClient
 @inject IRunsClient RunsClient
 @inject NavigationManager Nav
-@inject ToastHelper Toast
 @inject IStringLocalizer Loc
 
 <PageTitle>@Loc["createRun.title"]</PageTitle>
 
-<FluentStack Orientation="Orientation.Vertical" VerticalGap="16" Style="max-width:600px">
+<FluentStack Orientation="Orientation.Vertical" VerticalGap="16" Style="max-inline-size:640px">
     <FluentLabel Typo="Typography.H1">@Loc["createRun.title"]</FluentLabel>
 
-    @if (loadError != null)
+    @if (_loadError is not null)
     {
-        <FluentMessageBar Intent="MessageIntent.Error">@loadError</FluentMessageBar>
+        <FluentMessageBar Intent="MessageIntent.Error">@_loadError</FluentMessageBar>
     }
 
-    @if (loading)
+    @if (_loading)
     {
         <FluentProgressRing />
     }
@@ -27,80 +33,198 @@
     {
         <FluentCard>
             <FluentStack Orientation="Orientation.Vertical" VerticalGap="12">
-                <FluentSelect
-                    Id="instance-select"
-                    Label="@Loc["createRun.instance"]"
-                    TOption="string"
-                    Value="@instanceId"
-                    ValueChanged="@OnInstanceChanged"
-                    Disabled="@submitting">
-                    <FluentOption Value="">@Loc["createRun.selectInstance"]</FluentOption>
-                    @foreach (var inst in instances)
+
+                @* ── Expansion selector ─────────────────────────────────── *@
+                <FluentSelect Id="expansion-select"
+                              Label="@Loc["createRun.expansion"]"
+                              TOption="string"
+                              Value="@_expansionId.ToString()"
+                              ValueChanged="@OnExpansionChanged"
+                              Disabled="@_submitting">
+                    @foreach (var exp in _expansions)
                     {
-                        <FluentOption Value="@inst.Id">@inst.Name (@inst.ModeKey)</FluentOption>
+                        <FluentOption Value="@exp.Id.ToString()">@exp.Name</FluentOption>
                     }
                 </FluentSelect>
 
-                <FluentTextField
-                    Id="modekey-input"
-                    Label="@Loc["createRun.modeKey"]"
-                    Value="@modeKey"
-                    ValueChanged="@(v => modeKey = v)"
-                    Disabled="@submitting"
-                    Placeholder="@Loc["createRun.modeKeyPlaceholder"]"
-                    @attributes="ModeKeyAttrs" />
+                @* ── Activity (Raid / Dungeon) ──────────────────────────── *@
+                <div>
+                    <label for="activity-toggle" class="field__label">@Loc["createRun.activity"]</label>
+                    <ToggleGroup TValue="ActivityKind"
+                                 Options="_activityOptions"
+                                 Value="_activity"
+                                 ValueChanged="OnActivityChanged"
+                                 AriaLabel="@Loc["createRun.activity"]"
+                                 Disabled="@_submitting" />
+                </div>
 
+                @* ── Dungeon sub-toggle (M+ only) ───────────────────────── *@
+                @if (_activity == ActivityKind.Dungeon && _difficulty == "MYTHIC_KEYSTONE")
+                {
+                    <div>
+                        <label for="dungeonScope-toggle" class="field__label">@Loc["createRun.dungeonScope"]</label>
+                        <ToggleGroup TValue="bool"
+                                     Options="_dungeonScopeOptions"
+                                     Value="_anyDungeon"
+                                     ValueChanged="OnDungeonScopeChanged"
+                                     AriaLabel="@Loc["createRun.dungeonScope"]"
+                                     Disabled="@_submitting" />
+                    </div>
+                }
+
+                @* ── Instance dropdown (hidden when M+ + any-dungeon) ───── *@
+                @if (ShowInstanceDropdown)
+                {
+                    <FluentSelect Id="instance-select"
+                                  Label="@Loc["createRun.instance"]"
+                                  TOption="string"
+                                  Value="@_instanceId.ToString()"
+                                  ValueChanged="@OnInstanceChanged"
+                                  Disabled="@_submitting">
+                        <FluentOption Value="0">@Loc["createRun.selectInstance"]</FluentOption>
+                        @foreach (var opt in FilteredInstances)
+                        {
+                            <FluentOption Value="@opt.InstanceId.ToString()">@opt.Name</FluentOption>
+                        }
+                    </FluentSelect>
+                }
+
+                @* ── Difficulty toggle (only when a specific instance is selected) ── *@
+                @if (ShowDifficultyToggle && _difficultyOptions.Count > 1)
+                {
+                    <div>
+                        <label for="difficulty-toggle" class="field__label">@Loc["createRun.difficulty"]</label>
+                        <ToggleGroup TValue="string"
+                                     Options="_difficultyOptions"
+                                     Value="_difficulty"
+                                     ValueChanged="OnDifficultyChanged"
+                                     AriaLabel="@Loc["createRun.difficulty"]"
+                                     Disabled="@_submitting" />
+                    </div>
+                }
+
+                @* ── Key level + WNL chip (M+ only) ─────────────────────── *@
+                @if (_difficulty == "MYTHIC_KEYSTONE")
+                {
+                    <div>
+                        <label for="keylevel-input" class="field__label">@Loc["createRun.keyLevel"]</label>
+                        <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="8" Wrap="true">
+                            <input id="keylevel-input"
+                                   type="number"
+                                   class="field__input"
+                                   min="2"
+                                   max="30"
+                                   inputmode="numeric"
+                                   placeholder="@Loc["createRun.keyLevel.placeholder"]"
+                                   @bind="_keystoneLevel"
+                                   @bind:event="oninput"
+                                   disabled="@_submitting"
+                                   style="inline-size:7rem" />
+                            <FluentButton Appearance="Appearance.Outline"
+                                          OnClick="@(() => _keystoneLevel = 10)"
+                                          Disabled="@_submitting"
+                                          Title="@Loc["createRun.keyLevel.wnlDescription"]"
+                                          aria-label="@Loc["createRun.keyLevel.wnlDescription"]">
+                                @Loc["createRun.keyLevel.wnl"]
+                            </FluentButton>
+                        </FluentStack>
+                        <small class="field__hint">
+                            @(_anyDungeon ? Loc["createRun.keyLevel.hintAny"] : Loc["createRun.keyLevel.hintSpecific"])
+                        </small>
+                    </div>
+                }
+
+                @* ── Start time ─────────────────────────────────────────── *@
                 <label class="field">
                     <span class="field__label">@Loc["createRun.startTime"]</span>
                     <input type="datetime-local"
                            id="starttime-input"
                            class="field__input"
-                           @bind="startTimeLocal"
-                           disabled="@submitting"
+                           @bind="_startTimeLocal"
+                           disabled="@_submitting"
                            required />
                 </label>
 
-                <label class="field">
-                    <span class="field__label">@Loc["createRun.signupCloseTime"]</span>
-                    <input type="datetime-local"
-                           id="signupclose-input"
-                           class="field__input"
-                           @bind="signupCloseLocal"
-                           disabled="@submitting" />
-                </label>
-
-                <FluentSelect
-                    Id="visibility-select"
-                    Label="@Loc["createRun.visibility"]"
-                    TOption="string"
-                    Value="@visibility"
-                    ValueChanged="@(v => visibility = v)"
-                    Disabled="@submitting">
-                    <FluentOption Value="PUBLIC">@Loc["createRun.public"]</FluentOption>
-                    <FluentOption Value="GUILD">@Loc["createRun.guildOnly"]</FluentOption>
-                </FluentSelect>
-
-                <FluentTextArea
-                    Id="description-input"
-                    Label="@Loc["createRun.description"]"
-                    Value="@description"
-                    ValueChanged="@(v => description = v)"
-                    Disabled="@submitting"
-                    Rows="5"
-                    Resize="TextAreaResize.Vertical"
-                    @attributes="DescriptionAttrs" />
-
-                <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="8" Wrap="true">
-                    <FluentButton
-                        Appearance="Appearance.Accent"
-                        OnClick="@HandleSubmit"
-                        Disabled="@(submitting || string.IsNullOrWhiteSpace(instanceId) || startTimeLocal is null || string.IsNullOrWhiteSpace(modeKey))">
-                        @(submitting ? Loc["common.loading"] : Loc["createRun.submit"])
+                @* ── Signups close (collapsible) ────────────────────────── *@
+                @if (_showSignupClose)
+                {
+                    <label class="field">
+                        <span class="field__label">@Loc["createRun.signupCloseTime"]</span>
+                        <input type="datetime-local"
+                               id="signupclose-input"
+                               class="field__input"
+                               @bind="_signupCloseLocal"
+                               disabled="@_submitting" />
+                    </label>
+                }
+                else
+                {
+                    <FluentButton Appearance="Appearance.Stealth"
+                                  OnClick="@(() => _showSignupClose = true)"
+                                  Disabled="@_submitting">
+                        @Loc["createRun.addSignupDeadline"]
                     </FluentButton>
-                    <FluentButton
-                        Appearance="Appearance.Outline"
-                        OnClick="@(() => Nav.NavigateTo("/runs"))"
-                        Disabled="@submitting">
+                }
+
+                @* ── Visibility ─────────────────────────────────────────── *@
+                @if (_canShowGuildOption)
+                {
+                    <div>
+                        <label for="visibility-toggle" class="field__label">@Loc["createRun.visibility"]</label>
+                        <ToggleGroup TValue="string"
+                                     Options="_visibilityOptions"
+                                     Value="_visibility"
+                                     ValueChanged="@(v => _visibility = v)"
+                                     AriaLabel="@Loc["createRun.visibility"]"
+                                     Disabled="@_submitting" />
+                        @if (!_canCreateGuildRuns)
+                        {
+                            <small class="field__hint">@Loc["createRun.visibility.guildDisabledReason"]</small>
+                        }
+                    </div>
+                }
+                else
+                {
+                    <div>
+                        <span class="field__label">@Loc["createRun.visibility"]</span>
+                        <small class="field__hint">@Loc["createRun.visibility.visibleToEveryone"]</small>
+                    </div>
+                }
+
+                @* ── Notes ──────────────────────────────────────────────── *@
+                <div>
+                    <FluentTextArea Id="description-input"
+                                    Label="@Loc["createRun.description"]"
+                                    Value="@_description"
+                                    ValueChanged="@(v => _description = v ?? string.Empty)"
+                                    Disabled="@_submitting"
+                                    Rows="5"
+                                    Resize="TextAreaResize.Vertical"
+                                    @attributes="DescriptionAttrs" />
+                    <small class="field__hint">@(Loc["createRun.description.charCount", _description.Length])</small>
+                </div>
+
+                @* ── Error surfacing ────────────────────────────────────── *@
+                @if (_inlineError is not null)
+                {
+                    <FluentMessageBar Intent="MessageIntent.Error">
+                        @foreach (var m in _inlineError.Messages)
+                        {
+                            <div>@m</div>
+                        }
+                    </FluentMessageBar>
+                }
+
+                @* ── Submit / Cancel ────────────────────────────────────── *@
+                <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="8" Wrap="true">
+                    <FluentButton Appearance="Appearance.Accent"
+                                  OnClick="@HandleSubmit"
+                                  Disabled="@(!CanSubmit || _submitting)">
+                        @(_submitting ? Loc["createRun.creating"] : Loc["createRun.submit"])
+                    </FluentButton>
+                    <FluentButton Appearance="Appearance.Outline"
+                                  OnClick="@(() => Nav.NavigateTo("/runs"))"
+                                  Disabled="@_submitting">
                         @Loc["createRun.cancel"]
                     </FluentButton>
                 </FluentStack>
@@ -110,32 +234,63 @@
 </FluentStack>
 
 @code {
-    private IReadOnlyList<InstanceDto> instances = [];
-    private bool loading = true;
-    private bool submitting;
-    private string? loadError;
+    // ── Loaded data ────────────────────────────────────────────────────────
+    private IReadOnlyList<ExpansionDto> _expansions = [];
+    private IReadOnlyList<InstanceOption> _allInstances = [];
+    private GuildDto? _guild;
 
-    private string instanceId = string.Empty;
-    private string modeKey = string.Empty;
-    private DateTime? startTimeLocal;
-    private DateTime? signupCloseLocal;
-    private string visibility = "PUBLIC";
-    private string description = string.Empty;
+    // ── Form state ─────────────────────────────────────────────────────────
+    private int _expansionId;
+    private ActivityKind _activity = ActivityKind.Dungeon;
+    private int _instanceId;                // 0 = unselected
+    private string _difficulty = "MYTHIC_KEYSTONE";
+    private int _size = 5;
+    private int? _keystoneLevel;
+    private bool _anyDungeon = true;        // M+ "Any dungeon" sub-toggle
+    private DateTime? _startTimeLocal;
+    private DateTime? _signupCloseLocal;
+    private bool _showSignupClose;
+    private string _visibility = "PUBLIC";
+    private string _description = string.Empty;
 
-    // The native <input type="datetime-local"> binds wall-clock time with no
-    // offset, so we must convert back to UTC before sending — otherwise the
-    // stored value would differ from the user's intent by the browser's TZ
-    // offset and round-trips through EditRunPage would drift on every save.
-    // Use "o" so the stored string matches what EditRunPage emits on re-save.
-    private static string? ToIsoOrNull(DateTime? dt) =>
-        dt is null ? null : dt.Value.ToUniversalTime().ToString("o");
+    // ── Page state ─────────────────────────────────────────────────────────
+    private bool _loading = true;
+    private bool _submitting;
+    private string? _loadError;
+    private RunError? _inlineError;
 
-    private static readonly Dictionary<string, object> ModeKeyAttrs = new()
+    // ── Options for the ToggleGroups ───────────────────────────────────────
+    private IReadOnlyList<(ActivityKind, string)> _activityOptions = [];
+    private IReadOnlyList<(bool, string)> _dungeonScopeOptions = [];
+    private IReadOnlyList<(string, string)> _difficultyOptions = [];
+    private IReadOnlyList<(string, string)> _visibilityOptions = [];
+
+    // ── Derived ────────────────────────────────────────────────────────────
+    private bool _canCreateGuildRuns;
+    private bool _canShowGuildOption => _guild?.Guild is not null;
+
+    private IEnumerable<InstanceOption> FilteredInstances =>
+        _allInstances.Where(o =>
+            (o.ExpansionId is null || o.ExpansionId == _expansionId) &&
+            o.Activity == _activity);
+
+    private bool ShowInstanceDropdown =>
+        !(_activity == ActivityKind.Dungeon && _difficulty == "MYTHIC_KEYSTONE" && _anyDungeon);
+
+    private bool ShowDifficultyToggle => _instanceId != 0 || !ShowInstanceDropdown;
+
+    private bool CanSubmit
     {
-        ["autocomplete"] = "off",
-        ["autocapitalize"] = "characters",
-        ["spellcheck"] = (bool?)false,
-    };
+        get
+        {
+            if (_startTimeLocal is null) return false;
+            var isMythicPlus = _activity == ActivityKind.Dungeon && _difficulty == "MYTHIC_KEYSTONE";
+            if (isMythicPlus && _anyDungeon)
+                return _keystoneLevel is >= 2 and <= 30;
+            if (_instanceId == 0) return false;
+            return !isMythicPlus || _keystoneLevel is null || _keystoneLevel is >= 2 and <= 30;
+        }
+    }
 
     private static readonly Dictionary<string, object> DescriptionAttrs = new()
     {
@@ -143,61 +298,189 @@
         ["maxlength"] = (int?)2000,
     };
 
+    // ── Lifecycle ──────────────────────────────────────────────────────────
     protected override async Task OnInitializedAsync()
     {
         try
         {
-            instances = await InstancesClient.ListAsync(CancellationToken.None);
+            var expansionsTask = ExpansionsClient.ListAsync(CancellationToken.None);
+            var instancesTask = InstancesClient.ListAsync(CancellationToken.None);
+            var guildTask = GuildClient.GetAsync(CancellationToken.None);
+            await Task.WhenAll(expansionsTask, instancesTask, guildTask);
+
+            _expansions = await expansionsTask;
+            _allInstances = InstanceOptions.Build(await instancesTask);
+
+            // A guild fetch failure must not block the form — fall back to
+            // PUBLIC-only visibility rather than an unusable screen.
+            try { _guild = await guildTask; }
+            catch { _guild = null; }
+
+            // Default to the newest (= last in Blizzard's canonical order) expansion.
+            if (_expansions.Count > 0) _expansionId = _expansions[^1].Id;
+
+            RebuildStaticOptions();
+            RefreshDifficultyOptions();
+            ApplyVisibilityDefault();
+
+            // Start-time defaults to next Thursday at 20:00 local wall-clock.
+            _startTimeLocal = RunTimeDefaults.NextThursday20(DateTime.Now);
         }
         catch (Exception ex)
         {
-            loadError = $"Failed to load instances: {ex.Message}";
+            _loadError = $"Failed to load form data: {ex.Message}";
         }
         finally
         {
-            loading = false;
+            _loading = false;
         }
     }
 
-    // Auto-fill modeKey from the selected instance. Each InstanceDto row carries
-    // one (instance, mode) pair, so picking a dropdown option fully determines
-    // the ModeKey — the text field below the dropdown is just a read/override
-    // affordance until the form is reshaped in a follow-up.
-    private void OnInstanceChanged(string value)
+    // ── Event handlers ─────────────────────────────────────────────────────
+    private void OnExpansionChanged(string value)
     {
-        instanceId = value;
-        modeKey = instances.FirstOrDefault(i => i.Id == value)?.ModeKey ?? string.Empty;
+        if (int.TryParse(value, out var id))
+        {
+            _expansionId = id;
+            _instanceId = 0;
+            _difficulty = _activity == ActivityKind.Dungeon ? "MYTHIC_KEYSTONE" : "";
+            _size = _activity == ActivityKind.Dungeon ? 5 : 0;
+            _keystoneLevel = null;
+            RefreshDifficultyOptions();
+        }
     }
 
+    private void OnActivityChanged(ActivityKind value)
+    {
+        _activity = value;
+        _instanceId = 0;
+        _anyDungeon = value == ActivityKind.Dungeon;
+        _difficulty = value == ActivityKind.Dungeon ? "MYTHIC_KEYSTONE" : "";
+        _size = value == ActivityKind.Dungeon ? 5 : 0;
+        _keystoneLevel = null;
+        RefreshDifficultyOptions();
+    }
+
+    private void OnDungeonScopeChanged(bool anyDungeon)
+    {
+        _anyDungeon = anyDungeon;
+        if (anyDungeon) _instanceId = 0;
+        RefreshDifficultyOptions();
+    }
+
+    private void OnInstanceChanged(string value)
+    {
+        if (!int.TryParse(value, out var id)) return;
+        _instanceId = id;
+        RefreshDifficultyOptions();
+        // Default to the highest-available difficulty of this instance.
+        if (_difficultyOptions.Count > 0 && !_difficultyOptions.Any(o => o.Item1 == _difficulty))
+        {
+            var topMode = FilteredInstances
+                .FirstOrDefault(o => o.InstanceId == id)?
+                .Difficulties.LastOrDefault();
+            if (topMode is not null)
+            {
+                _difficulty = topMode.DifficultyId;
+                _size = topMode.Size;
+            }
+        }
+    }
+
+    private void OnDifficultyChanged(string value)
+    {
+        _difficulty = value;
+        var match = FilteredInstances
+            .FirstOrDefault(o => o.InstanceId == _instanceId)?
+            .Difficulties.FirstOrDefault(d => d.DifficultyId == value);
+        _size = match?.Size ?? 0;
+        if (value != "MYTHIC_KEYSTONE") _keystoneLevel = null;
+    }
+
+    // ── Option builders ────────────────────────────────────────────────────
+    private void RebuildStaticOptions()
+    {
+        _activityOptions = new (ActivityKind, string)[]
+        {
+            (ActivityKind.Raid, Loc["createRun.activity.raid"].Value),
+            (ActivityKind.Dungeon, Loc["createRun.activity.dungeon"].Value),
+        };
+        _dungeonScopeOptions = new (bool, string)[]
+        {
+            (true, Loc["createRun.dungeonScope.any"].Value),
+            (false, Loc["createRun.dungeonScope.specific"].Value),
+        };
+        _visibilityOptions = new (string, string)[]
+        {
+            ("GUILD", Loc["createRun.guildOnly"].Value),
+            ("PUBLIC", Loc["createRun.public"].Value),
+        };
+    }
+
+    private void RefreshDifficultyOptions()
+    {
+        var match = FilteredInstances.FirstOrDefault(o => o.InstanceId == _instanceId);
+        _difficultyOptions = match is null
+            ? []
+            : match.Difficulties
+                .Select(d => (d.DifficultyId, d.DisplayName))
+                .ToList();
+    }
+
+    private void ApplyVisibilityDefault()
+    {
+        _canCreateGuildRuns = _guild?.MemberPermissions?.CanCreateGuildRuns ?? false;
+        if (_canShowGuildOption && _canCreateGuildRuns)
+            _visibility = "GUILD";
+        else
+            _visibility = "PUBLIC";
+    }
+
+    // The native <input type="datetime-local"> binds wall-clock time with no
+    // offset, so we must convert back to UTC before sending — otherwise the
+    // stored value would differ from the user's intent by the browser's TZ
+    // offset and round-trips through EditRunPage would drift on every save.
+    private static string? ToIsoOrNull(DateTime? dt) =>
+        dt is null ? null : dt.Value.ToUniversalTime().ToString("o");
+
+    // ── Submit ─────────────────────────────────────────────────────────────
     private async Task HandleSubmit()
     {
-        submitting = true;
-        var selectedInstance = instances.FirstOrDefault(i => i.Id == instanceId);
+        _submitting = true;
+        _inlineError = null;
+        var isMythicPlus = _activity == ActivityKind.Dungeon && _difficulty == "MYTHIC_KEYSTONE";
+        var instanceOption = isMythicPlus && _anyDungeon
+            ? null
+            : FilteredInstances.FirstOrDefault(o => o.InstanceId == _instanceId);
+
         try
         {
             var request = new CreateRunRequest(
-                StartTime: ToIsoOrNull(startTimeLocal) ?? string.Empty,
-                SignupCloseTime: ToIsoOrNull(signupCloseLocal),
-                Description: string.IsNullOrWhiteSpace(description) ? null : description,
-                ModeKey: modeKey,
-                Visibility: visibility,
-                InstanceId: selectedInstance?.InstanceNumericId,
-                InstanceName: selectedInstance?.Name);
+                StartTime: ToIsoOrNull(_startTimeLocal) ?? string.Empty,
+                SignupCloseTime: ToIsoOrNull(_signupCloseLocal),
+                Description: string.IsNullOrWhiteSpace(_description) ? null : _description,
+                ModeKey: null,
+                Visibility: _visibility,
+                InstanceId: instanceOption?.InstanceId,
+                InstanceName: instanceOption?.Name,
+                Difficulty: _difficulty,
+                Size: _size,
+                KeystoneLevel: isMythicPlus ? _keystoneLevel : null);
 
             var created = await RunsClient.CreateAsync(request, CancellationToken.None);
             if (created is null)
             {
-                Toast.ShowError(Loc["createRun.failed"]);
-                submitting = false;
+                _inlineError = new RunError(RunErrorKind.Unknown, [Loc["createRun.failed"].Value]);
+                _submitting = false;
                 return;
             }
 
             Nav.NavigateTo($"/runs/{Uri.EscapeDataString(created.Id)}");
         }
-        catch
+        catch (Exception ex)
         {
-            Toast.ShowError(Loc["createRun.failed"]);
-            submitting = false;
+            _inlineError = RunErrorParser.Network(ex);
+            _submitting = false;
         }
     }
 }

--- a/app/Pages/EditRunPage.razor
+++ b/app/Pages/EditRunPage.razor
@@ -1,10 +1,17 @@
 @page "/runs/{RunId}/edit"
+@using Lfm.App.Components
+@using Lfm.App.Runs
 @using Lfm.App.Services
+@using Lfm.Contracts.Expansions
+@using Lfm.Contracts.Guild
 @using Lfm.Contracts.Instances
 @using Lfm.Contracts.Runs
+@using RunError = Lfm.App.Runs.RunError
 @attribute [Authorize]
 @implements IAsyncDisposable
 @inject IInstancesClient InstancesClient
+@inject IExpansionsClient ExpansionsClient
+@inject IGuildClient GuildClient
 @inject IRunsClient RunsClient
 @inject NavigationManager Nav
 @inject ToastHelper Toast
@@ -13,10 +20,10 @@
 
 <PageTitle>@Loc["editRun.title"]</PageTitle>
 
-<FluentStack Orientation="Orientation.Vertical" VerticalGap="16" Style="max-width:800px">
+<FluentStack Orientation="Orientation.Vertical" VerticalGap="16" Style="max-inline-size:800px">
     <FluentLabel Typo="Typography.H1">@Loc["editRun.title"]</FluentLabel>
 
-    @switch (state)
+    @switch (_state)
     {
         case LoadingState<RunDetailDto>.Idle:
         case LoadingState<RunDetailDto>.Loading:
@@ -31,100 +38,198 @@
             break;
 
         case LoadingState<RunDetailDto>.Success s:
-            <!-- Edit form -->
             <FluentCard>
                 <FluentStack Orientation="Orientation.Vertical" VerticalGap="12">
                     <FluentLabel Typo="Typography.H4">@Loc["editRun.runDetails"]</FluentLabel>
 
-                    <FluentSelect
-                        Id="instance-select"
-                        Label="@Loc["createRun.instance"]"
-                        TOption="string"
-                        Value="@instanceId"
-                        ValueChanged="@(v => instanceId = v)"
-                        Disabled="@(saving || hasSignups)">
-                        <FluentOption Value="">@Loc["createRun.selectInstance"]</FluentOption>
-                        @foreach (var inst in instances)
+                    @* Expansion selector — locked once the run has signups so the
+                       instance list stays stable on the row the run is pinned to. *@
+                    <FluentSelect Id="expansion-select"
+                                  Label="@Loc["createRun.expansion"]"
+                                  TOption="string"
+                                  Value="@_expansionId.ToString()"
+                                  ValueChanged="@OnExpansionChanged"
+                                  Disabled="@(_saving || _hasSignups)">
+                        @foreach (var exp in _expansions)
                         {
-                            <FluentOption Value="@inst.Id">@inst.Name (@inst.ModeKey)</FluentOption>
+                            <FluentOption Value="@exp.Id.ToString()">@exp.Name</FluentOption>
                         }
                     </FluentSelect>
 
-                    <FluentTextField
-                        Id="modekey-input"
-                        Label="@Loc["createRun.modeKey"]"
-                        Value="@modeKey"
-                        ValueChanged="@(v => modeKey = v)"
-                        Disabled="@saving"
-                        @attributes="ModeKeyAttrs" />
+                    <div>
+                        <label for="activity-toggle" class="field__label">@Loc["createRun.activity"]</label>
+                        <ToggleGroup TValue="ActivityKind"
+                                     Options="_activityOptions"
+                                     Value="_activity"
+                                     ValueChanged="OnActivityChanged"
+                                     AriaLabel="@Loc["createRun.activity"]"
+                                     Disabled="@(_saving || _hasSignups)" />
+                    </div>
+
+                    @if (_activity == ActivityKind.Dungeon && _difficulty == "MYTHIC_KEYSTONE")
+                    {
+                        <div>
+                            <label for="dungeonScope-toggle" class="field__label">@Loc["createRun.dungeonScope"]</label>
+                            <ToggleGroup TValue="bool"
+                                         Options="_dungeonScopeOptions"
+                                         Value="_anyDungeon"
+                                         ValueChanged="OnDungeonScopeChanged"
+                                         AriaLabel="@Loc["createRun.dungeonScope"]"
+                                         Disabled="@(_saving || _hasSignups)" />
+                        </div>
+                    }
+
+                    @if (ShowInstanceDropdown)
+                    {
+                        <FluentSelect Id="instance-select"
+                                      Label="@Loc["createRun.instance"]"
+                                      TOption="string"
+                                      Value="@_instanceId.ToString()"
+                                      ValueChanged="@OnInstanceChanged"
+                                      Disabled="@(_saving || _hasSignups)">
+                            <FluentOption Value="0">@Loc["createRun.selectInstance"]</FluentOption>
+                            @foreach (var opt in FilteredInstances)
+                            {
+                                <FluentOption Value="@opt.InstanceId.ToString()">@opt.Name</FluentOption>
+                            }
+                        </FluentSelect>
+                    }
+
+                    @if (ShowDifficultyToggle && _difficultyOptions.Count > 1)
+                    {
+                        <div>
+                            <label for="difficulty-toggle" class="field__label">@Loc["createRun.difficulty"]</label>
+                            <ToggleGroup TValue="string"
+                                         Options="_difficultyOptions"
+                                         Value="_difficulty"
+                                         ValueChanged="OnDifficultyChanged"
+                                         AriaLabel="@Loc["createRun.difficulty"]"
+                                         Disabled="@(_saving || _hasSignups)" />
+                        </div>
+                    }
+
+                    @if (_difficulty == "MYTHIC_KEYSTONE")
+                    {
+                        <div>
+                            <label for="keylevel-input" class="field__label">@Loc["createRun.keyLevel"]</label>
+                            <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="8" Wrap="true">
+                                <input id="keylevel-input"
+                                       type="number"
+                                       class="field__input"
+                                       min="2"
+                                       max="30"
+                                       inputmode="numeric"
+                                       placeholder="@Loc["createRun.keyLevel.placeholder"]"
+                                       @bind="_keystoneLevel"
+                                       @bind:event="oninput"
+                                       disabled="@_saving"
+                                       style="inline-size:7rem" />
+                                <FluentButton Appearance="Appearance.Outline"
+                                              OnClick="@(() => _keystoneLevel = 10)"
+                                              Disabled="@_saving"
+                                              Title="@Loc["createRun.keyLevel.wnlDescription"]"
+                                              aria-label="@Loc["createRun.keyLevel.wnlDescription"]">
+                                    @Loc["createRun.keyLevel.wnl"]
+                                </FluentButton>
+                            </FluentStack>
+                            <small class="field__hint">
+                                @(_anyDungeon ? Loc["createRun.keyLevel.hintAny"] : Loc["createRun.keyLevel.hintSpecific"])
+                            </small>
+                        </div>
+                    }
 
                     <label class="field">
                         <span class="field__label">@Loc["createRun.startTime"]</span>
                         <input type="datetime-local"
                                id="starttime-input"
                                class="field__input"
-                               @bind="startTimeLocal"
-                               disabled="@(saving || hasSignups)"
+                               @bind="_startTimeLocal"
+                               disabled="@(_saving || _hasSignups)"
                                required />
                     </label>
 
-                    <label class="field">
-                        <span class="field__label">@Loc["createRun.signupCloseTime"]</span>
-                        <input type="datetime-local"
-                               id="signupclose-input"
-                               class="field__input"
-                               @bind="signupCloseLocal"
-                               disabled="@saving" />
-                    </label>
+                    @if (_showSignupClose)
+                    {
+                        <label class="field">
+                            <span class="field__label">@Loc["createRun.signupCloseTime"]</span>
+                            <input type="datetime-local"
+                                   id="signupclose-input"
+                                   class="field__input"
+                                   @bind="_signupCloseLocal"
+                                   disabled="@_saving" />
+                        </label>
+                    }
+                    else
+                    {
+                        <FluentButton Appearance="Appearance.Stealth"
+                                      OnClick="@(() => _showSignupClose = true)"
+                                      Disabled="@_saving">
+                            @Loc["createRun.addSignupDeadline"]
+                        </FluentButton>
+                    }
 
-                    <FluentSelect
-                        Id="visibility-select"
-                        Label="@Loc["createRun.visibility"]"
-                        TOption="string"
-                        Value="@visibility"
-                        ValueChanged="@(v => visibility = v)"
-                        Disabled="@saving">
-                        <FluentOption Value="PUBLIC">@Loc["createRun.public"]</FluentOption>
-                        <FluentOption Value="GUILD">@Loc["createRun.guildOnly"]</FluentOption>
-                    </FluentSelect>
+                    @if (_canShowGuildOption)
+                    {
+                        <div>
+                            <label for="visibility-toggle" class="field__label">@Loc["createRun.visibility"]</label>
+                            <ToggleGroup TValue="string"
+                                         Options="_visibilityOptions"
+                                         Value="_visibility"
+                                         ValueChanged="@(v => _visibility = v)"
+                                         AriaLabel="@Loc["createRun.visibility"]"
+                                         Disabled="@_saving" />
+                            @if (!_canCreateGuildRuns)
+                            {
+                                <small class="field__hint">@Loc["createRun.visibility.guildDisabledReason"]</small>
+                            }
+                        </div>
+                    }
 
-                    <FluentTextArea
-                        Id="description-input"
-                        Label="@Loc["createRun.description"]"
-                        Value="@description"
-                        ValueChanged="@(v => description = v)"
-                        Disabled="@saving"
-                        Rows="5"
-                        Resize="TextAreaResize.Vertical"
-                        @attributes="DescriptionAttrs" />
+                    <div>
+                        <FluentTextArea Id="description-input"
+                                        Label="@Loc["createRun.description"]"
+                                        Value="@_description"
+                                        ValueChanged="@(v => _description = v ?? string.Empty)"
+                                        Disabled="@_saving"
+                                        Rows="5"
+                                        Resize="TextAreaResize.Vertical"
+                                        @attributes="DescriptionAttrs" />
+                        <small class="field__hint">@(Loc["createRun.description.charCount", _description.Length])</small>
+                    </div>
+
+                    @if (_inlineError is not null)
+                    {
+                        <FluentMessageBar Intent="MessageIntent.Error">
+                            @foreach (var m in _inlineError.Messages)
+                            {
+                                <div>@m</div>
+                            }
+                        </FluentMessageBar>
+                    }
 
                     <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="8" Wrap="true">
-                        <FluentButton
-                            Appearance="Appearance.Accent"
-                            OnClick="@HandleSave"
-                            Disabled="@(saving || deleting)">
-                            @(saving ? Loc["common.loading"] : Loc["editRun.saveChanges"])
+                        <FluentButton Appearance="Appearance.Accent"
+                                      OnClick="@HandleSave"
+                                      Disabled="@(_saving || _deleting)">
+                            @(_saving ? Loc["common.loading"] : Loc["editRun.saveChanges"])
                         </FluentButton>
-                        <FluentButton
-                            Appearance="Appearance.Outline"
-                            OnClick="@HandleCancel"
-                            Disabled="@(saving || deleting)">
+                        <FluentButton Appearance="Appearance.Outline"
+                                      OnClick="@HandleCancel"
+                                      Disabled="@(_saving || _deleting)">
                             @Loc["editRun.cancel"]
                         </FluentButton>
                         <FluentSpacer />
-                        <FluentButton
-                            Appearance="Appearance.Outline"
-                            OnClick="@ShowDeleteConfirm"
-                            Disabled="@(saving || deleting)"
-                            Style="color:var(--error)">
-                            @(deleting ? Loc["editRun.deleting"] : Loc["editRun.deleteRun"])
+                        <FluentButton Appearance="Appearance.Outline"
+                                      OnClick="@ShowDeleteConfirm"
+                                      Disabled="@(_saving || _deleting)"
+                                      Style="color:var(--error)">
+                            @(_deleting ? Loc["editRun.deleting"] : Loc["editRun.deleteRun"])
                         </FluentButton>
                     </FluentStack>
                 </FluentStack>
             </FluentCard>
 
-            <!-- Delete confirmation (native <dialog>: focus trap, Esc, focus restore) -->
-            <dialog @ref="deleteDialogRef"
+            <dialog @ref="_deleteDialogRef"
                     class="confirm-dialog"
                     aria-labelledby="delete-dialog-title"
                     aria-describedby="delete-dialog-body">
@@ -132,25 +237,22 @@
                     <FluentLabel Typo="Typography.H5" Id="delete-dialog-title">@Loc["editRun.confirmDelete"]</FluentLabel>
                     <FluentLabel Id="delete-dialog-body">@Loc["editRun.confirmDeleteBody"]</FluentLabel>
                     <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="8" Wrap="true">
-                        <FluentButton
-                            Appearance="Appearance.Accent"
-                            OnClick="@HandleDelete"
-                            Disabled="@(saving || deleting)"
-                            Style="background:var(--error)">
-                            @(deleting ? Loc["editRun.deleting"] : Loc["editRun.yesDelete"])
+                        <FluentButton Appearance="Appearance.Accent"
+                                      OnClick="@HandleDelete"
+                                      Disabled="@(_saving || _deleting)"
+                                      Style="background:var(--error)">
+                            @(_deleting ? Loc["editRun.deleting"] : Loc["editRun.yesDelete"])
                         </FluentButton>
-                        <FluentButton
-                            Appearance="Appearance.Outline"
-                            OnClick="@CloseDeleteConfirm"
-                            Disabled="@(saving || deleting)"
-                            autofocus="true">
+                        <FluentButton Appearance="Appearance.Outline"
+                                      OnClick="@CloseDeleteConfirm"
+                                      Disabled="@(_saving || _deleting)"
+                                      autofocus="true">
                             @Loc["common.cancel"]
                         </FluentButton>
                     </FluentStack>
                 </FluentStack>
             </dialog>
 
-            <!-- Roster grid -->
             <FluentCard>
                 <FluentStack Orientation="Orientation.Vertical" VerticalGap="8">
                     <FluentLabel Typo="Typography.H4">@Loc["editRun.rosterSignedUp", s.Value.RunCharacters.Count]</FluentLabel>
@@ -176,42 +278,52 @@
 @code {
     [Parameter] public string? RunId { get; set; }
 
-    private LoadingState<RunDetailDto> state = new LoadingState<RunDetailDto>.Idle();
-    private IReadOnlyList<InstanceDto> instances = [];
-    private bool saving;
-    private bool deleting;
-    private bool hasSignups;
-    private ElementReference deleteDialogRef;
-    private IJSObjectReference? dialogModule;
+    // ── Loading ────────────────────────────────────────────────────────────
+    private LoadingState<RunDetailDto> _state = new LoadingState<RunDetailDto>.Idle();
+    private IReadOnlyList<ExpansionDto> _expansions = [];
+    private IReadOnlyList<InstanceOption> _allInstances = [];
+    private GuildDto? _guild;
 
-    // Form fields (initialised from loaded run)
-    private string instanceId = string.Empty;
-    private string modeKey = string.Empty;
-    private DateTime? startTimeLocal;
-    private DateTime? signupCloseLocal;
-    private string visibility = "PUBLIC";
-    private string description = string.Empty;
+    // ── Form state ─────────────────────────────────────────────────────────
+    private int _expansionId;
+    private ActivityKind _activity = ActivityKind.Raid;
+    private int _instanceId;
+    private string _difficulty = "";
+    private int _size;
+    private int? _keystoneLevel;
+    private bool _anyDungeon;
+    private DateTime? _startTimeLocal;
+    private DateTime? _signupCloseLocal;
+    private bool _showSignupClose;
+    private string _visibility = "PUBLIC";
+    private string _description = string.Empty;
 
-    private static DateTime? ParseIso(string? iso) =>
-        string.IsNullOrWhiteSpace(iso) ? null
-            : DateTimeOffset.TryParse(iso, out var dto) ? dto.LocalDateTime
-            : null;
+    // ── Page state ─────────────────────────────────────────────────────────
+    private bool _saving;
+    private bool _deleting;
+    private bool _hasSignups;
+    private RunError? _inlineError;
+    private ElementReference _deleteDialogRef;
+    private IJSObjectReference? _dialogModule;
 
-    // The native <input type="datetime-local"> binds wall-clock time with no
-    // offset, so we must convert back to UTC before sending — otherwise the
-    // round-trip would shift the stored value by the browser's TZ offset and
-    // the API's locked-field check would reject unchanged values as changed.
-    // Use "o" to preserve full tick precision so the round-trip is byte-stable
-    // against stored values written with sub-second precision.
-    private static string? ToIsoOrNull(DateTime? dt) =>
-        dt is null ? null : dt.Value.ToUniversalTime().ToString("o");
+    // ── Derived ────────────────────────────────────────────────────────────
+    private bool _canCreateGuildRuns;
+    private bool _canShowGuildOption => _guild?.Guild is not null;
 
-    private static readonly Dictionary<string, object> ModeKeyAttrs = new()
-    {
-        ["autocomplete"] = "off",
-        ["autocapitalize"] = "characters",
-        ["spellcheck"] = (bool?)false,
-    };
+    private IEnumerable<InstanceOption> FilteredInstances =>
+        _allInstances.Where(o =>
+            (o.ExpansionId is null || o.ExpansionId == _expansionId) &&
+            o.Activity == _activity);
+
+    private bool ShowInstanceDropdown =>
+        !(_activity == ActivityKind.Dungeon && _difficulty == "MYTHIC_KEYSTONE" && _anyDungeon);
+
+    private bool ShowDifficultyToggle => _instanceId != 0 || !ShowInstanceDropdown;
+
+    private IReadOnlyList<(ActivityKind, string)> _activityOptions = [];
+    private IReadOnlyList<(bool, string)> _dungeonScopeOptions = [];
+    private IReadOnlyList<(string, string)> _difficultyOptions = [];
+    private IReadOnlyList<(string, string)> _visibilityOptions = [];
 
     private static readonly Dictionary<string, object> DescriptionAttrs = new()
     {
@@ -219,115 +331,237 @@
         ["maxlength"] = (int?)2000,
     };
 
+    private static DateTime? ParseIso(string? iso) =>
+        string.IsNullOrWhiteSpace(iso) ? null
+            : DateTimeOffset.TryParse(iso, out var dto) ? dto.LocalDateTime
+            : null;
+
+    private static string? ToIsoOrNull(DateTime? dt) =>
+        dt is null ? null : dt.Value.ToUniversalTime().ToString("o");
+
+    // ── Lifecycle ──────────────────────────────────────────────────────────
     protected override async Task OnInitializedAsync()
     {
         if (string.IsNullOrEmpty(RunId))
         {
-            state = new LoadingState<RunDetailDto>.Failure("No run ID provided.");
+            _state = new LoadingState<RunDetailDto>.Failure("No run ID provided.");
             return;
         }
 
-        state = new LoadingState<RunDetailDto>.Loading();
+        _state = new LoadingState<RunDetailDto>.Loading();
         try
         {
-            var (run, insts) = await LoadBothAsync();
+            var runTask = RunsClient.GetAsync(RunId!, CancellationToken.None);
+            var instancesTask = InstancesClient.ListAsync(CancellationToken.None);
+            var expansionsTask = ExpansionsClient.ListAsync(CancellationToken.None);
+            var guildTask = GuildClient.GetAsync(CancellationToken.None);
+            await Task.WhenAll(runTask, instancesTask, expansionsTask, guildTask);
+
+            var run = await runTask;
             if (run is null)
             {
-                state = new LoadingState<RunDetailDto>.Failure(Loc["editRun.error.notFound"]);
+                _state = new LoadingState<RunDetailDto>.Failure(Loc["editRun.error.notFound"]);
                 return;
             }
 
-            instances = insts;
-            hasSignups = run.RunCharacters.Count > 0;
+            _allInstances = InstanceOptions.Build(await instancesTask);
+            _expansions = await expansionsTask;
+            try { _guild = await guildTask; } catch { _guild = null; }
+
+            _hasSignups = run.RunCharacters.Count > 0;
+            RebuildStaticOptions();
             PopulateForm(run);
-            state = new LoadingState<RunDetailDto>.Success(run);
+            _state = new LoadingState<RunDetailDto>.Success(run);
         }
         catch (Exception ex)
         {
-            state = new LoadingState<RunDetailDto>.Failure($"Failed to load run: {ex.Message}");
+            _state = new LoadingState<RunDetailDto>.Failure($"Failed to load run: {ex.Message}");
         }
     }
 
-    private async Task<(RunDetailDto? Run, IReadOnlyList<InstanceDto> Instances)> LoadBothAsync()
-    {
-        var runTask = RunsClient.GetAsync(RunId!, CancellationToken.None);
-        var instsTask = InstancesClient.ListAsync(CancellationToken.None);
-        await Task.WhenAll(runTask, instsTask);
-        return (await runTask, await instsTask);
-    }
-
+    // ── Pre-fill from loaded run ───────────────────────────────────────────
     private void PopulateForm(RunDetailDto run)
     {
-        // InstanceDto.Id is a composite "{numericId}:{modeKey}" because the
-        // dropdown lists one option per (instance, mode) pair. Match the stored
-        // run's (InstanceId, ModeKey) pair against the flat InstanceDto list
-        // and use the matching row's composite Id as the dropdown value.
-        var match = instances.FirstOrDefault(i =>
-            i.InstanceNumericId == run.InstanceId && i.ModeKey == run.ModeKey);
-        instanceId = match?.Id ?? string.Empty;
-        modeKey = run.ModeKey;
-        startTimeLocal = ParseIso(run.StartTime);
-        signupCloseLocal = ParseIso(run.SignupCloseTime);
-        visibility = run.Visibility;
-        description = run.Description;
+        // Pick the InstanceOption that matches the stored InstanceNumericId.
+        // If the run is an M+ "any dungeon" session (InstanceId null), fall back
+        // to the dungeon-any branch with no specific instance selected.
+        var match = run.InstanceId is int id
+            ? _allInstances.FirstOrDefault(o => o.InstanceId == id)
+            : null;
+
+        _activity = match?.Activity
+            ?? (run.Difficulty == "MYTHIC_KEYSTONE" ? ActivityKind.Dungeon : ActivityKind.Raid);
+        _expansionId = match?.ExpansionId ?? _expansions.LastOrDefault()?.Id ?? 0;
+        _instanceId = match?.InstanceId ?? 0;
+        _difficulty = string.IsNullOrEmpty(run.Difficulty)
+            ? (match?.Difficulties.LastOrDefault()?.DifficultyId ?? "")
+            : run.Difficulty;
+        _size = run.Size > 0 ? run.Size : (match?.Difficulties.FirstOrDefault(d => d.DifficultyId == _difficulty)?.Size ?? 0);
+        _keystoneLevel = run.KeystoneLevel;
+        _anyDungeon = _activity == ActivityKind.Dungeon
+                      && _difficulty == "MYTHIC_KEYSTONE"
+                      && run.InstanceId is null;
+
+        _startTimeLocal = ParseIso(run.StartTime);
+        _signupCloseLocal = ParseIso(run.SignupCloseTime);
+        _showSignupClose = _signupCloseLocal is not null;
+        _visibility = string.IsNullOrEmpty(run.Visibility) ? "PUBLIC" : run.Visibility;
+        _description = run.Description ?? string.Empty;
+
+        RefreshDifficultyOptions();
+        _canCreateGuildRuns = _guild?.MemberPermissions?.CanCreateGuildRuns ?? false;
     }
 
+    private void OnExpansionChanged(string value)
+    {
+        if (int.TryParse(value, out var id))
+        {
+            _expansionId = id;
+            _instanceId = 0;
+            _difficulty = _activity == ActivityKind.Dungeon ? "MYTHIC_KEYSTONE" : "";
+            _size = _activity == ActivityKind.Dungeon ? 5 : 0;
+            _keystoneLevel = null;
+            RefreshDifficultyOptions();
+        }
+    }
+
+    private void OnActivityChanged(ActivityKind value)
+    {
+        _activity = value;
+        _instanceId = 0;
+        _anyDungeon = value == ActivityKind.Dungeon;
+        _difficulty = value == ActivityKind.Dungeon ? "MYTHIC_KEYSTONE" : "";
+        _size = value == ActivityKind.Dungeon ? 5 : 0;
+        _keystoneLevel = null;
+        RefreshDifficultyOptions();
+    }
+
+    private void OnDungeonScopeChanged(bool anyDungeon)
+    {
+        _anyDungeon = anyDungeon;
+        if (anyDungeon) _instanceId = 0;
+        RefreshDifficultyOptions();
+    }
+
+    private void OnInstanceChanged(string value)
+    {
+        if (!int.TryParse(value, out var id)) return;
+        _instanceId = id;
+        RefreshDifficultyOptions();
+        if (_difficultyOptions.Count > 0 && !_difficultyOptions.Any(o => o.Item1 == _difficulty))
+        {
+            var topMode = FilteredInstances
+                .FirstOrDefault(o => o.InstanceId == id)?
+                .Difficulties.LastOrDefault();
+            if (topMode is not null)
+            {
+                _difficulty = topMode.DifficultyId;
+                _size = topMode.Size;
+            }
+        }
+    }
+
+    private void OnDifficultyChanged(string value)
+    {
+        _difficulty = value;
+        var match = FilteredInstances
+            .FirstOrDefault(o => o.InstanceId == _instanceId)?
+            .Difficulties.FirstOrDefault(d => d.DifficultyId == value);
+        _size = match?.Size ?? 0;
+        if (value != "MYTHIC_KEYSTONE") _keystoneLevel = null;
+    }
+
+    private void RebuildStaticOptions()
+    {
+        _activityOptions = new (ActivityKind, string)[]
+        {
+            (ActivityKind.Raid, Loc["createRun.activity.raid"].Value),
+            (ActivityKind.Dungeon, Loc["createRun.activity.dungeon"].Value),
+        };
+        _dungeonScopeOptions = new (bool, string)[]
+        {
+            (true, Loc["createRun.dungeonScope.any"].Value),
+            (false, Loc["createRun.dungeonScope.specific"].Value),
+        };
+        _visibilityOptions = new (string, string)[]
+        {
+            ("GUILD", Loc["createRun.guildOnly"].Value),
+            ("PUBLIC", Loc["createRun.public"].Value),
+        };
+    }
+
+    private void RefreshDifficultyOptions()
+    {
+        var match = FilteredInstances.FirstOrDefault(o => o.InstanceId == _instanceId);
+        _difficultyOptions = match is null
+            ? []
+            : match.Difficulties
+                .Select(d => (d.DifficultyId, d.DisplayName))
+                .ToList();
+    }
+
+    // ── Save / delete ──────────────────────────────────────────────────────
     private async Task HandleSave()
     {
-        saving = true;
-        var selectedInstance = instances.FirstOrDefault(i => i.Id == instanceId);
+        _saving = true;
+        _inlineError = null;
+        var isMythicPlus = _activity == ActivityKind.Dungeon && _difficulty == "MYTHIC_KEYSTONE";
+        var instanceOption = isMythicPlus && _anyDungeon
+            ? null
+            : FilteredInstances.FirstOrDefault(o => o.InstanceId == _instanceId);
+
         try
         {
             var request = new UpdateRunRequest(
-                StartTime: ToIsoOrNull(startTimeLocal) ?? string.Empty,
-                SignupCloseTime: ToIsoOrNull(signupCloseLocal),
-                Description: description,
-                ModeKey: modeKey,
-                Visibility: visibility,
-                InstanceId: selectedInstance?.InstanceNumericId,
-                InstanceName: selectedInstance?.Name);
+                StartTime: ToIsoOrNull(_startTimeLocal) ?? string.Empty,
+                SignupCloseTime: ToIsoOrNull(_signupCloseLocal),
+                Description: _description,
+                ModeKey: null,
+                Visibility: _visibility,
+                InstanceId: instanceOption?.InstanceId,
+                InstanceName: instanceOption?.Name,
+                Difficulty: _difficulty,
+                Size: _size,
+                KeystoneLevel: isMythicPlus ? _keystoneLevel : null);
 
             var updated = await RunsClient.UpdateAsync(RunId!, request, CancellationToken.None);
             if (updated is null)
             {
-                Toast.ShowError(Loc["editRun.saveFailed"]);
+                _inlineError = new RunError(RunErrorKind.Unknown, [Loc["editRun.saveFailed"].Value]);
             }
             else
             {
                 Toast.ShowSuccess(Loc["editRun.saveSuccess"]);
-                state = new LoadingState<RunDetailDto>.Success(updated);
+                _state = new LoadingState<RunDetailDto>.Success(updated);
             }
         }
-        catch
+        catch (Exception ex)
         {
-            Toast.ShowError(Loc["editRun.saveFailed"]);
+            _inlineError = RunErrorParser.Network(ex);
         }
         finally
         {
-            saving = false;
+            _saving = false;
         }
     }
 
-    private void HandleCancel()
-    {
-        Nav.NavigateTo($"/runs/{Uri.EscapeDataString(RunId!)}");
-    }
+    private void HandleCancel() => Nav.NavigateTo($"/runs/{Uri.EscapeDataString(RunId!)}");
 
     private async Task ShowDeleteConfirm()
     {
-        dialogModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/dialog.js");
-        await dialogModule.InvokeVoidAsync("showModal", deleteDialogRef);
+        _dialogModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/dialog.js");
+        await _dialogModule.InvokeVoidAsync("showModal", _deleteDialogRef);
     }
 
     private async Task CloseDeleteConfirm()
     {
-        if (dialogModule is not null)
-            await dialogModule.InvokeVoidAsync("close", deleteDialogRef);
+        if (_dialogModule is not null)
+            await _dialogModule.InvokeVoidAsync("close", _deleteDialogRef);
     }
 
     private async Task HandleDelete()
     {
-        deleting = true;
+        _deleting = true;
         try
         {
             var ok = await RunsClient.DeleteAsync(RunId!, CancellationToken.None);
@@ -338,23 +572,23 @@
             else
             {
                 Toast.ShowError(Loc["editRun.deleteFailed"]);
-                deleting = false;
+                _deleting = false;
                 await CloseDeleteConfirm();
             }
         }
         catch
         {
             Toast.ShowError("Failed to delete run. Please try again.");
-            deleting = false;
+            _deleting = false;
             await CloseDeleteConfirm();
         }
     }
 
     public async ValueTask DisposeAsync()
     {
-        if (dialogModule is not null)
+        if (_dialogModule is not null)
         {
-            try { await dialogModule.DisposeAsync(); } catch { }
+            try { await _dialogModule.DisposeAsync(); } catch { }
         }
     }
 

--- a/app/Pages/EditRunPage.razor
+++ b/app/Pages/EditRunPage.razor
@@ -57,24 +57,24 @@
                     </FluentSelect>
 
                     <div>
-                        <label for="activity-toggle" class="field__label">@Loc["createRun.activity"]</label>
+                        <span id="editRun-activity-label" class="field__label">@Loc["createRun.activity"]</span>
                         <ToggleGroup TValue="ActivityKind"
                                      Options="_activityOptions"
                                      Value="_activity"
                                      ValueChanged="OnActivityChanged"
-                                     AriaLabel="@Loc["createRun.activity"]"
+                                     AriaLabelledBy="editRun-activity-label"
                                      Disabled="@(_saving || _hasSignups)" />
                     </div>
 
                     @if (_activity == ActivityKind.Dungeon && _difficulty == "MYTHIC_KEYSTONE")
                     {
                         <div>
-                            <label for="dungeonScope-toggle" class="field__label">@Loc["createRun.dungeonScope"]</label>
+                            <span id="editRun-dungeonScope-label" class="field__label">@Loc["createRun.dungeonScope"]</span>
                             <ToggleGroup TValue="bool"
                                          Options="_dungeonScopeOptions"
                                          Value="_anyDungeon"
                                          ValueChanged="OnDungeonScopeChanged"
-                                         AriaLabel="@Loc["createRun.dungeonScope"]"
+                                         AriaLabelledBy="editRun-dungeonScope-label"
                                          Disabled="@(_saving || _hasSignups)" />
                         </div>
                     }
@@ -98,12 +98,12 @@
                     @if (ShowDifficultyToggle && _difficultyOptions.Count > 1)
                     {
                         <div>
-                            <label for="difficulty-toggle" class="field__label">@Loc["createRun.difficulty"]</label>
+                            <span id="editRun-difficulty-label" class="field__label">@Loc["createRun.difficulty"]</span>
                             <ToggleGroup TValue="string"
                                          Options="_difficultyOptions"
                                          Value="_difficulty"
                                          ValueChanged="OnDifficultyChanged"
-                                         AriaLabel="@Loc["createRun.difficulty"]"
+                                         AriaLabelledBy="editRun-difficulty-label"
                                          Disabled="@(_saving || _hasSignups)" />
                         </div>
                     }
@@ -171,12 +171,12 @@
                     @if (_canShowGuildOption)
                     {
                         <div>
-                            <label for="visibility-toggle" class="field__label">@Loc["createRun.visibility"]</label>
+                            <span id="editRun-visibility-label" class="field__label">@Loc["createRun.visibility"]</span>
                             <ToggleGroup TValue="string"
                                          Options="_visibilityOptions"
                                          Value="_visibility"
                                          ValueChanged="@(v => _visibility = v)"
-                                         AriaLabel="@Loc["createRun.visibility"]"
+                                         AriaLabelledBy="editRun-visibility-label"
                                          Disabled="@_saving" />
                             @if (!_canCreateGuildRuns)
                             {

--- a/tests/Lfm.App.Tests/FormsInputTypeTests.cs
+++ b/tests/Lfm.App.Tests/FormsInputTypeTests.cs
@@ -7,6 +7,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Lfm.App.Pages;
 using Lfm.App.Services;
+using Lfm.Contracts.Expansions;
+using Lfm.Contracts.Guild;
 using Lfm.Contracts.Instances;
 using Xunit;
 
@@ -15,17 +17,41 @@ namespace Lfm.App.Tests;
 public class FormsInputTypeTests : ComponentTestBase
 {
     private static InstanceDto MakeInstance() =>
-        new(Id: "1:MYTHIC", InstanceNumericId: 1, Name: "Test", ModeKey: "MYTHIC", Expansion: "TWW");
+        new(Id: "1:MYTHIC_KEYSTONE:5",
+            InstanceNumericId: 1,
+            Name: "Test Dungeon",
+            ModeKey: "MYTHIC_KEYSTONE:5",
+            Expansion: "The War Within",
+            Category: "DUNGEON",
+            ExpansionId: 505,
+            Difficulty: "MYTHIC_KEYSTONE",
+            Size: 5);
 
-    [Fact]
-    public void CreateRunPage_StartTime_Is_DatetimeLocal_Input()
+    private void WireCreateRunServices()
     {
         this.AddAuthorization().SetAuthorized("player#1234");
         var instances = new Mock<IInstancesClient>();
         instances.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[] { MakeInstance() });
         Services.AddSingleton(instances.Object);
+
+        var expansions = new Mock<IExpansionsClient>();
+        expansions.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { new ExpansionDto(505, "The War Within") });
+        Services.AddSingleton(expansions.Object);
+
+        var guild = new Mock<IGuildClient>();
+        guild.Setup(c => c.GetAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GuildDto?)null);
+        Services.AddSingleton(guild.Object);
+
         Services.AddSingleton(new Mock<IRunsClient>().Object);
+    }
+
+    [Fact]
+    public void CreateRunPage_StartTime_Is_DatetimeLocal_Input()
+    {
+        WireCreateRunServices();
 
         var cut = Render<CreateRunPage>();
 
@@ -37,43 +63,31 @@ public class FormsInputTypeTests : ComponentTestBase
     }
 
     [Fact]
-    public void CreateRunPage_SignupClose_Is_DatetimeLocal_Input()
+    public void CreateRunPage_SignupClose_Collapsible_Reveals_DatetimeLocal_Input_After_Click()
     {
-        this.AddAuthorization().SetAuthorized("player#1234");
-        var instances = new Mock<IInstancesClient>();
-        instances.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[] { MakeInstance() });
-        Services.AddSingleton(instances.Object);
-        Services.AddSingleton(new Mock<IRunsClient>().Object);
+        // Signup-close is collapsed behind an "+ Add signup deadline" button on
+        // the reshaped form — rarely-used affordance tucked away. Clicking it
+        // must render the datetime-local input the test originally pinned.
+        WireCreateRunServices();
 
         var cut = Render<CreateRunPage>();
+
+        cut.WaitForAssertion(() =>
+        {
+            // The input is NOT in the initial markup.
+            Assert.Empty(cut.FindAll("input#signupclose-input"));
+        });
+
+        // Click the reveal button (matched by its localized label).
+        var revealLabel = Loc("createRun.addSignupDeadline");
+        var revealBtn = cut.FindAll("fluent-button")
+            .First(b => b.TextContent.Contains(revealLabel));
+        revealBtn.Click();
 
         cut.WaitForAssertion(() =>
         {
             var input = cut.Find("input#signupclose-input");
             Assert.Equal("datetime-local", input.GetAttribute("type"));
-        });
-    }
-
-    [Fact]
-    public void CreateRunPage_ModeKey_Has_Autocapitalize_Characters()
-    {
-        this.AddAuthorization().SetAuthorized("player#1234");
-        var instances = new Mock<IInstancesClient>();
-        instances.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[] { MakeInstance() });
-        Services.AddSingleton(instances.Object);
-        Services.AddSingleton(new Mock<IRunsClient>().Object);
-
-        var cut = Render<CreateRunPage>();
-
-        // FluentTextField renders as a <fluent-text-field> web component in bUnit.
-        // Unknown HTML attributes (autocapitalize) flow through to the element and
-        // are verifiable via DOM. This confirms the ModeKeyAttrs splat is wired.
-        cut.WaitForAssertion(() =>
-        {
-            var modeKey = cut.Find("#modekey-input");
-            Assert.Equal("characters", modeKey.GetAttribute("autocapitalize"));
         });
     }
 }

--- a/tests/Lfm.App.Tests/HeadingStructureTests.cs
+++ b/tests/Lfm.App.Tests/HeadingStructureTests.cs
@@ -8,6 +8,7 @@ using Moq;
 using Lfm.App.Pages;
 using Lfm.App.Services;
 using Lfm.Contracts.Characters;
+using Lfm.Contracts.Expansions;
 using Lfm.Contracts.Guild;
 using Lfm.Contracts.Instances;
 using Lfm.Contracts.Me;
@@ -37,12 +38,16 @@ public class HeadingStructureTests : ComponentTestBase
         var instances = new Mock<IInstancesClient>();
         instances.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<InstanceDto>());
+        var expansions = new Mock<IExpansionsClient>();
+        expansions.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<ExpansionDto>());
 
         Services.AddSingleton(battleNet.Object);
         Services.AddSingleton(me.Object);
         Services.AddSingleton(guild.Object);
         Services.AddSingleton(runs.Object);
         Services.AddSingleton(instances.Object);
+        Services.AddSingleton(expansions.Object);
     }
 
     [Theory]

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -6,6 +6,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Lfm.App.Pages;
 using Lfm.App.Services;
+using Lfm.Contracts.Expansions;
+using Lfm.Contracts.Guild;
 using Lfm.Contracts.Instances;
 using Lfm.Contracts.Runs;
 using Xunit;
@@ -298,15 +300,38 @@ public class RunsPagesTests : ComponentTestBase
 
     // ── CreateRunPage ────────────────────────────────────────────────────────
 
+    private void WireCreateRunServices(
+        IReadOnlyList<InstanceDto>? instances = null,
+        IReadOnlyList<ExpansionDto>? expansions = null,
+        GuildDto? guild = null,
+        TaskCompletionSource<IReadOnlyList<InstanceDto>>? instancesPending = null)
+    {
+        var instancesClient = new Mock<IInstancesClient>();
+        if (instancesPending is not null)
+            instancesClient.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+                .Returns(instancesPending.Task);
+        else
+            instancesClient.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(instances ?? []);
+        Services.AddSingleton(instancesClient.Object);
+
+        var expansionsClient = new Mock<IExpansionsClient>();
+        expansionsClient.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expansions ?? [new ExpansionDto(505, "The War Within")]);
+        Services.AddSingleton(expansionsClient.Object);
+
+        var guildClient = new Mock<IGuildClient>();
+        guildClient.Setup(c => c.GetAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(guild);
+        Services.AddSingleton(guildClient.Object);
+
+        Services.AddSingleton(new Mock<IRunsClient>().Object);
+    }
+
     [Fact]
     public void CreateRunPage_Renders_Loading_Ring_On_Mount()
     {
-        var instancesClient = new Mock<IInstancesClient>();
-        var runsClient = new Mock<IRunsClient>();
-        var tcs = new TaskCompletionSource<IReadOnlyList<InstanceDto>>();
-        instancesClient.Setup(c => c.ListAsync(It.IsAny<CancellationToken>())).Returns(tcs.Task);
-        Services.AddSingleton(instancesClient.Object);
-        Services.AddSingleton(runsClient.Object);
+        WireCreateRunServices(instancesPending: new TaskCompletionSource<IReadOnlyList<InstanceDto>>());
 
         var cut = Render<CreateRunPage>();
 
@@ -314,14 +339,13 @@ public class RunsPagesTests : ComponentTestBase
     }
 
     [Fact]
-    public void CreateRunPage_Renders_Form_After_Instances_Load()
+    public void CreateRunPage_Renders_Form_After_Load()
     {
-        var instancesClient = new Mock<IInstancesClient>();
-        var runsClient = new Mock<IRunsClient>();
-        instancesClient.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<InstanceDto> { new("1:raid", 1, "Liberation of Undermine", "raid", "tww") });
-        Services.AddSingleton(instancesClient.Object);
-        Services.AddSingleton(runsClient.Object);
+        WireCreateRunServices(instances: new List<InstanceDto>
+        {
+            new("1:MYTHIC_KEYSTONE:5", 1, "Ara-Kara", "MYTHIC_KEYSTONE:5",
+                "The War Within", "DUNGEON", 505, "MYTHIC_KEYSTONE", 5),
+        });
 
         var cut = Render<CreateRunPage>();
 
@@ -332,12 +356,7 @@ public class RunsPagesTests : ComponentTestBase
     [Fact]
     public void CreateRunPage_Renders_Create_Button()
     {
-        var instancesClient = new Mock<IInstancesClient>();
-        var runsClient = new Mock<IRunsClient>();
-        instancesClient.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<InstanceDto>());
-        Services.AddSingleton(instancesClient.Object);
-        Services.AddSingleton(runsClient.Object);
+        WireCreateRunServices();
 
         var cut = Render<CreateRunPage>();
 

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -44,12 +44,18 @@ public class RunsPagesTests : ComponentTestBase
             StartTime: FutureStartTime,
             SignupCloseTime: FutureSignupCloseTime,
             Description: "Test run",
-            ModeKey: "heroic",
+            ModeKey: "HEROIC:25",
             Visibility: "PUBLIC",
             CreatorGuild: "Stormchasers",
             InstanceId: 1,
             InstanceName: "Liberation of Undermine",
-            RunCharacters: []);
+            RunCharacters: [],
+            Difficulty: "HEROIC",
+            Size: 25);
+
+    private static InstanceDto MakeInstanceFixture() =>
+        new("1:HEROIC:25", 1, "Liberation of Undermine", "HEROIC:25",
+            "The War Within", "RAID", 505, "HEROIC", 25);
 
     // ── RunsPage ─────────────────────────────────────────────────────────────
 
@@ -366,17 +372,36 @@ public class RunsPagesTests : ComponentTestBase
 
     // ── EditRunPage ──────────────────────────────────────────────────────────
 
+    private Mock<IRunsClient> WireEditRunServices(
+        Mock<IRunsClient>? runsClient = null,
+        IReadOnlyList<InstanceDto>? instances = null,
+        IReadOnlyList<ExpansionDto>? expansions = null,
+        GuildDto? guild = null)
+    {
+        runsClient ??= new Mock<IRunsClient>();
+        var instancesClient = new Mock<IInstancesClient>();
+        instancesClient.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(instances ?? [MakeInstanceFixture()]);
+        var expansionsClient = new Mock<IExpansionsClient>();
+        expansionsClient.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expansions ?? [new ExpansionDto(505, "The War Within")]);
+        var guildClient = new Mock<IGuildClient>();
+        guildClient.Setup(c => c.GetAsync(It.IsAny<CancellationToken>())).ReturnsAsync(guild);
+
+        Services.AddSingleton(instancesClient.Object);
+        Services.AddSingleton(expansionsClient.Object);
+        Services.AddSingleton(guildClient.Object);
+        Services.AddSingleton(runsClient.Object);
+        return runsClient;
+    }
+
     [Fact]
     public void EditRunPage_Renders_Loading_Ring_On_Mount()
     {
-        var instancesClient = new Mock<IInstancesClient>();
         var runsClient = new Mock<IRunsClient>();
         var tcs = new TaskCompletionSource<RunDetailDto?>();
         runsClient.Setup(c => c.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(tcs.Task);
-        instancesClient.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<InstanceDto>());
-        Services.AddSingleton(instancesClient.Object);
-        Services.AddSingleton(runsClient.Object);
+        WireEditRunServices(runsClient);
 
         var cut = Render<EditRunPage>(p => p.Add(x => x.RunId, "run-1"));
 
@@ -386,14 +411,10 @@ public class RunsPagesTests : ComponentTestBase
     [Fact]
     public void EditRunPage_Renders_Form_After_Run_Loads()
     {
-        var instancesClient = new Mock<IInstancesClient>();
         var runsClient = new Mock<IRunsClient>();
         runsClient.Setup(c => c.GetAsync("run-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(MakeDetail());
-        instancesClient.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<InstanceDto> { new("1:raid", 1, "Liberation of Undermine", "raid", "tww") });
-        Services.AddSingleton(instancesClient.Object);
-        Services.AddSingleton(runsClient.Object);
+        WireEditRunServices(runsClient);
 
         var cut = Render<EditRunPage>(p => p.Add(x => x.RunId, "run-1"));
 
@@ -404,14 +425,10 @@ public class RunsPagesTests : ComponentTestBase
     [Fact]
     public void EditRunPage_Shows_Error_When_Run_Not_Found()
     {
-        var instancesClient = new Mock<IInstancesClient>();
         var runsClient = new Mock<IRunsClient>();
         runsClient.Setup(c => c.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((RunDetailDto?)null);
-        instancesClient.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<InstanceDto>());
-        Services.AddSingleton(instancesClient.Object);
-        Services.AddSingleton(runsClient.Object);
+        WireEditRunServices(runsClient, instances: []);
 
         var cut = Render<EditRunPage>(p => p.Add(x => x.RunId, "missing-id"));
 
@@ -430,10 +447,6 @@ public class RunsPagesTests : ComponentTestBase
         const string OriginalStart = "2026-05-20T15:30:45.1234567Z";
         const string OriginalSignup = "2026-05-20T15:00:45.1234567Z";
 
-        var instancesClient = new Mock<IInstancesClient>();
-        instancesClient.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<InstanceDto> { new("1:raid", 1, "Liberation of Undermine", "raid", "tww") });
-
         UpdateRunRequest? captured = null;
         var runsClient = new Mock<IRunsClient>();
         runsClient.Setup(c => c.GetAsync("run-1", It.IsAny<CancellationToken>()))
@@ -441,9 +454,7 @@ public class RunsPagesTests : ComponentTestBase
         runsClient.Setup(c => c.UpdateAsync("run-1", It.IsAny<UpdateRunRequest>(), It.IsAny<CancellationToken>()))
             .Callback<string, UpdateRunRequest, CancellationToken>((_, req, _) => captured = req)
             .ReturnsAsync((RunDetailDto?)null);
-
-        Services.AddSingleton(instancesClient.Object);
-        Services.AddSingleton(runsClient.Object);
+        WireEditRunServices(runsClient);
 
         var cut = Render<EditRunPage>(p => p.Add(x => x.RunId, "run-1"));
 
@@ -466,14 +477,10 @@ public class RunsPagesTests : ComponentTestBase
     [Fact]
     public void EditRunPage_Delete_Button_Opens_Native_Dialog_Via_Interop()
     {
-        var instancesClient = new Mock<IInstancesClient>();
         var runsClient = new Mock<IRunsClient>();
         runsClient.Setup(c => c.GetAsync("run-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(MakeDetail());
-        instancesClient.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<InstanceDto>());
-        Services.AddSingleton(instancesClient.Object);
-        Services.AddSingleton(runsClient.Object);
+        WireEditRunServices(runsClient, instances: []);
 
         var dialogModule = JSInterop.SetupModule("./js/dialog.js");
 


### PR DESCRIPTION
## Summary

The UX-visible culmination of the create-run-page-improvements plan. Reshapes both pages from the current DTO-shaped form (instance dropdown + cryptic "Mode Key" text field + ISO 8601 labels + long description under 500 chars) into a flow that asks a raid leader questions they can actually answer without opening a second tab:

```
Expansion     [ The War Within ▾ ]
Activity      [ Raid ] [•Dungeon•]
(Dungeon M+)  [•Any dungeon•] [ Specific dungeon ]
Instance      [ Ara-Kara, City of Echoes ▾ ]    (only when "Specific" or raid)
Difficulty    [ Normal ] [ Heroic ] [ Mythic ] [•M+•]  (hidden for single-mode)
Key level     [ − ] [ 10 ] [ + ]  [ WNL (+10) ]  (only for M+)
Start time    [ Thu 30 Apr 2026, 20:00 ]
Signups close [ + Add signup deadline ]          (collapsed by default)
Visibility    [•Guild only•] [ Public ]           (defaults to Guild only
                                                   when eligible; collapses
                                                   to a single line for
                                                   users with no guild)
Notes (0 / 2000)
  [ multi-line text area                         ]
```

Consumers of PR 6a's helpers (`InstanceOptions.Build`, `DifficultyLabel.Format`, `RunErrorParser.Parse`, `RunTimeDefaults.NextThursday20`, `ActivityKind.FromCategory`) and PR 4's `<ToggleGroup>`. Smart defaults, progressive disclosure, and inline error surfacing land as designed.

### Behavioural changes the user will see

- **`ModeKey` is gone from the UI.** Users no longer type or see `"RAID:25"` / `"MYTHIC_KEYSTONE:5"`. The wire still carries ModeKey server-side for one cycle per PR 5; submit writes the typed `Difficulty` / `Size` / `KeystoneLevel` fields and lets the server derive ModeKey.
- **`"(ISO 8601)"` gone from datetime labels** (already done in PR 1; this PR confirms).
- **Visibility default** flips from always-Public to **Guild only** when the user has a guild and the `CanCreateGuildRuns` rank permission. Users without a guild see "Visible to everyone" instead of a dropdown. Users in a guild without the rank see the toggle with the Guild-only option disabled and an inline reason.
- **Notes** is now a `FluentTextArea` (5 rows, vertical resize) with a live char counter. Max length raised from 500 to 2000 to match the server validator.
- **M+ "Any dungeon"** — the form now supports dungeon-agnostic Mythic+ sessions (InstanceId null, KeystoneLevel required). Matches how most M+ sessions actually get scheduled.
- **EditRunPage** preserves the hasSignups lock on expansion / activity / dungeon-scope / instance / difficulty / start-time, the native `<dialog>` delete-confirmation flow, and the byte-stable UTC ISO round-trip (#53 regression test still pins it).
- **Errors inline** — validation errors, guild-rank-denied (403), and network failures each render inline instead of the old one-size-fits-all "Failed to create run" toast.

### Schema / env changes

- No wire, Cosmos, Bicep, workflow, auth, or locale changes (locale keys already landed in PR 6a). All plumbing is consuming existing helpers.

## Test plan

- [x] `dotnet build lfm.sln -c Release` clean.
- [x] `dotnet format lfm.sln --verify-no-changes` clean.
- [x] `Lfm.Api.Tests` — 458 pass. No API changes in this PR; schema validators already cover the M+ rules.
- [x] `Lfm.App.Core.Tests` — 170 pass.
- [x] `Lfm.App.Tests` — 174 pass (net −1: `CreateRunPage_ModeKey_Has_Autocapitalize_Characters` deleted because the ModeKey field is gone; `FormsInputTypeTests.CreateRunPage_SignupClose_Collapsible_Reveals_DatetimeLocal_Input_After_Click` replaces the old signup-close input test to reflect the collapsible; `RunsPagesTests` + `HeadingStructureTests` updated to mock `IExpansionsClient` and `IGuildClient` + use the new typed-field instance fixture).
- [x] Delete flow test (`EditRunPage_Delete_Button_Opens_Native_Dialog_Via_Interop`) still green — the `<dialog>` JS-interop path is preserved.
- [x] UTC round-trip regression test (`EditRunPage_Save_Without_Edit_Preserves_Utc_Iso_Round_Trip`) still green.
- [ ] Post-deploy smoke: a) schedule a raid Mythic run via the new form, b) schedule an M+ "any dungeon +10" session, c) edit each, d) try as a non-guild-member (visibility row collapses), e) try as a member without `CanCreateGuildRuns` (Guild-only option visibly disabled).

### Out of scope for this PR (small follow-up)

`DifficultyPill.razor`, `RunListItem.razor`, and `RunVisualization.cs` currently read `ModeKey` via `RunMode.Parse` to pick their difficulty class. Since PR 5 populates the typed `Difficulty` / `Size` fields on the wire, those consumers can switch to reading the typed fields directly — pure simplification, no UX change. Deferred to a small follow-up PR so this one stays focused on the form reshape.
