### PR TITLE
Drop ModeKey parsing from DifficultyPill / RunVisualization consumers

### DIFF
--- a/app/Components/DifficultyPill.razor
+++ b/app/Components/DifficultyPill.razor
@@ -1,37 +1,33 @@
-@using Lfm.Contracts.Runs
-
-<span class="difficulty-pill difficulty-pill--@DifficultyClass(ModeKey)" title="@ModeKey">
-    @DifficultyLabel(ModeKey)
+@*
+    Difficulty badge rendered in the run list and run detail. Reads the
+    typed Difficulty field from the wire DTO — the server guarantees it is
+    populated (see RunModeResolver) so no client-side ModeKey parsing.
+*@
+<span class="difficulty-pill difficulty-pill--@DifficultyClass(Difficulty)" title="@Difficulty">
+    @DifficultyLabel(Difficulty)
 </span>
 
 @code {
-    [Parameter, EditorRequired] public string ModeKey { get; set; } = "";
+    [Parameter, EditorRequired] public string? Difficulty { get; set; }
 
-    private static string DifficultyLabel(string modeKey)
+    private static string DifficultyLabel(string? difficulty) => difficulty switch
     {
-        var (difficulty, _) = RunMode.Parse(modeKey);
-        return difficulty switch
-        {
-            "MYTHIC_KEYSTONE" => "M+",
-            "MYTHIC" => "Mythic",
-            "HEROIC" => "Heroic",
-            "NORMAL" => "Normal",
-            "LFR" => "LFR",
-            _ => difficulty.Length == 0 ? "—" : char.ToUpperInvariant(difficulty[0]) + difficulty[1..].ToLowerInvariant()
-        };
-    }
+        "MYTHIC_KEYSTONE" => "M+",
+        "MYTHIC" => "Mythic",
+        "HEROIC" => "Heroic",
+        "NORMAL" => "Normal",
+        "LFR" => "LFR",
+        null or "" => "—",
+        _ => char.ToUpperInvariant(difficulty[0]) + difficulty[1..].ToLowerInvariant(),
+    };
 
-    private static string DifficultyClass(string modeKey)
+    private static string DifficultyClass(string? difficulty) => difficulty switch
     {
-        var (difficulty, _) = RunMode.Parse(modeKey);
-        return difficulty switch
-        {
-            "MYTHIC_KEYSTONE" => "mplus",
-            "MYTHIC" => "mythic",
-            "HEROIC" => "heroic",
-            "NORMAL" => "normal",
-            "LFR" => "lfr",
-            _ => "unknown"
-        };
-    }
+        "MYTHIC_KEYSTONE" => "mplus",
+        "MYTHIC" => "mythic",
+        "HEROIC" => "heroic",
+        "NORMAL" => "normal",
+        "LFR" => "lfr",
+        _ => "unknown",
+    };
 }

--- a/app/Components/RunListItem.razor
+++ b/app/Components/RunListItem.razor
@@ -14,7 +14,7 @@
         @onclick="HandleClick">
     <span class="run-list-item__header">
         <span class="run-list-item__title">@Run.InstanceName</span>
-        <DifficultyPill ModeKey="@Run.ModeKey" />
+        <DifficultyPill Difficulty="@Run.Difficulty" />
     </span>
     <span class="run-list-item__meta">
         <span class="run-list-item__date">@FormatDate(Run.StartTime)</span>
