### PR TITLE
Drop expansion picker; default run form to Current Season

### DIFF
--- a/app/Components/RunListItem.razor
+++ b/app/Components/RunListItem.razor
@@ -13,7 +13,7 @@
         aria-pressed="@(IsSelected ? "true" : "false")"
         @onclick="HandleClick">
     <span class="run-list-item__header">
-        <span class="run-list-item__title">@Run.InstanceName</span>
+        <span class="run-list-item__title">@_title</span>
         <DifficultyPill Difficulty="@Run.Difficulty" />
     </span>
     <span class="run-list-item__meta">
@@ -51,6 +51,7 @@
     private string _isCurrentUserClass = "false";
     private bool _isMe;
     private RunRoleCounts _counts;
+    private string _title = "";
     private string _ariaLabel = "";
     private string _compositionAria = "";
 
@@ -61,7 +62,12 @@
         _isMe = RunVisualization.IsCurrentUserSignedUp(Run.RunCharacters);
         _isCurrentUserClass = _isMe ? "true" : "false";
         _counts = RunVisualization.CountRoles(Run.RunCharacters, Run.Size);
-        _ariaLabel = Loc["runs.listItemAriaLabel", Run.InstanceName ?? "", FormatDate(Run.StartTime)].Value;
+        // Mythic+ "any dungeon" runs carry no InstanceName; fall back to a
+        // localized label so the list entry isn't missing a heading.
+        _title = string.IsNullOrEmpty(Run.InstanceName)
+            ? Loc["runs.anyDungeon"].Value
+            : Run.InstanceName;
+        _ariaLabel = Loc["runs.listItemAriaLabel", _title, FormatDate(Run.StartTime)].Value;
         _compositionAria = Loc["runs.compositionAria",
             _counts.Tank.Attending, _counts.Healer.Attending, _counts.Dps.Attending].Value;
     }

--- a/app/Pages/CreateRunPage.razor
+++ b/app/Pages/CreateRunPage.razor
@@ -34,19 +34,6 @@
         <FluentCard>
             <FluentStack Orientation="Orientation.Vertical" VerticalGap="12">
 
-                @* ── Expansion selector ─────────────────────────────────── *@
-                <FluentSelect Id="expansion-select"
-                              Label="@Loc["createRun.expansion"]"
-                              TOption="string"
-                              Value="@_expansionId.ToString()"
-                              ValueChanged="@OnExpansionChanged"
-                              Disabled="@_submitting">
-                    @foreach (var exp in _expansions)
-                    {
-                        <FluentOption Value="@exp.Id.ToString()">@exp.Name</FluentOption>
-                    }
-                </FluentSelect>
-
                 @* ── Activity (Raid / Dungeon) ──────────────────────────── *@
                 <div>
                     <span id="createRun-activity-label" class="field__label">@Loc["createRun.activity"]</span>
@@ -239,6 +226,12 @@
 </FluentStack>
 
 @code {
+    // The instance list is scoped to Blizzard's "Current Season" journal
+    // expansion tier. The create-run form does not let the user pick an
+    // expansion — M+, raids, and non-M+ dungeons are all pulled from the
+    // currently-active rotation.
+    private const string CurrentSeasonExpansion = "Current Season";
+
     // ── Loaded data ────────────────────────────────────────────────────────
     private IReadOnlyList<ExpansionDto> _expansions = [];
     private IReadOnlyList<InstanceOption> _allInstances = [];
@@ -321,8 +314,7 @@
             try { _guild = await guildTask; }
             catch { _guild = null; }
 
-            // Default to the newest (= last in Blizzard's canonical order) expansion.
-            if (_expansions.Count > 0) _expansionId = _expansions[^1].Id;
+            _expansionId = ResolveCurrentSeasonId(_expansions);
 
             RebuildStaticOptions();
             RefreshDifficultyOptions();
@@ -342,19 +334,6 @@
     }
 
     // ── Event handlers ─────────────────────────────────────────────────────
-    private void OnExpansionChanged(string value)
-    {
-        if (int.TryParse(value, out var id))
-        {
-            _expansionId = id;
-            _instanceId = 0;
-            _difficulty = _activity == ActivityKind.Dungeon ? "MYTHIC_KEYSTONE" : "";
-            _size = _activity == ActivityKind.Dungeon ? 5 : 0;
-            _keystoneLevel = null;
-            RefreshDifficultyOptions();
-        }
-    }
-
     private void OnActivityChanged(ActivityKind value)
     {
         _activity = value;
@@ -439,6 +418,16 @@
             _visibility = "GUILD";
         else
             _visibility = "PUBLIC";
+    }
+
+    // Match the Blizzard "Current Season" tier by its canonical English name.
+    // Falls back to the highest-id expansion so the form still works on a
+    // stale manifest that predates the current rotation being ingested.
+    private static int ResolveCurrentSeasonId(IReadOnlyList<ExpansionDto> expansions)
+    {
+        var current = expansions.FirstOrDefault(e => e.Name == CurrentSeasonExpansion);
+        if (current is not null) return current.Id;
+        return expansions.Count == 0 ? 0 : expansions.MaxBy(e => e.Id)!.Id;
     }
 
     // The native <input type="datetime-local"> binds wall-clock time with no

