### PR TITLE
3.1 Runs — client-facing ETag + If-Match guarding

### DIFF
--- a/api/Functions/RunsCancelSignupFunction.cs
+++ b/api/Functions/RunsCancelSignupFunction.cs
@@ -93,9 +93,11 @@ public class RunsCancelSignupFunction(
         var updatedCharacters = run.RunCharacters.ToList();
         updatedCharacters.RemoveAt(existingIndex);
 
-        // 6. Persist the updated run document.
+        // 6. Persist the updated run document. ifMatchEtag is null here — cancel
+        //    signup is not a client-driven If-Match flow; the repository falls back
+        //    to run.ETag for concurrency.
         var updated = run with { RunCharacters = updatedCharacters };
-        var persisted = await runsRepo.UpdateAsync(updated, ct);
+        var persisted = await runsRepo.UpdateAsync(updated, ifMatchEtag: null, ct);
 
         AuditLog.Emit(logger, new AuditEvent("signup.cancel", principal.BattleNetId, id, "success", null));
 

--- a/api/Functions/RunsDetailFunction.cs
+++ b/api/Functions/RunsDetailFunction.cs
@@ -66,6 +66,13 @@ public class RunsDetailFunction(IRunsRepository repo, IRaidersRepository raiders
                 return Problem.NotFound(req.HttpContext, "run-not-found", "Run not found.");
         }
 
+        // Emit the Cosmos _etag as a strong HTTP ETag so callers can send it back
+        // on PUT /api/runs/{id} as an If-Match header for optimistic concurrency.
+        // The Cosmos _etag is already a double-quoted opaque string, e.g.
+        // "\"abc123\"" — use it verbatim.
+        if (!string.IsNullOrEmpty(run.ETag))
+            req.HttpContext.Response.Headers.ETag = run.ETag;
+
         return new OkObjectResult(Sanitize(run, principal.BattleNetId));
     }
 

