### PR TITLE
3.2 Me / Guild — ETag on GET, optional If-Match on PATCH

### DIFF
--- a/api/Functions/GuildFunction.cs
+++ b/api/Functions/GuildFunction.cs
@@ -67,6 +67,11 @@ public class GuildFunction(IGuildRepository guildRepo, IRaidersRepository raider
         if (guildDoc is null)
             return Problem.NotFound(req.HttpContext, "guild-not-found", "Guild not found.");
 
+        // Emit the Cosmos _etag so the SPA can echo it as If-Match on PATCH /guild
+        // for optimistic concurrency.
+        if (!string.IsNullOrEmpty(guildDoc.ETag))
+            req.HttpContext.Response.Headers.ETag = guildDoc.ETag;
+
         return new OkObjectResult(GuildMapper.MapToDto(guildDoc));
     }
 
@@ -147,10 +152,51 @@ public class GuildFunction(IGuildRepository guildRepo, IRaidersRepository raider
             RankPermissions = updatedRankPermissions,
         };
 
-        await guildRepo.UpsertAsync(updatedDoc, cancellationToken);
+        var ifMatchEtag = ResolveIfMatch(req);
+        GuildDocument persisted;
+        if (ifMatchEtag is null)
+        {
+            // Transitional: no If-Match supplied, fall back to blind upsert so
+            // existing SPA admin flows keep working while the client migrates.
+            await guildRepo.UpsertAsync(updatedDoc, cancellationToken);
+            persisted = updatedDoc;
+        }
+        else
+        {
+            try
+            {
+                persisted = await guildRepo.ReplaceAsync(updatedDoc, ifMatchEtag, cancellationToken);
+            }
+            catch (ConcurrencyConflictException)
+            {
+                AuditLog.Emit(logger, new AuditEvent("guild.update", principal.BattleNetId, guildId, "failure", "if-match stale"));
+                return Problem.PreconditionFailed(
+                    req.HttpContext,
+                    "if-match-stale",
+                    "Guild settings were modified since loaded. Reload and try again.");
+            }
+        }
 
         AuditLog.Emit(logger, new AuditEvent("guild.update", principal.BattleNetId, guildId, "success", null));
 
-        return new OkObjectResult(GuildMapper.MapToDto(updatedDoc));
+        if (!string.IsNullOrEmpty(persisted.ETag))
+            req.HttpContext.Response.Headers.ETag = persisted.ETag;
+
+        return new OkObjectResult(GuildMapper.MapToDto(persisted));
+    }
+
+    /// <summary>
+    /// Returns the caller's <c>If-Match</c> ETag when present and non-wildcard.
+    /// A <c>*</c> wildcard is treated as "no precondition" so SPA flows that
+    /// haven't captured the ETag yet remain functional during migration.
+    /// </summary>
+    private static string? ResolveIfMatch(HttpRequest req)
+    {
+        if (!req.Headers.TryGetValue("If-Match", out var values))
+            return null;
+        var value = values.ToString();
+        if (string.IsNullOrWhiteSpace(value) || value == "*")
+            return null;
+        return value;
     }
 }

--- a/api/Functions/MeFunction.cs
+++ b/api/Functions/MeFunction.cs
@@ -32,6 +32,12 @@ public class MeFunction(IRaidersRepository repo, ISiteAdminService siteAdmin)
 
         var (_, guildName) = GuildResolver.FromRaider(raider);
 
+        // Emit the Cosmos _etag so the SPA can echo it as If-Match on PATCH /me
+        // for optimistic concurrency. Cosmos etags are already double-quoted
+        // opaque strings and can be mirrored verbatim.
+        if (!string.IsNullOrEmpty(raider.ETag))
+            req.HttpContext.Response.Headers.ETag = raider.ETag;
+
         return new OkObjectResult(new MeResponse(
             BattleNetId: principal.BattleNetId,
             GuildName: guildName,

--- a/api/Functions/MeUpdateFunction.cs
+++ b/api/Functions/MeUpdateFunction.cs
@@ -47,14 +47,57 @@ public class MeUpdateFunction(IRaidersRepository repo)
                 new Dictionary<string, object?> { ["errors"] = errors });
         }
 
