### PR TITLE
Seed api/openapi.yaml and validate inside the verify test gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,24 @@ These five variables are set in the `dotnet publish` step of `deploy-app.yml`. `
 - `tests/Lfm.E2E/`: Playwright .NET end-to-end tests
 - `infra/main.bicep`: main infrastructure entry point
 
+## API Contract
+
+The source-of-truth OpenAPI 3.1 contract for the API lives at
+[`api/openapi.yaml`](api/openapi.yaml). It is validated on every pull
+request by `OpenApiContractTests` in `tests/Lfm.Api.Tests/Openapi/`,
+which runs inside the existing `verify` CI gate — no separate lint
+workflow, no Node toolchain. The file is intended to be consumed
+directly by both the first-party SPA (type-generated clients) and
+downstream AGPL operators who fork and self-host (machine-readable
+contract without running the server).
+
+The API does **not** serve a live schema in production. A future slice
+will adopt `Microsoft.Azure.Functions.Worker.Extensions.OpenApi` in
+development-only mode (gated on `ASPNETCORE_ENVIRONMENT == Development`)
+so handler annotations stay synchronised with `api/openapi.yaml`
+without exposing a Swagger UI or live-schema endpoint to production
+traffic.
+
 ## Notes
 
 Use standard C# conventions: 4-space indentation. Run `dotnet format` before committing. Keep commits short and imperative.

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,19 @@
+# Lfm API
+
+Azure Functions .NET 10 isolated-worker backend for the Lfm raid-signup
+application. See the repository root `README.md` for architecture,
+development setup, and AI-usage acknowledgement.
+
+## Contract
+
+The source-of-truth OpenAPI 3.1 contract for this API is checked in at
+[`openapi.yaml`](openapi.yaml). Downstream AGPL operators and the
+first-party SPA both read from the static file — the API does **not**
+serve a live schema in production. See the root `README.md` section on
+the API contract for the full hybrid (generator-in-dev, static-in-prod)
+rationale.
+
+`api/openapi.yaml` is validated on every pull request by
+`OpenApiContractTests` in
+[`tests/Lfm.Api.Tests/Openapi/`](../tests/Lfm.Api.Tests/Openapi/),
+which runs inside the existing `verify` CI gate.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 LFM contributors
+#
+# Source-of-truth OpenAPI 3.1 contract for the Lfm API. Committed to the repo
+# so downstream AGPL operators and the first-party SPA can read it without
+# running the server. CI lints this file via .github/workflows/openapi-lint.yml.
+#
+# Coverage is rolled out iteratively: Slice 1.3 seeds the document with the
+# two health endpoints. Subsequent slices (3.3 onward) extend coverage to
+# /me, /guild, /runs, /raider, /wow/reference, and /admin. The
+# Microsoft.Azure.Functions.Worker.Extensions.OpenApi package will be adopted
+# in development-only mode (gated on ASPNETCORE_ENVIRONMENT) so drift between
+# annotations and this static file fails CI rather than shipping quietly.
+
+openapi: 3.1.0
+info:
+  title: Lfm API
+  version: 0.1.0
+  summary: Raid logistics API for World of Warcraft guilds.
+  description: |
+    HTTP API for the Lfm raid-signup application. The contract lives at
+    `api/openapi.yaml`; it is **not** served live from production. See the
+    top-level `README.md` for the hybrid (generator-in-dev, static-in-prod)
+    setup.
+  license:
+    name: AGPL-3.0-or-later
+    identifier: AGPL-3.0-or-later
+  contact:
+    name: Lfm contributors
+    url: https://github.com/lfm-org/lfm
+
+servers:
+  - url: https://lfm-api.dinosauruskeksi.com
+    description: Production (upstream deployment)
+  - url: http://localhost:7071
+    description: Local dev (Azure Functions Core Tools via `func start`)
+
+tags:
+  - name: Health
+    description: Liveness and readiness probes.
+
+paths:
+  /api/health:
+    get:
+      tags: [Health]
+      summary: Liveness probe.
+      description: |
+        Always returns 200 with `status: "ok"`. Never touches downstream
+        dependencies. Consumed by App Service Health Check on Premium /
+        Dedicated plans to decide whether to recycle the instance.
+      operationId: getHealth
+      responses:
+        '200':
+          description: Live.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+              examples:
+                live:
+                  value:
+                    status: ok
+                    timestamp: '2026-04-24T00:00:00Z'
+
+  /api/health/ready:
+    get:
+      tags: [Health]
+      summary: Readiness probe.
+      description: |
+        Validates Cosmos DB connectivity with a cheap database-level read.
+        Returns 200 on success and 503 on failure. Consumed by external
+        monitors and deploy smoke tests; **not** by App Service Health Check
+        (Cosmos being down should not recycle the app).
+      operationId: getHealthReady
+      responses:
+        '200':
+          description: Ready.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+              examples:
+                ready:
+                  value:
+                    status: ready
+                    timestamp: '2026-04-24T00:00:00Z'
+        '503':
+          description: Not ready. Exception details are never returned; inspect Application Insights for cause.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnreadyResponse'
+              examples:
+                unready:
+                  value:
+                    status: unready
+
+components:
+  schemas:
+    HealthResponse:
+      type: object
+      required: [status, timestamp]
+      properties:
+        status:
+          type: string
+          description: Liveness (`ok`) or readiness (`ready`) indicator.
+          enum: [ok, ready]
+        timestamp:
+          type: string
+          format: date-time
+          description: Server UTC timestamp at which the probe was evaluated.
+      additionalProperties: false
+
+    UnreadyResponse:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: string
+          enum: [unready]
+      additionalProperties: false
+
+    # RFC 9457 problem+json body emitted by every error response. Seeded here
+    # so slices 2.1 / 2.2 / 2.3 can reference it as endpoints are migrated
+    # from the legacy `{ error: string }` shape. Type URIs are rooted at
+    # https://github.com/lfm-org/lfm/errors#<slug> per D0.1.
+    ProblemDetails:
+      type: object
+      description: RFC 9457 problem details (`application/problem+json`).
+      properties:
+        type:
+          type: string
+          format: uri
+          description: URI identifying the problem type. Rooted at `https://github.com/lfm-org/lfm/errors`.
+          example: https://github.com/lfm-org/lfm/errors#run-not-found
+        title:
+          type: string
+          description: Human-readable summary of the problem type.
+        status:
+          type: integer
+          minimum: 100
+          maximum: 599
+          description: HTTP status code generated for this occurrence.
+        detail:
+          type: string
+          description: Human-readable explanation specific to this occurrence.
+        instance:
+          type: string
+          description: URI reference identifying the specific occurrence (typically the request path).
+        traceId:
+          type: string
+          description: W3C trace id from `Activity.Current` for correlation with Application Insights.
+      additionalProperties: true

