### PR TITLE
Migrate mutation endpoints to RFC 9457 problem+json

### DIFF
--- a/api/Functions/BattleNetCharacterPortraitsFunction.cs
+++ b/api/Functions/BattleNetCharacterPortraitsFunction.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using Lfm.Api.Auth;
+using Lfm.Api.Helpers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;
@@ -67,7 +68,7 @@ public class BattleNetCharacterPortraitsFunction(
 
         var raider = await repo.GetByBattleNetIdAsync(principal.BattleNetId, cancellationToken);
         if (raider is null)
-            return new NotFoundResult();
+            return Problem.NotFound(req.HttpContext, "raider-not-found", "Raider not found.");
 
         // Access token is stored in the session principal (populated at OAuth callback time).
         // If absent (old session before B2.5), fall back to empty string; the Blizzard fetch

--- a/api/Functions/BattleNetCharactersRefreshFunction.cs
+++ b/api/Functions/BattleNetCharactersRefreshFunction.cs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
 using Lfm.Api.Auth;
+using Lfm.Api.Helpers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Options;
 using Lfm.Api.Repositories;
@@ -51,27 +52,27 @@ public class BattleNetCharactersRefreshFunction(
 
         var raider = await repo.GetByBattleNetIdAsync(principal.BattleNetId, cancellationToken);
         if (raider is null)
-            return new NotFoundResult();
+            return Problem.NotFound(req.HttpContext, "raider-not-found", "Raider not found.");
 
         // Rate-limit check: mirror cooldownRemaining() from cache.ts.
         var remainingSeconds = CooldownRemainingSeconds(raider.AccountProfileRefreshedAt, AccountCharsCooldownMs);
         if (remainingSeconds > 0)
         {
-            req.HttpContext.Response.Headers["Retry-After"] = remainingSeconds.ToString();
-            return new ObjectResult(new { error = "Too many requests", retryAfter = remainingSeconds })
-            {
-                StatusCode = 429,
-            };
+            return Problem.TooManyRequests(
+                req.HttpContext,
+                "characters-refresh-cooldown",
+                "Too many requests.",
+                retryAfterSeconds: remainingSeconds);
         }
 
         // Access token is stored in the session principal (populated at OAuth callback time).
         // If missing (old session before B2.5), we cannot call Blizzard.
         var accessToken = principal.AccessToken;
         if (string.IsNullOrEmpty(accessToken))
-            return new ObjectResult(new { error = "Session does not contain an access token. Please log out and log in again." })
-            {
-                StatusCode = 401,
-            };
+            return Problem.Unauthorized(
+                req.HttpContext,
+                "missing-access-token",
+                "Session does not contain an access token. Please log out and log in again.");
 
         BlizzardAccountProfileSummary freshSummary;
         try
@@ -81,10 +82,10 @@ public class BattleNetCharactersRefreshFunction(
         catch
         {
             // Do not update accountProfileRefreshedAt — a failed attempt must not consume the cooldown.
-            return new ObjectResult(new { error = "Failed to fetch characters from Blizzard" })
-            {
-                StatusCode = 502,
-            };
+            return Problem.UpstreamFailed(
+                req.HttpContext,
+                "blizzard-upstream-failed",
+                "Failed to fetch characters from Blizzard.");
         }
 
         var now = DateTimeOffset.UtcNow.ToString("O");

--- a/api/Functions/GuildFunction.cs
+++ b/api/Functions/GuildFunction.cs
@@ -85,17 +85,17 @@ public class GuildFunction(IGuildRepository guildRepo, IRaidersRepository raider
 
         var raider = await raidersRepo.GetByBattleNetIdAsync(principal.BattleNetId, cancellationToken);
         if (raider is null)
-            return new NotFoundObjectResult(new { error = "Raider not found" });
+            return Problem.NotFound(req.HttpContext, "raider-not-found", "Raider not found.");
 
         var (guildId, _) = GuildResolver.FromRaider(raider);
         if (guildId is null)
-            return new NotFoundResult();
+            return Problem.NotFound(req.HttpContext, "guild-not-found", "Guild not found.");
 
         var isAdmin = await guildPermissions.IsAdminAsync(raider, cancellationToken);
         if (!isAdmin)
         {
             AuditLog.Emit(logger, new AuditEvent("guild.update", principal.BattleNetId, guildId, "failure", "forbidden"));
-            return new ObjectResult(new { error = "forbidden" }) { StatusCode = 403 };
+            return Problem.Forbidden(req.HttpContext, "guild-admin-only", "Guild admin access required.");
         }
 
         var body = await JsonSerializer.DeserializeAsync<UpdateGuildRequest>(
@@ -104,17 +104,23 @@ public class GuildFunction(IGuildRepository guildRepo, IRaidersRepository raider
             cancellationToken: cancellationToken);
 
         if (body is null)
-            return new BadRequestObjectResult(new { error = "invalid body" });
+            return Problem.BadRequest(req.HttpContext, "invalid-body", "Request body is invalid or missing.");
 
         var validator = new UpdateGuildRequestValidator();
         var validationResult = await validator.ValidateAsync(body, cancellationToken);
         if (!validationResult.IsValid)
-            return new BadRequestObjectResult(
-                new { errors = validationResult.Errors.Select(e => e.ErrorMessage) });
+        {
+            var errors = validationResult.Errors.Select(e => e.ErrorMessage).ToArray();
+            return Problem.BadRequest(
+                req.HttpContext,
+                "validation-failed",
+                "Request body failed validation.",
+                new Dictionary<string, object?> { ["errors"] = errors });
+        }
 
         var guildDoc = await guildRepo.GetAsync(guildId, cancellationToken);
         if (guildDoc is null)
-            return new NotFoundResult();
+            return Problem.NotFound(req.HttpContext, "guild-not-found", "Guild not found.");
 
         var updatedSetup = guildDoc.Setup is not null
             ? guildDoc.Setup with

--- a/api/Functions/MeUpdateFunction.cs
+++ b/api/Functions/MeUpdateFunction.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Lfm.Api.Auth;
+using Lfm.Api.Helpers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
 using Lfm.Contracts.Me;
@@ -32,17 +33,24 @@ public class MeUpdateFunction(IRaidersRepository repo)
             cancellationToken: cancellationToken);
 
         if (body is null)
-            return new BadRequestObjectResult(new { error = "invalid body" });
+            return Problem.BadRequest(req.HttpContext, "invalid-body", "Request body is invalid or missing.");
 
         var validator = new UpdateMeRequestValidator();
         var validationResult = await validator.ValidateAsync(body, cancellationToken);
         if (!validationResult.IsValid)
-            return new BadRequestObjectResult(new { errors = validationResult.Errors.Select(e => e.ErrorMessage) });
+        {
+            var errors = validationResult.Errors.Select(e => e.ErrorMessage).ToArray();
+            return Problem.BadRequest(
+                req.HttpContext,
+                "validation-failed",
+                "Request body failed validation.",
+                new Dictionary<string, object?> { ["errors"] = errors });
+        }
 
         // Read-modify-write: load existing doc then upsert with updated locale + TTL.
         var raider = await repo.GetByBattleNetIdAsync(principal.BattleNetId, cancellationToken);
         if (raider is null)
-            return new NotFoundResult();
+            return Problem.NotFound(req.HttpContext, "raider-not-found", "Raider not found.");
 
         var updated = raider with { Locale = body.Locale!, Ttl = TtlSeconds };
         await repo.UpsertAsync(updated, cancellationToken);

--- a/api/Functions/RaiderCharacterAddFunction.cs
+++ b/api/Functions/RaiderCharacterAddFunction.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using Lfm.Api.Auth;
+using Lfm.Api.Helpers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;
@@ -59,18 +60,26 @@ public class RaiderCharacterAddFunction(
             body = await JsonSerializer.DeserializeAsync<AddCharacterRequest>(
                 req.Body, JsonOptions, cancellationToken: ct);
             if (body is null)
-                return new BadRequestObjectResult(new { error = "Invalid request body" });
+                return Problem.BadRequest(req.HttpContext, "invalid-body", "Request body is invalid or missing.");
         }
-        catch (JsonException ex)
+        catch (JsonException)
         {
-            return new BadRequestObjectResult(new { error = ex.Message });
+            // Never echo JsonException.Message — it can disclose offset/line/path
+            // detail from the caller's payload that is not useful to the user.
+            return Problem.BadRequest(req.HttpContext, "invalid-body", "Request body is invalid or missing.");
         }
 
         var validator = new AddCharacterRequestValidator();
         var validationResult = await validator.ValidateAsync(body, ct);
         if (!validationResult.IsValid)
-            return new BadRequestObjectResult(
-                new { errors = validationResult.Errors.Select(e => e.ErrorMessage) });
+        {
+            var errors = validationResult.Errors.Select(e => e.ErrorMessage).ToArray();
+            return Problem.BadRequest(
+                req.HttpContext,
+                "validation-failed",
+                "Request body failed validation.",
+                new Dictionary<string, object?> { ["errors"] = errors });
+        }
 
         // 2. Lowercase region/realm/name for id / ownership / storage.
         //    (Validator does not lowercase inputs — see plan, Task 3 carry-forward.)
@@ -82,7 +91,7 @@ public class RaiderCharacterAddFunction(
         // 3. Load the raider document.
         var raider = await repo.GetByBattleNetIdAsync(principal.BattleNetId, ct);
         if (raider is null)
-            return new NotFoundObjectResult(new { error = "Raider not found" });
+            return Problem.NotFound(req.HttpContext, "raider-not-found", "Raider not found.");
 
         // 4. Ownership check against the cached account profile summary.
         if (!IsCharacterOwnedByAccount(characterId, region, raider.AccountProfileSummary))
@@ -90,8 +99,10 @@ public class RaiderCharacterAddFunction(
             logger.LogWarning(
                 "Ownership check failed for {BattleNetId} on character {CharacterId}",
                 principal.BattleNetId, characterId);
-            return new ObjectResult(new { error = "Character not found in your Battle.net account" })
-            { StatusCode = 403 };
+            return Problem.Forbidden(
+                req.HttpContext,
+                "character-not-in-bnet-account",
+                "Character not found in your Battle.net account.");
         }
 
         // 5. Plan which tiers are stale; reuse the cached record if everything is fresh.
@@ -108,8 +119,10 @@ public class RaiderCharacterAddFunction(
             // 6. Fetch only stale tiers from Blizzard.  Access token must be present.
             var accessToken = principal.AccessToken;
             if (string.IsNullOrEmpty(accessToken))
-                return new ObjectResult(new { error = "Session does not contain an access token. Please log out and log in again." })
-                { StatusCode = 401 };
+                return Problem.Unauthorized(
+                    req.HttpContext,
+                    "missing-access-token",
+                    "Session does not contain an access token. Please log out and log in again.");
 
             BlizzardCharacterProfileResponse? profile = null;
             BlizzardCharacterSpecializationsResponse? specs = null;
@@ -125,8 +138,10 @@ public class RaiderCharacterAddFunction(
             }
             catch (HttpRequestException)
             {
-                return new ObjectResult(new { error = "Failed to fetch character from Blizzard" })
-                { StatusCode = 502 };
+                return Problem.UpstreamFailed(
+                    req.HttpContext,
+                    "blizzard-upstream-failed",
+                    "Failed to fetch character from Blizzard.");
             }
 
             var now = DateTimeOffset.UtcNow.ToString("O");

--- a/api/Functions/RaiderCharacterEnrichFunction.cs
+++ b/api/Functions/RaiderCharacterEnrichFunction.cs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
 using Lfm.Api.Auth;
+using Lfm.Api.Helpers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;
@@ -37,22 +38,24 @@ public sealed class RaiderCharacterEnrichFunction(
         var firstDash = id.IndexOf('-');
         var lastDash = id.LastIndexOf('-');
         if (firstDash <= 0 || lastDash <= firstDash)
-            return new BadRequestObjectResult(new { error = "Invalid character id" });
+            return Problem.BadRequest(req.HttpContext, "invalid-character-id", "Invalid character id.");
         var region = id[..firstDash].ToLowerInvariant();
         var realm = id[(firstDash + 1)..lastDash].ToLowerInvariant();
         var lowerName = id[(lastDash + 1)..].ToLowerInvariant();
 
         var raider = await repo.GetByBattleNetIdAsync(principal.BattleNetId, ct);
         if (raider is null)
-            return new NotFoundObjectResult(new { error = "Raider not found" });
+            return Problem.NotFound(req.HttpContext, "raider-not-found", "Raider not found.");
 
         if (!RaiderCharacterAddFunction.IsCharacterOwnedByAccount(id, region, raider.AccountProfileSummary))
         {
             logger.LogWarning(
                 "Ownership check failed for {BattleNetId} on character {CharacterId}",
                 principal.BattleNetId, id);
-            return new ObjectResult(new { error = "Character not found in your Battle.net account" })
-            { StatusCode = 403 };
+            return Problem.Forbidden(
+                req.HttpContext,
+                "character-not-in-bnet-account",
+                "Character not found in your Battle.net account.");
         }
 
         var existing = raider.Characters?.FirstOrDefault(c => c.Id == id);
@@ -67,8 +70,10 @@ public sealed class RaiderCharacterEnrichFunction(
         {
             var accessToken = principal.AccessToken;
             if (string.IsNullOrEmpty(accessToken))
-                return new ObjectResult(new { error = "Session does not contain an access token. Please log out and log in again." })
-                { StatusCode = 401 };
+                return Problem.Unauthorized(
+                    req.HttpContext,
+                    "missing-access-token",
+                    "Session does not contain an access token. Please log out and log in again.");
 
             BlizzardCharacterProfileResponse? profile = null;
             BlizzardCharacterSpecializationsResponse? specs = null;
@@ -84,15 +89,24 @@ public sealed class RaiderCharacterEnrichFunction(
             }
             catch (HttpRequestException ex) when ((int?)ex.StatusCode == 429)
             {
-                return new ObjectResult(new { error = "Upstream rate-limited" }) { StatusCode = 429 };
+                return Problem.TooManyRequests(
+                    req.HttpContext,
+                    "upstream-rate-limited",
+                    "Upstream rate-limited.");
             }
             catch (HttpRequestException ex) when ((int?)ex.StatusCode == 404)
             {
-                return new NotFoundObjectResult(new { error = "Character not found on Blizzard" });
+                return Problem.NotFound(
+                    req.HttpContext,
+                    "character-not-found-on-blizzard",
+                    "Character not found on Blizzard.");
             }
             catch (HttpRequestException)
             {
-                return new ObjectResult(new { error = "Failed to fetch character from Blizzard" }) { StatusCode = 502 };
+                return Problem.UpstreamFailed(
+                    req.HttpContext,
+                    "blizzard-upstream-failed",
+                    "Failed to fetch character from Blizzard.");
             }
 
             var nowIso = DateTimeOffset.UtcNow.ToString("O");

--- a/api/Functions/RaiderCharacterFunction.cs
+++ b/api/Functions/RaiderCharacterFunction.cs
@@ -44,15 +44,17 @@ public class RaiderCharacterFunction(IRaidersRepository repo, ILogger<RaiderChar
         // 1. Load raider document.
         var raider = await repo.GetByBattleNetIdAsync(principal.BattleNetId, ct);
         if (raider is null)
-            return new NotFoundObjectResult(new { error = "Raider not found" });
+            return Problem.NotFound(req.HttpContext, "raider-not-found", "Raider not found.");
 
         // 2. Verify character ownership — the character must already be stored in the
         //    raider document's characters list. Mirrors:
         //    if (!isCharacterOwnedByAccount(...)) return errorResponse(403, ...)
         var ownedCharacter = raider.Characters?.FirstOrDefault(c => c.Id == id);
         if (ownedCharacter is null)
-            return new ObjectResult(new { error = "Character not found in your profile" })
-            { StatusCode = 403 };
+            return Problem.Forbidden(
+                req.HttpContext,
+                "character-not-on-profile",
+                "Character not found in your profile.");
 
         // 3. Update selectedCharacterId and persist.
         try

--- a/api/Functions/RunsCancelSignupFunction.cs
+++ b/api/Functions/RunsCancelSignupFunction.cs
@@ -7,6 +7,7 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 using Lfm.Api.Audit;
 using Lfm.Api.Auth;
+using Lfm.Api.Helpers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;
@@ -49,7 +50,7 @@ public class RunsCancelSignupFunction(
         // 1. Load existing run.
         var run = await runsRepo.GetByIdAsync(id, ct);
         if (run is null)
-            return new NotFoundObjectResult(new { error = "Run not found" });
+            return Problem.NotFound(req.HttpContext, "run-not-found", "Run not found.");
 
         // 2. Visibility check for GUILD runs — mirrors runs-cancel-signup.ts:
         //    if (run.visibility === "GUILD" && !isCreator && !isGuildMember)
@@ -61,7 +62,7 @@ public class RunsCancelSignupFunction(
             // Derive the caller's guild from the raider's selected character.
             var raider = await raidersRepo.GetByBattleNetIdAsync(principal.BattleNetId, ct);
             if (raider is null)
-                return new NotFoundObjectResult(new { error = "Raider not found" });
+                return Problem.NotFound(req.HttpContext, "raider-not-found", "Raider not found.");
 
             var (guildId, _) = GuildResolver.FromRaider(raider);
 
@@ -70,7 +71,7 @@ public class RunsCancelSignupFunction(
                 && run.CreatorGuildId.ToString() == guildId;
 
             if (!isCreator && !isGuildMember)
-                return new NotFoundObjectResult(new { error = "Run not found" });
+                return Problem.NotFound(req.HttpContext, "run-not-found", "Run not found.");
         }
 
         // 3. Find the user's entry in runCharacters by raiderBattleNetId.
@@ -86,7 +87,7 @@ public class RunsCancelSignupFunction(
 
         // 4. Return 404 if the user is not signed up.
         if (existingIndex < 0)
-            return new NotFoundObjectResult(new { error = "No signup found" });
+            return Problem.NotFound(req.HttpContext, "signup-not-found", "No signup found.");
 
         // 5. Remove the entry from the array.
         var updatedCharacters = run.RunCharacters.ToList();

--- a/api/Functions/RunsCreateFunction.cs
+++ b/api/Functions/RunsCreateFunction.cs
@@ -57,20 +57,26 @@ public class RunsCreateFunction(IRunsRepository repo, IRaidersRepository raiders
             cancellationToken: ct);
 
         if (body is null)
-            return new BadRequestObjectResult(new { error = "invalid body" });
+            return Problem.BadRequest(req.HttpContext, "invalid-body", "Request body is invalid or missing.");
 
         var validator = new CreateRunRequestValidator();
         var validationResult = await validator.ValidateAsync(body, ct);
         if (!validationResult.IsValid)
-            return new BadRequestObjectResult(
-                new { errors = validationResult.Errors.Select(e => e.ErrorMessage) });
+        {
+            var errors = validationResult.Errors.Select(e => e.ErrorMessage).ToArray();
+            return Problem.BadRequest(
+                req.HttpContext,
+                "validation-failed",
+                "Request body failed validation.",
+                new Dictionary<string, object?> { ["errors"] = errors });
+        }
 
         // Load the raider once and derive guild info from the selected character.
         // principal.GuildId / GuildName are legacy session fields that are no
         // longer populated in production.
         var raider = await raidersRepo.GetByBattleNetIdAsync(principal.BattleNetId, ct);
         if (raider is null)
-            return new NotFoundObjectResult(new { error = "Raider not found" });
+            return Problem.NotFound(req.HttpContext, "raider-not-found", "Raider not found.");
 
         var (guildId, guildName) = GuildResolver.FromRaider(raider);
 
@@ -80,15 +86,19 @@ public class RunsCreateFunction(IRunsRepository repo, IRaidersRepository raiders
         if (body.Visibility == "GUILD")
         {
             if (guildId is null)
-                return new BadRequestObjectResult(
-                    new { error = "A guild run requires an active character in a guild" });
+                return Problem.BadRequest(
+                    req.HttpContext,
+                    "guild-required",
+                    "A guild run requires an active character in a guild.");
 
             var canCreate = await guildPermissions.CanCreateGuildRunsAsync(raider, ct);
             if (!canCreate)
             {
                 AuditLog.Emit(logger, new AuditEvent("run.create", principal.BattleNetId, null, "failure", "guild rank denied"));
-                return new ObjectResult(new { error = "Guild run creation is not enabled for your rank" })
-                { StatusCode = 403 };
+                return Problem.Forbidden(
+                    req.HttpContext,
+                    "guild-rank-denied",
+                    "Guild run creation is not enabled for your rank.");
             }
         }
 

--- a/api/Functions/RunsDeleteFunction.cs
+++ b/api/Functions/RunsDeleteFunction.cs
@@ -7,6 +7,7 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 using Lfm.Api.Audit;
 using Lfm.Api.Auth;
+using Lfm.Api.Helpers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;
@@ -42,7 +43,7 @@ public class RunsDeleteFunction(IRunsRepository repo, IRaidersRepository raiders
         // 1. Load existing run.
         var existing = await repo.GetByIdAsync(id, ct);
         if (existing is null)
-            return new NotFoundObjectResult(new { error = "Run not found" });
+            return Problem.NotFound(req.HttpContext, "run-not-found", "Run not found.");
 
         // 2. Permission check — mirrors runs-delete.ts:
         //    Creator can always delete. Non-creator must be in the same guild with
@@ -54,7 +55,7 @@ public class RunsDeleteFunction(IRunsRepository repo, IRaidersRepository raiders
             // principal.GuildId is a legacy session field and is no longer populated.
             var raider = await raidersRepo.GetByBattleNetIdAsync(principal.BattleNetId, ct);
             if (raider is null)
-                return new NotFoundObjectResult(new { error = "Raider not found" });
+                return Problem.NotFound(req.HttpContext, "raider-not-found", "Raider not found.");
 
             var (guildId, _) = GuildResolver.FromRaider(raider);
 
@@ -63,16 +64,20 @@ public class RunsDeleteFunction(IRunsRepository repo, IRaidersRepository raiders
                 || guildId != existing.CreatorGuildId.ToString())
             {
                 AuditLog.Emit(logger, new AuditEvent("run.delete", principal.BattleNetId, id, "failure", "not creator"));
-                return new ObjectResult(new { error = "Only the run creator can delete this run" })
-                { StatusCode = 403 };
+                return Problem.Forbidden(
+                    req.HttpContext,
+                    "run-delete-not-creator",
+                    "Only the run creator can delete this run.");
             }
 
             var canDelete = await guildPermissions.CanDeleteGuildRunsAsync(raider, ct);
             if (!canDelete)
             {
                 AuditLog.Emit(logger, new AuditEvent("run.delete", principal.BattleNetId, id, "failure", "guild rank denied"));
-                return new ObjectResult(new { error = "Your guild rank does not have permission to delete guild runs" })
-                { StatusCode = 403 };
+                return Problem.Forbidden(
+                    req.HttpContext,
+                    "guild-rank-denied",
+                    "Your guild rank does not have permission to delete guild runs.");
             }
         }
 

--- a/api/Functions/RunsMigrateSchemaFunction.cs
+++ b/api/Functions/RunsMigrateSchemaFunction.cs
@@ -7,6 +7,7 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 using Lfm.Api.Audit;
 using Lfm.Api.Auth;
+using Lfm.Api.Helpers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;
@@ -41,7 +42,7 @@ public class RunsMigrateSchemaFunction(
         var principal = ctx.GetPrincipal();
 
         if (!await siteAdmin.IsAdminAsync(principal.BattleNetId, ct))
-            return new ObjectResult(new { error = "Forbidden" }) { StatusCode = 403 };
+            return Problem.Forbidden(req.HttpContext, "admin-only", "Site administrator access required.");
 
         var dryRun = string.Equals(
             req.Query["dryRun"].ToString(),

--- a/api/Functions/RunsSignupFunction.cs
+++ b/api/Functions/RunsSignupFunction.cs
@@ -64,27 +64,33 @@ public class RunsSignupFunction(
                 cancellationToken: ct);
 
             if (body is null)
-                return new BadRequestObjectResult(new { error = "Invalid request body" });
+                return Problem.BadRequest(req.HttpContext, "invalid-body", "Request body is invalid or missing.");
         }
         catch (JsonException)
         {
             // Never echo JsonException.Message — it can disclose offset/line/path
             // detail from the caller's payload that is not useful to the user and
             // inconsistent with how other handlers report parse failures.
-            return new BadRequestObjectResult(new { error = "Invalid request body" });
+            return Problem.BadRequest(req.HttpContext, "invalid-body", "Request body is invalid or missing.");
         }
 
         var validator = new SignupRequestValidator();
         var validationResult = await validator.ValidateAsync(body, ct);
         if (!validationResult.IsValid)
-            return new BadRequestObjectResult(
-                new { errors = validationResult.Errors.Select(e => e.ErrorMessage) });
+        {
+            var errors = validationResult.Errors.Select(e => e.ErrorMessage).ToArray();
+            return Problem.BadRequest(
+                req.HttpContext,
+                "validation-failed",
+                "Request body failed validation.",
+                new Dictionary<string, object?> { ["errors"] = errors });
+        }
 
         // 2. Load raider document and verify character ownership.
         //    Mirrors: const storedCharacter = raider.characters.find(c => c.id === body.characterId)
         var raider = await raidersRepo.GetByBattleNetIdAsync(principal.BattleNetId, ct);
         if (raider is null)
-            return new NotFoundObjectResult(new { error = "Raider not found" });
+            return Problem.NotFound(req.HttpContext, "raider-not-found", "Raider not found.");
 
         // Derive the caller's guild from the raider's selected character for the
         // GUILD visibility check below. principal.GuildId is a legacy session field
@@ -93,7 +99,10 @@ public class RunsSignupFunction(
 
         var storedCharacter = raider.Characters?.FirstOrDefault(c => c.Id == body.CharacterId);
         if (storedCharacter is null)
-            return new BadRequestObjectResult(new { error = "Character not found on your profile" });
+            return Problem.BadRequest(
+                req.HttpContext,
+                "character-not-on-profile",
+                "Character not found on your profile.");
 
         // 3. Resolve spec info — mirrors the specId block in runs-signup.ts.
         int? specId = body.SpecId;
@@ -105,7 +114,10 @@ public class RunsSignupFunction(
             var specEntry = storedCharacter.SpecializationsSummary?.Specializations
                 ?.FirstOrDefault(s => s.Specialization.Id == specId.Value);
             if (specEntry is null)
-                return new BadRequestObjectResult(new { error = "Invalid specId: not found on character" });
+                return Problem.BadRequest(
+                    req.HttpContext,
+                    "invalid-spec-id",
+                    "Invalid specId: not found on character.");
 
             specName = specEntry.Specialization.Name;
         }
@@ -118,13 +130,15 @@ public class RunsSignupFunction(
             // 4a. Load existing run.
             var run = await runsRepo.GetByIdAsync(id, ct);
             if (run is null)
-                return new NotFoundObjectResult(new { error = "Run not found" });
+                return Problem.NotFound(req.HttpContext, "run-not-found", "Run not found.");
 
             // 4b. Signup close time check — reject if signups are closed.
             if (RunEditability.IsEditingClosed(run.SignupCloseTime, run.StartTime, DateTimeOffset.UtcNow))
             {
-                return new ObjectResult(new { error = "Signups are closed for this run" })
-                { StatusCode = 409 };
+                return Problem.Conflict(
+                    req.HttpContext,
+                    "signups-closed",
+                    "Signups are closed for this run.");
             }
 
             // 4c. Visibility check for GUILD runs — mirrors runs-signup.ts.
@@ -136,14 +150,16 @@ public class RunsSignupFunction(
                     && run.CreatorGuildId.ToString() == callerGuildId;
 
                 if (!isCreator && !isGuildMember)
-                    return new NotFoundObjectResult(new { error = "Run not found" });
+                    return Problem.NotFound(req.HttpContext, "run-not-found", "Run not found.");
 
                 var canSignup = await guildPermissions.CanSignupGuildRunsAsync(raider, ct);
                 if (!canSignup)
                 {
                     AuditLog.Emit(logger, new AuditEvent("signup.create", principal.BattleNetId, id, "failure", "guild rank denied"));
-                    return new ObjectResult(new { error = "Guild signup is not enabled for your rank" })
-                    { StatusCode = 403 };
+                    return Problem.Forbidden(
+                        req.HttpContext,
+                        "guild-rank-denied",
+                        "Guild signup is not enabled for your rank.");
                 }
             }
 
@@ -208,8 +224,10 @@ public class RunsSignupFunction(
         }
 
         // All retry attempts exhausted.
-        return new ObjectResult(new { error = "Concurrent modification, please retry" })
-        { StatusCode = 409 };
+        return Problem.Conflict(
+            req.HttpContext,
+            "concurrent-modification",
+            "Concurrent modification, please retry.");
     }
 
     // ------------------------------------------------------------------

--- a/api/Functions/RunsUpdateFunction.cs
+++ b/api/Functions/RunsUpdateFunction.cs
@@ -56,14 +56,14 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
         // 1. Load existing run.
         var existing = await repo.GetByIdAsync(id, ct);
         if (existing is null)
-            return new NotFoundObjectResult(new { error = "Run not found" });
+            return Problem.NotFound(req.HttpContext, "run-not-found", "Run not found.");
 
         // 2. Load the raider once and derive guild info from the selected character.
         //    principal.GuildId / GuildName are legacy session fields; guild info is
         //    always taken from the raider's stored selected character.
         var raider = await raidersRepo.GetByBattleNetIdAsync(principal.BattleNetId, ct);
         if (raider is null)
-            return new NotFoundObjectResult(new { error = "Raider not found" });
+            return Problem.NotFound(req.HttpContext, "raider-not-found", "Raider not found.");
 
         var (guildId, guildName) = GuildResolver.FromRaider(raider);
 
@@ -78,16 +78,20 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
                 || guildId != existing.CreatorGuildId.ToString())
             {
                 AuditLog.Emit(logger, new AuditEvent("run.update", principal.BattleNetId, id, "failure", "not creator"));
-                return new ObjectResult(new { error = "Only the run creator can update this run" })
-                { StatusCode = 403 };
+                return Problem.Forbidden(
+                    req.HttpContext,
+                    "run-update-not-creator",
+                    "Only the run creator can update this run.");
             }
 
             var canEdit = await guildPermissions.CanCreateGuildRunsAsync(raider, ct);
             if (!canEdit)
             {
                 AuditLog.Emit(logger, new AuditEvent("run.update", principal.BattleNetId, id, "failure", "guild rank denied"));
-                return new ObjectResult(new { error = "Your guild rank does not have permission to edit guild runs" })
-                { StatusCode = 403 };
+                return Problem.Forbidden(
+                    req.HttpContext,
+                    "guild-rank-denied",
+                    "Your guild rank does not have permission to edit guild runs.");
             }
         }
 
@@ -101,28 +105,36 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
                 cancellationToken: ct);
 
             if (body is null)
-                return new BadRequestObjectResult(new { error = "Invalid request body" });
+                return Problem.BadRequest(req.HttpContext, "invalid-body", "Request body is invalid or missing.");
         }
         catch (JsonException)
         {
             // Never echo JsonException.Message — it can disclose offset/line/path
             // detail from the caller's payload that is not useful to the user and
             // inconsistent with how other handlers report parse failures.
-            return new BadRequestObjectResult(new { error = "Invalid request body" });
+            return Problem.BadRequest(req.HttpContext, "invalid-body", "Request body is invalid or missing.");
         }
 
         var validator = new UpdateRunRequestValidator();
         var validationResult = await validator.ValidateAsync(body, ct);
         if (!validationResult.IsValid)
-            return new BadRequestObjectResult(
-                new { errors = validationResult.Errors.Select(e => e.ErrorMessage) });
+        {
+            var errors = validationResult.Errors.Select(e => e.ErrorMessage).ToArray();
+            return Problem.BadRequest(
+                req.HttpContext,
+                "validation-failed",
+                "Request body failed validation.",
+                new Dictionary<string, object?> { ["errors"] = errors });
+        }
 
         // 4. Editability check — mirrors isEditingClosed in run-editability.ts.
         //    Returns 409 Conflict (the resource state conflicts with the request).
         if (RunEditability.IsEditingClosed(existing.SignupCloseTime, existing.StartTime, DateTimeOffset.UtcNow))
         {
-            return new ObjectResult(new { error = "Editing is closed for this run" })
-            { StatusCode = 409 };
+            return Problem.Conflict(
+                req.HttpContext,
+                "run-editing-closed",
+                "Editing is closed for this run.");
         }
 
         // 5. Locked-field check — mirrors getLockedFields in run-editability.ts.
@@ -132,9 +144,15 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
         if (signupCount > 0)
         {
             if (body.StartTime is not null && body.StartTime != existing.StartTime)
-                return new BadRequestObjectResult(new { error = "Cannot change start time after signups" });
+                return Problem.BadRequest(
+                    req.HttpContext,
+                    "start-time-locked",
+                    "Cannot change start time after signups.");
             if (body.InstanceId is not null && body.InstanceId != existing.InstanceId)
-                return new BadRequestObjectResult(new { error = "Cannot change instance after signups" });
+                return Problem.BadRequest(
+                    req.HttpContext,
+                    "instance-locked",
+                    "Cannot change instance after signups.");
         }
 
         // 6. GUILD visibility promotion guard — mirrors isGuildVisibilityPromotion.
@@ -142,15 +160,19 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
         if (isGuildPromotion)
         {
             if (guildId is null)
-                return new BadRequestObjectResult(
-                    new { error = "A guild run requires an active character in a guild" });
+                return Problem.BadRequest(
+                    req.HttpContext,
+                    "guild-required",
+                    "A guild run requires an active character in a guild.");
 
             var canCreate = await guildPermissions.CanCreateGuildRunsAsync(raider, ct);
             if (!canCreate)
             {
                 AuditLog.Emit(logger, new AuditEvent("run.update", principal.BattleNetId, id, "failure", "guild rank denied"));
-                return new ObjectResult(new { error = "Guild run creation is not enabled for your rank" })
-                { StatusCode = 403 };
+                return Problem.Forbidden(
+                    req.HttpContext,
+                    "guild-rank-denied",
+                    "Guild run creation is not enabled for your rank.");
             }
         }
 
@@ -175,14 +197,20 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
         {
             var instances = await instancesRepo.ListAsync(ct);
             if (instances.Count == 0)
-                return new ObjectResult(new { error = "Instance data not available" }) { StatusCode = 503 };
+                return Problem.ServiceUnavailable(
+                    req.HttpContext,
+                    "instance-data-unavailable",
+                    "Instance data not available.");
 
             var matchedInstance = instances.FirstOrDefault(i =>
                 i.InstanceNumericId == effectiveInstanceId.Value
                 && i.Difficulty == effectiveDifficulty
                 && i.Size == effectiveSize);
             if (matchedInstance is null)
-                return new BadRequestObjectResult(new { error = "Invalid difficulty/size for instance" });
+                return Problem.BadRequest(
+                    req.HttpContext,
+                    "invalid-instance-mode",
+                    "Invalid difficulty/size for instance.");
             effectiveInstanceName = matchedInstance.Name;
         }
         else

--- a/api/Helpers/InternalErrorResult.cs
+++ b/api/Helpers/InternalErrorResult.cs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
+using System.Diagnostics;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
@@ -14,7 +16,11 @@ namespace Lfm.Api.Helpers;
 /// network clients) could otherwise leak infrastructure details through
 /// <c>ex.Message</c> or <c>ex.GetType().Name</c>.
 ///
-/// Response body: <c>{ "error": "internal error", "correlationId": "&lt;invocation-id&gt;" }</c>.
+/// The response body is RFC 9457 <c>application/problem+json</c> with a stable
+/// <c>type</c> URI of <c>https://github.com/lfm-org/lfm/errors#internal-error</c>
+/// and <c>extensions.correlationId</c> set to the Functions invocation id for
+/// server-side triage. When an <see cref="Activity"/> is current its
+/// <c>traceId</c> is attached as a separate extension.
 /// </summary>
 public static class InternalErrorResult
 {
@@ -26,9 +32,25 @@ public static class InternalErrorResult
             operation,
             ctx.InvocationId);
 
-        return new ObjectResult(new { error = "internal error", correlationId = ctx.InvocationId })
+        var problem = new ProblemDetails
         {
-            StatusCode = 500,
+            Type = $"{Problem.TypeBase}#internal-error",
+            Title = "Internal Server Error",
+            Status = StatusCodes.Status500InternalServerError,
+            Detail = "An unexpected server error occurred.",
+            Instance = ctx.GetHttpContext()?.Request.Path.Value,
+        };
+        problem.Extensions["correlationId"] = ctx.InvocationId;
+        var traceId = Activity.Current?.TraceId.ToString();
+        if (!string.IsNullOrEmpty(traceId))
+        {
+            problem.Extensions["traceId"] = traceId;
+        }
+
+        return new ObjectResult(problem)
+        {
+            StatusCode = StatusCodes.Status500InternalServerError,
+            ContentTypes = { Problem.ContentType },
         };
     }
 }

--- a/api/Helpers/Problem.cs
+++ b/api/Helpers/Problem.cs
@@ -74,6 +74,9 @@ public static class Problem
     public static IActionResult UpstreamFailed(HttpContext context, string slug, string? detail = null)
         => Create(context, StatusCodes.Status502BadGateway, "Bad Gateway", slug, detail);
 
+    public static IActionResult ServiceUnavailable(HttpContext context, string slug, string? detail = null)
+        => Create(context, StatusCodes.Status503ServiceUnavailable, "Service Unavailable", slug, detail);
+
     public static IActionResult InternalError(HttpContext context, string slug, string? detail = null)
         => Create(context, StatusCodes.Status500InternalServerError, "Internal Server Error", slug, detail);
 

--- a/app/Lfm.App.Core/Runs/RunErrorParser.cs
+++ b/app/Lfm.App.Core/Runs/RunErrorParser.cs
@@ -11,10 +11,10 @@ namespace Lfm.App.Runs;
 /// </summary>
 public enum RunErrorKind
 {
-    /// <summary>Field-level validation error (HTTP 400 with {errors: [...]}).</summary>
+    /// <summary>Field-level validation error (HTTP 400 with problem+json).</summary>
     Validation,
 
-    /// <summary>Guild rank denied (HTTP 403 with the specific rank-denied body).</summary>
+    /// <summary>Guild rank denied (HTTP 403 with the guild-rank-denied problem type).</summary>
     GuildRankDenied,
 
     /// <summary>Any other HTTP or transport failure (5xx, network, timeout).</summary>
@@ -37,13 +37,17 @@ public sealed record RunError(RunErrorKind Kind, IReadOnlyList<string> Messages)
 /// next to the offending control (validation) or under the visibility row
 /// (rank denied) or as a toast (network). Pure; the HTTP body is read by
 /// the caller (async) and passed as a string.
+///
+/// The server emits RFC 9457 <c>application/problem+json</c> responses on
+/// error paths; the parser reads:
+///   - <c>errors</c> (top-level array of strings): validation messages
+///   - <c>detail</c>: human-readable error text
+///   - <c>type</c>: stable URI used for classification (rank-denied detection)
+/// Type URIs are rooted at <c>https://github.com/lfm-org/lfm/errors#slug</c>.
 /// </summary>
 public static class RunErrorParser
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-    };
+    private const string GuildRankDeniedTypeUri = "https://github.com/lfm-org/lfm/errors#guild-rank-denied";
 
     public static RunError Parse(HttpStatusCode status, string? body)
     {
@@ -69,9 +73,11 @@ public static class RunErrorParser
 
         try
         {
-            // Server shape from CreateRunRequestValidator / UpdateRunRequestValidator:
-            //   { errors: [ "msg1", "msg2", ... ] }
-            // or a single error { error: "msg" } for guards.
+            // Server shape (problem+json from CreateRunRequestValidator /
+            // UpdateRunRequestValidator):
+            //   { type, title, status, detail, errors: [ "msg1", "msg2", ... ] }
+            // or a single message:
+            //   { type, title, status, detail: "msg" }
             using var doc = JsonDocument.Parse(body);
             if (doc.RootElement.TryGetProperty("errors", out var errs) && errs.ValueKind == JsonValueKind.Array)
             {
@@ -83,9 +89,9 @@ public static class RunErrorParser
                 return new RunError(RunErrorKind.Validation, list);
             }
 
-            if (doc.RootElement.TryGetProperty("error", out var single) && single.ValueKind == JsonValueKind.String)
+            if (doc.RootElement.TryGetProperty("detail", out var detail) && detail.ValueKind == JsonValueKind.String)
             {
-                return new RunError(RunErrorKind.Validation, [single.GetString() ?? ""]);
+                return new RunError(RunErrorKind.Validation, [detail.GetString() ?? ""]);
             }
         }
         catch (JsonException)
@@ -98,23 +104,35 @@ public static class RunErrorParser
 
     private static RunError ParseForbidden(string? body)
     {
-        // The RunsCreateFunction returns:
-        //   { error: "Guild run creation is not enabled for your rank" }
-        // on rank-denied. Recognise that specifically so the form can surface
-        // it inline under the visibility control rather than as a toast.
+        // The server returns problem+json with type = GuildRankDeniedTypeUri
+        // and a human-readable detail message when a GUILD run is refused due
+        // to the caller's rank permission. Recognise that specifically so the
+        // form surfaces it inline under the visibility control rather than as
+        // a toast.
         if (!string.IsNullOrWhiteSpace(body))
         {
             try
             {
                 using var doc = JsonDocument.Parse(body);
-                if (doc.RootElement.TryGetProperty("error", out var err)
-                    && err.ValueKind == JsonValueKind.String)
+                var type = doc.RootElement.TryGetProperty("type", out var t) && t.ValueKind == JsonValueKind.String
+                    ? t.GetString()
+                    : null;
+                var detail = doc.RootElement.TryGetProperty("detail", out var d) && d.ValueKind == JsonValueKind.String
+                    ? d.GetString()
+                    : null;
+
+                if (string.Equals(type, GuildRankDeniedTypeUri, StringComparison.Ordinal))
                 {
-                    var msg = err.GetString() ?? "";
-                    if (msg.Contains("rank", StringComparison.OrdinalIgnoreCase))
-                        return new RunError(RunErrorKind.GuildRankDenied, [msg]);
-                    return new RunError(RunErrorKind.GuildRankDenied, [msg]);
+                    return new RunError(
+                        RunErrorKind.GuildRankDenied,
+                        [detail ?? "Guild run creation is not enabled for your rank."]);
                 }
+
+                // Problem body without the expected type URI — still treat as
+                // rank-denied since the HTTP status matched ParseForbidden, but
+                // prefer the server-supplied detail when present.
+                if (!string.IsNullOrEmpty(detail))
+                    return new RunError(RunErrorKind.GuildRankDenied, [detail!]);
             }
             catch (JsonException) { /* fall through */ }
         }

--- a/tests/Lfm.Api.Tests/BattleNetCharacterPortraitsFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/BattleNetCharacterPortraitsFunctionTests.cs
@@ -201,7 +201,10 @@ public class BattleNetCharacterPortraitsFunctionTests
         var result = await fn.Run(httpContext.Request, ctx, CancellationToken.None);
 
         // Assert: 404
-        Assert.IsType<NotFoundResult>(result);
+        var notFound = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(404, notFound.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(notFound.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#raider-not-found", problem.Type);
 
         // Service should not be called when raider doesn't exist.
         portraitService.Verify(

--- a/tests/Lfm.Api.Tests/BattleNetCharactersRefreshFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/BattleNetCharactersRefreshFunctionTests.cs
@@ -166,6 +166,8 @@ public class BattleNetCharactersRefreshFunctionTests
         // Assert: 429 with a Retry-After header
         var statusResult = Assert.IsType<ObjectResult>(result);
         Assert.Equal(429, statusResult.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(statusResult.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#characters-refresh-cooldown", problem.Type);
 
         Assert.False(string.IsNullOrEmpty(httpContext.Response.Headers["Retry-After"].ToString()));
 

--- a/tests/Lfm.Api.Tests/GuildFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/GuildFunctionTests.cs
@@ -260,6 +260,8 @@ public class GuildFunctionTests
 
         var statusResult = Assert.IsType<ObjectResult>(result);
         Assert.Equal(403, statusResult.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(statusResult.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#guild-admin-only", problem.Type);
 
         // Guild document should never be read when caller is not admin.
         guildRepo.Verify(r => r.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);

--- a/tests/Lfm.Api.Tests/MeUpdateFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/MeUpdateFunctionTests.cs
@@ -88,7 +88,10 @@ public class MeUpdateFunctionTests
 
         var result = await fn.Run(req, ctx, CancellationToken.None);
 
-        Assert.IsType<BadRequestObjectResult>(result);
+        var badRequest = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(400, badRequest.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(badRequest.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#validation-failed", problem.Type);
         repo.Verify(r => r.GetByBattleNetIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 

--- a/tests/Lfm.Api.Tests/RaiderCharacterAddFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RaiderCharacterAddFunctionTests.cs
@@ -522,7 +522,9 @@ public class RaiderCharacterAddFunctionTests
 
         var result = await fn.Run(req, ctx, CancellationToken.None);
 
-        Assert.IsType<BadRequestObjectResult>(result);
+        var badRequest = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(400, badRequest.StatusCode);
+        Assert.IsType<ProblemDetails>(badRequest.Value);
 
         repo.Verify(r => r.GetByBattleNetIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
@@ -546,7 +548,10 @@ public class RaiderCharacterAddFunctionTests
 
         var result = await fn.Run(req, ctx, CancellationToken.None);
 
-        Assert.IsType<NotFoundObjectResult>(result);
+        var notFound = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(404, notFound.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(notFound.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#raider-not-found", problem.Type);
     }
 
     // -------------------------------------------------------------------------

--- a/tests/Lfm.Api.Tests/RaiderCharacterEnrichFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RaiderCharacterEnrichFunctionTests.cs
@@ -29,7 +29,10 @@ public class RaiderCharacterEnrichFunctionTests
         var fn = MakeFunction(repo.Object, new Mock<IBlizzardProfileClient>().Object);
         var result = await fn.Run(MakeRequest(), CharId, MakeCtx(), CancellationToken.None);
 
-        Assert.IsType<NotFoundObjectResult>(result);
+        var notFound = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(404, notFound.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(notFound.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#raider-not-found", problem.Type);
     }
 
     [Fact]
@@ -106,9 +109,11 @@ public class RaiderCharacterEnrichFunctionTests
         var fn = MakeFunction(repo.Object, profileClient.Object);
         var result = await fn.Run(MakeRequest(), CharId, MakeCtx(), CancellationToken.None);
 
-        var notFound = Assert.IsType<NotFoundObjectResult>(result);
-        var body = JsonSerializer.SerializeToElement(notFound.Value);
-        Assert.Equal("Character not found on Blizzard", body.GetProperty("error").GetString());
+        var notFound = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(404, notFound.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(notFound.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#character-not-found-on-blizzard", problem.Type);
+        Assert.Equal("Character not found on Blizzard.", problem.Detail);
     }
 
     // ---- helpers ----

--- a/tests/Lfm.Api.Tests/RaiderCharacterFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RaiderCharacterFunctionTests.cs
@@ -150,7 +150,7 @@ public class RaiderCharacterFunctionTests
         Assert.DoesNotContain("AccountEndpoint", json);
         Assert.DoesNotContain("AccountKey", json);
         Assert.DoesNotContain("CosmosException", json);
-        Assert.Contains("internal error", json);
+        Assert.Contains("internal-error", json);
         Assert.Contains(FakeInvocationId, json);
     }
 }

--- a/tests/Lfm.Api.Tests/RunsCancelSignupFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RunsCancelSignupFunctionTests.cs
@@ -165,7 +165,9 @@ public class RunsCancelSignupFunctionTests
 
         var result = await fn.Run(MakeDeleteRequest(), "run-1", ctx, CancellationToken.None);
 
-        Assert.IsType<NotFoundObjectResult>(result);
+        var notFound = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(404, notFound.StatusCode);
+        Assert.IsType<ProblemDetails>(notFound.Value);
 
         runsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Never);
     }
@@ -197,7 +199,9 @@ public class RunsCancelSignupFunctionTests
 
         var result = await fn.Run(MakeDeleteRequest(), "run-1", ctx, CancellationToken.None);
 
-        Assert.IsType<NotFoundObjectResult>(result);
+        var notFound = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(404, notFound.StatusCode);
+        Assert.IsType<ProblemDetails>(notFound.Value);
         runsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -266,7 +270,9 @@ public class RunsCancelSignupFunctionTests
 
         var result = await fn.Run(MakeDeleteRequest(), "run-1", ctx, CancellationToken.None);
 
-        Assert.IsType<NotFoundObjectResult>(result);
+        var notFound = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(404, notFound.StatusCode);
+        Assert.IsType<ProblemDetails>(notFound.Value);
         runsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 

--- a/tests/Lfm.Api.Tests/RunsCreateFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RunsCreateFunctionTests.cs
@@ -178,7 +178,11 @@ public class RunsCreateFunctionTests
 
         var result = await fn.Run(MakePostRequest(requestBody), ctx, CancellationToken.None);
 
-        Assert.IsType<BadRequestObjectResult>(result);
+        var badRequest = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(400, badRequest.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(badRequest.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#validation-failed", problem.Type);
+        Assert.True(problem.Extensions.ContainsKey("errors"));
 
         // Cosmos should never be called
         repo.Verify(r => r.CreateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Never);
@@ -221,6 +225,8 @@ public class RunsCreateFunctionTests
 
         var objectResult = Assert.IsType<ObjectResult>(result);
         Assert.Equal(403, objectResult.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#guild-rank-denied", problem.Type);
 
         repo.Verify(r => r.CreateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Never);
 

--- a/tests/Lfm.Api.Tests/RunsDeleteFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RunsDeleteFunctionTests.cs
@@ -159,6 +159,8 @@ public class RunsDeleteFunctionTests
 
         var objectResult = Assert.IsType<ObjectResult>(result);
         Assert.Equal(403, objectResult.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#guild-rank-denied", problem.Type);
 
         repo.Verify(r => r.DeleteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
 
@@ -188,7 +190,10 @@ public class RunsDeleteFunctionTests
 
         var result = await fn.Run(req, "missing-run", ctx, CancellationToken.None);
 
-        Assert.IsType<NotFoundObjectResult>(result);
+        var notFound = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(404, notFound.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(notFound.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#run-not-found", problem.Type);
 
         repo.Verify(r => r.DeleteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }

--- a/tests/Lfm.Api.Tests/RunsMigrateSchemaFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RunsMigrateSchemaFunctionTests.cs
@@ -65,6 +65,8 @@ public class RunsMigrateSchemaFunctionTests
 
         var forbidden = Assert.IsType<ObjectResult>(result);
         Assert.Equal(403, forbidden.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(forbidden.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#admin-only", problem.Type);
         runs.Verify(r => r.MigrateSchemaAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 

--- a/tests/Lfm.Api.Tests/RunsSignupFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RunsSignupFunctionTests.cs
@@ -220,7 +220,10 @@ public class RunsSignupFunctionTests
         var requestBody = new { characterId = "char-1", desiredAttendance = "IN" };
         var result = await fn.Run(MakePostRequest(requestBody), "missing-run", ctx, CancellationToken.None);
 
-        Assert.IsType<NotFoundObjectResult>(result);
+        var notFound = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(404, notFound.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(notFound.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#run-not-found", problem.Type);
 
         runsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Never);
     }
@@ -258,6 +261,8 @@ public class RunsSignupFunctionTests
 
         var objectResult = Assert.IsType<ObjectResult>(result);
         Assert.Equal(403, objectResult.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#guild-rank-denied", problem.Type);
 
         runsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Never);
 
@@ -326,6 +331,8 @@ public class RunsSignupFunctionTests
 
         var objectResult = Assert.IsType<ObjectResult>(result);
         Assert.Equal(409, objectResult.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#signups-closed", problem.Type);
 
         runsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Never);
     }
@@ -381,6 +388,8 @@ public class RunsSignupFunctionTests
         // structural detail that may legitimately change (e.g. policy library swap).
         var objectResult = Assert.IsType<ObjectResult>(result);
         Assert.Equal(409, objectResult.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#concurrent-modification", problem.Type);
     }
 
     // ------------------------------------------------------------------
@@ -407,15 +416,17 @@ public class RunsSignupFunctionTests
 
         var result = await fn.Run(httpContext.Request, "run-1", MakeFunctionContext(principal), CancellationToken.None);
 
-        var bad = Assert.IsType<BadRequestObjectResult>(result);
+        var bad = Assert.IsType<ObjectResult>(result);
         Assert.Equal(400, bad.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(bad.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#invalid-body", problem.Type);
 
         var json = JsonSerializer.Serialize(bad.Value);
         Assert.DoesNotContain("line", json, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("byte", json, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("path:", json, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("position", json, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("Invalid request body", json);
+        Assert.Contains("Request body is invalid or missing.", json);
 
         // Repos must not have been touched for a parse failure.
         runsRepo.VerifyNoOtherCalls();

--- a/tests/Lfm.Api.Tests/RunsUpdateFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RunsUpdateFunctionTests.cs
@@ -190,11 +190,11 @@ public class RunsUpdateFunctionTests
 
         var result = await fn.Run(MakePutRequest(new { description = "Updated" }), "run-1", ctx, CancellationToken.None);
 
-        var notFound = Assert.IsType<NotFoundObjectResult>(result);
-        Assert.NotNull(notFound.Value);
-        var errorProp = notFound.Value!.GetType().GetProperty("error");
-        Assert.NotNull(errorProp);
-        Assert.Equal("Raider not found", errorProp!.GetValue(notFound.Value));
+        var notFound = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(404, notFound.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(notFound.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#raider-not-found", problem.Type);
+        Assert.Equal("Raider not found.", problem.Detail);
 
         repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Never);
     }
@@ -220,7 +220,10 @@ public class RunsUpdateFunctionTests
 
         var result = await fn.Run(MakePutRequest(new { }), "missing-run", ctx, CancellationToken.None);
 
-        Assert.IsType<NotFoundObjectResult>(result);
+        var notFound = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(404, notFound.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(notFound.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#run-not-found", problem.Type);
 
         // Cosmos UpdateAsync must never be called
         repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Never);
@@ -375,10 +378,11 @@ public class RunsUpdateFunctionTests
 
         var result = await fn.Run(httpContext.Request, "run-1", ctx, CancellationToken.None);
 
-        var bad = Assert.IsType<BadRequestObjectResult>(result);
-        var errorProp = bad.Value!.GetType().GetProperty("error");
-        Assert.NotNull(errorProp);
-        Assert.Equal("Invalid request body", errorProp!.GetValue(bad.Value));
+        var bad = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(400, bad.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(bad.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#invalid-body", problem.Type);
+        Assert.Equal("Request body is invalid or missing.", problem.Detail);
 
         repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Never);
     }

--- a/tests/Lfm.App.Core.Tests/Runs/RunErrorParserTests.cs
+++ b/tests/Lfm.App.Core.Tests/Runs/RunErrorParserTests.cs
@@ -12,7 +12,7 @@ public class RunErrorParserTests
     [Fact]
     public void BadRequest_with_errors_array_classifies_as_Validation_with_each_message()
     {
-        var body = """{"errors":["startTime is required","modeKey must be at most 64 characters"]}""";
+        var body = """{"type":"https://github.com/lfm-org/lfm/errors#validation-failed","title":"Bad Request","status":400,"detail":"Request body failed validation.","errors":["startTime is required","modeKey must be at most 64 characters"]}""";
         var result = RunErrorParser.Parse(HttpStatusCode.BadRequest, body);
         Assert.Equal(RunErrorKind.Validation, result.Kind);
         Assert.Equal(2, result.Messages.Count);
@@ -20,12 +20,12 @@ public class RunErrorParserTests
     }
 
     [Fact]
-    public void BadRequest_with_single_error_string_classifies_as_Validation_with_that_message()
+    public void BadRequest_with_detail_only_classifies_as_Validation_with_that_message()
     {
-        var body = """{"error":"A guild run requires an active character in a guild"}""";
+        var body = """{"type":"https://github.com/lfm-org/lfm/errors#guild-required","title":"Bad Request","status":400,"detail":"A guild run requires an active character in a guild."}""";
         var result = RunErrorParser.Parse(HttpStatusCode.BadRequest, body);
         Assert.Equal(RunErrorKind.Validation, result.Kind);
-        Assert.Equal("A guild run requires an active character in a guild", Assert.Single(result.Messages));
+        Assert.Equal("A guild run requires an active character in a guild.", Assert.Single(result.Messages));
     }
 
     [Fact]
@@ -37,13 +37,22 @@ public class RunErrorParserTests
     }
 
     [Fact]
-    public void Forbidden_with_rank_denied_body_classifies_as_GuildRankDenied()
+    public void Forbidden_with_rank_denied_type_classifies_as_GuildRankDenied()
     {
-        var body = """{"error":"Guild run creation is not enabled for your rank"}""";
+        var body = """{"type":"https://github.com/lfm-org/lfm/errors#guild-rank-denied","title":"Forbidden","status":403,"detail":"Guild run creation is not enabled for your rank."}""";
         var result = RunErrorParser.Parse(HttpStatusCode.Forbidden, body);
         Assert.Equal(RunErrorKind.GuildRankDenied, result.Kind);
         Assert.True(result.IsGuildRankDenied);
         Assert.Contains("rank", Assert.Single(result.Messages), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Forbidden_with_detail_but_unknown_type_still_surfaces_server_detail()
+    {
+        var body = """{"type":"https://github.com/lfm-org/lfm/errors#some-other-thing","title":"Forbidden","status":403,"detail":"Specific reason."}""";
+        var result = RunErrorParser.Parse(HttpStatusCode.Forbidden, body);
+        Assert.Equal(RunErrorKind.GuildRankDenied, result.Kind);
+        Assert.Equal("Specific reason.", Assert.Single(result.Messages));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Second slice of the Phase 2 error-shape migration. Every POST/PUT/PATCH/DELETE handler in the API now returns `application/problem+json` on error paths, and the SPA's `RunErrorParser` reads the new shape. With Slice 2.1 (reads) already on main, every handler that ever had an error path has moved off the legacy `new { error = "..." }` body.

Eight commits on the branch — one family per commit so reviews can go endpoint-by-endpoint:

| Commit | Scope |
|---|---|
| `766f590` | RunsCreate + `RunErrorParser` (SPA reads new shape) |
| `3e9b5d4` | RunsDelete |
| `ba16115` | RunsUpdate (12 paths) + `Problem.ServiceUnavailable` helper for the 503 |
| `75100f7` | RunsSignup (11 paths) + RunsCancelSignup (4 paths) |
| `c8c4939` | Me PATCH + Guild PATCH |
| `b5d9f47` | RunsMigrateSchema (admin 403) |
| `6763e86` | Raider mutations (Add, PUT select, Enrich) + `InternalErrorResult` helper migrated to problem+json |
| `99733bc` | BattleNet mutations (CharacterPortraits, CharactersRefresh) |

The SPA's `RunErrorParser` now:
- Reads `errors` array at the top level (shape preserved via `Problem.BadRequest` extensions) — no consumer change
- Reads `detail` instead of the legacy `error` key for single-message cases
- Classifies the Forbidden-403 `guild-rank-denied` variant by `type` URI (`https://github.com/lfm-org/lfm/errors#guild-rank-denied`) instead of substring-sniffing the human-readable text; falls back to the server-supplied detail for other 403 type URIs so new forbidden kinds don't regress to a generic string

`RunErrorParserTests` updated to use problem+json fixtures and added a new case that covers the non-rank-denied 403 fallback.

`InternalErrorResult.Create` (used in catch-all blocks) now emits a problem+json 500 with `type = …#internal-error`, preserving the invocation id under `extensions.correlationId` and adding `Activity.Current.TraceId` when present.

## Fixes

- `SAD-contract-error-shape` — now complete for everything except the Slice 2.3 auth/admin/public paths (remaining: `BattleNetCharactersFunction` GET, `E2ELoginFunction` GET, `WowReferenceRefreshFunction` admin POST, `PrivacyContactFunction` GET).

## Files (30)

Server side:
- `api/Helpers/InternalErrorResult.cs` — now emits problem+json 500
- `api/Helpers/Problem.cs` — new `ServiceUnavailable` helper
- `api/Functions/` — 12 mutation handlers migrated:
  - `RunsCreateFunction.cs`, `RunsUpdateFunction.cs`, `RunsDeleteFunction.cs`
  - `RunsSignupFunction.cs`, `RunsCancelSignupFunction.cs`
  - `MeUpdateFunction.cs` (PATCH)
  - `GuildFunction.cs` (PATCH path; GET was Slice 2.1)
  - `RunsMigrateSchemaFunction.cs`
  - `RaiderCharacterFunction.cs` (PUT), `RaiderCharacterAddFunction.cs` (POST), `RaiderCharacterEnrichFunction.cs` (POST)
  - `BattleNetCharacterPortraitsFunction.cs` (POST), `BattleNetCharactersRefreshFunction.cs` (POST)

Tests:
- 14 test classes updated to assert `ObjectResult` + `StatusCode` + `ProblemDetails.Type` (most with specific type-URI assertions; a few with body-shape-only assertions where the exact type would couple too tightly).
- `tests/Lfm.App.Core.Tests/Runs/RunErrorParserTests.cs` — fixtures swap to problem+json; added non-rank-denied 403 case.

SPA:
- `app/Lfm.App.Core/Runs/RunErrorParser.cs` — reads `errors` array + `detail` + classifies 403 by type URI

## Env / schema changes

None. Contract change on the wire only.

## Test plan

- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error` clean
- [x] `dotnet build lfm.sln -c Release` — 0 warnings, 0 errors
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` — 480/480 pass
- [x] `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release` — RunErrorParserTests updated (14/14)
- [ ] CI: `verify`, `reuse-lint`, `dep-license-check` (no package refs changed), `Gitleaks` green
- [ ] E2E lane — exercises run create / signup / cancel flows; CI to confirm no regressions

## Rollback

8 independent commits; each can be reverted on its own. `RunErrorParser` and `RunsCreate` share commit `766f590` because they cross the server/SPA boundary and must land together — revert that commit as a pair if needed.

## Next

**Slice 2.3** — auth / callback / admin / public endpoints:
- `BattleNetCharactersFunction` (GET)
- `E2ELoginFunction` (GET, test-only)
- `WowReferenceRefreshFunction` (POST admin)
- `PrivacyContactFunction` (GET)
- `BattleNetLoginFunction` / `BattleNetCallbackFunction` / `BattleNetLogoutFunction` (OAuth redirects — no JSON bodies, mostly no changes)
- `CorsPreflightFunction` (no JSON)