### PR TITLE
Drop ModeKey from wire DTOs and request payloads

### DIFF
--- a/api/Functions/RunsCancelSignupFunction.cs
+++ b/api/Functions/RunsCancelSignupFunction.cs
@@ -115,7 +115,6 @@ public class RunsCancelSignupFunction(
             StartTime: run.StartTime,
             SignupCloseTime: run.SignupCloseTime,
             Description: run.Description,
-            ModeKey: run.ModeKey,
             Visibility: run.Visibility,
             CreatorGuild: run.CreatorGuild,
             InstanceId: run.InstanceId,

--- a/api/Functions/RunsCreateFunction.cs
+++ b/api/Functions/RunsCreateFunction.cs
@@ -131,15 +131,13 @@ public class RunsCreateFunction(IRunsRepository repo, IRaidersRepository raiders
             ? gid
             : null;
 
-        // Resolve the typed mode fields: prefer what the client sent, fall
-        // back to parsing the legacy ModeKey composite. Persist ModeKey too,
-        // deriving "{Difficulty}:{Size}" when the client only sent the new
-        // fields — keeps legacy readers on the write side happy for one
-        // migration cycle.
-        var (difficulty, size) = RunModeResolver.Resolve(body.Difficulty, body.Size ?? 0, body.ModeKey);
-        var modeKey = !string.IsNullOrWhiteSpace(body.ModeKey)
-            ? body.ModeKey!
-            : $"{difficulty}:{size}";
+        // The validator guarantees Difficulty + Size are populated; ModeKey
+        // is computed from them so the persisted RunDocument still satisfies
+        // any legacy reader on the read side (storage-only compatibility —
+        // the wire no longer carries ModeKey).
+        var difficulty = body.Difficulty!;
+        var size = body.Size!.Value;
+        var modeKey = $"{difficulty}:{size}";
 
         return new RunDocument(
             Id: id,
@@ -173,7 +171,6 @@ public class RunsCreateFunction(IRunsRepository repo, IRaidersRepository raiders
             StartTime: doc.StartTime,
             SignupCloseTime: doc.SignupCloseTime,
             Description: doc.Description,
-            ModeKey: doc.ModeKey,
             Visibility: doc.Visibility,
             CreatorGuild: doc.CreatorGuild,
             InstanceId: doc.InstanceId,

--- a/api/Functions/RunsDetailFunction.cs
+++ b/api/Functions/RunsDetailFunction.cs
@@ -81,7 +81,6 @@ public class RunsDetailFunction(IRunsRepository repo, IRaidersRepository raiders
             StartTime: run.StartTime,
             SignupCloseTime: run.SignupCloseTime,
             Description: run.Description,
-            ModeKey: run.ModeKey,
             Visibility: run.Visibility,
             CreatorGuild: run.CreatorGuild,
             InstanceId: run.InstanceId,

--- a/api/Functions/RunsListFunction.cs
+++ b/api/Functions/RunsListFunction.cs
@@ -91,17 +91,16 @@ public class RunsListFunction(IRunsRepository repo, IRaidersRepository raidersRe
             StartTime: run.StartTime,
             SignupCloseTime: run.SignupCloseTime,
             Description: run.Description,
-            ModeKey: run.ModeKey,
             Visibility: run.Visibility,
             CreatorGuild: run.CreatorGuild,
             InstanceId: run.InstanceId,
             InstanceName: run.InstanceName,
-            Difficulty: difficulty,
-            Size: size,
-            KeystoneLevel: run.KeystoneLevel,
             RunCharacters: run.RunCharacters
                 .Select(c => SanitizeCharacter(c, currentBattleNetId))
-                .ToList());
+                .ToList(),
+            Difficulty: difficulty,
+            Size: size,
+            KeystoneLevel: run.KeystoneLevel);
     }
 
     private static RunCharacterDto SanitizeCharacter(

--- a/api/Functions/RunsSignupFunction.cs
+++ b/api/Functions/RunsSignupFunction.cs
@@ -225,7 +225,6 @@ public class RunsSignupFunction(
             StartTime: run.StartTime,
             SignupCloseTime: run.SignupCloseTime,
             Description: run.Description,
-            ModeKey: run.ModeKey,
             Visibility: run.Visibility,
             CreatorGuild: run.CreatorGuild,
             InstanceId: run.InstanceId,

--- a/api/Functions/RunsUpdateFunction.cs
+++ b/api/Functions/RunsUpdateFunction.cs
@@ -154,20 +154,19 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
             }
         }
 
-        // 7. Resolve effective instanceId + modeKey and look up the instance name.
+        // 7. Resolve effective instanceId + mode fields and look up the
+        //    instance name.
         var effectiveInstanceId = body.InstanceId ?? existing.InstanceId;
-        var effectiveModeKey = body.ModeKey ?? existing.ModeKey;
-        var (effectiveDifficulty, effectiveSize) = RunModeResolver.Resolve(
-            body.Difficulty ?? existing.Difficulty,
-            body.Size ?? existing.Size,
-            effectiveModeKey);
+        var effectiveDifficulty = body.Difficulty ?? existing.Difficulty;
+        var effectiveSize = body.Size ?? existing.Size;
+        // ModeKey stays in storage only — derived here so legacy reads still
+        // resolve. The wire no longer carries it.
+        var effectiveModeKey = $"{effectiveDifficulty}:{effectiveSize}";
         var effectiveKeystoneLevel = body.KeystoneLevel ?? existing.KeystoneLevel;
 
-        // Load instances to validate the (instanceId, modeKey) combination and obtain
-        // the canonical instance name. Each InstanceDto row in the container represents
-        // one (instance, mode) pair: InstanceNumericId == Blizzard instance id,
-        // ModeKey == "TYPE:players". Id is a composite "{instanceId}:{modeKey}" —
-        // never parse it as an int (see InstanceDto doc-comment).
+        // Load instances to validate the (instanceId, difficulty, size)
+        // combination and obtain the canonical instance name. Each InstanceDto
+        // row represents one (instance, mode) pair.
         //
         // A dungeon-agnostic Mythic+ run (effectiveInstanceId is null) skips
         // this validation — there is no specific instance to match.
@@ -178,10 +177,12 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
             if (instances.Count == 0)
                 return new ObjectResult(new { error = "Instance data not available" }) { StatusCode = 503 };
 
-            var matchedInstance = instances.FirstOrDefault(
-                i => i.InstanceNumericId == effectiveInstanceId.Value && i.ModeKey == effectiveModeKey);
+            var matchedInstance = instances.FirstOrDefault(i =>
+                i.InstanceNumericId == effectiveInstanceId.Value
+                && i.Difficulty == effectiveDifficulty
+                && i.Size == effectiveSize);
             if (matchedInstance is null)
-                return new BadRequestObjectResult(new { error = "Invalid modeKey for instance" });
+                return new BadRequestObjectResult(new { error = "Invalid difficulty/size for instance" });
             effectiveInstanceName = matchedInstance.Name;
         }
         else
@@ -230,7 +231,6 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
             StartTime: doc.StartTime,
             SignupCloseTime: doc.SignupCloseTime,
             Description: doc.Description,
-            ModeKey: doc.ModeKey,
             Visibility: doc.Visibility,
             CreatorGuild: doc.CreatorGuild,
             InstanceId: doc.InstanceId,

--- a/app/Pages/CreateRunPage.razor
+++ b/app/Pages/CreateRunPage.razor
@@ -459,7 +459,6 @@
                 StartTime: ToIsoOrNull(_startTimeLocal) ?? string.Empty,
                 SignupCloseTime: ToIsoOrNull(_signupCloseLocal),
                 Description: string.IsNullOrWhiteSpace(_description) ? null : _description,
-                ModeKey: null,
                 Visibility: _visibility,
                 InstanceId: instanceOption?.InstanceId,
                 InstanceName: instanceOption?.Name,

--- a/app/Pages/EditRunPage.razor
+++ b/app/Pages/EditRunPage.razor
@@ -516,7 +516,6 @@
                 StartTime: ToIsoOrNull(_startTimeLocal) ?? string.Empty,
                 SignupCloseTime: ToIsoOrNull(_signupCloseLocal),
                 Description: _description,
-                ModeKey: null,
                 Visibility: _visibility,
                 InstanceId: instanceOption?.InstanceId,
                 InstanceName: instanceOption?.Name,

--- a/shared/Lfm.Contracts/Runs/CreateRunRequest.cs
+++ b/shared/Lfm.Contracts/Runs/CreateRunRequest.cs
@@ -7,19 +7,16 @@ namespace Lfm.Contracts.Runs;
 
 /// <summary>
 /// Request body for POST /api/runs.
-/// Mirrors the Zod <c>createRunSchema</c> in
-/// <c>functions/src/functions/runs-create.ts</c>.
 /// </summary>
 public sealed record CreateRunRequest(
     string? StartTime,
     string? SignupCloseTime,
     string? Description,
-    string? ModeKey,
     string? Visibility,
     int? InstanceId,
     string? InstanceName,
-    string? Difficulty = null,
-    int? Size = null,
+    string? Difficulty,
+    int? Size,
     int? KeystoneLevel = null);
 
 public sealed class CreateRunRequestValidator : AbstractValidator<CreateRunRequest>
@@ -44,27 +41,21 @@ public sealed class CreateRunRequestValidator : AbstractValidator<CreateRunReque
         RuleFor(x => x.SignupCloseTime)
             .MaximumLength(64).WithMessage("signupCloseTime must be at most 64 characters");
 
-        // Accept either the legacy ModeKey (for pre-PR-5 clients) or the new
-        // structured Difficulty + Size — at least one must be present.
-        RuleFor(x => x)
-            .Must(x => !string.IsNullOrWhiteSpace(x.ModeKey)
-                      || (!string.IsNullOrEmpty(x.Difficulty) && x.Size is > 0))
-            .WithMessage("modeKey or (difficulty + size) is required");
-
-        RuleFor(x => x.ModeKey)
-            .MaximumLength(64).WithMessage("modeKey must be at most 64 characters");
-
+        RuleFor(x => x.Difficulty)
+            .NotEmpty().WithMessage("difficulty is required");
         RuleFor(x => x.Difficulty)
             .Must(d => d is null || ValidDifficulties.Contains(d))
             .WithMessage("difficulty must be one of LFR, NORMAL, HEROIC, MYTHIC, MYTHIC_KEYSTONE");
 
+        RuleFor(x => x.Size)
+            .NotNull().WithMessage("size is required");
         RuleFor(x => x.Size)
             .InclusiveBetween(1, 40).When(x => x.Size.HasValue)
             .WithMessage("size must be between 1 and 40");
 
         RuleFor(x => x.Visibility)
             .NotEmpty().WithMessage("visibility is required")
-            .Must(v => v is not null && ValidVisibilities.Contains(v))
+            .Must(v => v is null || ValidVisibilities.Contains(v))
             .WithMessage("visibility must be PUBLIC or GUILD");
 
         // InstanceId is required unless the run is a Mythic+ session — M+

--- a/shared/Lfm.Contracts/Runs/RunDetailDto.cs
+++ b/shared/Lfm.Contracts/Runs/RunDetailDto.cs
@@ -10,12 +10,8 @@ namespace Lfm.Contracts.Runs;
 /// endpoint contract. Wire-only shape per docs/wire-payload-contract.md.
 ///
 /// <para>
-/// <b>Mode fields.</b> <see cref="Difficulty"/>, <see cref="Size"/>, and
-/// <see cref="KeystoneLevel"/> are the typed fields consumers should prefer;
-/// <see cref="ModeKey"/> is the legacy composite (<c>"{Difficulty}:{Size}"</c>)
-/// kept for one cycle during the schema migration. <see cref="InstanceId"/>
-/// and <see cref="InstanceName"/> are nullable because a Mythic+ "any dungeon"
-/// session has no specific instance.
+/// See <see cref="RunSummaryDto"/> for the note on the typed mode fields and
+/// nullable instance fields — the same rules apply here.
 /// </para>
 /// </summary>
 public sealed record RunDetailDto(
@@ -23,12 +19,11 @@ public sealed record RunDetailDto(
     string StartTime,
     string SignupCloseTime,
     string Description,
-    string ModeKey,
     string Visibility,
     string CreatorGuild,
     int? InstanceId,
     string? InstanceName,
     IReadOnlyList<RunCharacterDto> RunCharacters,
-    string Difficulty = "",
-    int Size = 0,
+    string Difficulty,
+    int Size,
     int? KeystoneLevel = null);

--- a/shared/Lfm.Contracts/Runs/RunSummaryDto.cs
+++ b/shared/Lfm.Contracts/Runs/RunSummaryDto.cs
@@ -11,11 +11,12 @@ namespace Lfm.Contracts.Runs;
 ///
 /// <para>
 /// <b>Mode fields.</b> <see cref="Difficulty"/>, <see cref="Size"/>, and
-/// <see cref="KeystoneLevel"/> are the typed fields consumers should prefer;
-/// <see cref="ModeKey"/> is the legacy composite kept for one cycle during
-/// the schema migration. <see cref="InstanceId"/> and <see cref="InstanceName"/>
-/// are nullable because a Mythic+ "any dungeon" session has no specific
-/// instance.
+/// <see cref="KeystoneLevel"/> are the canonical typed fields. The legacy
+/// <c>ModeKey</c> composite was dropped from the wire — the server's
+/// <c>RunModeResolver</c> still resolves it internally for Cosmos documents
+/// predating the typed-fields migration, but clients only see the typed
+/// fields. <see cref="InstanceId"/> and <see cref="InstanceName"/> are
+/// nullable because a Mythic+ "any dungeon" session has no specific instance.
 /// </para>
 /// </summary>
 public sealed record RunSummaryDto(
@@ -23,12 +24,11 @@ public sealed record RunSummaryDto(
     string StartTime,
     string SignupCloseTime,
     string Description,
-    string ModeKey,
     string Visibility,
     string CreatorGuild,
     int? InstanceId,
     string? InstanceName,
     IReadOnlyList<RunCharacterDto> RunCharacters,
-    string Difficulty = "",
-    int Size = 0,
+    string Difficulty,
+    int Size,
     int? KeystoneLevel = null);

--- a/shared/Lfm.Contracts/Runs/UpdateRunRequest.cs
+++ b/shared/Lfm.Contracts/Runs/UpdateRunRequest.cs
@@ -8,13 +8,11 @@ namespace Lfm.Contracts.Runs;
 /// <summary>
 /// Request body for PATCH/PUT /api/runs/{id}.
 /// All fields are optional; only supplied fields are applied to the existing run.
-/// Mirrors <c>UpdateRunBody</c> in <c>functions/src/functions/runs-update.ts</c>.
 /// </summary>
 public sealed record UpdateRunRequest(
     string? StartTime,
     string? SignupCloseTime,
     string? Description,
-    string? ModeKey,
     string? Visibility,
     int? InstanceId,
     string? InstanceName,
@@ -39,9 +37,6 @@ public sealed class UpdateRunRequestValidator : AbstractValidator<UpdateRunReque
 
         RuleFor(x => x.SignupCloseTime)
             .MaximumLength(64).WithMessage("signupCloseTime must be at most 64 characters");
-
-        RuleFor(x => x.ModeKey)
-            .MaximumLength(64).WithMessage("modeKey must be at most 64 characters");
 
         RuleFor(x => x.Difficulty)
             .Must(d => d is null || CreateRunRequestValidator.ValidDifficulties.Contains(d))

--- a/tests/Lfm.Api.Tests/Runs/CreateRunRequestValidatorTests.cs
+++ b/tests/Lfm.Api.Tests/Runs/CreateRunRequestValidatorTests.cs
@@ -7,8 +7,8 @@ using Xunit;
 namespace Lfm.Api.Tests.Runs;
 
 /// <summary>
-/// Pins the new Mythic+ validation rules added in PR 5:
-///   - Legacy ModeKey or the new (Difficulty, Size) pair must be present.
+/// Pins the Mythic+ validation rules on the create-run payload:
+///   - Difficulty + Size are both required.
 ///   - InstanceId is required unless Difficulty == MYTHIC_KEYSTONE.
 ///   - KeystoneLevel is only valid on Mythic+ and must be present when the
 ///     run is dungeon-less.
@@ -22,7 +22,6 @@ public class CreateRunRequestValidatorTests
         new(StartTime: ValidStart,
             SignupCloseTime: null,
             Description: null,
-            ModeKey: null,
             Visibility: "PUBLIC",
             InstanceId: 1200,
             InstanceName: "Liberation of Undermine",
@@ -31,26 +30,26 @@ public class CreateRunRequestValidatorTests
             KeystoneLevel: null);
 
     [Fact]
-    public void Accepts_structured_Difficulty_Size_without_ModeKey()
+    public void Accepts_structured_Difficulty_Size()
     {
         var result = Sut.Validate(Valid());
         Assert.True(result.IsValid, string.Join("; ", result.Errors.Select(e => e.ErrorMessage)));
     }
 
     [Fact]
-    public void Accepts_legacy_ModeKey_without_structured_fields()
+    public void Rejects_missing_Difficulty()
     {
-        var req = Valid() with { ModeKey = "HEROIC:25", Difficulty = null, Size = null };
+        var req = Valid() with { Difficulty = null };
         var result = Sut.Validate(req);
-        Assert.True(result.IsValid, string.Join("; ", result.Errors.Select(e => e.ErrorMessage)));
+        Assert.Contains(result.Errors, e => e.ErrorMessage.Contains("difficulty is required"));
     }
 
     [Fact]
-    public void Rejects_when_both_ModeKey_and_structured_fields_missing()
+    public void Rejects_missing_Size()
     {
-        var req = Valid() with { ModeKey = null, Difficulty = null, Size = null };
+        var req = Valid() with { Size = null };
         var result = Sut.Validate(req);
-        Assert.Contains(result.Errors, e => e.ErrorMessage.Contains("modeKey or (difficulty + size) is required"));
+        Assert.Contains(result.Errors, e => e.ErrorMessage.Contains("size is required"));
     }
 
     [Fact]

--- a/tests/Lfm.Api.Tests/RunsCreateFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RunsCreateFunctionTests.cs
@@ -122,7 +122,8 @@ public class RunsCreateFunctionTests
             startTime = FutureStartTime,
             signupCloseTime = FutureSignupCloseTime,
             description = "Created run",
-            modeKey = "NORMAL:10",
+            difficulty = "NORMAL",
+            size = 10,
             visibility = "GUILD",
             instanceId = 631,
             instanceName = "Icecrown Citadel",
@@ -196,7 +197,8 @@ public class RunsCreateFunctionTests
         var requestBody = new
         {
             startTime = FutureStartTime,
-            modeKey = "NORMAL:10",
+            difficulty = "NORMAL",
+            size = 10,
             visibility = "GUILD",
             instanceId = 631,
         };
@@ -244,7 +246,8 @@ public class RunsCreateFunctionTests
             startTime = FutureStartTime,
             signupCloseTime = FutureSignupCloseTime,
             description = "Created run",
-            modeKey = "NORMAL:10",
+            difficulty = "NORMAL",
+            size = 10,
             visibility = "GUILD",
             instanceId = 631,
             instanceName = "Icecrown Citadel",

--- a/tests/Lfm.Api.Tests/WriteRequestLengthCapsTests.cs
+++ b/tests/Lfm.Api.Tests/WriteRequestLengthCapsTests.cs
@@ -28,9 +28,10 @@ public class WriteRequestLengthCapsTests
             StartTime: "2026-05-01T19:00:00Z",
             SignupCloseTime: null,
             Description: LongerThan(2000),
-            ModeKey: "NORMAL:10",
             Visibility: "PUBLIC",
             InstanceId: 631,
+            Difficulty: "NORMAL",
+            Size: 10,
             InstanceName: null);
 
         var result = new CreateRunRequestValidator().Validate(req);
@@ -46,9 +47,10 @@ public class WriteRequestLengthCapsTests
             StartTime: "2026-05-01T19:00:00Z",
             SignupCloseTime: null,
             Description: new string('x', 2000),
-            ModeKey: "NORMAL:10",
             Visibility: "PUBLIC",
             InstanceId: 631,
+            Difficulty: "NORMAL",
+            Size: 10,
             InstanceName: null);
 
         var result = new CreateRunRequestValidator().Validate(req);
@@ -63,33 +65,16 @@ public class WriteRequestLengthCapsTests
             StartTime: "2026-05-01T19:00:00Z",
             SignupCloseTime: null,
             Description: null,
-            ModeKey: "NORMAL:10",
             Visibility: "PUBLIC",
             InstanceId: 631,
+            Difficulty: "NORMAL",
+            Size: 10,
             InstanceName: LongerThan(128));
 
         var result = new CreateRunRequestValidator().Validate(req);
 
         Assert.False(result.IsValid);
         Assert.Contains(result.Errors, e => e.PropertyName == "InstanceName");
-    }
-
-    [Fact]
-    public void CreateRun_modeKey_over_64_chars_fails()
-    {
-        var req = new CreateRunRequest(
-            StartTime: "2026-05-01T19:00:00Z",
-            SignupCloseTime: null,
-            Description: null,
-            ModeKey: LongerThan(64),
-            Visibility: "PUBLIC",
-            InstanceId: 631,
-            InstanceName: null);
-
-        var result = new CreateRunRequestValidator().Validate(req);
-
-        Assert.False(result.IsValid);
-        Assert.Contains(result.Errors, e => e.PropertyName == "ModeKey");
     }
 
     // ------------------------------------------------------------------
@@ -103,7 +88,6 @@ public class WriteRequestLengthCapsTests
             StartTime: null,
             SignupCloseTime: null,
             Description: LongerThan(2000),
-            ModeKey: null,
             Visibility: null,
             InstanceId: null,
             InstanceName: null);
