### PR TITLE
Fix /runs/new ToggleGroup contrast + add missing axe-core scan

### DIFF
--- a/app/Components/ToggleGroup.razor.css
+++ b/app/Components/ToggleGroup.razor.css
@@ -85,7 +85,13 @@
 
 .toggle-group__option[data-selected="true"] {
     background-color: var(--accent-fill-rest);
-    color: var(--accent-foreground-rest, #fff);
+    /* --foreground-on-accent-rest is the FluentUI token for text placed ON
+       TOP OF accent fill (contrast-paired with --accent-fill-rest).
+       --accent-foreground-rest is a different token — accent color used AS
+       text (link emphasis, icon tint) — pairing it with --accent-fill-rest
+       produces accent-on-accent with no contrast. See
+       docs/frontend-style-guide.md §Tokens. */
+    color: var(--foreground-on-accent-rest, #fff);
     /* Match the selected border to the fill so the boundary with adjacent
        unselected buttons reads as a single coherent shape rather than a
        stripe. Keep the same width to avoid layout shift. */

--- a/app/Pages/CreateRunPage.razor
+++ b/app/Pages/CreateRunPage.razor
@@ -120,11 +120,16 @@
                                    @bind:event="oninput"
                                    disabled="@_submitting"
                                    style="inline-size:7rem" />
+                            @* The visible text ("WNL (+10)") is the accessible name so SC 2.5.3
+                               (Label in Name) holds — voice control users can say the button's
+                               visible label to activate it. Title still exposes the explanation
+                               as a pointer tooltip + screen-reader description. A separate
+                               aria-label duplicating the description would hide "WNL (+10)" from
+                               the accessible name and fail the label-in-name check. *@
                             <FluentButton Appearance="Appearance.Outline"
                                           OnClick="@(() => _keystoneLevel = 10)"
                                           Disabled="@_submitting"
-                                          Title="@Loc["createRun.keyLevel.wnlDescription"]"
-                                          aria-label="@Loc["createRun.keyLevel.wnlDescription"]">
+                                          Title="@Loc["createRun.keyLevel.wnlDescription"]">
                                 @Loc["createRun.keyLevel.wnl"]
                             </FluentButton>
                         </FluentStack>

--- a/tests/Lfm.E2E/Specs/AccessibilitySpec.cs
+++ b/tests/Lfm.E2E/Specs/AccessibilitySpec.cs
@@ -274,6 +274,42 @@ public class AccessibilitySpec(AccessibilityFixture fixture, ITestOutputHelper o
         await AccessibilityHelper.ScanAndAssert(page, Output, "/instances");
     }
 
+    [Fact]
+    public async Task CreateRunPage_MeetsWcag22AA()
+    {
+        // `/runs/new` (Schedule a run) was reshaped on 2026-04-22 without any
+        // axe-core coverage. This scan would have caught the ToggleGroup
+        // selected-state contrast regression where `--accent-foreground-rest`
+        // (wrong token — accent-color-as-text) was paired with
+        // `--accent-fill-rest` (accent fill) instead of
+        // `--foreground-on-accent-rest`. The post-interaction scan swaps the
+        // selected radio so the active accent-fill pairing is exercised even
+        // if the default (`Raid`) happened to pass (`E-HC-A2`).
+        await using var authContext = await AuthHelper.AuthenticatedContextAsync(
+            fixture.Stack.Browser,
+            fixture.Stack.ApiBaseUrl,
+            fixture.Stack.AppBaseUrl);
+
+        var page = await authContext.NewPageAsync();
+
+        await page.GotoAsync($"{fixture.Stack.AppBaseUrl}/runs/new",
+            new() { WaitUntil = WaitUntilState.NetworkIdle });
+
+        await Assertions.Expect(
+            page.GetByRole(AriaRole.Heading, new() { Name = "Schedule a run" }))
+            .ToBeVisibleAsync(new() { Timeout = 15000 });
+
+        await AccessibilityHelper.ScanAndAssert(page, Output, "/runs/new (load)");
+
+        // Toggling Activity re-renders the selected ToggleGroup option, the
+        // conditional Dungeon sub-toggle, and the instance dropdown — all
+        // surfaces whose contrast / labels are invisible at load time.
+        await AccessibilityHelper.ScanAfterAsync(page, Output, "/runs/new (Dungeon selected)", async () =>
+        {
+            await page.GetByRole(AriaRole.Radio, new() { Name = "Dungeon" }).ClickAsync();
+        });
+    }
+
     // -------------------------------------------------------------------------
     // Keyboard navigation tests
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Bug:** The selected state on `ToggleGroup` (Activity, Dungeon, Visibility pickers on `/runs/new`) used `color: var(--accent-foreground-rest, #fff)` on top of `background-color: var(--accent-fill-rest)`. `--accent-foreground-rest` is FluentUI's "accent color used **as** text" token (link emphasis, icon tint) — not the same as `--foreground-on-accent-rest`, which is the contrast-paired "text **on top of** accent fill" token. The visible fallback `#fff` rendered white-on-light-cyan at load time. Switch to the correct token, matching `CharactersPage.razor:61`, `app.css:31`, and `docs/frontend-style-guide.md §Tokens`.
- **Root cause of the miss:** `/runs/new` had no axe-core coverage in the E2E suite. Added `CreateRunPage_MeetsWcag22AA` with a post-toggle re-scan so the selected accent-fill pairing is exercised even if the default-selected option happens to pass.
- **Also:** The WNL (+10) button had an `aria-label` that omitted the visible text, violating SC 2.5.3 (Label in Name). Dropped the aria-label; `Title` still carries the explanation as tooltip/accessible description.

## Expansion-picker side question

The user asked whether Blizzard's Game Data API exposes a "current expansion" flag. Short answer in the plan: **no**. `/data/wow/journal-expansion/index` returns tiers with `{id, name, key}` — no `isCurrent`, no release date. The ids aren't even in release order (Classic=68, Burning Crusade=67 — Classic was backfilled after the Journal system shipped). The canonical community conventions are "last element of tiers" (this app, matches Blizzard's return order) or "highest id in tiers". Current pipeline is doing the right thing — no change.

## Test plan

- [x] `dotnet build lfm.sln -c Release` (0 warnings / 0 errors)
- [x] `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release` (174 passing)
- [x] `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release` (172 passing)
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` (459 passing)
- [x] `dotnet format lfm.sln --verify-no-changes --severity error` (clean)
- [ ] `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --filter "FullyQualifiedName~CreateRunPage_MeetsWcag22AA"` — could not run locally (Azurite 3.28.0 pinned in `StackFixture.cs:56-57` rejects the Azure SDK's newer `2026-02-06` API version, pre-existing infra issue independent of this change). CI runs the E2E suite.

## Screenshots

Before (original screenshot the user shared):

![before](https://via.placeholder.com/0?text=see-issue-screenshot) <!-- user screenshot shows cyan fill + low-contrast white text on Dungeon/Any dungeon/Public -->

After: the selected-state text now uses `--foreground-on-accent-rest`, which FluentUI guarantees is contrast-paired with `--accent-fill-rest`. The Windows High Contrast fallback (`forced-colors: active` block) is unchanged.