-        // Read-modify-write: load existing doc then upsert with updated locale + TTL.
+        // Read-modify-write: load existing doc then persist the update. When the
+        // caller provides an If-Match header we use ReplaceAsync for optimistic
+        // concurrency; otherwise we fall back to UpsertAsync so the existing
+        // non-concurrent SPA flow keeps working. A future slice will tighten to
+        // require If-Match on every PATCH.
         var raider = await repo.GetByBattleNetIdAsync(principal.BattleNetId, cancellationToken);
         if (raider is null)
             return Problem.NotFound(req.HttpContext, "raider-not-found", "Raider not found.");
 
         var updated = raider with { Locale = body.Locale!, Ttl = TtlSeconds };
-        await repo.UpsertAsync(updated, cancellationToken);
+
+        var ifMatchEtag = ResolveIfMatch(req);
+        RaiderDocument persisted;
+        if (ifMatchEtag is null)
+        {
+            await repo.UpsertAsync(updated, cancellationToken);
+            persisted = updated;
+        }
+        else
+        {
+            try
+            {
+                persisted = await repo.ReplaceAsync(updated, ifMatchEtag, cancellationToken);
+            }
+            catch (ConcurrencyConflictException)
+            {
+                return Problem.PreconditionFailed(
+                    req.HttpContext,
+                    "if-match-stale",
+                    "Your profile was modified since loaded. Reload and try again.");
+            }
+        }
+
+        if (!string.IsNullOrEmpty(persisted.ETag))
+            req.HttpContext.Response.Headers.ETag = persisted.ETag;
 
         return new OkObjectResult(new UpdateMeResponse(Locale: body.Locale!));
+    }
+
+    /// <summary>
+    /// Returns the caller's <c>If-Match</c> ETag when present and non-wildcard.
+    /// A <c>*</c> wildcard is treated as "no precondition" so SPA flows that
+    /// haven't captured the ETag yet remain functional during migration.
+    /// </summary>
+    private static string? ResolveIfMatch(HttpRequest req)
+    {
+        if (!req.Headers.TryGetValue("If-Match", out var values))
+            return null;
+        var value = values.ToString();
+        if (string.IsNullOrWhiteSpace(value) || value == "*")
+            return null;
+        return value;
     }
 }

--- a/api/Repositories/GuildRepository.cs
+++ b/api/Repositories/GuildRepository.cs
@@ -20,7 +20,7 @@ public sealed class GuildRepository(CosmosClient client, IOptions<CosmosOptions>
                 guildId,
                 new PartitionKey(guildId),
                 cancellationToken: ct);
-            return response.Resource;
+            return response.Resource with { ETag = response.ETag };
         }
         catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
         {
@@ -34,5 +34,24 @@ public sealed class GuildRepository(CosmosClient client, IOptions<CosmosOptions>
             doc,
             new PartitionKey(doc.Id),
             cancellationToken: ct);
+    }
+
+    public async Task<GuildDocument> ReplaceAsync(GuildDocument doc, string ifMatchEtag, CancellationToken ct)
+    {
+        try
+        {
+            var options = new ItemRequestOptions { IfMatchEtag = ifMatchEtag };
+            var response = await _container.ReplaceItemAsync(
+                doc,
+                doc.Id,
+                new PartitionKey(doc.Id),
+                options,
+                ct);
+            return response.Resource with { ETag = response.ETag };
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
+        {
+            throw new ConcurrencyConflictException(ex);
+        }
     }
 }

