### PR TITLE
Migrate auth, admin, and public endpoints to RFC 9457 (closes Phase 2)

### DIFF
--- a/api/Functions/BattleNetCharactersFunction.cs
+++ b/api/Functions/BattleNetCharactersFunction.cs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
 using Lfm.Api.Auth;
+using Lfm.Api.Helpers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Options;
 using Lfm.Api.Repositories;
@@ -44,7 +45,7 @@ public class BattleNetCharactersFunction(
 
         var raider = await repo.GetByBattleNetIdAsync(principal.BattleNetId, cancellationToken);
         if (raider is null)
-            return new NotFoundResult();
+            return Problem.NotFound(req.HttpContext, "raider-not-found", "Raider not found.");
 
         if (!ShouldServeCachedAccountProfile(raider))
             return new NoContentResult();

--- a/api/Functions/E2ELoginFunction.cs
+++ b/api/Functions/E2ELoginFunction.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Options;
 using Lfm.Api.Auth;
+using Lfm.Api.Helpers;
 using Lfm.Api.Options;
 
 namespace Lfm.Api.Functions;
@@ -24,7 +25,7 @@ public class E2ELoginFunction(ISessionCipher cipher, IOptions<AuthOptions> authO
     {
         if (!string.Equals(Environment.GetEnvironmentVariable("E2E_TEST_MODE"), "true", StringComparison.OrdinalIgnoreCase))
         {
-            return new NotFoundResult();
+            return Problem.NotFound(req.HttpContext, "endpoint-disabled", "E2E test-only endpoint; enable via E2E_TEST_MODE=true.");
         }
 
         var auth = authOpts.Value;

--- a/api/Functions/PrivacyContactFunction.cs
+++ b/api/Functions/PrivacyContactFunction.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Configuration;
+using Lfm.Api.Helpers;
 
 namespace Lfm.Api.Functions;
 
@@ -21,7 +22,7 @@ public class PrivacyContactFunction(IConfiguration config)
     {
         var email = config["PRIVACY_EMAIL"];
         if (string.IsNullOrEmpty(email))
-            return new NotFoundResult();
+            return Problem.NotFound(req.HttpContext, "privacy-email-unconfigured", "Privacy contact email is not configured for this deployment.");
 
         return new OkObjectResult(new { email });
     }

--- a/api/Functions/WowReferenceRefreshFunction.cs
+++ b/api/Functions/WowReferenceRefreshFunction.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Channels;
 using Lfm.Api.Auth;
+using Lfm.Api.Helpers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Services;
 using Lfm.Contracts.Admin;
@@ -72,7 +73,7 @@ public class WowReferenceRefreshFunction(
                 principal.BattleNetId,
                 "wow/reference/refresh",
                 Activity.Current?.TraceId.ToString());
-            return new ObjectResult(new { error = "Forbidden" }) { StatusCode = 403 };
+            return Problem.Forbidden(req.HttpContext, "admin-only", "Site administrator access required.");
         }
 
         var response = req.HttpContext.Response;

--- a/tests/Lfm.Api.Tests/PrivacyContactFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/PrivacyContactFunctionTests.cs
@@ -46,7 +46,10 @@ public class PrivacyContactFunctionTests
 
         var result = fn.GetEmail(new DefaultHttpContext().Request);
 
-        Assert.IsType<NotFoundResult>(result);
+        var notFound = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(404, notFound.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(notFound.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#privacy-email-unconfigured", problem.Type);
     }
 
     [Fact]
@@ -56,6 +59,9 @@ public class PrivacyContactFunctionTests
 
         var result = fn.GetEmail(new DefaultHttpContext().Request);
 
-        Assert.IsType<NotFoundResult>(result);
+        var notFound = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(404, notFound.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(notFound.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#privacy-email-unconfigured", problem.Type);
     }
 }


### PR DESCRIPTION
## Summary

Final slice of the Phase 2 error-shape migration. With Slices 2.1 (reads) and 2.2 (mutations) already on main, four handlers still held onto the legacy error-body shape — this PR migrates them.

| Endpoint | Path migrated | Slug |
|---|---|---|
| `BattleNetCharactersFunction` (GET `/api/battlenet/characters`) | 404 when raider missing (was bare `NotFoundResult`) | `raider-not-found` |
| `E2ELoginFunction` (GET `/api/e2e/login`, E2E-only) | 404 when `E2E_TEST_MODE` is off (was bare `NotFoundResult`) | `endpoint-disabled` |
| `PrivacyContactFunction` (GET `/api/privacy-contact/email`) | 404 when config absent (was bare `NotFoundResult`) | `privacy-email-unconfigured` |
| `WowReferenceRefreshFunction` (POST `/api/wow/reference/refresh`, admin) | 403 for non-admins (was `{ error = "Forbidden" }`) | `admin-only` (same slug as `GuildAdmin` and `RunsMigrateSchema`) |

## Fixes

- **Closes `SAD-contract-error-shape`.** After this PR, `grep -r "new BadRequestObjectResult\|new NotFoundObjectResult\|new NotFoundResult\b\|new { error" api/Functions/` returns zero hits. Every handler error path emits `application/problem+json`.

## Files (5)

- `api/Functions/BattleNetCharactersFunction.cs` — add `Lfm.Api.Helpers` import + `Problem.NotFound`
- `api/Functions/E2ELoginFunction.cs` — same
- `api/Functions/PrivacyContactFunction.cs` — same
- `api/Functions/WowReferenceRefreshFunction.cs` — add import + `Problem.Forbidden`
- `tests/Lfm.Api.Tests/PrivacyContactFunctionTests.cs` — two `Assert.IsType<NotFoundResult>` assertions upgraded to `ObjectResult` + `ProblemDetails.Type`

## Env / schema changes

None.

## Test plan

- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error` clean
- [x] `dotnet build lfm.sln -c Release` — 0 warnings, 0 errors
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` — 480/480 pass
- [ ] CI: `verify`, `reuse-lint`, `dep-license-check` (no package refs changed), `Gitleaks` green
- [ ] E2E lane — `E2ELoginFunction` behaviour change is contained (body shape only; status code unchanged); other migrated endpoints are read-path and should not affect E2E flows

## Rollback

Single-commit PR. Revert is clean.

## What's next

**Phase 2 complete.** The migration from `new { error }` to problem+json is done across every handler.

**Phase 3** — contract discipline: ETag/If-Match on resource endpoints + the rest of the OpenAPI rollout. See `/home/souroldgeezer/.claude/plans/review-api-precious-dewdrop.md`.