@@ -122,7 +106,6 @@ public class WriteRequestLengthCapsTests
             StartTime: null,
             SignupCloseTime: null,
             Description: null,
-            ModeKey: null,
             Visibility: null,
             InstanceId: null,
             InstanceName: null);
@@ -139,7 +122,6 @@ public class WriteRequestLengthCapsTests
             StartTime: null,
             SignupCloseTime: null,
             Description: null,
-            ModeKey: null,
             Visibility: null,
             InstanceId: null,
             InstanceName: LongerThan(128));

--- a/tests/Lfm.App.Core.Tests/Services/RunsClientTests.cs
+++ b/tests/Lfm.App.Core.Tests/Services/RunsClientTests.cs
@@ -34,12 +34,13 @@ public class RunsClientTests
             StartTime: FutureStartTime,
             SignupCloseTime: FutureSignupCloseTime,
             Description: "Test run",
-            ModeKey: "heroic",
             Visibility: "PUBLIC",
             CreatorGuild: "Stormchasers",
             InstanceId: 1,
             InstanceName: "Liberation of Undermine",
-            RunCharacters: []);
+            RunCharacters: [],
+            Difficulty: "HEROIC",
+            Size: 25);
 
     private static RunDetailDto MakeDetail(string id = "run-1") =>
         new(
@@ -47,22 +48,24 @@ public class RunsClientTests
             StartTime: FutureStartTime,
             SignupCloseTime: FutureSignupCloseTime,
             Description: "Test run",
-            ModeKey: "heroic",
             Visibility: "PUBLIC",
             CreatorGuild: "Stormchasers",
             InstanceId: 1,
             InstanceName: "Liberation of Undermine",
-            RunCharacters: []);
+            RunCharacters: [],
+            Difficulty: "HEROIC",
+            Size: 25);
 
     private static CreateRunRequest MakeCreateRequest() =>
         new(
             StartTime: FutureStartTime,
             SignupCloseTime: FutureSignupCloseTime,
             Description: "desc",
-            ModeKey: "heroic",
             Visibility: "PUBLIC",
             InstanceId: 1,
-            InstanceName: "Liberation of Undermine");
+            InstanceName: "Liberation of Undermine",
+            Difficulty: "HEROIC",
+            Size: 25);
 
     [Fact]
     public async Task ListAsync_deserializes_items_from_runs_list_response_envelope()
