### PR TITLE
Migrate GET endpoints to RFC 9457 problem+json

### DIFF
--- a/api/Functions/GuildAdminFunction.cs
+++ b/api/Functions/GuildAdminFunction.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Lfm.Api.Auth;
+using Lfm.Api.Helpers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;
@@ -29,15 +30,15 @@ public class GuildAdminFunction(IGuildRepository guildRepo, ISiteAdminService si
         var principal = ctx.GetPrincipal(); // non-null: [RequireAuth] + AuthPolicyMiddleware guarantee
 
         if (!await siteAdmin.IsAdminAsync(principal.BattleNetId, cancellationToken))
-            return new ObjectResult(new { error = "Forbidden" }) { StatusCode = 403 };
+            return Problem.Forbidden(req.HttpContext, "admin-only", "Site administrator access required.");
 
         var guildId = req.Query["guildId"].FirstOrDefault();
         if (string.IsNullOrWhiteSpace(guildId))
-            return new BadRequestObjectResult(new { error = "guildId query parameter is required" });
+            return Problem.BadRequest(req.HttpContext, "missing-parameter", "guildId query parameter is required.");
 
         var guildDoc = await guildRepo.GetAsync(guildId, cancellationToken);
         if (guildDoc is null)
-            return new NotFoundResult();
+            return Problem.NotFound(req.HttpContext, "guild-not-found", "Guild not found.");
 
         return new OkObjectResult(GuildMapper.MapToDto(guildDoc));
     }

--- a/api/Functions/GuildFunction.cs
+++ b/api/Functions/GuildFunction.cs
@@ -8,6 +8,7 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 using Lfm.Api.Audit;
 using Lfm.Api.Auth;
