### PR TITLE
4.3 Echo Retry-After when enrich hits Blizzard 429

### DIFF
--- a/api/Functions/RaiderCharacterEnrichFunction.cs
+++ b/api/Functions/RaiderCharacterEnrichFunction.cs
@@ -20,6 +20,7 @@ namespace Lfm.Api.Functions;
 public sealed class RaiderCharacterEnrichFunction(
     IRaidersRepository repo,
     IBlizzardProfileClient profileClient,
+    IBlizzardRateLimiter rateLimiter,
     ILogger<RaiderCharacterEnrichFunction> logger)
 {
     [Function("raider-character-enrich")]
@@ -89,10 +90,19 @@ public sealed class RaiderCharacterEnrichFunction(
             }
             catch (HttpRequestException ex) when ((int?)ex.StatusCode == 429)
             {
+                // Surface the shared rate-limiter's pause budget as RFC 9110
+                // Retry-After so clients schedule the retry instead of
+                // guessing. Ceiling to the next whole second — a sub-second
+                // Retry-After is out of spec and would round down to 0.
+                var pause = rateLimiter.RemainingPause;
+                var retryAfterSeconds = pause is TimeSpan p
+                    ? (int)Math.Ceiling(p.TotalSeconds)
+                    : (int?)null;
                 return Problem.TooManyRequests(
                     req.HttpContext,
                     "upstream-rate-limited",
-                    "Upstream rate-limited.");
+                    "Upstream rate-limited.",
+                    retryAfterSeconds);
             }
             catch (HttpRequestException ex) when ((int?)ex.StatusCode == 404)
             {

--- a/api/Services/BlizzardRateLimiter.cs
+++ b/api/Services/BlizzardRateLimiter.cs
@@ -38,5 +38,15 @@ public sealed class BlizzardRateLimiter : IBlizzardRateLimiter, IDisposable
         Interlocked.Exchange(ref _pauseUntilTicks, until.UtcTicks);
     }
 
+    public TimeSpan? RemainingPause
+    {
+        get
+        {
+            var pause = Interlocked.Read(ref _pauseUntilTicks);
+            var remaining = pause - DateTimeOffset.UtcNow.UtcTicks;
+            return remaining > 0 ? TimeSpan.FromTicks(remaining) : null;
+        }
+    }
+
     public void Dispose() => _limiter.Dispose();
 }

--- a/api/Services/IBlizzardRateLimiter.cs
+++ b/api/Services/IBlizzardRateLimiter.cs
@@ -12,4 +12,13 @@ public interface IBlizzardRateLimiter
 {
     ValueTask<BlizzardLease> AcquireAsync(CancellationToken ct);
     void PauseUntil(DateTimeOffset until);
+
+    /// <summary>
+    /// How long the rate limiter is currently pausing outgoing Blizzard calls,
+    /// if a pause is in effect; null otherwise. Used by callers that surface
+    /// 429 to the browser so they can echo a RFC 9110 <c>Retry-After</c>
+    /// header. The value is the pause budget remaining from the limiter's
+    /// last <see cref="PauseUntil"/> call and clamps to non-negative.
+    /// </summary>
+    TimeSpan? RemainingPause { get; }
 }

--- a/tests/Lfm.Api.Tests/RaiderCharacterEnrichFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RaiderCharacterEnrichFunctionTests.cs
@@ -96,6 +96,54 @@ public class RaiderCharacterEnrichFunctionTests
     }
 
     [Fact]
+    public async Task Returns_429_with_Retry_After_header_when_Blizzard_rate_limits()
+    {
+        var raider = MakeRaider(accountChars: [("stormreaver", "Shalena")]);
+        var repo = RepoReturning(raider);
+        var profileClient = new Mock<IBlizzardProfileClient>();
+        profileClient.Setup(p => p.GetCharacterProfileAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException(
+                "Too Many Requests", inner: null, statusCode: System.Net.HttpStatusCode.TooManyRequests));
+
+        var rateLimiter = new Mock<IBlizzardRateLimiter>();
+        rateLimiter.SetupGet(r => r.RemainingPause).Returns(TimeSpan.FromSeconds(7));
+
+        var fn = MakeFunction(repo.Object, profileClient.Object, rateLimiter.Object);
+        var request = MakeRequest();
+        var result = await fn.Run(request, CharId, MakeCtx(), CancellationToken.None);
+
+        var tooMany = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(429, tooMany.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(tooMany.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#upstream-rate-limited", problem.Type);
+        Assert.Equal("7", request.HttpContext.Response.Headers.RetryAfter.ToString());
+    }
+
+    [Fact]
+    public async Task Returns_429_without_Retry_After_when_limiter_reports_no_pause()
+    {
+        var raider = MakeRaider(accountChars: [("stormreaver", "Shalena")]);
+        var repo = RepoReturning(raider);
+        var profileClient = new Mock<IBlizzardProfileClient>();
+        profileClient.Setup(p => p.GetCharacterProfileAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException(
+                "Too Many Requests", inner: null, statusCode: System.Net.HttpStatusCode.TooManyRequests));
+
+        var rateLimiter = new Mock<IBlizzardRateLimiter>();
+        rateLimiter.SetupGet(r => r.RemainingPause).Returns((TimeSpan?)null);
+
+        var fn = MakeFunction(repo.Object, profileClient.Object, rateLimiter.Object);
+        var request = MakeRequest();
+        var result = await fn.Run(request, CharId, MakeCtx(), CancellationToken.None);
+
+        var tooMany = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(429, tooMany.StatusCode);
+        Assert.False(request.HttpContext.Response.Headers.ContainsKey("Retry-After"));
+    }
+
+    [Fact]
     public async Task Returns_404_when_Blizzard_returns_404()
     {
         var raider = MakeRaider(accountChars: [("stormreaver", "Shalena")]);
@@ -118,8 +166,14 @@ public class RaiderCharacterEnrichFunctionTests
 
     // ---- helpers ----
     private static RaiderCharacterEnrichFunction MakeFunction(
-        IRaidersRepository repo, IBlizzardProfileClient profile)
-        => new(repo, profile, NullLogger<RaiderCharacterEnrichFunction>.Instance);
+        IRaidersRepository repo,
+        IBlizzardProfileClient profile,
+        IBlizzardRateLimiter? rateLimiter = null)
+        => new(
+            repo,
+            profile,
+            rateLimiter ?? new Mock<IBlizzardRateLimiter>().Object,
+            NullLogger<RaiderCharacterEnrichFunction>.Instance);
 
     private static HttpRequest MakeRequest() => new DefaultHttpContext().Request;
 


### PR DESCRIPTION
## Summary

Slice 4.3 of the `review-api-precious-dewdrop` plan — propagates the shared Blizzard rate limiter's pause budget through the `POST /api/raider/characters/{id}/enrich` 429 response as an RFC 9110 `Retry-After` header.

- `IBlizzardRateLimiter` gains `TimeSpan? RemainingPause`.
- `BlizzardRateLimiter` derives it from the existing `_pauseUntilTicks` with clamping.
- `RaiderCharacterEnrichFunction` injects the limiter, reads `RemainingPause` on upstream 429, and feeds it through the existing `Problem.TooManyRequests(..., retryAfterSeconds)` helper (which already sets the header).

Fixes **SAD-rel-429-no-retry-after**.

## Test plan

- [x] `dotnet build lfm.sln -c Release`
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` (518 pass, +2 new covering both the limiter-paused and limiter-idle branches)