--- a/api/Functions/RunsSignupFunction.cs
+++ b/api/Functions/RunsSignupFunction.cs
@@ -210,7 +210,9 @@ public class RunsSignupFunction(
             var updated = run with { RunCharacters = updatedCharacters };
             try
             {
-                var persisted = await runsRepo.UpdateAsync(updated, ct);
+                // Pass null so the repository falls back to run.ETag — this is an
+                // internal retry loop, not a client-driven If-Match flow.
+                var persisted = await runsRepo.UpdateAsync(updated, ifMatchEtag: null, ct);
 
                 AuditLog.Emit(logger, new AuditEvent("signup.create", principal.BattleNetId, id, "success", null));
 

--- a/api/Functions/RunsUpdateFunction.cs
+++ b/api/Functions/RunsUpdateFunction.cs
@@ -53,6 +53,20 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
     {
         var principal = ctx.GetPrincipal(); // non-null: [RequireAuth] + AuthPolicyMiddleware guarantee
 
+        // 0. Require an If-Match header carrying the ETag from the previous
+        //    GET /api/runs/{id}. Optimistic concurrency guard — rejects the
+        //    "two tabs, stale form" case with RFC 9110 428 Precondition
+        //    Required before any work.
+        if (!req.Headers.TryGetValue("If-Match", out var ifMatchValues)
+            || string.IsNullOrWhiteSpace(ifMatchValues.ToString()))
+        {
+            return Problem.PreconditionRequired(
+                req.HttpContext,
+                "if-match-required",
+                "This resource requires an If-Match header echoing the ETag from a prior GET.");
+        }
+        var ifMatchEtag = ifMatchValues.ToString();
+
         // 1. Load existing run.
         var existing = await repo.GetByIdAsync(id, ct);
         if (existing is null)
@@ -239,10 +253,28 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
                 : existing.CreatorGuildId,
         };
 
-        // 9. Replace in Cosmos.
-        var persisted = await repo.UpdateAsync(updated, ct);
+        // 9. Replace in Cosmos. A stale If-Match surfaces as ConcurrencyConflict
+        //    from the repo — map it to 412 Precondition Failed so the client can
+        //    reload and retry.
+        RunDocument persisted;
+        try
+        {
+            persisted = await repo.UpdateAsync(updated, ifMatchEtag, ct);
+        }
+        catch (ConcurrencyConflictException)
+        {
+            AuditLog.Emit(logger, new AuditEvent("run.update", principal.BattleNetId, id, "failure", "if-match stale"));
+            return Problem.PreconditionFailed(
+                req.HttpContext,
+                "if-match-stale",
+                "The run was modified since you loaded it. Reload and try again.");
+        }
 
         AuditLog.Emit(logger, new AuditEvent("run.update", principal.BattleNetId, id, "success", null));
+
+        // Echo the new ETag so a follow-up PUT without reloading still works.
+        if (!string.IsNullOrEmpty(persisted.ETag))
+            req.HttpContext.Response.Headers.ETag = persisted.ETag;
 
         return new OkObjectResult(MapToDto(persisted, principal.BattleNetId));
     }

--- a/api/Helpers/Problem.cs
+++ b/api/Helpers/Problem.cs
@@ -57,6 +57,14 @@ public static class Problem
         => Create(context, StatusCodes.Status413PayloadTooLarge, "Payload Too Large", slug, detail);
 
     /// <summary>
+    /// RFC 6585 §3 — the origin server requires the request to be conditional.
+    /// Returned when a mutating request omits an expected <c>If-Match</c>
+    /// header on an endpoint that uses ETag-based optimistic concurrency.
+    /// </summary>
+    public static IActionResult PreconditionRequired(HttpContext context, string slug, string? detail = null)
+        => Create(context, StatusCodes.Status428PreconditionRequired, "Precondition Required", slug, detail);
+
+    /// <summary>
     /// 429 response with RFC 9110 <c>Retry-After</c> header when a duration
     /// is supplied. Callers that have a richer hint (e.g. shared rate-limiter
     /// pause budget) should pass <paramref name="retryAfterSeconds"/> so the

--- a/api/Repositories/IRunsRepository.cs
+++ b/api/Repositories/IRunsRepository.cs
@@ -124,10 +124,18 @@ public interface IRunsRepository
 
     /// <summary>
     /// Replaces an existing run document in the "runs" container.
-    /// Returns the persisted document after the replace.
-    /// Mirrors <c>getRunsContainer().item(id, id).replace(updated)</c> in runs-update.ts.
+    ///
+    /// <para>
+    /// <paramref name="ifMatchEtag"/> is the optimistic-concurrency token. When
+    /// non-null it is passed as <c>IfMatchEtag</c> to Cosmos; when null the
+    /// repository falls back to <c>run.ETag</c>. Callers surfacing a client
+    /// <c>If-Match</c> header should pass it explicitly so that a stale token
+    /// produces a 412-flavoured <see cref="ConcurrencyConflictException"/> even
+    /// when the <paramref name="run"/> document was re-fetched between read
+    /// and write.
+    /// </para>
     /// </summary>
-    Task<RunDocument> UpdateAsync(RunDocument run, CancellationToken ct);
+    Task<RunDocument> UpdateAsync(RunDocument run, string? ifMatchEtag, CancellationToken ct);
 
     /// <summary>
     /// Deletes a run document by its id. Idempotent: if the document does not

--- a/api/Repositories/RunsRepository.cs
+++ b/api/Repositories/RunsRepository.cs
@@ -105,11 +105,14 @@ public sealed class RunsRepository(CosmosClient client, IOptions<CosmosOptions> 
         return response.Resource;
     }
 
-    public async Task<RunDocument> UpdateAsync(RunDocument run, CancellationToken ct)
+    public async Task<RunDocument> UpdateAsync(RunDocument run, string? ifMatchEtag, CancellationToken ct)
     {
         try
         {
-            var options = new ItemRequestOptions { IfMatchEtag = run.ETag };
+            // An explicit ifMatchEtag (from a client If-Match header) always wins;
+            // fall back to the document's stored ETag for internal retry loops
+            // (e.g. RunsSignupFunction) that re-fetch the run each attempt.
+            var options = new ItemRequestOptions { IfMatchEtag = ifMatchEtag ?? run.ETag };
             var response = await _container.ReplaceItemAsync(
                 run,
                 run.Id,

--- a/app/Lfm.App.Core/Runs/StaleEtagException.cs
+++ b/app/Lfm.App.Core/Runs/StaleEtagException.cs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+namespace Lfm.App.Runs;
+
+/// <summary>
+/// Thrown by <see cref="Services.IRunsClient.UpdateAsync"/> when the server
+/// rejects a PUT with 412 Precondition Failed — the <c>If-Match</c> ETag
+/// the page loaded is stale and another client has modified the run since.
+/// Pages should catch this distinctly and prompt the user to reload.
+/// </summary>
+public sealed class StaleEtagException : Exception
+{
+    public StaleEtagException(string? detail = null)
+        : base(detail ?? "Run modified since loaded.") { }
+}

--- a/app/Lfm.App.Core/Services/IRunsClient.cs
+++ b/app/Lfm.App.Core/Services/IRunsClient.cs
@@ -5,12 +5,34 @@ using Lfm.Contracts.Runs;
 
 namespace Lfm.App.Services;
 
+/// <summary>
+/// A run-detail response paired with its HTTP <c>ETag</c>. Pages that plan
+/// to PUT a subsequent update echo the ETag back as <c>If-Match</c> so the
+/// server can enforce optimistic concurrency.
+/// </summary>
+public sealed record RunDetailWithEtag(RunDetailDto Run, string? ETag);
+
 public interface IRunsClient
 {
     Task<IReadOnlyList<RunSummaryDto>> ListAsync(CancellationToken ct);
     Task<RunDetailDto?> GetAsync(string id, CancellationToken ct);
+
+    /// <summary>
+    /// GET /api/runs/{id} that also captures the response ETag so the
+    /// caller can echo it on a subsequent PUT as <c>If-Match</c>.
+    /// </summary>
+    Task<RunDetailWithEtag?> GetWithEtagAsync(string id, CancellationToken ct);
+
     Task<RunDetailDto?> CreateAsync(CreateRunRequest request, CancellationToken ct);
-    Task<RunDetailDto?> UpdateAsync(string id, UpdateRunRequest request, CancellationToken ct);
+
+    /// <summary>
+    /// PUT /api/runs/{id} guarded by <paramref name="ifMatchEtag"/>. Throws
+    /// <see cref="Runs.StaleEtagException"/> when the server rejects the
+    /// request with 412 Precondition Failed so the caller can prompt the
+    /// user to reload instead of showing a generic "save failed" error.
+    /// </summary>
+    Task<RunDetailDto?> UpdateAsync(string id, UpdateRunRequest request, string ifMatchEtag, CancellationToken ct);
+
     Task<bool> DeleteAsync(string id, CancellationToken ct);
     Task<RunDetailDto?> SignupAsync(string runId, SignupRequest request, CancellationToken ct);
     Task<RunDetailDto?> CancelSignupAsync(string runId, CancellationToken ct);

--- a/app/Lfm.App.Core/Services/RunsClient.cs
+++ b/app/Lfm.App.Core/Services/RunsClient.cs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
+using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using Lfm.App.Runs;
 using Lfm.Contracts.Runs;
 
 namespace Lfm.App.Services;
@@ -25,6 +28,19 @@ public sealed class RunsClient(IHttpClientFactory factory) : IRunsClient
         return await http.GetFromJsonAsync<RunDetailDto>($"api/runs/{Uri.EscapeDataString(id)}", ct);
     }
 
+    public async Task<RunDetailWithEtag?> GetWithEtagAsync(string id, CancellationToken ct)
+    {
+        var http = factory.CreateClient("api");
+        using var response = await http.GetAsync($"api/runs/{Uri.EscapeDataString(id)}", ct);
+        if (!response.IsSuccessStatusCode) return null;
+
+        var dto = await response.Content.ReadFromJsonAsync<RunDetailDto>(ct);
+        if (dto is null) return null;
+
+        var etag = response.Headers.ETag?.Tag;
+        return new RunDetailWithEtag(dto, etag);
+    }
+
     public async Task<RunDetailDto?> CreateAsync(CreateRunRequest request, CancellationToken ct)
     {
         var http = factory.CreateClient("api");
@@ -33,10 +49,28 @@ public sealed class RunsClient(IHttpClientFactory factory) : IRunsClient
         return await response.Content.ReadFromJsonAsync<RunDetailDto>(ct);
     }
 
-    public async Task<RunDetailDto?> UpdateAsync(string id, UpdateRunRequest request, CancellationToken ct)
+    public async Task<RunDetailDto?> UpdateAsync(
+        string id, UpdateRunRequest request, string ifMatchEtag, CancellationToken ct)
     {
         var http = factory.CreateClient("api");
-        var response = await http.PutAsJsonAsync($"api/runs/{Uri.EscapeDataString(id)}", request, ct);
+
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Put, $"api/runs/{Uri.EscapeDataString(id)}")
+        {
+            Content = JsonContent.Create(request),
+        };
+        // Cosmos ETags are already double-quoted opaque strings; mirror them
+        // verbatim into the EntityTagHeaderValue so HttpClient doesn't re-quote.
+        httpRequest.Headers.IfMatch.Add(new EntityTagHeaderValue(ifMatchEtag));
+
+        using var response = await http.SendAsync(httpRequest, ct);
+        if (response.StatusCode == HttpStatusCode.PreconditionFailed)
+        {
+            // The server sends problem+json on 412; surface it to the caller via
+            // a dedicated exception so the page can offer a reload prompt rather
+            // than the generic "save failed" inline error.
+            var body = await response.Content.ReadAsStringAsync(ct);
+            throw new StaleEtagException(body);
+        }
         if (!response.IsSuccessStatusCode) return null;
         return await response.Content.ReadFromJsonAsync<RunDetailDto>(ct);
     }

--- a/app/Pages/EditRunPage.razor
+++ b/app/Pages/EditRunPage.razor
@@ -294,6 +294,10 @@
     private bool _saving;
     private bool _deleting;
     private bool _hasSignups;
+
+    // ETag captured from the GET response. Sent back as If-Match on PUT so
+    // the server can enforce optimistic concurrency (RFC 9110 §13.1.1).
+    private string? _runEtag;
     private RunError? _inlineError;
     private ElementReference _deleteDialogRef;
     private IJSObjectReference? _dialogModule;
@@ -353,18 +357,21 @@
         _state = new LoadingState<RunDetailDto>.Loading();
         try
         {
-            var runTask = RunsClient.GetAsync(RunId!, CancellationToken.None);
+            var runTask = RunsClient.GetWithEtagAsync(RunId!, CancellationToken.None);
             var instancesTask = InstancesClient.ListAsync(CancellationToken.None);
             var expansionsTask = ExpansionsClient.ListAsync(CancellationToken.None);
             var guildTask = GuildClient.GetAsync(CancellationToken.None);
             await Task.WhenAll(runTask, instancesTask, expansionsTask, guildTask);
 
-            var run = await runTask;
-            if (run is null)
+            var runEnvelope = await runTask;
+            if (runEnvelope is null)
             {
                 _state = new LoadingState<RunDetailDto>.Failure(Loc["editRun.error.notFound"]);
                 return;
             }
+
+            var run = runEnvelope.Run;
+            _runEtag = runEnvelope.ETag;
 
             _allInstances = InstanceOptions.Build(await instancesTask);
             _expansions = await expansionsTask;
@@ -512,7 +519,16 @@
                 Size: _size,
                 KeystoneLevel: isMythicPlus ? _keystoneLevel : null);
 
-            var updated = await RunsClient.UpdateAsync(RunId!, request, CancellationToken.None);
+            if (string.IsNullOrEmpty(_runEtag))
+            {
+                // Defensive: if we never captured an ETag the page is in an
+                // inconsistent state; ask the user to reload rather than
+                // issuing a PUT that would 428 anyway.
+                _inlineError = new RunError(RunErrorKind.Unknown, [Loc["editRun.error.staleEtag"].Value]);
+                return;
+            }
+
+            var updated = await RunsClient.UpdateAsync(RunId!, request, _runEtag!, CancellationToken.None);
             if (updated is null)
             {
                 _inlineError = new RunError(RunErrorKind.Unknown, [Loc["editRun.saveFailed"].Value]);
@@ -522,6 +538,14 @@
                 Toast.ShowSuccess(Loc["editRun.saveSuccess"]);
                 _state = new LoadingState<RunDetailDto>.Success(updated);
             }
+        }
+        catch (StaleEtagException)
+        {
+            // The run was modified since we loaded it. Clear the stale ETag so
+            // a second click-without-reload short-circuits at the defensive
+            // guard above, then surface an inline error prompting a reload.
+            _runEtag = null;
+            _inlineError = new RunError(RunErrorKind.Unknown, [Loc["editRun.error.staleEtag"].Value]);
         }
         catch (Exception ex)
         {

--- a/app/wwwroot/locales/en.json
+++ b/app/wwwroot/locales/en.json
@@ -163,6 +163,7 @@
     "editRun.saveSuccess": "Run saved successfully.",
     "editRun.deleteFailed": "Failed to delete run. Please try again.",
     "editRun.error.notFound": "Run not found.",
+    "editRun.error.staleEtag": "This run was changed by someone else. Reload the page to see the latest details before saving.",
     "editRun.rosterSignedUp": "Roster ({0} signed up)",
     "editRun.noSignups": "No signups yet.",
     "editRun.columns.character": "Character",

--- a/app/wwwroot/locales/fi.json
+++ b/app/wwwroot/locales/fi.json
@@ -150,6 +150,7 @@
     "editRun.saveSuccess": "Runi tallennettu.",
     "editRun.deleteFailed": "Runin poistaminen ep\u00e4onnistui. Yrit\u00e4 uudelleen.",
     "editRun.error.notFound": "Runia ei l\u00f6ytynyt.",
+    "editRun.error.staleEtag": "Joku muu muutti t\u00e4t\u00e4 runia. Lataa sivu uudelleen n\u00e4hd\u00e4ksesi uusimmat tiedot ennen tallennusta.",
     "editRun.rosterSignedUp": "Kokoonpano ({0} ilmoittautunut)",
     "editRun.noSignups": "Ei ilmoittautumisia viel\u00e4.",
     "editRun.columns.character": "Hahmo",

--- a/tests/Lfm.Api.Tests/RunsCancelSignupFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RunsCancelSignupFunctionTests.cs
@@ -130,7 +130,7 @@ public class RunsCancelSignupFunctionTests
         var runsRepo = new Mock<IRunsRepository>();
         runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(run);
-        runsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()))
+        runsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(updatedRun);
 
         var fn = MakeFunction(runsRepo);
@@ -142,7 +142,7 @@ public class RunsCancelSignupFunctionTests
         var dto = Assert.IsType<RunDetailDto>(okResult.Value);
         Assert.Empty(dto.RunCharacters);
 
-        runsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Once);
+        runsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     // ------------------------------------------------------------------
@@ -169,7 +169,7 @@ public class RunsCancelSignupFunctionTests
         Assert.Equal(404, notFound.StatusCode);
         Assert.IsType<ProblemDetails>(notFound.Value);
 