+using Lfm.Api.Helpers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;
@@ -55,7 +56,7 @@ public class GuildFunction(IGuildRepository guildRepo, IRaidersRepository raider
         // session principal's GuildId is a legacy field that is no longer populated.
         var raider = await raidersRepo.GetByBattleNetIdAsync(principal.BattleNetId, cancellationToken);
         if (raider is null)
-            return new NotFoundObjectResult(new { error = "Raider not found" });
+            return Problem.NotFound(req.HttpContext, "raider-not-found", "Raider not found.");
 
         var (guildId, _) = GuildResolver.FromRaider(raider);
 
@@ -64,7 +65,7 @@ public class GuildFunction(IGuildRepository guildRepo, IRaidersRepository raider
 
         var guildDoc = await guildRepo.GetAsync(guildId, cancellationToken);
         if (guildDoc is null)
-            return new NotFoundResult();
+            return Problem.NotFound(req.HttpContext, "guild-not-found", "Guild not found.");
 
         return new OkObjectResult(GuildMapper.MapToDto(guildDoc));
     }

--- a/api/Functions/MeFunction.cs
+++ b/api/Functions/MeFunction.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Lfm.Api.Auth;
+using Lfm.Api.Helpers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;
@@ -25,7 +26,7 @@ public class MeFunction(IRaidersRepository repo, ISiteAdminService siteAdmin)
 
         var raider = await repo.GetByBattleNetIdAsync(principal.BattleNetId, cancellationToken);
         if (raider is null)
-            return new NotFoundResult();
+            return Problem.NotFound(req.HttpContext, "raider-not-found", "Raider not found.");
 
         var isAdmin = await siteAdmin.IsAdminAsync(principal.BattleNetId, cancellationToken);
 

--- a/api/Functions/RunsDetailFunction.cs
+++ b/api/Functions/RunsDetailFunction.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Lfm.Api.Auth;
+using Lfm.Api.Helpers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;
@@ -39,7 +40,7 @@ public class RunsDetailFunction(IRunsRepository repo, IRaidersRepository raiders
 
         var run = await repo.GetByIdAsync(id, ct);
         if (run is null)
-            return new NotFoundObjectResult(new { error = "Run not found" });
+            return Problem.NotFound(req.HttpContext, "run-not-found", "Run not found.");
 
         // Visibility check — mirrors runs-detail.ts:
         //   if (resource.visibility === "GUILD" && !isCreator && !isGuildMember)
@@ -53,7 +54,7 @@ public class RunsDetailFunction(IRunsRepository repo, IRaidersRepository raiders
             // (principal.GuildId is a legacy session field that is no longer populated).
             var raider = await raidersRepo.GetByBattleNetIdAsync(principal.BattleNetId, ct);
             if (raider is null)
-                return new NotFoundObjectResult(new { error = "Raider not found" });
+                return Problem.NotFound(req.HttpContext, "raider-not-found", "Raider not found.");
 
             var (guildId, _) = GuildResolver.FromRaider(raider);
 
@@ -62,7 +63,7 @@ public class RunsDetailFunction(IRunsRepository repo, IRaidersRepository raiders
                 && run.CreatorGuildId.ToString() == guildId;
 
             if (!isCreator && !isGuildMember)
-                return new NotFoundObjectResult(new { error = "Run not found" });
+                return Problem.NotFound(req.HttpContext, "run-not-found", "Run not found.");
         }
 
         return new OkObjectResult(Sanitize(run, principal.BattleNetId));

--- a/api/Functions/RunsListFunction.cs
+++ b/api/Functions/RunsListFunction.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Lfm.Api.Auth;
+using Lfm.Api.Helpers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;
@@ -43,7 +44,7 @@ public class RunsListFunction(IRunsRepository repo, IRaidersRepository raidersRe
 
         var raider = await raidersRepo.GetByBattleNetIdAsync(principal.BattleNetId, ct);
         if (raider is null)
-            return new NotFoundObjectResult(new { error = "Raider not found" });
+            return Problem.NotFound(req.HttpContext, "raider-not-found", "Raider not found.");
 
         var (guildId, _) = GuildResolver.FromRaider(raider);
 

--- a/tests/Lfm.Api.Tests/GuildAdminFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/GuildAdminFunctionTests.cs
@@ -78,6 +78,8 @@ public class GuildAdminFunctionTests
 
         var forbidden = Assert.IsType<ObjectResult>(result);
         Assert.Equal(403, forbidden.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(forbidden.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#admin-only", problem.Type);
 
         guildRepo.Verify(r => r.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
@@ -102,7 +104,10 @@ public class GuildAdminFunctionTests
 
         var result = await fn.Run(MakeRequest(null), ctx, CancellationToken.None);
 
-        Assert.IsType<BadRequestObjectResult>(result);
+        var badRequest = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(400, badRequest.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(badRequest.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#missing-parameter", problem.Type);
     }
 
     // ---------------------------------------------------------------------------
@@ -156,7 +161,10 @@ public class GuildAdminFunctionTests
 
         var result = await fn.Run(MakeRequest("nonexistent"), ctx, CancellationToken.None);
 
-        Assert.IsType<NotFoundResult>(result);
+        var notFound = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(404, notFound.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(notFound.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#guild-not-found", problem.Type);
     }
 
 }

--- a/tests/Lfm.Api.Tests/GuildFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/GuildFunctionTests.cs
@@ -140,11 +140,11 @@ public class GuildFunctionTests
 
         var result = await fn.GuildGet(MakeGetRequest(), ctx, CancellationToken.None);
 
-        var notFound = Assert.IsType<NotFoundObjectResult>(result);
-        var value = Assert.IsAssignableFrom<object>(notFound.Value);
-        var errorProp = value.GetType().GetProperty("error");
-        Assert.NotNull(errorProp);
-        Assert.Equal("Raider not found", errorProp!.GetValue(value));
+        var notFound = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(404, notFound.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(notFound.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#raider-not-found", problem.Type);
+        Assert.Equal("Raider not found.", problem.Detail);
     }
 
     // ------------------------------------------------------------------

--- a/tests/Lfm.Api.Tests/MeFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/MeFunctionTests.cs
@@ -96,7 +96,10 @@ public class MeFunctionTests
 
         var result = await fn.Run(new DefaultHttpContext().Request, ctx, CancellationToken.None);
 
-        Assert.IsType<NotFoundResult>(result);
+        var notFound = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(404, notFound.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(notFound.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#raider-not-found", problem.Type);
         siteAdmin.Verify(s => s.IsAdminAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 

--- a/tests/Lfm.Api.Tests/RunsDetailFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RunsDetailFunctionTests.cs
@@ -168,7 +168,9 @@ public class RunsDetailFunctionTests
             ctx,
             CancellationToken.None);
 
-        Assert.IsType<NotFoundObjectResult>(result);
+        var problem = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(404, problem.StatusCode);
+        Assert.IsType<ProblemDetails>(problem.Value);
 
         // Ordering contract: the run must be looked up before the raider.
         // If a future refactor reverses the order, this short-circuit test
@@ -211,7 +213,9 @@ public class RunsDetailFunctionTests
             ctx,
             CancellationToken.None);
 
-        Assert.IsType<NotFoundObjectResult>(result);
+        var problem = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(404, problem.StatusCode);
+        Assert.IsType<ProblemDetails>(problem.Value);
     }
 
     // ------------------------------------------------------------------
@@ -247,7 +251,9 @@ public class RunsDetailFunctionTests
             ctx,
             CancellationToken.None);
 
-        Assert.IsType<NotFoundObjectResult>(result);
+        var problem = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(404, problem.StatusCode);
+        Assert.IsType<ProblemDetails>(problem.Value);
     }
 
 }

--- a/tests/Lfm.Api.Tests/RunsListFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RunsListFunctionTests.cs
@@ -160,11 +160,11 @@ public class RunsListFunctionTests
 
         var result = await fn.Run(new DefaultHttpContext().Request, ctx, CancellationToken.None);
 
-        var notFound = Assert.IsType<NotFoundObjectResult>(result);
-        Assert.NotNull(notFound.Value);
-        var errorProp = notFound.Value!.GetType().GetProperty("error");
-        Assert.NotNull(errorProp);
-        Assert.Equal("Raider not found", errorProp!.GetValue(notFound.Value));
+        var notFound = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(404, notFound.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(notFound.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#raider-not-found", problem.Type);
+        Assert.Equal("Raider not found.", problem.Detail);
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

First slice of the Phase 2 error-shape migration. Every GET endpoint on the API now returns `application/problem+json` on error paths instead of the legacy `new { error = "..." }` body shape. Each `ProblemDetails.Type` URI is rooted at `https://github.com/lfm-org/lfm/errors#<slug>` per D0.1 and carries an `Activity.Current.TraceId` extension for Application Insights correlation (wired up in Slice 1.2).

SPA consumers of these endpoints never parse the error body — they just surface a localised "load failed" message via `LoadingState.Failure`. `RunErrorParser` is confined to **mutation** endpoints and gets its updates in Slice 2.2 alongside the Runs mutation migration. No SPA change required in this PR.

## Fixes

- `SAD-contract-error-shape` — partial (reads complete; mutations + auth remain in Slices 2.2 / 2.3)

## Commits (3)

| Commit | Scope |
|---|---|
| `f9edcf6` | `RunsDetail` + `RunsList` (+ tests) — 4 x 404 paths migrated |
| `ef1778a` | `Me` + `GuildAdmin` (+ tests) — 4 paths: 3 in GuildAdmin (403/400/404) + 1 in Me (404, body upgraded from empty) |
| `24229a1` | `Guild` GET (+ tests) — 2 x 404 paths; PATCH stays legacy until Slice 2.2 |

## Files (10)

| File | Change |
|---|---|
| `api/Functions/RunsDetailFunction.cs` | 3 × `NotFoundObjectResult(new { error = … })` → `Problem.NotFound` with stable slugs `run-not-found` / `raider-not-found` |
| `api/Functions/RunsListFunction.cs` | 1 × `NotFoundObjectResult` → `Problem.NotFound` with `raider-not-found` slug |
| `api/Functions/MeFunction.cs` | `NotFoundResult()` (empty body) → `Problem.NotFound` with `raider-not-found` slug. **Behavioural change**: previously an empty 404; now a proper problem+json body. SPA consumer doesn't parse the body. |
| `api/Functions/GuildFunction.cs` | GET path only: 2 × 404 → `Problem.NotFound` with `raider-not-found` / `guild-not-found` slugs. PATCH path unchanged (Slice 2.2). |
| `api/Functions/GuildAdminFunction.cs` | 403 `admin-only`, 400 `missing-parameter`, 404 `guild-not-found` — all three paths migrated |
| `tests/Lfm.Api.Tests/RunsDetailFunctionTests.cs` | 3 × `Assert.IsType<NotFoundObjectResult>(result)` → `ObjectResult` + `StatusCode` + `ProblemDetails` pattern |
| `tests/Lfm.Api.Tests/RunsListFunctionTests.cs` | Reflection-based `error` property assertion → `ProblemDetails.Type` + `.Detail` assertion |
| `tests/Lfm.Api.Tests/MeFunctionTests.cs` | `NotFoundResult` assertion → `ObjectResult` + `ProblemDetails.Type = #raider-not-found` |
| `tests/Lfm.Api.Tests/GuildFunctionTests.cs` | Reflection-based assertion → `ProblemDetails.Type = #raider-not-found` + `Detail` |
| `tests/Lfm.Api.Tests/GuildAdminFunctionTests.cs` | All 3 failure-path assertions upgraded to include `ProblemDetails.Type` checks — contract URIs are now covered, not just integer status codes |

## Env / schema changes

None. The contract change is on the wire only.

## Test plan

- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error` clean
- [x] `dotnet build lfm.sln -c Release` — 0 warnings, 0 errors
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` — 480/480 pass
- [ ] CI: `verify`, `reuse-lint`, `dep-license-check`, `Gitleaks` green
- [ ] E2E lane — not affected (no mutation paths touched); CI to confirm

## Rollback

Three independent commits; each can be reverted individually if a specific endpoint's migration surfaces an issue. No state migrations, no persistent coupling between them.

## Next

- **Slice 2.2** — mutations (POST/PUT/PATCH/DELETE on Runs / Me / Guild / Raider / BattleNet). Includes the `RunErrorParser` update for the Runs mutation commit. Split across ~3 commits on a single branch for reviewability.
- **Slice 2.3** — auth / callback / admin endpoints (BattleNet OAuth, E2E login, PrivacyContact, WowReferenceRefresh, RunsMigrateSchema).