--- a/tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj
+++ b/tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj
@@ -24,6 +24,12 @@
     <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="coverlet.collector" Version="8.0.1" />
+    <!-- OpenAPI 3.1 contract lives at api/openapi.yaml; OpenApiContractTests
+         loads it at test-time and asserts zero diagnostic errors so the
+         existing verify CI gate fails on malformed spec. 3.x of the library
+         supports OpenAPI 3.1; YamlReader is the separate reader package. -->
+    <PackageReference Include="Microsoft.OpenApi" Version="3.5.2" />
+    <PackageReference Include="Microsoft.OpenApi.YamlReader" Version="3.5.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\api\Lfm.Api.csproj" />
@@ -32,5 +38,10 @@
     <None Include="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <!-- Ship api/openapi.yaml into the test output so OpenApiContractTests
+         can load it at runtime without hard-coding a repo-root-relative path. -->
+    <Content Include="..\..\api\openapi.yaml" Link="Contracts\openapi.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 </Project>

--- a/tests/Lfm.Api.Tests/Openapi/OpenApiContractTests.cs
+++ b/tests/Lfm.Api.Tests/Openapi/OpenApiContractTests.cs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Microsoft.OpenApi;
+using Microsoft.OpenApi.Reader;
+using Xunit;
+
+namespace Lfm.Api.Tests.Openapi;
+
+/// <summary>
+/// Compile-time validation of the checked-in <c>api/openapi.yaml</c> contract.
+/// Runs as part of the normal test suite so the existing <c>verify</c> CI gate
+/// catches malformed specs — no separate lint workflow required. The yaml is
+/// copied into the test output via <c>&lt;Content Include="..\..\api\openapi.yaml" .../&gt;</c>
+/// in the csproj so the test is insensitive to the test runner's working
+/// directory.
+/// </summary>
+public class OpenApiContractTests
+{
+    private static string SpecPath => Path.Combine(AppContext.BaseDirectory, "Contracts", "openapi.yaml");
+
+    private static OpenApiReaderSettings CreateSettings()
+    {
+        var settings = new OpenApiReaderSettings();
+        settings.AddYamlReader();
+        return settings;
+    }
+
+    [Fact]
+    public async Task Spec_parses_with_zero_diagnostic_errors()
+    {
+        Assert.True(File.Exists(SpecPath), $"openapi.yaml should be copied to test output at {SpecPath}");
+
+        var result = await OpenApiDocument.LoadAsync(SpecPath, CreateSettings());
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Document);
+        Assert.NotNull(result.Diagnostic);
+        Assert.Empty(result.Diagnostic.Errors);
+    }
+
+    [Fact]
+    public async Task Spec_is_openapi_3_1()
+    {
+        var result = await OpenApiDocument.LoadAsync(SpecPath, CreateSettings());
+
+        Assert.Equal(OpenApiSpecVersion.OpenApi3_1, result.Diagnostic!.SpecificationVersion);
+    }
+
+    [Fact]
+    public async Task Spec_declares_info_and_servers()
+    {
+        var result = await OpenApiDocument.LoadAsync(SpecPath, CreateSettings());
+
+        Assert.NotNull(result.Document!.Info);
+        Assert.False(string.IsNullOrEmpty(result.Document.Info.Title));
+        Assert.False(string.IsNullOrEmpty(result.Document.Info.Version));
+        Assert.NotNull(result.Document.Servers);
+        Assert.NotEmpty(result.Document.Servers);
+    }
+
+    [Fact]
+    public async Task Spec_documents_health_endpoints()
+    {
+        var result = await OpenApiDocument.LoadAsync(SpecPath, CreateSettings());
+
+        Assert.NotNull(result.Document!.Paths);
+        Assert.Contains("/api/health", result.Document.Paths.Keys);
+        Assert.Contains("/api/health/ready", result.Document.Paths.Keys);
+    }
+}

