### PR TITLE
Log 403 on admin refresh + dark-mode fail color + auth doc

### DIFF
--- a/api/Functions/WowReferenceRefreshFunction.cs
+++ b/api/Functions/WowReferenceRefreshFunction.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
+using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Channels;
@@ -11,6 +12,7 @@ using Lfm.Contracts.Admin;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
 
 namespace Lfm.Api.Functions;
 
@@ -30,8 +32,20 @@ namespace Lfm.Api.Functions;
 /// Auth:
 ///   - [RequireAuth] → AuthPolicyMiddleware returns 401 for unauthenticated callers.
 ///   - ISiteAdminService check → 403 for authenticated non-admin callers.
+///
+/// <para>
+/// Host trigger level is <c>AuthorizationLevel.Anonymous</c> — the repo-wide
+/// convention because every HTTP function fronts a browser-based Blazor WASM
+/// SPA that cannot safely carry a Functions host key (the key would be
+/// extractable from the bundle). Auth is enforced entirely in application
+/// code by the Battle.net OAuth cookie + <c>[RequireAuth]</c> +
+/// <c>ISiteAdminService</c> chain. See <c>docs/security-architecture.md</c>.
+/// </para>
 /// </summary>
-public class WowReferenceRefreshFunction(ISiteAdminService siteAdmin, IReferenceSync referenceSync)
+public class WowReferenceRefreshFunction(
+    ISiteAdminService siteAdmin,
+    IReferenceSync referenceSync,
+    ILogger<WowReferenceRefreshFunction> logger)
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
     {
@@ -48,7 +62,18 @@ public class WowReferenceRefreshFunction(ISiteAdminService siteAdmin, IReference
         var principal = ctx.GetPrincipal(); // non-null: [RequireAuth] + AuthPolicyMiddleware guarantee
 
         if (!await siteAdmin.IsAdminAsync(principal.BattleNetId, ct))
+        {
+            // Non-admin attempts on the reference-refresh endpoint are worth
+            // recording — the endpoint is site-wide destructive (overwrites
+            // blob). TraceId ties the log line to the Application Insights
+            // end-to-end trace for the same request.
+            logger.LogWarning(
+                "403 Forbidden: non-admin caller {BattleNetId} on {Route} (trace {TraceId})",
+                principal.BattleNetId,
+                "wow/reference/refresh",
+                Activity.Current?.TraceId.ToString());
             return new ObjectResult(new { error = "Forbidden" }) { StatusCode = 403 };
+        }
 
         var response = req.HttpContext.Response;
         response.StatusCode = StatusCodes.Status200OK;

--- a/app/Pages/AdminReferenceRefreshPage.razor.css
+++ b/app/Pages/AdminReferenceRefreshPage.razor.css
@@ -23,8 +23,14 @@
     color: var(--neutral-foreground-hint-rest);
 }
 
+/*
+ * #c0392b passes 4.5:1 on white but disappears on dark surfaces; #ff6b6b
+ * is the tuned dark-mode variant (≥ 4.5:1 on Fluent's dark neutral fill).
+ * light-dark() keeps both values local to this rule — no separate
+ * prefers-color-scheme media query needed.
+ */
 .admin-reference-results tbody tr[data-status="failed"] td {
-    color: #c0392b;
+    color: light-dark(#c0392b, #ff6b6b);
 }
 
 @media (forced-colors: active) {

--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -1,0 +1,47 @@
+# Security Architecture
+
+## HTTP auth at the Functions trigger layer
+
+**Decision.** Every HTTP-triggered function in `api/Functions/` declares
+`AuthorizationLevel.Anonymous`. All authentication and authorization is
+enforced in application code by the Battle.net OAuth cookie + the
+`[RequireAuth]` attribute + `AuthPolicyMiddleware` + (for admin endpoints)
+`ISiteAdminService`.
+
+**Why not `AuthorizationLevel.Function`?** The Functions host's function
+keys are the obvious second layer, but they don't fit a browser-based
+Blazor WASM SPA:
+
+- The SPA is shipped to every visitor's browser. A function key embedded in
+  the bundle or fetched from a config endpoint is extractable, so it is not
+  a credential — it's just a token with extra operational cost (rotation,
+  leak-response).
+- A server-side proxy that injects the key per request would solve the
+  extraction problem but adds a tier we don't run in Static Web Apps Free.
+  See `docs/storage-architecture.md` for the hosting footprint.
+- The app-layer cookie is already derived from user identity (signed,
+  encrypted with Data Protection keys in Key Vault). It authenticates the
+  specific Battle.net principal, which a host-level key can't do.
+
+**Accepted risk.** A bug in `AuthPolicyMiddleware` or the `[RequireAuth]`
+filter leaves the endpoint open to unauthenticated callers — there is no
+host-level fallback. Mitigated by:
+
+- Unit tests for the middleware on every PR that touches `api/Middleware/`.
+- The 403 path on admin endpoints logs the caller's Battle.net id + the
+  ambient `Activity.TraceId` for Application Insights correlation, so
+  failed attempts are visible in ops dashboards.
+- `ISiteAdminService.IsAdminAsync` checks a small site-admin allowlist
+  derived from Battle.net ids; adding a new admin is a deploy-gated action.
+
+**Callers that bypass the HTTP trigger.** Timer triggers
+(e.g. `WowReferenceRefreshTimerFunction`) don't go through the HTTP
+middleware chain at all — they are host-gated by the Functions runtime.
+Ad-hoc master-key invocation (documented on the function itself) is the
+ops escape hatch when the cookie flow is unavailable.
+
+## Related documents
+
+- `docs/threat-models/session-cookie-api.md` — cookie → API threat model.
+- `docs/threat-models/battlenet-oauth-callback.md` — OAuth callback threat model.
+- `docs/wire-payload-contract.md` — what leaves the API boundary.

--- a/tests/Lfm.Api.Tests/WowReferenceRefreshFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/WowReferenceRefreshFunctionTests.cs
@@ -5,6 +5,8 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Lfm.Api.Auth;
 using Lfm.Api.Functions;
@@ -96,7 +98,7 @@ public class WowReferenceRefreshFunctionTests
             .Setup(r => r.SyncAllAsync(It.IsAny<CancellationToken>(), It.IsAny<IProgress<WowReferenceRefreshProgress>?>()))
             .ReturnsAsync(expectedResponse);
 
-        var fn = new WowReferenceRefreshFunction(siteAdmin.Object, referenceSync.Object);
+        var fn = new WowReferenceRefreshFunction(siteAdmin.Object, referenceSync.Object, NullLogger<WowReferenceRefreshFunction>.Instance);
         var ctx = MakeFunctionContext(principal);
 
         var (http, lines) = await InvokeAndReadBody(fn, ctx);
@@ -116,11 +118,13 @@ public class WowReferenceRefreshFunctionTests
     }
 
     // ---------------------------------------------------------------------------
-    // Test 2: Admin-only gate — non-admin caller returns 403 (no stream)
+    // Test 2: Admin-only gate — non-admin caller returns 403 and the rejection
+    // is logged with the caller's Battle.net id so operators can see failed
+    // attempts in App Insights (dns.HC-8 mitigation).
     // ---------------------------------------------------------------------------
 
     [Fact]
-    public async Task Returns_403_when_caller_is_not_site_admin()
+    public async Task Returns_403_and_logs_warning_when_caller_is_not_site_admin()
     {
         var principal = MakePrincipal("raider-1");
 
@@ -129,8 +133,9 @@ public class WowReferenceRefreshFunctionTests
             .ReturnsAsync(false);
 
         var referenceSync = new Mock<IReferenceSync>();
+        var logger = new Mock<ILogger<WowReferenceRefreshFunction>>();
 
-        var fn = new WowReferenceRefreshFunction(siteAdmin.Object, referenceSync.Object);
+        var fn = new WowReferenceRefreshFunction(siteAdmin.Object, referenceSync.Object, logger.Object);
         var ctx = MakeFunctionContext(principal);
 
         var result = await fn.Run(new DefaultHttpContext().Request, ctx, CancellationToken.None);
@@ -138,10 +143,21 @@ public class WowReferenceRefreshFunctionTests
         var forbidden = Assert.IsType<ObjectResult>(result);
         Assert.Equal(403, forbidden.StatusCode);
 
-        // SyncAllAsync must NOT be called for non-admin callers.
         referenceSync.Verify(
             r => r.SyncAllAsync(It.IsAny<CancellationToken>(), It.IsAny<IProgress<WowReferenceRefreshProgress>?>()),
             Times.Never);
+
+        // Warning-level log with the rejected Battle.net id in the formatted
+        // message. ILogger is awkward to verify structurally in Moq; matching
+        // on the rendered message keeps the assertion at the observable level.
+        logger.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((o, _) => o.ToString()!.Contains("raider-1")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
     }
 
     // ---------------------------------------------------------------------------
@@ -173,7 +189,7 @@ public class WowReferenceRefreshFunctionTests
                 return Task.FromResult(finalResponse);
             });
 