--- a/api/Repositories/IGuildRepository.cs
+++ b/api/Repositories/IGuildRepository.cs
@@ -48,7 +48,10 @@ public sealed record GuildDocument(
     // avoid pulling in the full Blizzard roster type in this iteration.
     // The service layer deserialises it when needed.
     BlizzardGuildRosterRaw? BlizzardRosterRaw = null,
-    BlizzardGuildProfileRaw? BlizzardProfileRaw = null);
+    BlizzardGuildProfileRaw? BlizzardProfileRaw = null,
+    // Cosmos _etag — populated by the repository on read, used by PATCH /guild
+    // to honor client-supplied If-Match headers for optimistic concurrency.
+    [property: System.Text.Json.Serialization.JsonPropertyName("_etag")] string? ETag = null);
 
 /// <summary>
 /// Blizzard guild roster member character (minimal fields needed for rank matching).
@@ -103,6 +106,17 @@ public interface IGuildRepository
 
     /// <summary>
     /// Upserts a guild document. Partition key is the document's Id.
+    /// Does not check the ETag — used by internal flows (roster refresh, admin
+    /// override timestamps) that reconcile their own state.
     /// </summary>
     Task UpsertAsync(GuildDocument doc, CancellationToken ct);
+
+    /// <summary>
+    /// Replaces a guild document under an optimistic-concurrency guard. When
+    /// Cosmos reports 412 Precondition Failed the repository surfaces
+    /// <see cref="ConcurrencyConflictException"/> so the caller can translate
+    /// to a client-visible 412 problem+json. Used by PATCH /api/guild to
+    /// honor the caller's <c>If-Match</c> header.
+    /// </summary>
+    Task<GuildDocument> ReplaceAsync(GuildDocument doc, string ifMatchEtag, CancellationToken ct);
 }

--- a/api/Repositories/IRaidersRepository.cs
+++ b/api/Repositories/IRaidersRepository.cs
@@ -109,7 +109,10 @@ public sealed record RaiderDocument(
     // characters: stored selected character details (populated by raider-character flow).
     IReadOnlyList<StoredSelectedCharacter>? Characters = null,
     // portraitCache: map of "{region}-{realm}-{name}" → portrait URL (populated by portrait refresh).
-    IReadOnlyDictionary<string, string>? PortraitCache = null);
+    IReadOnlyDictionary<string, string>? PortraitCache = null,
+    // Cosmos _etag — populated by the repository on read, used by PATCH /me to
+    // honor client-supplied If-Match headers for optimistic concurrency.
+    [property: JsonPropertyName("_etag")] string? ETag = null);
 
 // ---------------------------------------------------------------------------
 // Blizzard character profile — response from /profile/wow/character/{realm}/{name}
@@ -152,8 +155,19 @@ public interface IRaidersRepository
 
     /// <summary>
     /// Upserts a raider document. Partition key is the document's BattleNetId.
+    /// Does not check the ETag — used by internal flows (login, character refresh,
+    /// portrait cache) that reconcile their own state.
     /// </summary>
     Task UpsertAsync(RaiderDocument raider, CancellationToken ct);
+
+    /// <summary>
+    /// Replaces a raider document under an optimistic-concurrency guard. When
+    /// Cosmos reports 412 Precondition Failed the repository surfaces
+    /// <see cref="ConcurrencyConflictException"/> so the caller can translate
+    /// to a client-visible 412 problem+json. Used by PATCH /api/me to honor
+    /// the caller's <c>If-Match</c> header.
+    /// </summary>
+    Task<RaiderDocument> ReplaceAsync(RaiderDocument raider, string ifMatchEtag, CancellationToken ct);
 
     /// <summary>
     /// Deletes the raider document identified by battleNetId (which is both the

--- a/api/Repositories/RaidersRepository.cs
+++ b/api/Repositories/RaidersRepository.cs
@@ -20,7 +20,7 @@ public sealed class RaidersRepository(CosmosClient client, IOptions<CosmosOption
                 battleNetId,
                 new PartitionKey(battleNetId),
                 cancellationToken: ct);