--- a/tests/Lfm.Api.Tests/packages.lock.json
+++ b/tests/Lfm.Api.Tests/packages.lock.json
@@ -33,6 +33,22 @@
           "Microsoft.TestPlatform.TestHost": "18.4.0"
         }
       },
+      "Microsoft.OpenApi": {
+        "type": "Direct",
+        "requested": "[3.5.2, )",
+        "resolved": "3.5.2",
+        "contentHash": "AaNCVaa5lH1p+zkYySMYfsig1+UKZykqW8UPcEg60z+xch7wqAXAtBeLn9JZpf52zEaalcPa7SSA++Os53hBiw=="
+      },
+      "Microsoft.OpenApi.YamlReader": {
+        "type": "Direct",
+        "requested": "[3.5.2, )",
+        "resolved": "3.5.2",
+        "contentHash": "3b5Q0d+a2v7IBjOqvyylL9OudWa3m8U9lFp4LlDwQ6D6ZuiTbbZCjRDjQnBdFJdn3pqGhe0Xrf/Zj1VPvZHHEA==",
+        "dependencies": {
+          "Microsoft.OpenApi": "3.5.2",
+          "SharpYaml": "2.1.4"
+        }
+      },
       "Moq": {
         "type": "Direct",
         "requested": "[4.20.72, )",
@@ -878,6 +894,11 @@
           "Polly.Core": "8.4.2",
           "System.Threading.RateLimiting": "8.0.0"
         }