@@ -56,11 +56,11 @@
 
     protected override void OnParametersSet()
     {
-        _difficultyClass = RunVisualization.GetDifficultyClass(Run.ModeKey);
-        _kindClass = RunVisualization.GetKindClass(RunVisualization.GetKind(Run.ModeKey));
+        _difficultyClass = RunVisualization.GetDifficultyClass(Run.Difficulty);
+        _kindClass = RunVisualization.GetKindClass(RunVisualization.GetKind(Run.Size));
         _isMe = RunVisualization.IsCurrentUserSignedUp(Run.RunCharacters);
         _isCurrentUserClass = _isMe ? "true" : "false";
-        _counts = RunVisualization.CountRoles(Run.RunCharacters, Run.ModeKey);
+        _counts = RunVisualization.CountRoles(Run.RunCharacters, Run.Size);
         _ariaLabel = Loc["runs.listItemAriaLabel", Run.InstanceName ?? "", FormatDate(Run.StartTime)].Value;
         _compositionAria = Loc["runs.compositionAria",
             _counts.Tank.Attending, _counts.Healer.Attending, _counts.Dps.Attending].Value;

--- a/app/Lfm.App.Core/Runs/RunVisualization.cs
+++ b/app/Lfm.App.Core/Runs/RunVisualization.cs
@@ -31,16 +31,12 @@ public readonly record struct RunRoleCounts(RoleCount Tank, RoleCount Healer, Ro
 
 public static class RunVisualization
 {
-    public static RunKind GetKind(string? modeKey)
+    public static RunKind GetKind(int size) => size switch
     {
-        var (_, size) = RunMode.Parse(modeKey);
-        return size switch
-        {
-            <= 0 => RunKind.Unknown,
-            <= 5 => RunKind.Dungeon,
-            _ => RunKind.Raid,
-        };
-    }
+        <= 0 => RunKind.Unknown,
+        <= 5 => RunKind.Dungeon,
+        _ => RunKind.Raid,
+    };
 
     public static string GetKindClass(RunKind kind) => kind switch
     {
@@ -49,18 +45,14 @@ public static class RunVisualization
         _ => "unknown",
     };
 
-    public static string GetDifficultyClass(string? modeKey)
+    public static string GetDifficultyClass(string? difficulty) => difficulty switch
     {
-        var (difficulty, _) = RunMode.Parse(modeKey);
-        return difficulty switch
-        {
-            "MYTHIC" => "mythic",
-            "HEROIC" => "heroic",
-            "NORMAL" => "normal",
-            "LFR" => "lfr",
-            _ => "unknown",
-        };
-    }
+        "MYTHIC" => "mythic",
+        "HEROIC" => "heroic",
+        "NORMAL" => "normal",
+        "LFR" => "lfr",
+        _ => "unknown",
+    };
 
     public static (int Tank, int Healer, int Dps) GetRoleTargets(int size) => size switch
     {
@@ -83,9 +75,8 @@ public static class RunVisualization
         _ => "DPS",
     };
 
-    public static RunRoleCounts CountRoles(IEnumerable<RunCharacterDto> characters, string? modeKey)
+    public static RunRoleCounts CountRoles(IEnumerable<RunCharacterDto> characters, int size)
     {
-        var (_, size) = RunMode.Parse(modeKey);
         var (tTarget, hTarget, dTarget) = GetRoleTargets(size);
 
         int tAttend = 0, hAttend = 0, dAttend = 0;

--- a/app/Pages/RunsPage.razor
+++ b/app/Pages/RunsPage.razor
@@ -105,7 +105,7 @@
                                             <p class="run-detail-description">@selectedRun.Description</p>
                                         }
                                     </div>
-                                    <DifficultyPill ModeKey="@selectedRun.ModeKey" />
+                                    <DifficultyPill Difficulty="@selectedRun.Difficulty" />
                                     <FluentButton Appearance="Appearance.Outline"
                                                   OnClick="@(() => Nav.NavigateTo($"/runs/{Uri.EscapeDataString(selectedRun.Id)}/edit"))"
                                                   Disabled="@IsSignupClosed(selectedRun.SignupCloseTime)">

--- a/tests/Lfm.App.Core.Tests/Runs/RunVisualizationTests.cs
+++ b/tests/Lfm.App.Core.Tests/Runs/RunVisualizationTests.cs
@@ -10,18 +10,16 @@ namespace Lfm.App.Core.Tests.Runs;
 public class RunVisualizationTests
 {
     [Theory]
-    [InlineData("MYTHIC:5", RunKind.Dungeon)]
-    [InlineData("HEROIC:5", RunKind.Dungeon)]
-    [InlineData("NORMAL:10", RunKind.Raid)]
-    [InlineData("MYTHIC:20", RunKind.Raid)]
-    [InlineData("LFR:25", RunKind.Raid)]
-    [InlineData("HEROIC:30", RunKind.Raid)]
-    [InlineData("MYTHIC", RunKind.Unknown)]
-    [InlineData("", RunKind.Unknown)]
-    [InlineData(null, RunKind.Unknown)]
-    public void GetKind_parses_size_from_mode_key(string? modeKey, RunKind expected)
+    [InlineData(5, RunKind.Dungeon)]
+    [InlineData(10, RunKind.Raid)]
+    [InlineData(20, RunKind.Raid)]
+    [InlineData(25, RunKind.Raid)]
+    [InlineData(30, RunKind.Raid)]
+    [InlineData(0, RunKind.Unknown)]
+    [InlineData(-1, RunKind.Unknown)]
+    public void GetKind_classifies_size_into_run_kind(int size, RunKind expected)
     {
-        Assert.Equal(expected, RunVisualization.GetKind(modeKey));
+        Assert.Equal(expected, RunVisualization.GetKind(size));
     }
 
     [Theory]
@@ -52,7 +50,7 @@ public class RunVisualizationTests
             MakeChar(null, "IN"),
         };
 
-        var counts = RunVisualization.CountRoles(chars, "MYTHIC:20");
+        var counts = RunVisualization.CountRoles(chars, size: 20);
 
         Assert.Equal(1, counts.Tank.Attending);
         Assert.Equal(2, counts.Tank.Target);
@@ -66,7 +64,7 @@ public class RunVisualizationTests
     public void CountRoles_marks_shortage_when_attending_below_target()
     {
         var chars = new List<RunCharacterDto> { MakeChar("HEALER", "IN") };
-        var counts = RunVisualization.CountRoles(chars, "NORMAL:10");
+        var counts = RunVisualization.CountRoles(chars, size: 10);
         Assert.True(counts.Tank.IsShortage);
         Assert.True(counts.Healer.IsShortage);
         Assert.True(counts.Dps.IsShortage);
@@ -76,7 +74,7 @@ public class RunVisualizationTests
     public void CountRoles_no_shortage_when_size_unknown()
     {
         var chars = new List<RunCharacterDto> { MakeChar("TANK", "IN") };
-        var counts = RunVisualization.CountRoles(chars, "MYTHIC");
+        var counts = RunVisualization.CountRoles(chars, size: 0);
         Assert.False(counts.Tank.IsShortage);
         Assert.False(counts.Healer.IsShortage);
         Assert.False(counts.Dps.IsShortage);
@@ -133,15 +131,16 @@ public class RunVisualizationTests
     }
 
     [Theory]
-    [InlineData("MYTHIC:20", "mythic")]
-    [InlineData("HEROIC:10", "heroic")]
-    [InlineData("NORMAL:5", "normal")]
-    [InlineData("LFR:25", "lfr")]
+    [InlineData("MYTHIC", "mythic")]
+    [InlineData("HEROIC", "heroic")]
+    [InlineData("NORMAL", "normal")]
+    [InlineData("LFR", "lfr")]
     [InlineData("weird", "unknown")]
     [InlineData("", "unknown")]
-    public void GetDifficultyClass_maps_difficulty_token(string modeKey, string expected)
+    [InlineData(null, "unknown")]
+    public void GetDifficultyClass_maps_difficulty_token(string? difficulty, string expected)
     {
-        Assert.Equal(expected, RunVisualization.GetDifficultyClass(modeKey));
+        Assert.Equal(expected, RunVisualization.GetDifficultyClass(difficulty));
     }
 
     [Theory]

--- a/tests/Lfm.App.Tests/DifficultyPillTests.cs
+++ b/tests/Lfm.App.Tests/DifficultyPillTests.cs
@@ -21,15 +21,13 @@ public class DifficultyPillTests : ComponentTestBase
 {
     [Theory]
     [InlineData("MYTHIC_KEYSTONE", "M+", "mplus")]
-    [InlineData("mythic_keystone:5", "M+", "mplus")]
     [InlineData("MYTHIC", "Mythic", "mythic")]
-    [InlineData("MYTHIC:25", "Mythic", "mythic")]
     [InlineData("HEROIC", "Heroic", "heroic")]
     [InlineData("NORMAL", "Normal", "normal")]
     [InlineData("LFR", "LFR", "lfr")]
-    public void Renders_Expected_Label_And_Class(string modeKey, string expectedLabel, string expectedVariant)
+    public void Renders_Expected_Label_And_Class(string difficulty, string expectedLabel, string expectedVariant)
     {
-        var cut = Render<DifficultyPill>(p => p.Add(x => x.ModeKey, modeKey));
+        var cut = Render<DifficultyPill>(p => p.Add(x => x.Difficulty, difficulty));
 
         var pill = cut.Find(".difficulty-pill");
         Assert.Contains(expectedLabel, pill.TextContent);
@@ -39,7 +37,7 @@ public class DifficultyPillTests : ComponentTestBase
     [Fact]
     public void MythicKeystone_Does_Not_Leak_Raw_Enum_Text()
     {
-        var cut = Render<DifficultyPill>(p => p.Add(x => x.ModeKey, "MYTHIC_KEYSTONE"));
+        var cut = Render<DifficultyPill>(p => p.Add(x => x.Difficulty, "MYTHIC_KEYSTONE"));
 
         var pill = cut.Find(".difficulty-pill");
         Assert.DoesNotContain("keystone", pill.TextContent, System.StringComparison.OrdinalIgnoreCase);
@@ -49,12 +47,27 @@ public class DifficultyPillTests : ComponentTestBase
     [Fact]
     public void Unknown_Difficulty_Falls_Back_To_TitleCased_Label()
     {
-        var cut = Render<DifficultyPill>(p => p.Add(x => x.ModeKey, "PVP"));
+        var cut = Render<DifficultyPill>(p => p.Add(x => x.Difficulty, "PVP"));
 
         var pill = cut.Find(".difficulty-pill");
         // Title-case rule: first letter upper, rest lower (invariant) — not
         // CultureInfo.TextInfo.ToTitleCase, which is locale-sensitive.
         Assert.Equal("Pvp", pill.TextContent.Trim());
+        Assert.Contains("difficulty-pill--unknown", pill.ClassName);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Empty_Or_Null_Difficulty_Renders_Em_Dash_Placeholder(string? difficulty)
+    {
+        var cut = Render<DifficultyPill>(p => p.Add(x => x.Difficulty, difficulty));
+
+        var pill = cut.Find(".difficulty-pill");
+        // Em dash (U+2014) signals "unknown difficulty" in the UI — the
+        // server's RunModeResolver is expected to populate Difficulty for
+        // every wire DTO, so this branch is defensive rather than a hot path.
+        Assert.Equal("—", pill.TextContent.Trim());
         Assert.Contains("difficulty-pill--unknown", pill.ClassName);
     }
 }

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -31,12 +31,14 @@ public class RunsPagesTests : ComponentTestBase
             StartTime: FutureStartTime,
             SignupCloseTime: FutureSignupCloseTime,
             Description: "Test run",
-            ModeKey: "heroic",
+            ModeKey: "HEROIC:25",
             Visibility: "PUBLIC",
             CreatorGuild: "Stormchasers",
             InstanceId: 1,
             InstanceName: "Liberation of Undermine",
-            RunCharacters: []);
+            RunCharacters: [],
+            Difficulty: "HEROIC",
+            Size: 25);
 
     private static RunDetailDto MakeDetail(string id = "run-1") =>
         new(
@@ -255,11 +257,11 @@ public class RunsPagesTests : ComponentTestBase
     public void RunsPage_RunListItem_RendersDifficultyPillAndCompositionSummary()
     {
         var client = new Mock<IRunsClient>();
-        // Seed 2 DPS attending (IN) and 1 DPS OUT in a MYTHIC:25 raid.
+        // Seed 2 DPS attending (IN) and 1 DPS OUT in a MYTHIC 25-man raid.
         // Standard composition target for 25-man is 2T / 5H / 18D, so the
         // rendered composition summary is "T 0/2 · H 0/5 · D 2/18" with the
         // tank + healer slots carrying the shortage modifier class.
-        var summary = MakeSummary() with { ModeKey = "MYTHIC:25" };
+        var summary = MakeSummary() with { Difficulty = "MYTHIC", Size = 25, ModeKey = "MYTHIC:25" };
         client.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<RunSummaryDto>
             {


### PR DESCRIPTION
## Summary

Follow-up from the create-run overhaul (PRs #99–#107). The server-side `RunModeResolver` already guarantees typed `Difficulty` / `Size` / `KeystoneLevel` fields on every wire DTO, so consumers no longer need to parse the legacy composite `ModeKey` string at render time.

- **`RunVisualization`** — `GetKind`, `GetDifficultyClass`, `CountRoles` now take typed args (`int size`, `string? difficulty`) directly. No more `RunMode.Parse(modeKey)` inside rendering hot paths.
- **`DifficultyPill`** — parameter renamed from `ModeKey` → `Difficulty`. Added an em-dash placeholder branch for defensive null/empty handling (the server should always fill this, but the UI renders gracefully if it doesn't).
- **`RunListItem` + `RunsPage`** — pass `Run.Difficulty` / `Run.Size` to the helpers and to `DifficultyPill` instead of `Run.ModeKey`.
- **Tests** — `RunVisualizationTests` and `DifficultyPillTests` rewritten to use typed inputs. `MakeSummary` helper in `RunsPagesTests` now populates both the legacy `ModeKey` and the new typed fields (mirrors the server's guarantee).

`ModeKey` stays on the DTOs for one more cycle — removing it is a separate PR.

## Test plan

- [x] `dotnet build lfm.sln -c Release` clean (0 warn / 0 err)
- [x] `dotnet format lfm.sln --verify-no-changes --severity error` clean
- [x] `dotnet test tests/Lfm.Api.Tests` — 459/459
- [x] `dotnet test tests/Lfm.App.Tests` — 174/174
- [x] `dotnet test tests/Lfm.App.Core.Tests` — 172/172