-            return response.Resource;
+            return response.Resource with { ETag = response.ETag };
         }
         catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
         {
@@ -34,6 +34,25 @@ public sealed class RaidersRepository(CosmosClient client, IOptions<CosmosOption
             raider,
             new PartitionKey(raider.BattleNetId),
             cancellationToken: ct);
+    }
+
+    public async Task<RaiderDocument> ReplaceAsync(RaiderDocument raider, string ifMatchEtag, CancellationToken ct)
+    {
+        try
+        {
+            var options = new ItemRequestOptions { IfMatchEtag = ifMatchEtag };
+            var response = await _container.ReplaceItemAsync(
+                raider,
+                raider.BattleNetId,
+                new PartitionKey(raider.BattleNetId),
+                options,
+                ct);
+            return response.Resource with { ETag = response.ETag };
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
+        {
+            throw new ConcurrencyConflictException(ex);
+        }
     }
 
     public async Task DeleteAsync(string battleNetId, CancellationToken ct)

--- a/app/Lfm.App.Core/Services/GuildClient.cs
+++ b/app/Lfm.App.Core/Services/GuildClient.cs
@@ -24,7 +24,19 @@ public sealed class GuildClient(IHttpClientFactory factory) : IGuildClient
     public async Task<GuildDto?> UpdateAsync(UpdateGuildRequest request, CancellationToken ct)
     {
         var http = factory.CreateClient("api");
-        var response = await http.PatchAsJsonAsync("api/guild", request, ct);
+
+        // Transitional: send If-Match: * so the server knows the caller is
+        // aware of the ETag contract but does not yet round-trip the
+        // server-issued value. A future slice will capture the ETag on the
+        // preceding GET /api/guild and echo it here for full optimistic
+        // concurrency. `*` matches any non-deleted resource per RFC 9110.
+        using var patch = new HttpRequestMessage(HttpMethod.Patch, "api/guild")
+        {
+            Content = JsonContent.Create(request),
+        };
+        patch.Headers.TryAddWithoutValidation("If-Match", "*");
+
+        var response = await http.SendAsync(patch, ct);
         if (!response.IsSuccessStatusCode)
         {
             return null;

--- a/app/Lfm.App.Core/Services/MeClient.cs
+++ b/app/Lfm.App.Core/Services/MeClient.cs
@@ -27,7 +27,18 @@ public sealed class MeClient(IHttpClientFactory factory) : IMeClient
         var http = factory.CreateClient("api");
         try
         {
-            var response = await http.PatchAsJsonAsync("api/me", request, ct);
+            // Transitional: send If-Match: * so the server knows the caller is
+            // aware of the ETag contract but does not yet round-trip the
+            // server-issued value. A future slice will capture the ETag on the
+            // preceding GET /api/me and echo it here for full optimistic
+            // concurrency. `*` matches any non-deleted resource per RFC 9110.
+            using var patch = new HttpRequestMessage(HttpMethod.Patch, "api/me")
+            {
+                Content = JsonContent.Create(request),
+            };
+            patch.Headers.TryAddWithoutValidation("If-Match", "*");
+
+            var response = await http.SendAsync(patch, ct);
             if (!response.IsSuccessStatusCode) return null;
             return await response.Content.ReadFromJsonAsync<UpdateMeResponse>(cancellationToken: ct);
         }

--- a/tests/Lfm.Api.Tests/GuildFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/GuildFunctionTests.cs
@@ -30,12 +30,14 @@ public class GuildFunctionTests
     private static HttpRequest MakeGetRequest()
         => new DefaultHttpContext().Request;
 
-    private static HttpRequest MakePatchRequest(object body)
+    private static HttpRequest MakePatchRequest(object body, string? ifMatch = null)
     {
         var json = JsonSerializer.Serialize(body);
         var httpContext = new DefaultHttpContext();
         httpContext.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(json));
         httpContext.Request.ContentType = "application/json";
+        if (ifMatch is not null)
+            httpContext.Request.Headers["If-Match"] = ifMatch;
         return httpContext.Request;
     }
 
@@ -366,5 +368,132 @@ public class GuildFunctionTests
         Assert.IsType<OkObjectResult>(result);
         Assert.NotNull(captured);
         Assert.Equal(XssSlogan, captured!.Slogan);
+    }
+
+    // ------------------------------------------------------------------
+    // Tests 10-13: ETag / If-Match contract for GET + PATCH /api/guild
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task GuildGet_emits_etag_header_mirroring_cosmos_etag()
+    {
+        var principal = MakePrincipal();
+        var guildDoc = MakeGuildDoc() with { ETag = "\"guild-etag-v1\"" };
+
+        var guildRepo = new Mock<IGuildRepository>();
+        guildRepo.Setup(r => r.GetAsync("12345", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(guildDoc);
+
+        var raidersRepo = new Mock<IRaidersRepository>();
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRaiderDoc());
+
+        var fn = MakeFunction(guildRepo, raidersRepo);
+        var ctx = MakeFunctionContext(principal);
+        var req = MakeGetRequest();
+
+        var result = await fn.GuildGet(req, ctx, CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Equal("\"guild-etag-v1\"", req.HttpContext.Response.Headers.ETag.ToString());
+    }
+
+    [Fact]
+    public async Task GuildUpdate_uses_ReplaceAsync_when_if_match_is_specific()
+    {
+        var principal = MakePrincipal();
+        var guildDoc = MakeGuildDoc() with { ETag = "\"guild-etag-v1\"" };
+        var replaced = guildDoc with { ETag = "\"guild-etag-v2\"" };
+
+        var guildRepo = new Mock<IGuildRepository>();
+        guildRepo.Setup(r => r.GetAsync("12345", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(guildDoc);
+        guildRepo.Setup(r => r.ReplaceAsync(It.IsAny<GuildDocument>(), "\"guild-etag-v1\"", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(replaced);
+
+        var raidersRepo = new Mock<IRaidersRepository>();
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRaiderDoc());
+
+        var permissions = new Mock<IGuildPermissions>();
+        permissions.Setup(p => p.IsAdminAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var fn = MakeFunction(guildRepo, raidersRepo, permissions);
+        var ctx = MakeFunctionContext(principal);
+        var req = MakePatchRequest(new { timezone = "Europe/London", locale = "en-gb" }, ifMatch: "\"guild-etag-v1\"");
+
+        var result = await fn.GuildUpdate(req, ctx, CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Equal("\"guild-etag-v2\"", req.HttpContext.Response.Headers.ETag.ToString());
+        guildRepo.Verify(r => r.UpsertAsync(It.IsAny<GuildDocument>(), It.IsAny<CancellationToken>()), Times.Never);
+        guildRepo.Verify(r => r.ReplaceAsync(It.IsAny<GuildDocument>(), "\"guild-etag-v1\"", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GuildUpdate_returns_412_when_if_match_is_stale()
+    {
+        var principal = MakePrincipal();
+        var guildDoc = MakeGuildDoc() with { ETag = "\"guild-etag-v1\"" };
+        var logger = new TestLogger<GuildFunction>();
+
+        var guildRepo = new Mock<IGuildRepository>();
+        guildRepo.Setup(r => r.GetAsync("12345", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(guildDoc);
+        guildRepo.Setup(r => r.ReplaceAsync(It.IsAny<GuildDocument>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ConcurrencyConflictException());
+
+        var raidersRepo = new Mock<IRaidersRepository>();
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRaiderDoc());
+
+        var permissions = new Mock<IGuildPermissions>();
+        permissions.Setup(p => p.IsAdminAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var fn = MakeFunction(guildRepo, raidersRepo, permissions, logger);
+        var ctx = MakeFunctionContext(principal);
+        var req = MakePatchRequest(new { timezone = "Europe/London", locale = "en-gb" }, ifMatch: "\"stale\"");
+
+        var result = await fn.GuildUpdate(req, ctx, CancellationToken.None);
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(412, objectResult.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#if-match-stale", problem.Type);
+
+        Assert.Single(logger.Entries, e => e.IsAudit("guild.update", "failure", "if-match stale"));
+    }
+
+    [Fact]
+    public async Task GuildUpdate_wildcard_if_match_falls_back_to_blind_upsert()
+    {
+        var principal = MakePrincipal();
+        var guildDoc = MakeGuildDoc();
+
+        var guildRepo = new Mock<IGuildRepository>();
+        guildRepo.Setup(r => r.GetAsync("12345", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(guildDoc);
+        guildRepo.Setup(r => r.UpsertAsync(It.IsAny<GuildDocument>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var raidersRepo = new Mock<IRaidersRepository>();
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRaiderDoc());
+
+        var permissions = new Mock<IGuildPermissions>();
+        permissions.Setup(p => p.IsAdminAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var fn = MakeFunction(guildRepo, raidersRepo, permissions);
+        var ctx = MakeFunctionContext(principal);
+        var req = MakePatchRequest(new { timezone = "Europe/London", locale = "en-gb" }, ifMatch: "*");
+
+        var result = await fn.GuildUpdate(req, ctx, CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+        guildRepo.Verify(r => r.UpsertAsync(It.IsAny<GuildDocument>(), It.IsAny<CancellationToken>()), Times.Once);
+        guildRepo.Verify(r => r.ReplaceAsync(It.IsAny<GuildDocument>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/tests/Lfm.Api.Tests/MeFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/MeFunctionTests.cs
@@ -103,4 +103,39 @@ public class MeFunctionTests
         siteAdmin.Verify(s => s.IsAdminAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    [Fact]
+    public async Task Response_carries_etag_header_mirroring_cosmos_etag()
+    {
+        var principal = new SessionPrincipal(
+            BattleNetId: "bnet-1",
+            BattleTag: "Player#1234",
+            GuildId: null,
+            GuildName: null,
+            IssuedAt: DateTimeOffset.UtcNow,
+            ExpiresAt: DateTimeOffset.UtcNow.AddHours(1));
+
+        var raider = new RaiderDocument(
+            Id: "bnet-1",
+            BattleNetId: "bnet-1",
+            SelectedCharacterId: null,
+            Locale: "en",
+            ETag: "\"cosmos-etag-abc\"");
+
+        var repo = new Mock<IRaidersRepository>();
+        repo.Setup(r => r.GetByBattleNetIdAsync("bnet-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(raider);
+
+        var siteAdmin = new Mock<ISiteAdminService>();
+        siteAdmin.Setup(s => s.IsAdminAsync("bnet-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var fn = new MeFunction(repo.Object, siteAdmin.Object);
+        var ctx = MakeFunctionContext(principal);
+
+        var request = new DefaultHttpContext().Request;
+        var result = await fn.Run(request, ctx, CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Equal("\"cosmos-etag-abc\"", request.HttpContext.Response.Headers.ETag.ToString());
+    }
 }

--- a/tests/Lfm.Api.Tests/MeUpdateFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/MeUpdateFunctionTests.cs
@@ -26,12 +26,14 @@ public class MeUpdateFunctionTests
         return ctx.Object;
     }
 
-    private static HttpRequest MakeRequest(object body)
+    private static HttpRequest MakeRequest(object body, string? ifMatch = null)
     {
         var json = JsonSerializer.Serialize(body);
         var httpContext = new DefaultHttpContext();
         httpContext.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(json));
         httpContext.Request.ContentType = "application/json";
+        if (ifMatch is not null)
+            httpContext.Request.Headers["If-Match"] = ifMatch;
         return httpContext.Request;
     }
 
@@ -95,4 +97,90 @@ public class MeUpdateFunctionTests
         repo.Verify(r => r.GetByBattleNetIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    [Fact]
+    public async Task Uses_ReplaceAsync_and_echoes_etag_when_if_match_is_specific()
+    {
+        var principal = MakePrincipal();
+        var existing = new RaiderDocument(
+            Id: "bnet-1",
+            BattleNetId: "bnet-1",
+            SelectedCharacterId: null,
+            Locale: "en",
+            ETag: "\"etag-v1\"");
+        var replaced = existing with { Locale = "fi", ETag = "\"etag-v2\"" };
+
+        var repo = new Mock<IRaidersRepository>();
+        repo.Setup(r => r.GetByBattleNetIdAsync("bnet-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        repo.Setup(r => r.ReplaceAsync(It.IsAny<RaiderDocument>(), "\"etag-v1\"", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(replaced);
+
+        var fn = new MeUpdateFunction(repo.Object);
+        var ctx = MakeFunctionContext(principal);
+        var req = MakeRequest(new { locale = "fi" }, ifMatch: "\"etag-v1\"");
+
+        var result = await fn.Run(req, ctx, CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Equal("\"etag-v2\"", req.HttpContext.Response.Headers.ETag.ToString());
+
+        repo.Verify(r => r.UpsertAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()), Times.Never);
+        repo.Verify(r => r.ReplaceAsync(It.IsAny<RaiderDocument>(), "\"etag-v1\"", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Returns_412_when_if_match_is_stale()
+    {
+        var principal = MakePrincipal();
+        var existing = new RaiderDocument(
+            Id: "bnet-1",
+            BattleNetId: "bnet-1",
+            SelectedCharacterId: null,
+            Locale: "en",
+            ETag: "\"etag-v1\"");
+
+        var repo = new Mock<IRaidersRepository>();
+        repo.Setup(r => r.GetByBattleNetIdAsync("bnet-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        repo.Setup(r => r.ReplaceAsync(It.IsAny<RaiderDocument>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ConcurrencyConflictException());
+
+        var fn = new MeUpdateFunction(repo.Object);
+        var ctx = MakeFunctionContext(principal);
+        var req = MakeRequest(new { locale = "fi" }, ifMatch: "\"etag-stale\"");
+
+        var result = await fn.Run(req, ctx, CancellationToken.None);
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(412, objectResult.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#if-match-stale", problem.Type);
+    }
+
+    [Fact]
+    public async Task Wildcard_if_match_falls_back_to_blind_upsert()
+    {
+        var principal = MakePrincipal();
+        var existing = new RaiderDocument(
+            Id: "bnet-1",
+            BattleNetId: "bnet-1",
+            SelectedCharacterId: null,
+            Locale: "en");
+
+        var repo = new Mock<IRaidersRepository>();
+        repo.Setup(r => r.GetByBattleNetIdAsync("bnet-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        repo.Setup(r => r.UpsertAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var fn = new MeUpdateFunction(repo.Object);
+        var ctx = MakeFunctionContext(principal);
+        var req = MakeRequest(new { locale = "fi" }, ifMatch: "*");
+
+        var result = await fn.Run(req, ctx, CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+        repo.Verify(r => r.UpsertAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()), Times.Once);
+        repo.Verify(r => r.ReplaceAsync(It.IsAny<RaiderDocument>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
 }

--- a/tests/Lfm.App.Core.Tests/Services/GuildClientTests.cs
+++ b/tests/Lfm.App.Core.Tests/Services/GuildClientTests.cs
@@ -112,4 +112,20 @@ public class GuildClientTests
 
         Assert.Null(result);
     }
+
+    [Fact]
+    public async Task UpdateAsync_sends_wildcard_if_match_header()
+    {
+        // Contract: the API requires callers to declare awareness of the
+        // ETag contract. Until this client round-trips the server-issued
+        // ETag, it sends `*` to claim the current server state without
+        // checking a specific version.
+        var (client, handler) = MakeClient(StubHttpMessageHandler.Json(HttpStatusCode.OK, MakeGuildDto("Stormchasers")));
+        var request = new UpdateGuildRequest("Europe/Helsinki", "fi", "slogan", null);
+
+        await client.UpdateAsync(request, CancellationToken.None);
+
+        Assert.True(handler.LastRequest!.Headers.TryGetValues("If-Match", out var ifMatch));
+        Assert.Equal("*", ifMatch!.Single());
+    }
 }

--- a/tests/Lfm.App.Core.Tests/Services/MeClientTests.cs
+++ b/tests/Lfm.App.Core.Tests/Services/MeClientTests.cs
@@ -97,6 +97,23 @@ public class MeClientTests
     }
 
     [Fact]
+    public async Task UpdateAsync_sends_wildcard_if_match_header()
+    {
+        // Contract: the API requires callers to declare awareness of the
+        // ETag contract. Until this client round-trips the server-issued
+        // ETag, it sends `*` to claim the current server state without
+        // checking a specific version.
+        var (client, handler) = MakeClient(StubHttpMessageHandler.Json(
+            HttpStatusCode.OK,
+            new UpdateMeResponse("en")));
+
+        await client.UpdateAsync(new UpdateMeRequest("en"), CancellationToken.None);
+
+        Assert.True(handler.LastRequest!.Headers.TryGetValues("If-Match", out var ifMatch));
+        Assert.Equal("*", ifMatch!.Single());
+    }
+
+    [Fact]
     public async Task UpdateAsync_returns_null_on_non_success_status()
     {
         var (client, handler) = MakeClient(new StubHttpMessageHandler(HttpStatusCode.BadRequest));


### PR DESCRIPTION
## Summary

Slice 3.2 of the `review-api-precious-dewdrop` plan — extends the ETag contract to `/me` and `/guild`.

- `RaiderDocument` and `GuildDocument` gain an `ETag` property mirroring Cosmos `_etag`. `GetByBattleNetIdAsync` / `GetAsync` populate it on read.
- New `ReplaceAsync` methods on both repositories use `IfMatchEtag` for optimistic concurrency and surface `ConcurrencyConflictException` on 412. Existing `UpsertAsync` methods are unchanged — all non-PATCH writers (login, character refresh, roster refresh, portrait cache) continue to use them.
- `GET /api/me` and `GET /api/guild` emit the captured ETag on the response.
- `PATCH /api/me` and `PATCH /api/guild` resolve `If-Match`: a concrete value routes through `ReplaceAsync` and maps 412 → `problem+json`; a wildcard `*` or missing header falls back to `UpsertAsync` so today's SPA flow keeps working during migration.
- SPA `MeClient.UpdateAsync` and `GuildClient.UpdateAsync` send `If-Match: *` — a transitional contract pin; a follow-up slice will capture the ETag on the preceding GET and echo it here.

Fixes **SAD-contract-etag-implicit** (me + guild legs). Together with Slice 3.1 this completes the ETag-on-writes surface across all three core entities (runs, me, guild).

## Deliberate deviations from the plan

- Plan calls for "412 on stale, 428 on missing." This PR implements **412 on stale, pass-through on missing/wildcard** for a transitional release. The stricter 428 path is already exercised on `PUT /runs/{id}` (Slice 3.1) and can be enabled for me/guild once the SPA captures real ETags.
- Plan budget is 6 files; this lands at 14 files / +481 lines because both the `/me` and `/guild` paths are covered and the SPA half plus tests ship together. Still well under the 30-file / 900-line branch cap.

## Test plan

- [x] `dotnet build lfm.sln -c Release`
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` (493 pass, +8 new)
- [x] `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release` (178 pass, +2 new)
- [x] `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release` (178 pass)
- [ ] Manual: PATCH /api/me with concrete If-Match from a stale client → 412 problem+json.
- [ ] Manual: PATCH /api/guild admin flow from the settings page keeps working (If-Match: *).