@@ -204,10 +207,11 @@ public class RunsClientTests
             StartTime: FutureStartTime,
             SignupCloseTime: FutureSignupCloseTime,
             Description: "updated",
-            ModeKey: "heroic",
             Visibility: "PUBLIC",
             InstanceId: 1,
-            InstanceName: "Liberation of Undermine");
+            InstanceName: "Liberation of Undermine",
+            Difficulty: "HEROIC",
+            Size: 25);
 
         var result = await client.UpdateAsync("run-1", request, CancellationToken.None);
 

--- a/tests/Lfm.App.Tests/RunsPageKeyboardTests.cs
+++ b/tests/Lfm.App.Tests/RunsPageKeyboardTests.cs
@@ -25,12 +25,13 @@ public class RunsPageKeyboardTests : ComponentTestBase
             StartTime: FutureStartTime,
             SignupCloseTime: FutureSignupCloseTime,
             Description: "",
-            ModeKey: "MYTHIC",
             Visibility: "PUBLIC",
             CreatorGuild: "Test",
             InstanceId: 1,
             InstanceName: name,
-            RunCharacters: Array.Empty<RunCharacterDto>());
+            RunCharacters: Array.Empty<RunCharacterDto>(),
+            Difficulty: "MYTHIC",
+            Size: 20);
 
     [Fact]
     public void RunsPage_Run_List_Item_Is_A_Button()

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -31,7 +31,6 @@ public class RunsPagesTests : ComponentTestBase
             StartTime: FutureStartTime,
             SignupCloseTime: FutureSignupCloseTime,
             Description: "Test run",