-        runsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Never);
+        runsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     // ------------------------------------------------------------------
@@ -202,7 +202,7 @@ public class RunsCancelSignupFunctionTests
         var notFound = Assert.IsType<ObjectResult>(result);
         Assert.Equal(404, notFound.StatusCode);
         Assert.IsType<ProblemDetails>(notFound.Value);
-        runsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Never);
+        runsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     // ------------------------------------------------------------------
@@ -224,7 +224,7 @@ public class RunsCancelSignupFunctionTests
         var runsRepo = new Mock<IRunsRepository>();
         runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(run);
-        runsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()))
+        runsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(updatedRun);
 
         var raidersRepo = new Mock<IRaidersRepository>();
@@ -240,7 +240,7 @@ public class RunsCancelSignupFunctionTests
         var dto = Assert.IsType<RunDetailDto>(okResult.Value);
         Assert.Empty(dto.RunCharacters);
 
-        runsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Once);
+        runsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     // ------------------------------------------------------------------
@@ -273,7 +273,7 @@ public class RunsCancelSignupFunctionTests
         var notFound = Assert.IsType<ObjectResult>(result);
         Assert.Equal(404, notFound.StatusCode);
         Assert.IsType<ProblemDetails>(notFound.Value);
-        runsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Never);
+        runsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     // ------------------------------------------------------------------
@@ -292,7 +292,7 @@ public class RunsCancelSignupFunctionTests
         var runsRepo = new Mock<IRunsRepository>();
         runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(run);