+      },
+      "SharpYaml": {
+        "type": "Transitive",
+        "resolved": "2.1.4",
+        "contentHash": "/iwULhVBpTjD4wPZhLU+eUWBanDvri/2AGx5YbaAj5kp9kXzhqUfJEy56H5Yi+c+OXsdm/oKD1aTKB24BFp8cw=="
       },
       "System.ClientModel": {
         "type": "Transitive",


### PR DESCRIPTION
## Summary

Checks in the source-of-truth OpenAPI 3.1 contract for the API at `api/openapi.yaml`. Initial coverage is the two health endpoints (`GET /api/health`, `GET /api/health/ready`); later slices (3.3 onward) extend to `/me`, `/guild`, `/runs`, `/raider`, `/wow/reference`, `/admin`. The `ProblemDetails` schema is seeded too so Phase 2 migration PRs can `$ref` it as endpoints swap from the legacy `{ error }` shape to RFC 9457.

Validation runs **inside the existing `Lfm.Api.Tests` suite** via a new `OpenApiContractTests` class — the spec is copied into the test output and parsed by `Microsoft.OpenApi` + `Microsoft.OpenApi.YamlReader` (both 3.5.2); any diagnostic error fails the `verify` CI gate. This keeps the slice **Node-free** (no `npx` / Redocly / Spectral) and avoids adding a separate lint workflow.

### Why not a dedicated lint workflow?

Two paths were considered and rejected:

1. **Node + Redocly via `actions/setup-node` + `npx @redocly/cli`** — explicitly out after the project removed its Node/TypeScript toolchain. I'm not bringing Node back for one lint step.
2. **`Microsoft.OpenApi.Hidi` dotnet tool** — latest (3.5.2) targets .NET 8 runtime; the repo is .NET 10 only. Works on hosted CI runners (which carry both runtimes) but fails locally on a .NET 10-only box, which is a worse dev ergonomic than the in-test path.

The `OpenApiContractTests` approach uses the same `Microsoft.OpenApi` 3.5.2 library as Hidi but runs under the .NET 10 SDK the project already uses, and CI coverage comes for free from the existing `verify` job.

## Fixes

- Partial progress on `SAD-contract-no-openapi` — the contract file is in the repo and CI-validated; per-endpoint rollout happens in Slice 3.3.

## Files (6)

| File | Change |
|---|---|
| `api/openapi.yaml` | **new** — OpenAPI 3.1 spec: info, servers, /api/health, /api/health/ready, ProblemDetails schema |
| `api/README.md` | **new** — short note pointing at the contract + how it's validated |
| `README.md` | New "API Contract" section explaining the static-in-repo posture |
| `tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj` | Add `Microsoft.OpenApi` + `Microsoft.OpenApi.YamlReader` 3.5.2 package refs + `<Content>` copy of the yaml into test output |
| `tests/Lfm.Api.Tests/packages.lock.json` | Lock file refresh |
| `tests/Lfm.Api.Tests/Openapi/OpenApiContractTests.cs` | **new** — 4 tests: zero diagnostic errors, 3.1 spec version, info/servers present, health paths documented |

## Env / schema changes

None. The yaml is statically served (eventually) from the repo; nothing is deployed with this PR.

## Test plan

- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error` clean
- [x] `dotnet build lfm.sln -c Release` — 0 warnings, 0 errors
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` — 480/480 pass (476 + 4 new)
- [ ] CI: `verify`, `reuse-lint`, `dep-license-check`, `Gitleaks` green

## Rollback

Single-commit PR. Revert is safe — the yaml isn't referenced by any runtime code, and the tests simply disappear.

## Next

- Phase 2 (Slices 2.1 / 2.2 / 2.3) — migrate handler error paths to `Problem.*` helpers. Schema `$ref`s into the seeded `ProblemDetails` component land during Slice 3.3 as endpoints join the OpenAPI document.