### PR TITLE
4.4 Cap request bodies at 64 KiB

### DIFF
--- a/api/Middleware/RequestSizeLimitMiddleware.cs
+++ b/api/Middleware/RequestSizeLimitMiddleware.cs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Diagnostics;
+using System.Text.Json;
+using Lfm.Api.Helpers;
+using Lfm.Api.Options;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Middleware;
+using Microsoft.Extensions.Options;
+
+namespace Lfm.Api.Middleware;
+
+/// <summary>
+/// Rejects requests whose advertised <c>Content-Length</c> exceeds
+/// <see cref="RequestSizeLimitOptions.MaxBytes"/> with 413 Payload Too Large
+/// + RFC 9457 <c>application/problem+json</c>. Runs early (before auth and
+/// the function body) so we do not burn compute on payloads the API would
+/// reject anyway.
+///
+/// <para>
+/// Requests without a <c>Content-Length</c> header (GET, DELETE, chunked
+/// uploads) bypass the guard. Chunked bodies are not on the API surface
+/// today — if that changes, a later slice can add a streaming cap that
+/// counts bytes as they arrive.
+/// </para>
+/// </summary>
+public sealed class RequestSizeLimitMiddleware : IFunctionsWorkerMiddleware
+{
+    private readonly RequestSizeLimitOptions _options;
+
+    public RequestSizeLimitMiddleware(IOptions<RequestSizeLimitOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
+    {
+        var httpContext = context.GetHttpContext();
+        if (httpContext is null)
+        {
+            await next(context);
+            return;
+        }
+
+        if (httpContext.Request.ContentLength is long length && length > _options.MaxBytes)
+        {
+            await WriteTooLargeAsync(httpContext, length);
+            return;
+        }
+
+        await next(context);
+    }
+
+    private async Task WriteTooLargeAsync(HttpContext httpContext, long advertisedLength)
+    {
+        var problem = new ProblemDetails
+        {
+            Type = $"{Problem.TypeBase}#payload-too-large",
+            Title = "Payload Too Large",
+            Status = StatusCodes.Status413PayloadTooLarge,
+            Detail = $"Request body exceeds the {_options.MaxBytes}-byte cap (got {advertisedLength}).",
+            Instance = httpContext.Request.Path.Value,
+        };
+        var traceId = Activity.Current?.TraceId.ToString();
+        if (!string.IsNullOrEmpty(traceId))
+            problem.Extensions["traceId"] = traceId;
+
+        httpContext.Response.StatusCode = StatusCodes.Status413PayloadTooLarge;
+        httpContext.Response.ContentType = Problem.ContentType;
+        await JsonSerializer.SerializeAsync(httpContext.Response.Body, problem);
+    }
+}

--- a/api/Options/RequestSizeLimitOptions.cs
+++ b/api/Options/RequestSizeLimitOptions.cs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.ComponentModel.DataAnnotations;
+
+namespace Lfm.Api.Options;
+
+/// <summary>
+/// Caps the size of inbound request bodies. The Azure Functions platform
+/// default is ~100 MB; the API never accepts payloads that large, so an
+/// earlier-in-the-pipeline guard keeps runaway uploads from burning RU
+/// or blob bandwidth. Fork operators can raise the cap by configuration
+/// if they need to accept larger payloads (e.g. image uploads) but the
+/// default is deliberately conservative.
+/// </summary>
+public sealed class RequestSizeLimitOptions
+{
+    public const string SectionName = "RequestSizeLimit";
+
+    /// <summary>
+    /// Maximum allowed <c>Content-Length</c> in bytes. Requests advertising
+    /// a larger body are rejected with 413 Payload Too Large before the
+    /// handler runs. Default is 64 KiB — larger than any legitimate write
+    /// on the current surface (the biggest being a full guild rank-permission
+    /// PATCH).
+    /// </summary>
+    [Range(1, int.MaxValue)]
+    public int MaxBytes { get; init; } = 65_536;
+}

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -19,6 +19,8 @@ var builder = FunctionsApplication.CreateBuilder(args);
 builder.ConfigureFunctionsWebApplication();
 builder.UseMiddleware<Lfm.Api.Middleware.CorsMiddleware>();
 builder.UseMiddleware<Lfm.Api.Middleware.SecurityHeadersMiddleware>();
+// Reject over-sized payloads before auth + handler work runs on them.
+builder.UseMiddleware<Lfm.Api.Middleware.RequestSizeLimitMiddleware>();
 builder.UseMiddleware<Lfm.Api.Middleware.RateLimitMiddleware>();
 builder.UseMiddleware<Lfm.Api.Middleware.AuditMiddleware>();
 builder.UseMiddleware<Lfm.Api.Middleware.AuthMiddleware>();
@@ -71,6 +73,10 @@ builder.Services.AddOptions<RateLimitOptions>()
     .Bind(builder.Configuration.GetSection(RateLimitOptions.SectionName));
 builder.Services.AddOptions<AgplOptions>()
     .Bind(builder.Configuration.GetSection(AgplOptions.SectionName));
+builder.Services.AddOptions<RequestSizeLimitOptions>()
+    .Bind(builder.Configuration.GetSection(RequestSizeLimitOptions.SectionName))
+    .ValidateDataAnnotations()
+    .ValidateOnStart();
 
 builder.Services.AddCors(options =>
 {

--- a/tests/Lfm.Api.Tests/Middleware/RequestSizeLimitMiddlewareTests.cs
+++ b/tests/Lfm.Api.Tests/Middleware/RequestSizeLimitMiddlewareTests.cs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Text;
+using System.Text.Json;
+using Lfm.Api.Middleware;
+using Lfm.Api.Options;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Middleware;
+using Moq;
+using Xunit;
+using MSOptions = Microsoft.Extensions.Options.Options;
+
+namespace Lfm.Api.Tests.Middleware;
+
+public class RequestSizeLimitMiddlewareTests
+{
+    private const string HttpContextKey = "HttpRequestContext";
+
+    private static (RequestSizeLimitMiddleware middleware, Mock<FunctionContext> context, DefaultHttpContext httpContext) CreateTestContext(
+        int maxBytes = 1024,
+        long? contentLength = null,
+        byte[]? body = null)
+    {
+        var httpContext = new DefaultHttpContext();
+        if (contentLength is long cl) httpContext.Request.ContentLength = cl;
+        if (body is not null) httpContext.Request.Body = new MemoryStream(body);
+        httpContext.Response.Body = new MemoryStream();
+
+        var items = new Dictionary<object, object> { [HttpContextKey] = httpContext };
+        var mockContext = new Mock<FunctionContext>();
+        mockContext.Setup(c => c.Items).Returns(items);
+
+        var options = MSOptions.Create(new RequestSizeLimitOptions { MaxBytes = maxBytes });
+        return (new RequestSizeLimitMiddleware(options), mockContext, httpContext);
+    }
+
+    [Fact]
+    public async Task Passes_through_when_content_length_within_cap()
+    {
+        var (middleware, ctx, httpContext) = CreateTestContext(maxBytes: 1024, contentLength: 500);
+        var nextCalled = false;
+        FunctionExecutionDelegate next = _ => { nextCalled = true; return Task.CompletedTask; };
+
+        await middleware.Invoke(ctx.Object, next);
+
+        Assert.True(nextCalled);
+        Assert.NotEqual(StatusCodes.Status413PayloadTooLarge, httpContext.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Passes_through_when_content_length_absent()
+    {
+        // GET / DELETE have no body and no Content-Length. The middleware must
+        // not reject these — that would break every read on the API.
+        var (middleware, ctx, httpContext) = CreateTestContext(maxBytes: 1024);
+        var nextCalled = false;
+        FunctionExecutionDelegate next = _ => { nextCalled = true; return Task.CompletedTask; };
+
+        await middleware.Invoke(ctx.Object, next);
+
+        Assert.True(nextCalled);
+    }
+
+    [Fact]
+    public async Task Rejects_413_when_content_length_exceeds_cap()
+    {
+        var (middleware, ctx, httpContext) = CreateTestContext(maxBytes: 1024, contentLength: 1025);
+        var nextCalled = false;
+        FunctionExecutionDelegate next = _ => { nextCalled = true; return Task.CompletedTask; };
+
+        await middleware.Invoke(ctx.Object, next);
+
+        Assert.False(nextCalled);
+        Assert.Equal(StatusCodes.Status413PayloadTooLarge, httpContext.Response.StatusCode);
+        Assert.Equal("application/problem+json", httpContext.Response.ContentType);
+    }
+
+    [Fact]
+    public async Task Emits_problem_json_with_type_uri_rooted_at_errors_slug()
+    {
+        var (middleware, ctx, httpContext) = CreateTestContext(maxBytes: 10, contentLength: 11);
+        FunctionExecutionDelegate next = _ => Task.CompletedTask;
+
+        await middleware.Invoke(ctx.Object, next);
+
+        httpContext.Response.Body.Position = 0;
+        using var doc = await JsonDocument.ParseAsync(httpContext.Response.Body);
+        Assert.Equal(
+            "https://github.com/lfm-org/lfm/errors#payload-too-large",
+            doc.RootElement.GetProperty("type").GetString());
+        Assert.Equal(413, doc.RootElement.GetProperty("status").GetInt32());
+    }
+
+    [Fact]
+    public async Task Passes_through_when_http_context_missing()
+    {
+        // Non-HTTP invocations (timer triggers) should never be rejected by
+        // this middleware. The guard must be a no-op on them.
+        var mockContext = new Mock<FunctionContext>();
+        mockContext.Setup(c => c.Items).Returns(new Dictionary<object, object>());
+        var options = MSOptions.Create(new RequestSizeLimitOptions { MaxBytes = 1024 });
+        var middleware = new RequestSizeLimitMiddleware(options);
+        var nextCalled = false;
+        FunctionExecutionDelegate next = _ => { nextCalled = true; return Task.CompletedTask; };
+
+        await middleware.Invoke(mockContext.Object, next);
+
+        Assert.True(nextCalled);
+    }
+}


### PR DESCRIPTION
## Summary

Slice 4.4 of the `review-api-precious-dewdrop` plan — adds a defense-in-depth guard that rejects oversize request bodies before any auth or handler work runs.

- `RequestSizeLimitMiddleware` inspects `Content-Length` and short-circuits with 413 Payload Too Large + `application/problem+json` when a request exceeds the cap. Requests without a `Content-Length` (GET / DELETE / chunked) pass through; chunked bodies aren't on the API surface today, and a later slice can add streaming accounting if that changes.
- `RequestSizeLimitOptions` (section `RequestSizeLimit`) exposes `MaxBytes` with `[Range(1, int.MaxValue)]` validation and a 64 KiB default — larger than any legitimate mutation on the current surface.
- The middleware is registered after `SecurityHeadersMiddleware` and before `RateLimitMiddleware` so error responses still pick up the security headers and source notice but we don't count over-cap requests against the IP's rate budget.

Fixes **SAD-rel-no-body-size-cap**.

## Test plan

- [x] `dotnet build lfm.sln -c Release`
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` (521 pass, +5 new covering within-cap pass-through, missing Content-Length pass-through, over-cap 413, problem+json shape, and non-HTTP invocation pass-through)
