### PR TITLE
Add ProblemDetails registration and Problem.* helpers

### DIFF
--- a/api/Helpers/Problem.cs
+++ b/api/Helpers/Problem.cs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Lfm.Api.Helpers;
+
+/// <summary>
+/// Factory for RFC 9457 <c>application/problem+json</c> responses. Each
+/// helper builds a <see cref="ProblemDetails"/> with a stable <c>type</c> URI
+/// rooted at <see cref="TypeBase"/>, attaches the current W3C trace id as an
+/// extension for downstream correlation, and returns an <see cref="IActionResult"/>
+/// so existing Function handlers can swap <c>new NotFoundObjectResult(new { error = … })</c>
+/// for <c>Problem.NotFound(req.HttpContext, "run-not-found", "…")</c> without
+/// changing return types.
+///
+/// Type URIs take the form <c>https://github.com/lfm-org/lfm/errors#&lt;slug&gt;</c>
+/// so downstream AGPL operators get a clickable, versionable reference that
+/// resolves to an anchor in the project's future error catalogue.
+/// </summary>
+public static class Problem
+{
+    /// <summary>
+    /// Base URL for problem <c>type</c> fragments. Per RFC 9457 §3.1.1 a
+    /// problem's <c>type</c> SHOULD dereference to documentation; this URL
+    /// points at the canonical upstream repository so forks that omit an
+    /// operator-specific catalogue still have a functioning link.
+    /// </summary>
+    public const string TypeBase = "https://github.com/lfm-org/lfm/errors";
+
+    /// <summary>
+    /// Standard Content-Type for problem responses per RFC 9457 §3.
+    /// </summary>
+    public const string ContentType = "application/problem+json";
+
+    public static IActionResult NotFound(HttpContext context, string slug, string? detail = null, IDictionary<string, object?>? extensions = null)
+        => Create(context, StatusCodes.Status404NotFound, "Not Found", slug, detail, extensions);
+
+    public static IActionResult BadRequest(HttpContext context, string slug, string? detail = null, IDictionary<string, object?>? extensions = null)
+        => Create(context, StatusCodes.Status400BadRequest, "Bad Request", slug, detail, extensions);
+
+    public static IActionResult Unauthorized(HttpContext context, string slug, string? detail = null)
+        => Create(context, StatusCodes.Status401Unauthorized, "Unauthorized", slug, detail);
+
+    public static IActionResult Forbidden(HttpContext context, string slug, string? detail = null)
+        => Create(context, StatusCodes.Status403Forbidden, "Forbidden", slug, detail);
+
+    public static IActionResult Conflict(HttpContext context, string slug, string? detail = null)
+        => Create(context, StatusCodes.Status409Conflict, "Conflict", slug, detail);
+
+    public static IActionResult PreconditionFailed(HttpContext context, string slug, string? detail = null)
+        => Create(context, StatusCodes.Status412PreconditionFailed, "Precondition Failed", slug, detail);
+
+    public static IActionResult PayloadTooLarge(HttpContext context, string slug, string? detail = null)
+        => Create(context, StatusCodes.Status413PayloadTooLarge, "Payload Too Large", slug, detail);
+
+    /// <summary>
+    /// 429 response with RFC 9110 <c>Retry-After</c> header when a duration
+    /// is supplied. Callers that have a richer hint (e.g. shared rate-limiter
+    /// pause budget) should pass <paramref name="retryAfterSeconds"/> so the
+    /// client can schedule instead of guessing.
+    /// </summary>
+    public static IActionResult TooManyRequests(HttpContext context, string slug, string? detail = null, int? retryAfterSeconds = null)
+    {
+        if (retryAfterSeconds is int seconds && seconds >= 0)
+        {
+            context.Response.Headers.Append("Retry-After", seconds.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        }
+        return Create(context, StatusCodes.Status429TooManyRequests, "Too Many Requests", slug, detail);
+    }
+
+    public static IActionResult UpstreamFailed(HttpContext context, string slug, string? detail = null)
+        => Create(context, StatusCodes.Status502BadGateway, "Bad Gateway", slug, detail);
+
+    public static IActionResult InternalError(HttpContext context, string slug, string? detail = null)
+        => Create(context, StatusCodes.Status500InternalServerError, "Internal Server Error", slug, detail);
+
+    private static IActionResult Create(
+        HttpContext context,
+        int statusCode,
+        string title,
+        string slug,
+        string? detail,
+        IDictionary<string, object?>? extensions = null)
+    {
+        var problem = new ProblemDetails
+        {
+            Type = $"{TypeBase}#{slug}",
+            Title = title,
+            Status = statusCode,
+            Detail = detail,
+            Instance = context.Request.Path.Value,
+        };
+
+        var traceId = Activity.Current?.TraceId.ToString();
+        if (!string.IsNullOrEmpty(traceId))
+        {
+            problem.Extensions["traceId"] = traceId;
+        }
+
+        if (extensions is not null)
+        {
+            foreach (var kvp in extensions)
+            {
+                problem.Extensions[kvp.Key] = kvp.Value;
+            }
+        }
+
+        return new ObjectResult(problem)
+        {
+            StatusCode = statusCode,
+            ContentTypes = { ContentType },
+        };
+    }
+}

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -27,6 +27,25 @@ builder.UseMiddleware<Lfm.Api.Middleware.AuthPolicyMiddleware>();
 builder.Services.AddApplicationInsightsTelemetryWorkerService();
 builder.Services.ConfigureFunctionsApplicationInsights();
 
+// RFC 9457 problem+json — registers IProblemDetailsService + a customizer that
+// enriches every problem response with the current W3C trace id so downstream
+// debugging has a join key from the client-visible body to Application Insights.
+// Explicit handler-layer construction lives in Lfm.Api.Helpers.Problem; this
+// registration makes the service available for future UseExceptionHandler /
+// UseStatusCodePages integration and for any future code path that leans on
+// the framework's automatic problem formatter.
+builder.Services.AddProblemDetails(options =>
+{
+    options.CustomizeProblemDetails = ctx =>
+    {
+        var traceId = System.Diagnostics.Activity.Current?.TraceId.ToString();
+        if (!string.IsNullOrEmpty(traceId))
+        {
+            ctx.ProblemDetails.Extensions.TryAdd("traceId", traceId);
+        }
+    };
+});
+
 // Options
 builder.Services.AddOptions<CosmosOptions>()
     .Bind(builder.Configuration.GetSection(CosmosOptions.SectionName))

--- a/tests/Lfm.Api.Tests/Helpers/ProblemTests.cs
+++ b/tests/Lfm.Api.Tests/Helpers/ProblemTests.cs
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Diagnostics;
+using Lfm.Api.Helpers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Lfm.Api.Tests.Helpers;
+
+public class ProblemTests
+{
+    private static HttpContext NewContext(string path = "/api/runs/abc")
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Path = path;
+        return ctx;
+    }
+
+    private static ProblemDetails Payload(IActionResult result)
+    {
+        var obj = Assert.IsType<ObjectResult>(result);
+        Assert.Contains(Problem.ContentType, obj.ContentTypes);
+        return Assert.IsType<ProblemDetails>(obj.Value);
+    }
+
+    [Fact]
+    public void NotFound_builds_404_problem_with_type_uri_and_instance()
+    {
+        var ctx = NewContext("/api/runs/missing");
+
+        var result = Problem.NotFound(ctx, "run-not-found", "Run does not exist.");
+
+        var obj = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(404, obj.StatusCode);
+        Assert.Contains(Problem.ContentType, obj.ContentTypes);
+        var body = Assert.IsType<ProblemDetails>(obj.Value);
+        Assert.Equal($"{Problem.TypeBase}#run-not-found", body.Type);
+        Assert.Equal("Not Found", body.Title);
+        Assert.Equal(404, body.Status);
+        Assert.Equal("Run does not exist.", body.Detail);
+        Assert.Equal("/api/runs/missing", body.Instance);
+    }
+
+    [Fact]
+    public void BadRequest_carries_supplied_extensions()
+    {
+        var ctx = NewContext();
+        var errors = new Dictionary<string, object?>
+        {
+            ["errors"] = new Dictionary<string, string[]>
+            {
+                ["title"] = new[] { "Title is required." },
+            },
+        };
+
+        var result = Problem.BadRequest(ctx, "validation-failed", "Request body failed validation.", errors);
+
+        var body = Payload(result);
+        Assert.Equal(400, body.Status);
+        Assert.Equal($"{Problem.TypeBase}#validation-failed", body.Type);
+        Assert.True(body.Extensions.ContainsKey("errors"));
+    }
+
+    [Fact]
+    public void Unauthorized_builds_401_problem()
+    {
+        var result = Problem.Unauthorized(NewContext(), "auth-required");
+        Assert.Equal(401, Payload(result).Status);
+    }
+
+    [Fact]
+    public void Forbidden_builds_403_problem()
+    {
+        var result = Problem.Forbidden(NewContext(), "admin-only");
+        Assert.Equal(403, Payload(result).Status);
+    }
+
+    [Fact]
+    public void Conflict_builds_409_problem()
+    {
+        var result = Problem.Conflict(NewContext(), "signup-closed");
+        Assert.Equal(409, Payload(result).Status);
+    }
+
+    [Fact]
+    public void PreconditionFailed_builds_412_problem()
+    {
+        var result = Problem.PreconditionFailed(NewContext(), "etag-mismatch");
+        Assert.Equal(412, Payload(result).Status);
+    }
+
+    [Fact]
+    public void PayloadTooLarge_builds_413_problem()
+    {
+        var result = Problem.PayloadTooLarge(NewContext(), "body-too-large");
+        Assert.Equal(413, Payload(result).Status);
+    }
+
+    [Fact]
+    public void TooManyRequests_sets_Retry_After_when_seconds_supplied()
+    {
+        var ctx = NewContext();
+
+        var result = Problem.TooManyRequests(ctx, "upstream-rate-limited", retryAfterSeconds: 45);
+
+        Assert.Equal(429, Payload(result).Status);
+        Assert.Equal("45", ctx.Response.Headers["Retry-After"].ToString());
+    }
+
+    [Fact]
+    public void TooManyRequests_omits_Retry_After_when_seconds_missing()
+    {
+        var ctx = NewContext();
+
+        Problem.TooManyRequests(ctx, "upstream-rate-limited");
+
+        Assert.False(ctx.Response.Headers.ContainsKey("Retry-After"));
+    }
+
+    [Fact]
+    public void UpstreamFailed_builds_502_problem()
+    {
+        var result = Problem.UpstreamFailed(NewContext(), "blizzard-unreachable");
+        Assert.Equal(502, Payload(result).Status);
+    }
+
+    [Fact]
+    public void InternalError_builds_500_problem()
+    {
+        var result = Problem.InternalError(NewContext(), "unexpected-error");
+        Assert.Equal(500, Payload(result).Status);
+    }
+
+    [Fact]
+    public void Problem_injects_traceId_when_Activity_is_current()
+    {
+        // Activity.Current is thread-local and relies on a live Activity — the
+        // cheapest reliable way to stage one in-process is new Activity().Start().
+        // ActivitySource.StartActivity would require an ActivityListener which
+        // we don't otherwise need in this test.
+        using var activity = new Activity("problem-traceid-test");
+        activity.Start();
+
+        var result = Problem.NotFound(NewContext(), "example");
+
+        var body = Payload(result);
+        Assert.True(body.Extensions.ContainsKey("traceId"));
+        var traceId = Assert.IsType<string>(body.Extensions["traceId"]);
+        Assert.False(string.IsNullOrEmpty(traceId));
+    }
+
+    [Fact]
+    public void Problem_has_no_traceId_when_no_Activity_is_current()
+    {
+        Activity.Current = null;
+
+        var result = Problem.NotFound(NewContext(), "example");
+
+        var body = Payload(result);
+        Assert.False(body.Extensions.ContainsKey("traceId"));
+    }
+}