-        runsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()))
+        runsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(updatedRun);
 
         var logger = new TestLogger<RunsCancelSignupFunction>();

--- a/tests/Lfm.Api.Tests/RunsDetailFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RunsDetailFunctionTests.cs
@@ -61,7 +61,8 @@ public class RunsDetailFunctionTests
         string visibility = "PUBLIC",
         string? creatorBattleNetId = null,
         int? creatorGuildId = null,
-        List<RunCharacterEntry>? runCharacters = null) =>
+        List<RunCharacterEntry>? runCharacters = null,
+        string? etag = null) =>
         new RunDocument(
             Id: id,
             StartTime: "2025-06-01T19:00:00Z",
@@ -76,7 +77,8 @@ public class RunsDetailFunctionTests
             CreatorBattleNetId: creatorBattleNetId,
             CreatedAt: "2025-05-01T00:00:00Z",
             Ttl: -1,
-            RunCharacters: runCharacters ?? []);
+            RunCharacters: runCharacters ?? [],
+            ETag: etag);
 
     private static RunCharacterEntry MakeCharacterEntry(string raiderBattleNetId = "bnet-1") =>
         new RunCharacterEntry(
@@ -256,4 +258,31 @@ public class RunsDetailFunctionTests
         Assert.IsType<ProblemDetails>(problem.Value);
     }
 