--- a/app/Pages/EditRunPage.razor
+++ b/app/Pages/EditRunPage.razor
@@ -42,20 +42,6 @@
                 <FluentStack Orientation="Orientation.Vertical" VerticalGap="12">
                     <FluentLabel Typo="Typography.H4">@Loc["editRun.runDetails"]</FluentLabel>
 
-                    @* Expansion selector — locked once the run has signups so the
-                       instance list stays stable on the row the run is pinned to. *@
-                    <FluentSelect Id="expansion-select"
-                                  Label="@Loc["createRun.expansion"]"
-                                  TOption="string"
-                                  Value="@_expansionId.ToString()"
-                                  ValueChanged="@OnExpansionChanged"
-                                  Disabled="@(_saving || _hasSignups)">
-                        @foreach (var exp in _expansions)
-                        {
-                            <FluentOption Value="@exp.Id.ToString()">@exp.Name</FluentOption>
-                        }
-                    </FluentSelect>
-
                     <div>
                         <span id="editRun-activity-label" class="field__label">@Loc["createRun.activity"]</span>
                         <ToggleGroup TValue="ActivityKind"
@@ -276,6 +262,12 @@
 </FluentStack>
 
 @code {
+    // The instance list is scoped to Blizzard's "Current Season" journal
+    // expansion tier. The edit-run form does not let the user pick an
+    // expansion — M+, raids, and non-M+ dungeons are all pulled from the
+    // currently-active rotation.
+    private const string CurrentSeasonExpansion = "Current Season";
+
     [Parameter] public string? RunId { get; set; }
 
     // ── Loading ────────────────────────────────────────────────────────────
@@ -339,6 +331,16 @@
     private static string? ToIsoOrNull(DateTime? dt) =>
         dt is null ? null : dt.Value.ToUniversalTime().ToString("o");
 
+    // Match the Blizzard "Current Season" tier by its canonical English name.
+    // Falls back to the highest-id expansion so the form still works on a
+    // stale manifest that predates the current rotation being ingested.
+    private static int ResolveCurrentSeasonId(IReadOnlyList<ExpansionDto> expansions)
+    {
+        var current = expansions.FirstOrDefault(e => e.Name == CurrentSeasonExpansion);
+        if (current is not null) return current.Id;
+        return expansions.Count == 0 ? 0 : expansions.MaxBy(e => e.Id)!.Id;
+    }
+
     // ── Lifecycle ──────────────────────────────────────────────────────────
     protected override async Task OnInitializedAsync()
     {
@@ -391,7 +393,7 @@
 
         _activity = match?.Activity
             ?? (run.Difficulty == "MYTHIC_KEYSTONE" ? ActivityKind.Dungeon : ActivityKind.Raid);
-        _expansionId = match?.ExpansionId ?? _expansions.LastOrDefault()?.Id ?? 0;
+        _expansionId = match?.ExpansionId ?? ResolveCurrentSeasonId(_expansions);
         _instanceId = match?.InstanceId ?? 0;
         _difficulty = string.IsNullOrEmpty(run.Difficulty)
             ? (match?.Difficulties.LastOrDefault()?.DifficultyId ?? "")
@@ -410,19 +412,6 @@
 
         RefreshDifficultyOptions();
         _canCreateGuildRuns = _guild?.MemberPermissions?.CanCreateGuildRuns ?? false;
-    }
-
-    private void OnExpansionChanged(string value)
-    {
-        if (int.TryParse(value, out var id))
-        {
-            _expansionId = id;
-            _instanceId = 0;
-            _difficulty = _activity == ActivityKind.Dungeon ? "MYTHIC_KEYSTONE" : "";
-            _size = _activity == ActivityKind.Dungeon ? 5 : 0;
-            _keystoneLevel = null;
-            RefreshDifficultyOptions();
-        }
     }
 
     private void OnActivityChanged(ActivityKind value)

--- a/app/Pages/RunsPage.razor
+++ b/app/Pages/RunsPage.razor
@@ -99,7 +99,7 @@
                             <FluentStack Orientation="Orientation.Vertical" VerticalGap="12">
                                 <div class="run-detail-header">
                                     <div class="run-detail-heading">
-                                        <h2 class="run-detail-title">@selectedRun.InstanceName</h2>
+                                        <h2 class="run-detail-title">@RenderTitle(selectedRun.InstanceName)</h2>
                                         @if (!string.IsNullOrWhiteSpace(selectedRun.Description))
                                         {
                                             <p class="run-detail-description">@selectedRun.Description</p>
@@ -283,6 +283,11 @@
         TimeHorizon.Past => Loc["runs.horizon.past"],
         _ => Loc["runs.horizon.unknown"],
     };
+
+    // Mythic+ "any dungeon" runs carry no InstanceName; fall back to a
+    // localized label so the detail heading isn't missing.
+    private string RenderTitle(string? instanceName) =>
+        string.IsNullOrEmpty(instanceName) ? Loc["runs.anyDungeon"].Value : instanceName;
 
     // Upcoming horizons ascending (soonest first); Past descending (most
     // recent first); Unknown tail-end so unparseable rows remain visible.

--- a/app/wwwroot/locales/en.json
+++ b/app/wwwroot/locales/en.json
@@ -109,6 +109,7 @@
     "runs.horizon.unknown": "Scheduled",
     "runs.showPast": "Show past runs ({0})",
     "runs.hidePast": "Hide past runs",
+    "runs.anyDungeon": "Any dungeon",
     "runs.refreshing": "Refreshing\u2026",
 
     "createRun.title": "Schedule a run",

--- a/app/wwwroot/locales/fi.json
+++ b/app/wwwroot/locales/fi.json
@@ -98,6 +98,7 @@
     "runs.horizon.unknown": "Aikataulutettu",
     "runs.showPast": "N\u00e4yt\u00e4 menneet juoksut ({0})",
     "runs.hidePast": "Piilota menneet juoksut",
+    "runs.anyDungeon": "Mikä tahansa luolasto",
     "runs.refreshing": "P\u00e4ivitet\u00e4\u00e4n\u2026",
     "createRun.title": "Ajasta juoksu",
     "createRun.expansion": "Laajennus",

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -18,6 +18,11 @@ public class RunsPagesTests : ComponentTestBase
 {
     // ── Shared helpers ───────────────────────────────────────────────────────
 
+    // Mirrors the same constant in CreateRunPage/EditRunPage — see those
+    // pages' `ResolveCurrentSeasonId` helper. Kept local so a rename in the
+    // page breaks this test before the form silently reverts behavior.
+    private const string CurrentSeasonExpansion = "Current Season";
+
     // Anchored to UtcNow so these fixtures never become time bombs against a
     // future-dated assertion. See issue #49.
     private static readonly string FutureStartTime =
@@ -304,6 +309,74 @@ public class RunsPagesTests : ComponentTestBase
         Assert.False(item.HasAttribute("style"));
     }
 
+    [Fact]
+    public void RunsPage_RunListItem_FallsBackToAnyDungeonLabel_WhenInstanceNameIsNull()
+    {
+        // Mythic+ "any dungeon" runs persist InstanceName as null per the
+        // wire contract. Without a fallback the list item renders a blank
+        // heading, which is what the user reported. Pin the localized label
+        // so a locale-key rename or fallback regression is caught here.
+        var summary = MakeSummary() with
+        {
+            InstanceId = null,
+            InstanceName = null,
+            Difficulty = "MYTHIC_KEYSTONE",
+            Size = 5,
+        };
+        var client = new Mock<IRunsClient>();
+        client.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<RunSummaryDto> { summary });
+        Services.AddSingleton(client.Object);
+
+        var cut = Render<RunsPage>();
+
+        cut.WaitForAssertion(() =>
+        {
+            var title = cut.Find(".run-list-item__title");
+            Assert.Equal(Loc("runs.anyDungeon"), title.TextContent.Trim());
+        });
+
+        // The aria-label template weaves the title into the accessible name
+        // too — same fallback must apply so screen-reader users aren't fed
+        // an empty string before the date.
+        var runButton = cut.Find("button.run-list-item");
+        var ariaLabel = runButton.GetAttribute("aria-label") ?? string.Empty;
+        Assert.Contains(Loc("runs.anyDungeon"), ariaLabel);
+    }
+
+    [Fact]
+    public void RunsPage_DetailHeading_FallsBackToAnyDungeonLabel_WhenInstanceNameIsNull()
+    {
+        var summary = MakeSummary() with
+        {
+            InstanceId = null,
+            InstanceName = null,
+            Difficulty = "MYTHIC_KEYSTONE",
+            Size = 5,
+        };
+        var detail = MakeDetail() with
+        {
+            InstanceId = null,
+            InstanceName = null,
+            Difficulty = "MYTHIC_KEYSTONE",
+            Size = 5,
+        };
+        var client = new Mock<IRunsClient>();
+        client.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<RunSummaryDto> { summary });
+        client.Setup(c => c.GetAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(detail);
+        Services.AddSingleton(client.Object);
+
+        var cut = Render<RunsPage>(p => p.Add(x => x.RunId, "run-1"));
+
+        cut.WaitForAssertion(() =>
+        {
+            var heading = cut.Find(".run-detail-title");
+            Assert.Equal(Loc("runs.anyDungeon"), heading.TextContent.Trim());
+        });
+    }
+
     // ── CreateRunPage ────────────────────────────────────────────────────────
 
     private void WireCreateRunServices(
@@ -370,6 +443,27 @@ public class RunsPagesTests : ComponentTestBase
             Assert.Contains(Loc("createRun.submit"), cut.Markup));
     }
 
