### PR TITLE
Add AGPL source headers and default Cache-Control middleware

### DIFF
--- a/api/Lfm.Api.csproj
+++ b/api/Lfm.Api.csproj
@@ -63,6 +63,13 @@
       <_Parameter1>Lfm.Api.Tests</_Parameter1>
     </AssemblyAttribute>
   </ItemGroup>
+  <!-- SecurityHeadersMiddleware reads this at startup to emit the
+       X-Source-Commit response header for AGPL §13 disclosure. CI supplies
+       the value via `dotnet build /p:GitCommit=$(git rev-parse HEAD)`; local
+       builds without the property fall back to "unknown". -->
+  <ItemGroup Condition="'$(GitCommit)' != ''">
+    <AssemblyMetadata Include="GitCommit" Value="$(GitCommit)" />
+  </ItemGroup>
   <ItemGroup>
     <None Update="host.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/api/Middleware/SecurityHeadersMiddleware.cs
+++ b/api/Middleware/SecurityHeadersMiddleware.cs
@@ -1,18 +1,34 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
+using System.Reflection;
+using Lfm.Api.Options;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Middleware;
+using Microsoft.Extensions.Options;
 
 namespace Lfm.Api.Middleware;
 
 /// <summary>
-/// Adds standard security response headers to every HTTP response.
-/// Runs early in the pipeline so headers are present even on error responses.
+/// Adds standard security response headers, the AGPL §13 source-code notice,
+/// and a default <c>Cache-Control: private, no-store</c> (for handlers that do
+/// not opt-in to a caching directive) to every HTTP response. Runs early in
+/// the pipeline so headers are present even on error responses; the
+/// <c>Cache-Control</c> default is applied in a <c>finally</c> block so it is
+/// still attached when the downstream pipeline throws.
 /// </summary>
 public sealed class SecurityHeadersMiddleware : IFunctionsWorkerMiddleware
 {
+    private static readonly string SourceCommit = ReadSourceCommit();
+
+    private readonly string _sourceRepositoryUrl;
+
+    public SecurityHeadersMiddleware(IOptions<AgplOptions> options)
+    {
+        _sourceRepositoryUrl = options.Value.SourceRepositoryUrl;
+    }
+
     public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
     {
         var httpContext = context.GetHttpContext();
@@ -27,7 +43,37 @@ public sealed class SecurityHeadersMiddleware : IFunctionsWorkerMiddleware
         httpContext.Response.Headers.Append("Referrer-Policy", "strict-origin-when-cross-origin");
         httpContext.Response.Headers.Append("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
         httpContext.Response.Headers.Append("Content-Security-Policy", "default-src 'none'; frame-ancestors 'none'");
+        httpContext.Response.Headers.Append("X-Source-Code", _sourceRepositoryUrl);
+        httpContext.Response.Headers.Append("X-Source-Commit", SourceCommit);
 
-        await next(context);
+        try
+        {
+            await next(context);
+        }
+        finally
+        {
+            if (!httpContext.Response.Headers.ContainsKey("Cache-Control"))
+            {
+                httpContext.Response.Headers.Append("Cache-Control", "private, no-store");
+            }
+        }
+    }
+
+    // Reads the build-time git commit from AssemblyMetadata("GitCommit", ...).
+    // Populated by CI via `dotnet build /p:GitCommit=<sha>`. Local builds
+    // without the property return "unknown", which is an acceptable AGPL
+    // disclosure (the X-Source-Code URL still identifies the repository).
+    private static string ReadSourceCommit()
+    {
+        var attrs = typeof(SecurityHeadersMiddleware).Assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>();
+        foreach (var attr in attrs)
+        {
+            if (attr.Key == "GitCommit" && !string.IsNullOrEmpty(attr.Value))
+            {
+                return attr.Value;
+            }
+        }
+        return "unknown";
     }
 }

--- a/api/Options/AgplOptions.cs
+++ b/api/Options/AgplOptions.cs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+namespace Lfm.Api.Options;
+
+/// <summary>
+/// AGPL §13 requires operators of network-interactive modified versions to
+/// prominently offer users the Corresponding Source. Fork operators configure
+/// <see cref="SourceRepositoryUrl"/> to point at their own source repository;
+/// the middleware layer advertises it as a response header on every request.
+/// </summary>
+public sealed class AgplOptions
+{
+    public const string SectionName = "Agpl";
+
+    /// <summary>
+    /// Public URL at which the Corresponding Source for this deployment is
+    /// available. Defaults to the canonical upstream repository; fork operators
+    /// MUST override this to point at their own modified source to satisfy
+    /// AGPL §13.
+    /// </summary>
+    public string SourceRepositoryUrl { get; init; } = "https://github.com/lfm-org/lfm";
+}

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -50,6 +50,8 @@ builder.Services.AddOptions<StorageOptions>()
     .ValidateOnStart();
 builder.Services.AddOptions<RateLimitOptions>()
     .Bind(builder.Configuration.GetSection(RateLimitOptions.SectionName));
+builder.Services.AddOptions<AgplOptions>()
+    .Bind(builder.Configuration.GetSection(AgplOptions.SectionName));
 
 builder.Services.AddCors(options =>
 {

--- a/tests/Lfm.Api.Tests/Middleware/SecurityHeadersMiddlewareTests.cs
+++ b/tests/Lfm.Api.Tests/Middleware/SecurityHeadersMiddlewareTests.cs
@@ -2,11 +2,13 @@
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
 using Lfm.Api.Middleware;
+using Lfm.Api.Options;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Middleware;
 using Moq;
 using Xunit;
+using MSOptions = Microsoft.Extensions.Options.Options;
 
 namespace Lfm.Api.Tests.Middleware;
 
@@ -19,7 +21,10 @@ public class SecurityHeadersMiddlewareTests
     /// </summary>
     private const string HttpContextKey = "HttpRequestContext";
 
-    private static (SecurityHeadersMiddleware middleware, Mock<FunctionContext> context, DefaultHttpContext httpContext) CreateTestContext()
+    private const string DefaultRepositoryUrl = "https://github.com/lfm-org/lfm";
+
+    private static (SecurityHeadersMiddleware middleware, Mock<FunctionContext> context, DefaultHttpContext httpContext) CreateTestContext(
+        string? sourceRepositoryUrl = null)
     {
         var httpContext = new DefaultHttpContext();
         var items = new Dictionary<object, object> { [HttpContextKey] = httpContext };
@@ -27,7 +32,12 @@ public class SecurityHeadersMiddlewareTests
         var mockContext = new Mock<FunctionContext>();
         mockContext.Setup(c => c.Items).Returns(items);
 
-        return (new SecurityHeadersMiddleware(), mockContext, httpContext);
+        var options = MSOptions.Create(new AgplOptions
+        {
+            SourceRepositoryUrl = sourceRepositoryUrl ?? DefaultRepositoryUrl,
+        });
+
+        return (new SecurityHeadersMiddleware(options), mockContext, httpContext);
     }
 
     [Fact]
@@ -70,12 +80,79 @@ public class SecurityHeadersMiddlewareTests
         var mockContext = new Mock<FunctionContext>();
         mockContext.Setup(c => c.Items).Returns(items);
 
-        var middleware = new SecurityHeadersMiddleware();
+        var options = MSOptions.Create(new AgplOptions { SourceRepositoryUrl = DefaultRepositoryUrl });
+
+        var middleware = new SecurityHeadersMiddleware(options);
         var nextCalled = false;
         FunctionExecutionDelegate next = _ => { nextCalled = true; return Task.CompletedTask; };
 
         await middleware.Invoke(mockContext.Object, next);
 
         Assert.True(nextCalled);
+    }
+
+    [Fact]
+    public async Task Sets_X_Source_Code_from_configured_repository_url()
+    {
+        var (middleware, mockContext, httpContext) = CreateTestContext(
+            sourceRepositoryUrl: "https://example.com/fork/lfm");
+        FunctionExecutionDelegate next = _ => Task.CompletedTask;
+
+        await middleware.Invoke(mockContext.Object, next);
+
+        Assert.Equal("https://example.com/fork/lfm", httpContext.Response.Headers["X-Source-Code"].ToString());
+    }
+
+    [Fact]
+    public async Task Sets_X_Source_Commit_header()
+    {
+        var (middleware, mockContext, httpContext) = CreateTestContext();
+        FunctionExecutionDelegate next = _ => Task.CompletedTask;
+
+        await middleware.Invoke(mockContext.Object, next);
+
+        // Local builds without /p:GitCommit=... return "unknown"; CI supplies
+        // the real SHA. Either value is a valid AGPL §13 disclosure when
+        // paired with X-Source-Code.
+        var commit = httpContext.Response.Headers["X-Source-Commit"].ToString();
+        Assert.False(string.IsNullOrEmpty(commit));
+    }
+
+    [Fact]
+    public async Task Default_Cache_Control_is_private_no_store_when_handler_does_not_set_one()
+    {
+        var (middleware, mockContext, httpContext) = CreateTestContext();
+        FunctionExecutionDelegate next = _ => Task.CompletedTask;
+
+        await middleware.Invoke(mockContext.Object, next);
+
+        Assert.Equal("private, no-store", httpContext.Response.Headers["Cache-Control"].ToString());
+    }
+
+    [Fact]
+    public async Task Default_Cache_Control_is_present_when_next_throws()
+    {
+        var (middleware, mockContext, httpContext) = CreateTestContext();
+        FunctionExecutionDelegate next = _ => throw new InvalidOperationException("downstream failure");
+
+        var act = () => middleware.Invoke(mockContext.Object, next);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
+        Assert.Equal("private, no-store", httpContext.Response.Headers["Cache-Control"].ToString());
+    }
+
+    [Fact]
+    public async Task Does_not_override_Cache_Control_set_by_handler()
+    {
+        var (middleware, mockContext, httpContext) = CreateTestContext();
+        FunctionExecutionDelegate next = _ =>
+        {
+            httpContext.Response.Headers["Cache-Control"] = "private, max-age=300";
+            return Task.CompletedTask;
+        };
+
+        await middleware.Invoke(mockContext.Object, next);
+
+        Assert.Equal("private, max-age=300", httpContext.Response.Headers["Cache-Control"].ToString());
     }
 }


### PR DESCRIPTION
## Summary

- `SecurityHeadersMiddleware` now emits `X-Source-Code` (repo URL, configurable via new `AgplOptions.SourceRepositoryUrl`) and `X-Source-Commit` (build-time git sha via `AssemblyMetadata`, falls back to `"unknown"` on local builds) on every response — discharges AGPL §13 for direct API consumers who never see the SPA footer.
- Applies a default `Cache-Control: private, no-store` in a `finally` block so it lands on both happy and exception paths. Handlers that opt in to their own directive (`BattleNetCharactersFunction:55`, `WowReferenceRefreshFunction:81`) continue to win via the indexer.
- First slice of the serverless-api-design review remediation plan at `/home/souroldgeezer/.claude/plans/review-api-precious-dewdrop.md`.

## Fixes

- `SAD-lic-agpl-source-notice` (AGPL §13 disclosure missing on API responses)
- `SAD-lic-privacy-cache-headers` (30/32 endpoints were caching-unsafe by default)

## Files (5)

| File | Change |
|---|---|
| `api/Options/AgplOptions.cs` | **new** — `SourceRepositoryUrl` with upstream default; fork operators override per §13 |
| `api/Program.cs` | Register `AgplOptions` options section |
| `api/Middleware/SecurityHeadersMiddleware.cs` | Constructor injection of options, new headers, `finally` block for cache default |
| `api/Lfm.Api.csproj` | Conditional `<AssemblyMetadata Include="GitCommit" ...>` for CI to stamp `/p:GitCommit=<sha>` |
| `tests/Lfm.Api.Tests/Middleware/SecurityHeadersMiddlewareTests.cs` | Extended to 8 tests covering new headers + cache default + handler override + exception path |

## Env / schema changes

- New config section: `Agpl:SourceRepositoryUrl` (optional — defaults to upstream repo URL; fork operators set in their environment to satisfy §13 for their own deployments)
- New MSBuild property: `GitCommit` (optional — CI should pass `/p:GitCommit=$(git rev-parse HEAD)` to stamp the commit into the `X-Source-Commit` header)

No Cosmos / Blob schema changes. No infra changes in this slice.

## Test plan

- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error` clean
- [x] `dotnet build lfm.sln -c Release` clean
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` — 463 tests pass
- [ ] Manual smoke: `func start` in `api/`; `curl -I http://localhost:7071/api/health` shows `X-Source-Code`, `X-Source-Commit`, `Cache-Control: private, no-store`
- [ ] Manual smoke: hit `BattleNetCharactersFunction` route and confirm its `Cache-Control: private, max-age=300` wins
- [ ] CI: `dotnet format --verify-no-changes`, build, test, gitleaks — all green

## Audit status

- Test-quality audit (quick mode): all 8 tests are specification-grade — expected values trace to RFC / AGPL / named production callers; no characterization tests; POS-1/2/3/5/6 signals throughout.
- DevSecOps audit (quick mode, dotnet-security extension): one `info` finding on the slice delta — `AgplOptions` omits `.ValidateDataAnnotations().ValidateOnStart()`. Accepted as debt for now (matches `RateLimitOptions` precedent for non-critical operational config); tracked for a follow-up slice if `[Url]` + `[Required]` discipline is wanted across all options.

## Rollback

Single-commit PR. Revert is safe and self-contained; no state migrations, no config keys that become load-bearing elsewhere in this slice.

## Follow-up slices (not in this PR)

- Slice 1.2 — Register `ProblemDetails` + shared `Problem.*` helpers (infrastructure for Phase 2 RFC 9457 migration)
- Slice 1.3 — Seed `api/openapi.yaml` + CI lint