+    // ------------------------------------------------------------------
+    // Test 5: Response carries ETag header mirroring the stored _etag
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task Run_emits_etag_header_on_success()
+    {
+        var principal = MakePrincipal(battleNetId: "bnet-1", guildId: "12345");
+        var doc = MakeRunDoc(
+            id: "run-1",
+            visibility: "PUBLIC",
+            etag: "\"cosmos-etag-xyz\"");
+
+        var repo = new Mock<IRunsRepository>();
+        repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(doc);
+
+        var raidersRepo = new Mock<IRaidersRepository>();
+        var fn = new RunsDetailFunction(repo.Object, raidersRepo.Object);
+        var ctx = MakeFunctionContext(principal);
+
+        var request = new DefaultHttpContext().Request;
+        var result = await fn.Run(request, "run-1", ctx, CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Equal("\"cosmos-etag-xyz\"", request.HttpContext.Response.Headers.ETag.ToString());
+    }
 }

--- a/tests/Lfm.Api.Tests/RunsRepositoryConcurrencyTests.cs
+++ b/tests/Lfm.Api.Tests/RunsRepositoryConcurrencyTests.cs
@@ -66,7 +66,7 @@ public class RunsRepositoryConcurrencyTests
 
         var run = MakeRunDoc(etag: "\"stale-etag\"");
 
-        var act = () => repo.UpdateAsync(run, CancellationToken.None);
+        var act = () => repo.UpdateAsync(run, null, CancellationToken.None);
 
         await Assert.ThrowsAsync<ConcurrencyConflictException>(act);
     }
@@ -96,7 +96,7 @@ public class RunsRepositoryConcurrencyTests
         var opts = Microsoft.Extensions.Options.Options.Create(new CosmosOptions { Endpoint = "https://test.documents.azure.com", DatabaseName = "testdb" });
         var repo = new RunsRepository(client.Object, opts);
 
-        var result = await repo.UpdateAsync(run, CancellationToken.None);
+        var result = await repo.UpdateAsync(run, null, CancellationToken.None);
 
         Assert.Equal("\"new-etag\"", result.ETag);
 

--- a/tests/Lfm.Api.Tests/RunsSignupFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RunsSignupFunctionTests.cs
@@ -150,7 +150,7 @@ public class RunsSignupFunctionTests
         var runsRepo = new Mock<IRunsRepository>();
         runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(run);
-        runsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()))
+        runsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(updatedRun);
 
         var raidersRepo = new Mock<IRaidersRepository>();
@@ -191,7 +191,7 @@ public class RunsSignupFunctionTests
         Assert.Single(dto.RunCharacters);
         Assert.True(dto.RunCharacters[0].IsCurrentUser);
 
-        fx.RunsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Once);
+        fx.RunsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     // ------------------------------------------------------------------
@@ -225,7 +225,7 @@ public class RunsSignupFunctionTests
         var problem = Assert.IsType<ProblemDetails>(notFound.Value);
         Assert.Equal("https://github.com/lfm-org/lfm/errors#run-not-found", problem.Type);
 
-        runsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Never);
+        runsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     // ------------------------------------------------------------------
@@ -264,7 +264,7 @@ public class RunsSignupFunctionTests
         var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
         Assert.Equal("https://github.com/lfm-org/lfm/errors#guild-rank-denied", problem.Type);
 
-        runsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Never);
+        runsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
 
         Assert.Single(logger.Entries, e => e.IsAudit("signup.create", "failure", "guild rank denied"));
     }
@@ -334,7 +334,7 @@ public class RunsSignupFunctionTests
         var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
         Assert.Equal("https://github.com/lfm-org/lfm/errors#signups-closed", problem.Type);
 
-        runsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Never);
+        runsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     // ------------------------------------------------------------------
@@ -351,8 +351,8 @@ public class RunsSignupFunctionTests
         // sees a successful 200 with the persisted run state. The exact retry
         // count is a loop-structure detail and is not pinned here.
         var callCount = 0;
-        fx.RunsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()))
-            .Returns<RunDocument, CancellationToken>((doc, _) =>
+        fx.RunsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns<RunDocument, string?, CancellationToken>((doc, _, _) =>
             {
                 callCount++;
                 if (callCount == 1)
@@ -377,7 +377,7 @@ public class RunsSignupFunctionTests
     {
         var fx = MakeHappyPath();
 
-        fx.RunsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()))
+        fx.RunsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new ConcurrencyConflictException());
 
         var fn = MakeFunction(fx.RunsRepo, fx.RaidersRepo, fx.Permissions, fx.Logger);

--- a/tests/Lfm.Api.Tests/RunsUpdateFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RunsUpdateFunctionTests.cs
@@ -70,12 +70,16 @@ public class RunsUpdateFunctionTests
         return m;
     }
 
-    private static HttpRequest MakePutRequest(object body)
+    private const string DefaultTestEtag = "\"test-etag\"";
+
+    private static HttpRequest MakePutRequest(object body, string? ifMatch = DefaultTestEtag)
     {
         var json = JsonSerializer.Serialize(body);
         var httpContext = new DefaultHttpContext();
         httpContext.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(json));
         httpContext.Request.ContentType = "application/json";
+        if (ifMatch is not null)
+            httpContext.Request.Headers["If-Match"] = ifMatch;
         return httpContext.Request;
     }
 
@@ -142,7 +146,7 @@ public class RunsUpdateFunctionTests
         var repo = new Mock<IRunsRepository>();
         repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(existing);
-        repo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()))
+        repo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(updatedDoc);
 
         var permissions = new Mock<IGuildPermissions>();
@@ -161,7 +165,7 @@ public class RunsUpdateFunctionTests
         Assert.IsType<RunDetailDto>(okResult.Value);
 
         // Cosmos UpdateAsync was called once
-        repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Once);
+        repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     // ------------------------------------------------------------------
@@ -196,7 +200,7 @@ public class RunsUpdateFunctionTests
         Assert.Equal("https://github.com/lfm-org/lfm/errors#raider-not-found", problem.Type);
         Assert.Equal("Raider not found.", problem.Detail);
 