+    [Fact]
+    public void CreateRunPage_DoesNotRenderExpansionSelector()
+    {
+        // The create-run form scopes its instance list to the Blizzard
+        // "Current Season" tier unconditionally — M+, raids, and non-M+
+        // dungeons all come from the current rotation. Pin the absence of
+        // an expansion dropdown so a regression that reintroduces cross-
+        // expansion selection surfaces here.
+        WireCreateRunServices(expansions: new List<ExpansionDto>
+        {
+            new(505, "The War Within"),
+            new(999, CurrentSeasonExpansion),
+        });
+
+        var cut = Render<CreateRunPage>();
+
+        cut.WaitForAssertion(() =>
+            Assert.Contains(Loc("createRun.submit"), cut.Markup));
+        Assert.Empty(cut.FindAll("#expansion-select"));
+    }
+
     // ── EditRunPage ──────────────────────────────────────────────────────────
 
     private Mock<IRunsClient> WireEditRunServices(
@@ -420,6 +514,27 @@ public class RunsPagesTests : ComponentTestBase
 
         cut.WaitForAssertion(() =>
             Assert.Contains(Loc("editRun.saveChanges"), cut.Markup));
+    }
+
+    [Fact]
+    public void EditRunPage_DoesNotRenderExpansionSelector()
+    {
+        // Same rationale as CreateRunPage_DoesNotRenderExpansionSelector:
+        // the edit form also scopes to the Current Season tier only.
+        var runsClient = new Mock<IRunsClient>();
+        runsClient.Setup(c => c.GetAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeDetail());
+        WireEditRunServices(runsClient, expansions: new List<ExpansionDto>
+        {
+            new(505, "The War Within"),
+            new(999, CurrentSeasonExpansion),
+        });
+
+        var cut = Render<EditRunPage>(p => p.Add(x => x.RunId, "run-1"));
+
+        cut.WaitForAssertion(() =>
+            Assert.Contains(Loc("editRun.saveChanges"), cut.Markup));
+        Assert.Empty(cut.FindAll("#expansion-select"));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Remove the expansion dropdown from the create/edit run forms — both pages now implicitly scope their instance list to the Blizzard "Current Season" journal tier for M+, raids, and non-M+ dungeons.
- When the "Current Season" tier is not in the manifest, the form falls back to the highest-id expansion so the picker is never empty on a stale ingest.
- Fall back to a localized "Any dungeon" label in the runs list and run-detail heading when an M+ any-dungeon run has no `InstanceName`.

## UI changes
- `/runs/new` and `/runs/{id}/edit` no longer render an expansion `FluentSelect`. The activity toggle is the first control.
- Runs list entries and the selected-run heading read "Any dungeon" (en) / "Mikä tahansa luolasto" (fi) when the run carries no instance, instead of a blank title.

## Tests
- `RunsPage_RunListItem_FallsBackToAnyDungeonLabel_WhenInstanceNameIsNull`
- `RunsPage_DetailHeading_FallsBackToAnyDungeonLabel_WhenInstanceNameIsNull`
- `CreateRunPage_DoesNotRenderExpansionSelector`
- `EditRunPage_DoesNotRenderExpansionSelector`

## Test plan
- [x] `dotnet build lfm.sln -c Release`
- [x] `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release` (178 passed)
- [x] `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release` (172 passed)
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` (458 passed)
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- [ ] Manually verify `/runs/new` defaults to dungeons from the current season and no longer offers an expansion selector
- [ ] Manually verify an M+ any-dungeon run renders "Any dungeon" in the list + detail heading