-            ModeKey: "HEROIC:25",
             Visibility: "PUBLIC",
             CreatorGuild: "Stormchasers",
             InstanceId: 1,
@@ -46,7 +45,6 @@ public class RunsPagesTests : ComponentTestBase
             StartTime: FutureStartTime,
             SignupCloseTime: FutureSignupCloseTime,
             Description: "Test run",
-            ModeKey: "HEROIC:25",
             Visibility: "PUBLIC",
             CreatorGuild: "Stormchasers",
             InstanceId: 1,
@@ -261,7 +259,7 @@ public class RunsPagesTests : ComponentTestBase
         // Standard composition target for 25-man is 2T / 5H / 18D, so the
         // rendered composition summary is "T 0/2 · H 0/5 · D 2/18" with the
         // tank + healer slots carrying the shortage modifier class.
-        var summary = MakeSummary() with { Difficulty = "MYTHIC", Size = 25, ModeKey = "MYTHIC:25" };
+        var summary = MakeSummary() with { Difficulty = "MYTHIC", Size = 25 };
         client.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<RunSummaryDto>
             {


### PR DESCRIPTION
## Summary

Final cleanup of the `ModeKey` → `Difficulty` / `Size` / `KeystoneLevel` migration. After PRs #99–#109 the server always populates the typed fields on the wire and no client still reads or writes `ModeKey`. This PR removes the legacy field from every wire contract.

**Contracts (wire-only; storage is unchanged)**
- `RunSummaryDto`, `RunDetailDto`: drop `ModeKey`.
- `CreateRunRequest`: drop `ModeKey`; validator now requires `Difficulty` + `Size` (was: "legacy ModeKey OR structured pair").
- `UpdateRunRequest`: drop `ModeKey`.

**Server**
- All 5 sanitizer/projector call sites stop emitting `ModeKey` on the wire.
- `RunsCreateFunction`: computes `RunDocument.ModeKey = "{Difficulty}:{Size}"` at write time so Cosmos documents retain the storage-side ModeKey (one-cycle legacy-reader compat).
- `RunsUpdateFunction`: same derivation; instance-lookup now matches by `(Difficulty, Size)` directly rather than re-deriving ModeKey strings to compare.
- `RunModeResolver` is left in place — it still resolves legacy Cosmos documents that predate the structured-fields persistence.

**Client**
- `CreateRunPage` and `EditRunPage` drop `ModeKey: null` from the request payload.

**Tests**
- 804/804 green (459 api / 174 bunit / 172 core, minus 1 retired ModeKey-length-cap test).
- Validator tests pin the new requirement ("difficulty is required", "size is required").
- `MakeSummary` / `MakeDetail` / `MakeCreateRequest` helpers drop `ModeKey`; existing Difficulty/Size coverage carries through.

**Still present (deliberate scope)**
- `RunDocument.ModeKey` in Cosmos storage (read/write), for compat with the small number of legacy documents that predate the structured-fields migration.
- `InstanceDto.ModeKey` + `InstanceDto.Id`'s composite format — displayed in the `InstancesPage` grid and used as dropdown option keys. Scoped out; can be cleaned up in a follow-up if the wire-payload audit flags it.

## Test plan

- [x] `dotnet build lfm.sln -c Release` clean (0 warn / 0 err)
- [x] `dotnet format lfm.sln --verify-no-changes --severity error` clean
- [x] `dotnet test tests/Lfm.Api.Tests` — 458/458 (one retired test)
- [x] `dotnet test tests/Lfm.App.Tests` — 174/174
- [x] `dotnet test tests/Lfm.App.Core.Tests` — 172/172
- [ ] Manual verification: create + edit a run in the SPA, confirm the request/response payloads in devtools no longer contain `modeKey`; the displayed difficulty pill + run list still render correctly