-        var fn = new WowReferenceRefreshFunction(siteAdmin.Object, referenceSync.Object);
+        var fn = new WowReferenceRefreshFunction(siteAdmin.Object, referenceSync.Object, NullLogger<WowReferenceRefreshFunction>.Instance);
         var ctx = MakeFunctionContext(principal);
 
         var (_, lines) = await InvokeAndReadBody(fn, ctx);
@@ -213,7 +229,7 @@ public class WowReferenceRefreshFunctionTests
             .Setup(r => r.SyncAllAsync(It.IsAny<CancellationToken>(), It.IsAny<IProgress<WowReferenceRefreshProgress>?>()))
             .ReturnsAsync(partialResponse);
 
-        var fn = new WowReferenceRefreshFunction(siteAdmin.Object, referenceSync.Object);
+        var fn = new WowReferenceRefreshFunction(siteAdmin.Object, referenceSync.Object, NullLogger<WowReferenceRefreshFunction>.Instance);
         var ctx = MakeFunctionContext(principal);
 
         var (http, lines) = await InvokeAndReadBody(fn, ctx);


### PR DESCRIPTION
## Summary

Addresses the three in-scope audit findings from PR #108 that were filed as follow-ups:

- **`dns.HC-8`** — `WowReferenceRefreshFunction` now logs a warning when a non-admin caller is rejected, with their Battle.net id and the ambient `Activity.TraceId` so failed attempts are visible in Application Insights. New unit test pins this behavior.
- **`RD-COLOR-HARDCODED`** — [AdminReferenceRefreshPage.razor.css:27](app/Pages/AdminReferenceRefreshPage.razor.css#L27) now uses `light-dark(#c0392b, #ff6b6b)` so the failed-row text stays ≥ 4.5:1 on both light and dark Fluent surfaces. The forced-colors fallback is unchanged.
- **`dns.HC-3`** — Accepted risk, documented. New [docs/security-architecture.md](docs/security-architecture.md) explains why every HTTP function uses `AuthorizationLevel.Anonymous` (a Blazor WASM SPA can't safely carry a Functions host key) and how the app-layer auth chain + the new 403 log mitigate the single-layer risk. The `WowReferenceRefreshFunction` class doc-comment now points at this doc.

## Test plan

- [x] `dotnet build lfm.sln -c Release` clean (0 warn / 0 err)
- [x] `dotnet format lfm.sln --verify-no-changes --severity error` clean
- [x] `dotnet test tests/Lfm.Api.Tests` — 459/459 passing (includes new 403-log test)
- [ ] Manual verification: open `/admin/reference` as a non-admin, confirm 403 lands in App Insights with the rejected Battle.net id + trace id
- [ ] Manual verification: toggle browser dark mode on `/admin/reference` results table — failed rows stay readable