-        repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Never);
+        repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     // ------------------------------------------------------------------
@@ -226,7 +230,7 @@ public class RunsUpdateFunctionTests
         Assert.Equal("https://github.com/lfm-org/lfm/errors#run-not-found", problem.Type);
 
         // Cosmos UpdateAsync must never be called
-        repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Never);
+        repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     // ------------------------------------------------------------------
@@ -259,7 +263,7 @@ public class RunsUpdateFunctionTests
         var objectResult = Assert.IsType<ObjectResult>(result);
         Assert.Equal(403, objectResult.StatusCode);
 
-        repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Never);
+        repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
 
         Assert.Single(
             logger.Entries,
@@ -308,7 +312,7 @@ public class RunsUpdateFunctionTests
         var objectResult = Assert.IsType<ObjectResult>(result);
         Assert.Equal(409, objectResult.StatusCode);
 
-        repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Never);
+        repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     // ------------------------------------------------------------------
@@ -328,7 +332,7 @@ public class RunsUpdateFunctionTests
         var repo = new Mock<IRunsRepository>();
         repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(existing);
-        repo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()))
+        repo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(updatedDoc);
 
         var permissions = new Mock<IGuildPermissions>();
@@ -375,6 +379,7 @@ public class RunsUpdateFunctionTests
         var httpContext = new DefaultHttpContext();
         httpContext.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes("{not valid json"));
         httpContext.Request.ContentType = "application/json";
+        httpContext.Request.Headers["If-Match"] = DefaultTestEtag;
 
         var result = await fn.Run(httpContext.Request, "run-1", ctx, CancellationToken.None);
 
@@ -384,7 +389,7 @@ public class RunsUpdateFunctionTests
         Assert.Equal("https://github.com/lfm-org/lfm/errors#invalid-body", problem.Type);
         Assert.Equal("Request body is invalid or missing.", problem.Detail);
 
-        repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Never);
+        repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     // ------------------------------------------------------------------
@@ -444,7 +449,7 @@ public class RunsUpdateFunctionTests
         var repo = new Mock<IRunsRepository>();
         repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(existing);
-        repo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()))
+        repo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(updated);
 
         var permissions = new Mock<IGuildPermissions>();