### PR DESCRIPTION
## Summary

Infrastructure for the RFC 9457 error-shape migration. No endpoint yet uses the new helpers — that's intentional. Phase 2 (slices 2.1/2.2/2.3) swaps a family of functions over per PR so the error-shape migration is reviewable in small chunks.

- `api/Helpers/Problem.cs` — static factory for 400/401/403/404/409/412/413/429/500/502 `application/problem+json` responses. `type` URIs rooted at `https://github.com/lfm-org/lfm/errors#<slug>` per D0.1. `Activity.Current?.TraceId` lands in the `traceId` extension so problem bodies and Application Insights share a join key. Returns `IActionResult` so existing handlers can swap `new NotFoundObjectResult(new { error = … })` for `Problem.NotFound(req.HttpContext, "run-not-found", "…")` without any return-type churn.
- `api/Program.cs` — `AddProblemDetails()` with a `CustomizeProblemDetails` callback that attaches the same `traceId`. Registration is a safe no-op today (nothing consumes `IProblemDetailsService` yet) and makes the service available when a future slice wires `UseExceptionHandler` / `UseStatusCodePages`.
- `tests/Lfm.Api.Tests/Helpers/ProblemTests.cs` — 13 tests covering status, type URI, Content-Type, `Instance`, the optional `Retry-After` header on 429, the validation `errors` extension on 400, and the `traceId` extension both with and without a current `Activity`.

## Fixes

- Infrastructure for `SAD-contract-error-shape` — the migration of `new { error = … }` bodies to RFC 9457 comes in Phase 2.

## Files (3)

| File | Change |
|---|---|
| `api/Helpers/Problem.cs` | **new** — 10 helper methods + private factory; returns `IActionResult` |
| `api/Program.cs` | Register `AddProblemDetails` with `traceId` customizer |
| `tests/Lfm.Api.Tests/Helpers/ProblemTests.cs` | **new** — 13 tests |

## Env / schema changes

None. Registration is purely in-memory DI wiring.

## Test plan

- [x] `dotnet format lfm.sln` clean
- [x] `dotnet build lfm.sln -c Release` — 0 warnings, 0 errors
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` — 476/476 pass (463 + 13 new)
- [ ] CI: `verify`, `reuse-lint`, `dep-license-check`, `Gitleaks` green
- [ ] E2E lane — not affected; CI to confirm

## Rollback

Single-commit PR. Revert is safe — the helper and registration aren't used by any endpoint yet; reverting reverses the no-op additions cleanly.

## Next

- Slice 1.3 — Seed `api/openapi.yaml` + CI lint (can land in parallel)
- Phase 2 — begin migrating handler error paths to `Problem.From(...)`