@@ -467,5 +472,148 @@ public class RunsUpdateFunctionTests
         var peerRow = dto.RunCharacters.Single(c => c.CharacterName == "Peerpriest");
         Assert.True(ownRow.IsCurrentUser);
         Assert.False(peerRow.IsCurrentUser);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 8: Missing If-Match header — returns 428 Precondition Required
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task Run_returns_428_when_if_match_header_is_missing()
+    {
+        var principal = MakePrincipal(battleNetId: "bnet-creator");
+
+        var repo = new Mock<IRunsRepository>();
+        var permissions = new Mock<IGuildPermissions>();
+        var instancesRepo = new Mock<IInstancesRepository>();
+
+        var fn = MakeFunction(repo, permissions, instancesRepo);
+        var ctx = MakeFunctionContext(principal);
+
+        var result = await fn.Run(
+            MakePutRequest(new { description = "x" }, ifMatch: null),
+            "run-1",
+            ctx,
+            CancellationToken.None);
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(428, objectResult.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#if-match-required", problem.Type);
+
+        // The handler must short-circuit before any repo work.
+        repo.Verify(r => r.GetByIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 9: Stale If-Match — returns 412 Precondition Failed and logs audit
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task Run_returns_412_when_if_match_is_stale()
+    {
+        var principal = MakePrincipal(battleNetId: "bnet-creator");
+        var existing = MakeOpenRunDoc(creatorBattleNetId: "bnet-creator");
+        var logger = new TestLogger<RunsUpdateFunction>();
+
+        var repo = new Mock<IRunsRepository>();
+        repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        repo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ConcurrencyConflictException());
+
+        var permissions = new Mock<IGuildPermissions>();
+        var instancesRepo = new Mock<IInstancesRepository>();
+        instancesRepo.Setup(r => r.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeInstances());
+
+        var raidersRepo = MakeRaidersRepoFor(MakeRaiderDoc("bnet-creator"));
+
+        var fn = MakeFunction(repo, permissions, instancesRepo, raidersRepo, logger: logger);
+        var ctx = MakeFunctionContext(principal);
+
+        var result = await fn.Run(
+            MakePutRequest(new { description = "Updated" }, ifMatch: "\"stale-etag\""),
+            "run-1",
+            ctx,
+            CancellationToken.None);
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(412, objectResult.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#if-match-stale", problem.Type);
+
+        Assert.Single(logger.Entries, e => e.IsAudit("run.update", "failure", "if-match stale"));
+    }
+
+    // ------------------------------------------------------------------
+    // Test 10: Happy path echoes the persisted ETag back on the response
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task Run_echoes_new_etag_on_successful_update()
+    {
+        var principal = MakePrincipal(battleNetId: "bnet-creator");
+        var existing = MakeOpenRunDoc(creatorBattleNetId: "bnet-creator");
+        var updatedDoc = (existing with { Description = "Updated description" }) with { ETag = "\"new-etag\"" };
+
+        var repo = new Mock<IRunsRepository>();
+        repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        repo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(updatedDoc);
+
+        var permissions = new Mock<IGuildPermissions>();
+        var instancesRepo = new Mock<IInstancesRepository>();
+        instancesRepo.Setup(r => r.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeInstances());
+
+        var raidersRepo = MakeRaidersRepoFor(MakeRaiderDoc("bnet-creator"));
+
+        var fn = MakeFunction(repo, permissions, instancesRepo, raidersRepo);
+        var ctx = MakeFunctionContext(principal);
+
+        var request = MakePutRequest(new { description = "Updated description" });
+        await fn.Run(request, "run-1", ctx, CancellationToken.None);
+
+        Assert.Equal("\"new-etag\"", request.HttpContext.Response.Headers.ETag.ToString());
+    }
+
+    // ------------------------------------------------------------------
+    // Test 11: Repo receives the client's If-Match header verbatim
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task Run_forwards_client_if_match_header_to_repository()
+    {
+        var principal = MakePrincipal(battleNetId: "bnet-creator");
+        var existing = MakeOpenRunDoc(creatorBattleNetId: "bnet-creator");
+        var updatedDoc = existing with { Description = "Updated description" };
+
+        var repo = new Mock<IRunsRepository>();
+        repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        repo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), "\"client-etag\"", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(updatedDoc);
+
+        var permissions = new Mock<IGuildPermissions>();
+        var instancesRepo = new Mock<IInstancesRepository>();
+        instancesRepo.Setup(r => r.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeInstances());
+
+        var raidersRepo = MakeRaidersRepoFor(MakeRaiderDoc("bnet-creator"));
+
+        var fn = MakeFunction(repo, permissions, instancesRepo, raidersRepo);
+        var ctx = MakeFunctionContext(principal);
+
+        var result = await fn.Run(
+            MakePutRequest(new { description = "Updated description" }, ifMatch: "\"client-etag\""),
+            "run-1",
+            ctx,
+            CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+        repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), "\"client-etag\"", It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/tests/Lfm.App.Core.Tests/Services/RunsClientTests.cs
+++ b/tests/Lfm.App.Core.Tests/Services/RunsClientTests.cs
@@ -200,7 +200,7 @@ public class RunsClientTests
     }
 
     [Fact]
-    public async Task UpdateAsync_puts_request_body_to_run_path()
+    public async Task UpdateAsync_puts_request_body_and_if_match_header()
     {
         var (client, handler) = MakeClient(StubHttpMessageHandler.Json(HttpStatusCode.OK, MakeDetail("run-1")));
         var request = new UpdateRunRequest(
@@ -213,12 +213,13 @@ public class RunsClientTests
             Difficulty: "HEROIC",
             Size: 25);
 
-        var result = await client.UpdateAsync("run-1", request, CancellationToken.None);
+        var result = await client.UpdateAsync("run-1", request, "\"etag-v1\"", CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(HttpMethod.Put, handler.LastRequest!.Method);
         Assert.Equal("/api/runs/run-1", handler.LastRequest.RequestUri!.PathAndQuery);
         Assert.Equal("application/json", handler.LastRequest.Content!.Headers.ContentType!.MediaType);
+        Assert.Equal("\"etag-v1\"", handler.LastRequest.Headers.IfMatch.Single().Tag);
     }
 
     [Fact]
@@ -227,7 +228,49 @@ public class RunsClientTests
         var (client, _) = MakeClient(new StubHttpMessageHandler(HttpStatusCode.BadRequest));
         var request = new UpdateRunRequest(null, null, null, null, null, null, null);
 
-        var result = await client.UpdateAsync("run-1", request, CancellationToken.None);
+        var result = await client.UpdateAsync("run-1", request, "\"etag-v1\"", CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_throws_StaleEtagException_on_412()
+    {
+        var (client, _) = MakeClient(new StubHttpMessageHandler(HttpStatusCode.PreconditionFailed));
+        var request = new UpdateRunRequest(null, null, null, null, null, null, null);
+
+        await Assert.ThrowsAsync<Lfm.App.Runs.StaleEtagException>(
+            () => client.UpdateAsync("run-1", request, "\"stale-etag\"", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetWithEtagAsync_captures_response_etag()
+    {
+        var detail = MakeDetail("run-1");
+        var handler = new StubHttpMessageHandler(_ =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = System.Net.Http.Json.JsonContent.Create(detail),
+            };
+            response.Headers.ETag = new System.Net.Http.Headers.EntityTagHeaderValue("\"cosmos-etag\"");
+            return response;
+        });
+        var (client, _) = MakeClient(handler);
+
+        var result = await client.GetWithEtagAsync("run-1", CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal("run-1", result!.Run.Id);
+        Assert.Equal("\"cosmos-etag\"", result.ETag);
+    }
+
+    [Fact]
+    public async Task GetWithEtagAsync_returns_null_when_server_returns_404()
+    {
+        var (client, _) = MakeClient(new StubHttpMessageHandler(HttpStatusCode.NotFound));
+
+        var result = await client.GetWithEtagAsync("missing", CancellationToken.None);
 
         Assert.Null(result);
     }

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -493,8 +493,8 @@ public class RunsPagesTests : ComponentTestBase
     public void EditRunPage_Renders_Loading_Ring_On_Mount()
     {
         var runsClient = new Mock<IRunsClient>();
-        var tcs = new TaskCompletionSource<RunDetailDto?>();
-        runsClient.Setup(c => c.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(tcs.Task);
+        var tcs = new TaskCompletionSource<RunDetailWithEtag?>();
+        runsClient.Setup(c => c.GetWithEtagAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(tcs.Task);
         WireEditRunServices(runsClient);
 
         var cut = Render<EditRunPage>(p => p.Add(x => x.RunId, "run-1"));
@@ -506,8 +506,8 @@ public class RunsPagesTests : ComponentTestBase
     public void EditRunPage_Renders_Form_After_Run_Loads()
     {
         var runsClient = new Mock<IRunsClient>();
-        runsClient.Setup(c => c.GetAsync("run-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeDetail());
+        runsClient.Setup(c => c.GetWithEtagAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunDetailWithEtag(MakeDetail(), "\"etag-v1\""));
         WireEditRunServices(runsClient);
 
         var cut = Render<EditRunPage>(p => p.Add(x => x.RunId, "run-1"));
@@ -522,8 +522,8 @@ public class RunsPagesTests : ComponentTestBase
         // Same rationale as CreateRunPage_DoesNotRenderExpansionSelector:
         // the edit form also scopes to the Current Season tier only.
         var runsClient = new Mock<IRunsClient>();
-        runsClient.Setup(c => c.GetAsync("run-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeDetail());
+        runsClient.Setup(c => c.GetWithEtagAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunDetailWithEtag(MakeDetail(), "\"etag-v1\""));
         WireEditRunServices(runsClient, expansions: new List<ExpansionDto>
         {
             new(505, "The War Within"),
@@ -541,8 +541,8 @@ public class RunsPagesTests : ComponentTestBase
     public void EditRunPage_Shows_Error_When_Run_Not_Found()
     {
         var runsClient = new Mock<IRunsClient>();
-        runsClient.Setup(c => c.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((RunDetailDto?)null);
+        runsClient.Setup(c => c.GetWithEtagAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RunDetailWithEtag?)null);
         WireEditRunServices(runsClient, instances: []);
 
         var cut = Render<EditRunPage>(p => p.Add(x => x.RunId, "missing-id"));
@@ -563,11 +563,18 @@ public class RunsPagesTests : ComponentTestBase
         const string OriginalSignup = "2026-05-20T15:00:45.1234567Z";
 
         UpdateRunRequest? captured = null;
+        string? capturedIfMatch = null;
         var runsClient = new Mock<IRunsClient>();
-        runsClient.Setup(c => c.GetAsync("run-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeDetail() with { StartTime = OriginalStart, SignupCloseTime = OriginalSignup });
-        runsClient.Setup(c => c.UpdateAsync("run-1", It.IsAny<UpdateRunRequest>(), It.IsAny<CancellationToken>()))
-            .Callback<string, UpdateRunRequest, CancellationToken>((_, req, _) => captured = req)
+        runsClient.Setup(c => c.GetWithEtagAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunDetailWithEtag(
+                MakeDetail() with { StartTime = OriginalStart, SignupCloseTime = OriginalSignup },
+                "\"etag-v1\""));
+        runsClient.Setup(c => c.UpdateAsync("run-1", It.IsAny<UpdateRunRequest>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<string, UpdateRunRequest, string, CancellationToken>((_, req, ifMatch, _) =>
+            {
+                captured = req;
+                capturedIfMatch = ifMatch;
+            })
             .ReturnsAsync((RunDetailDto?)null);
         WireEditRunServices(runsClient);
 
@@ -583,6 +590,9 @@ public class RunsPagesTests : ComponentTestBase
         cut.WaitForAssertion(() => Assert.NotNull(captured));
         Assert.Equal(OriginalStart, captured!.StartTime);
         Assert.Equal(OriginalSignup, captured.SignupCloseTime);
+        // Save must echo the loaded ETag on If-Match so the server can reject
+        // stale updates with 412 instead of silently overwriting.
+        Assert.Equal("\"etag-v1\"", capturedIfMatch);
     }
 
     // RD-DIALOG-1 (#26): the delete confirmation renders as a native <dialog>
@@ -593,8 +603,8 @@ public class RunsPagesTests : ComponentTestBase
     public void EditRunPage_Delete_Button_Opens_Native_Dialog_Via_Interop()
     {
         var runsClient = new Mock<IRunsClient>();
-        runsClient.Setup(c => c.GetAsync("run-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeDetail());
+        runsClient.Setup(c => c.GetWithEtagAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunDetailWithEtag(MakeDetail(), "\"etag-v1\""));
         WireEditRunServices(runsClient, instances: []);
 
         var dialogModule = JSInterop.SetupModule("./js/dialog.js");


### PR DESCRIPTION
## Summary

Slice 3.1 of the `review-api-precious-dewdrop` plan — opens the ETag contract on runs so the "two tabs, stale form" lost-update case is rejected instead of silently overwriting.

- `GET /api/runs/{id}` emits the Cosmos `_etag` as a strong HTTP `ETag`.
- `PUT /api/runs/{id}` now requires an `If-Match` header. Missing → `428 Precondition Required`; stale → `412 Precondition Failed`. Both surface as `application/problem+json`.
- `RunsRepository.UpdateAsync` takes an explicit `ifMatchEtag` parameter (nullable — null falls back to `run.ETag` so `RunsSignup`/`RunsCancelSignup` retry loops are unchanged).
- SPA: `RunsClient.GetWithEtagAsync` captures the response ETag; `UpdateAsync` takes an `ifMatch` argument and throws `StaleEtagException` on 412. `EditRunPage` stores the ETag on load, echoes it on save, and renders a localized reload prompt on 412.

Fixes **SAD-contract-etag-implicit** (runs leg).

## Test plan

- [x] `dotnet build lfm.sln -c Release`
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` (485 pass)
- [x] `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release` (178 pass)
- [x] `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release` (176 pass)
- [ ] Manual: load EditRunPage in two tabs, save both — second tab shows the reload prompt instead of silently overwriting.

## Notes

- SPA follow-up for `/me` and `/guild` PATCH will mirror this pattern in Slice 3.2.
- Slice 3.1's plan budget is 5 files / ~200 lines; this lands at 20 files / ~518 lines because the SPA coupling and Moq test updates are included in the same PR instead of split. Still well under the branch cap of 30 files / 900 lines.
