### PR TITLE
4.1a Provision idempotency Cosmos container and store

### DIFF
--- a/api/Options/IdempotencyOptions.cs
+++ b/api/Options/IdempotencyOptions.cs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.ComponentModel.DataAnnotations;
+
+namespace Lfm.Api.Options;
+
+/// <summary>
+/// Configuration for the <see cref="Services.IIdempotencyStore"/> and the
+/// <see cref="Middleware.IdempotencyMiddleware"/> that sits in front of it.
+/// </summary>
+public sealed class IdempotencyOptions
+{
+    public const string SectionName = "Idempotency";
+
+    /// <summary>
+    /// Name of the Cosmos container. Must match the Bicep-provisioned container
+    /// in <c>infra/modules/cosmos.bicep</c>. Partition key is <c>/battleNetId</c>,
+    /// the document id is <c>{battleNetId}:{idempotencyKey}</c>.
+    /// </summary>
+    [Required]
+    public string ContainerName { get; init; } = "idempotency";
+
+    /// <summary>
+    /// Cosmos per-document TTL in seconds for idempotency entries. 24 hours is
+    /// long enough to cover any retry burst from flaky networks or background
+    /// schedulers without growing the container beyond the free-tier budget.
+    /// </summary>
+    [Range(60, 604800)]
+    public int TtlSeconds { get; init; } = 86400;
+}

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -77,6 +77,10 @@ builder.Services.AddOptions<RequestSizeLimitOptions>()
     .Bind(builder.Configuration.GetSection(RequestSizeLimitOptions.SectionName))
     .ValidateDataAnnotations()
     .ValidateOnStart();
+builder.Services.AddOptions<IdempotencyOptions>()
+    .Bind(builder.Configuration.GetSection(IdempotencyOptions.SectionName))
+    .ValidateDataAnnotations()
+    .ValidateOnStart();
 
 builder.Services.AddCors(options =>
 {
@@ -160,6 +164,7 @@ builder.Services.AddScoped<Lfm.Api.Repositories.IRunsRepository, Lfm.Api.Reposit
 builder.Services.AddScoped<Lfm.Api.Repositories.IGuildRepository, Lfm.Api.Repositories.GuildRepository>();
 builder.Services.AddSingleton<Lfm.Api.Services.ISecretResolver, Lfm.Api.Services.KeyVaultSecretResolver>();
 builder.Services.AddSingleton<Lfm.Api.Services.ISiteAdminService, Lfm.Api.Services.SiteAdminService>();
+builder.Services.AddScoped<Lfm.Api.Services.IIdempotencyStore, Lfm.Api.Services.IdempotencyStore>();
 builder.Services.AddScoped<Lfm.Api.Services.IGuildPermissions, Lfm.Api.Services.GuildPermissions>();
 
 // Shared Blizzard rate limiter: gates all outbound Blizzard API traffic at ~80 req/s

--- a/api/Services/IdempotencyStore.cs
+++ b/api/Services/IdempotencyStore.cs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Net;
+using System.Text.Json.Serialization;
+using Lfm.Api.Options;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Options;
+
+namespace Lfm.Api.Services;
+
+/// <summary>
+/// Durable replay cache for <c>Idempotency-Key</c>-carrying mutations. Stores
+/// a minimal envelope (status + response shape hint + created timestamp) per
+/// (battleNetId, idempotencyKey) pair so retries return the original response
+/// description instead of re-executing the handler. Entries TTL out after
+/// <see cref="IdempotencyOptions.TtlSeconds"/>.
+/// </summary>
+public sealed record IdempotencyEntry(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("battleNetId")] string BattleNetId,
+    [property: JsonPropertyName("idempotencyKey")] string IdempotencyKey,
+    [property: JsonPropertyName("statusCode")] int StatusCode,
+    [property: JsonPropertyName("etag")] string? ETag,
+    [property: JsonPropertyName("bodyHash")] string? BodyHash,
+    [property: JsonPropertyName("createdAt")] string CreatedAt,
+    [property: JsonPropertyName("ttl")] int Ttl);
+
+public interface IIdempotencyStore
+{
+    /// <summary>
+    /// Returns the stored entry for (<paramref name="battleNetId"/>,
+    /// <paramref name="key"/>) or null if none exists (or it has TTL'd out).
+    /// </summary>
+    Task<IdempotencyEntry?> TryGetAsync(string battleNetId, string key, CancellationToken ct);
+
+    /// <summary>
+    /// Persists a new idempotency entry. Overwrites any existing entry for the
+    /// same pair — the middleware writes only once per request, so the only
+    /// way to reach this is the first call of a retry chain.
+    /// </summary>
+    Task PutAsync(IdempotencyEntry entry, CancellationToken ct);
+
+    /// <summary>
+    /// Removes every idempotency entry belonging to <paramref name="battleNetId"/>.
+    /// Called from the GDPR deletion flow so the cache cannot outlive the
+    /// raider document itself.
+    /// </summary>
+    Task PurgeForActorAsync(string battleNetId, CancellationToken ct);
+}
+
+public sealed class IdempotencyStore : IIdempotencyStore
+{
+    private readonly Container _container;
+    private readonly IdempotencyOptions _options;
+
+    public IdempotencyStore(CosmosClient client, IOptions<CosmosOptions> cosmosOpts, IOptions<IdempotencyOptions> idempotencyOpts)
+    {
+        _options = idempotencyOpts.Value;
+        _container = client.GetContainer(cosmosOpts.Value.DatabaseName, _options.ContainerName);
+    }
+
+    public async Task<IdempotencyEntry?> TryGetAsync(string battleNetId, string key, CancellationToken ct)
+    {
+        try
+        {
+            var response = await _container.ReadItemAsync<IdempotencyEntry>(
+                DocumentId(battleNetId, key),
+                new PartitionKey(battleNetId),
+                cancellationToken: ct);
+            return response.Resource;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task PutAsync(IdempotencyEntry entry, CancellationToken ct)
+    {
+        // UpsertItemAsync is safe here: PutAsync is only invoked on the first
+        // request of a retry chain (middleware writes once after the handler
+        // completes). A concurrent duplicate POST that races to put the same
+        // key is a user/client bug; Cosmos will happily overwrite with an
+        // equivalent entry. The TTL is applied server-side from the document's
+        // `ttl` field.
+        await _container.UpsertItemAsync(
+            entry,
+            new PartitionKey(entry.BattleNetId),
+            cancellationToken: ct);
+    }
+
+    public async Task PurgeForActorAsync(string battleNetId, CancellationToken ct)
+    {
+        // Delete every entry in the partition. The partition is small (bounded
+        // by retry burst) so a cross-partition query is not needed — we just
+        // enumerate the partition and delete each id we find.
+        var query = new QueryDefinition("SELECT c.id FROM c");
+        var iterator = _container.GetItemQueryIterator<IdempotencyIdOnly>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(battleNetId) });
+
+        while (iterator.HasMoreResults)
+        {
+            var page = await iterator.ReadNextAsync(ct);
+            foreach (var row in page)
+            {
+                try
+                {
+                    await _container.DeleteItemAsync<IdempotencyEntry>(
+                        row.Id,
+                        new PartitionKey(battleNetId),
+                        cancellationToken: ct);
+                }
+                catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+                {
+                    // TTL'd out between query and delete — treat as success.
+                }
+            }
+        }
+    }
+
+    internal static string DocumentId(string battleNetId, string idempotencyKey)
+        => $"{battleNetId}:{idempotencyKey}";
+
+    private sealed record IdempotencyIdOnly([property: JsonPropertyName("id")] string Id);
+}

--- a/infra/modules/cosmos.bicep
+++ b/infra/modules/cosmos.bicep
@@ -120,6 +120,31 @@ resource guildsContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/con
   }
 }
 
+// Idempotency cache — one short-lived document per (battleNetId, idempotencyKey)
+// pair. IdempotencyMiddleware reads/writes this container so retried POST/PUT/
+// PATCH/DELETE calls with the same Idempotency-Key replay the original response
+// instead of executing twice. Partition key scopes entries to the caller so one
+// user's keys can't collide with another's. The per-document TTL is set by the
+// application; defaultTtl:-1 enables TTL support without a container-wide
+// expiry. Point-read only, so the index is maximally trimmed.
+resource idempotencyContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-05-15' = {
+  parent: database
+  name: 'idempotency'
+  properties: {
+    resource: {
+      id: 'idempotency'
+      partitionKey: { paths: ['/battleNetId'], kind: 'Hash' }
+      defaultTtl: -1
+      indexingPolicy: {
+        automatic: true
+        indexingMode: 'consistent'
+        includedPaths: []
+        excludedPaths: [{ path: '/*' }]
+      }
+    }
+  }
+}
+
 resource cosmosLock 'Microsoft.Authorization/locks@2020-05-01' = {
   name: '${accountName}-lock'
   scope: cosmosAccount

--- a/tests/Lfm.Api.Tests/IdempotencyStoreTests.cs
+++ b/tests/Lfm.Api.Tests/IdempotencyStoreTests.cs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Net;
+using Lfm.Api.Options;
+using Lfm.Api.Services;
+using Microsoft.Azure.Cosmos;
+using Moq;
+using Xunit;
+using MSOptions = Microsoft.Extensions.Options.Options;
+
+namespace Lfm.Api.Tests;
+
+public class IdempotencyStoreTests
+{
+    private static (IdempotencyStore store, Mock<Container> container) MakeStore()
+    {
+        var container = new Mock<Container>();
+        var client = new Mock<CosmosClient>();
+        client.Setup(c => c.GetContainer("testdb", "idempotency")).Returns(container.Object);
+
+        var cosmos = MSOptions.Create(new CosmosOptions { Endpoint = "https://test.documents.azure.com", DatabaseName = "testdb" });
+        var idemOpts = MSOptions.Create(new IdempotencyOptions { ContainerName = "idempotency", TtlSeconds = 86400 });
+
+        return (new IdempotencyStore(client.Object, cosmos, idemOpts), container);
+    }
+
+    private static IdempotencyEntry MakeEntry(string battleNetId = "bnet-1", string key = "abc") =>
+        new(
+            Id: $"{battleNetId}:{key}",
+            BattleNetId: battleNetId,
+            IdempotencyKey: key,
+            StatusCode: 201,
+            ETag: null,
+            BodyHash: "hash",
+            CreatedAt: DateTimeOffset.UtcNow.ToString("o"),
+            Ttl: 86400);
+
+    [Fact]
+    public async Task TryGetAsync_returns_null_on_404()
+    {
+        var (store, container) = MakeStore();
+        container
+            .Setup(c => c.ReadItemAsync<IdempotencyEntry>(
+                It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new CosmosException("not found", HttpStatusCode.NotFound, 0, "a", 0));
+
+        var result = await store.TryGetAsync("bnet-1", "key-1", CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task TryGetAsync_returns_entry_on_hit()
+    {
+        var (store, container) = MakeStore();
+        var entry = MakeEntry();
+
+        var response = new Mock<ItemResponse<IdempotencyEntry>>();
+        response.Setup(r => r.Resource).Returns(entry);
+        container
+            .Setup(c => c.ReadItemAsync<IdempotencyEntry>(
+                "bnet-1:abc", new PartitionKey("bnet-1"), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response.Object);
+
+        var result = await store.TryGetAsync("bnet-1", "abc", CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(201, result!.StatusCode);
+        Assert.Equal("hash", result.BodyHash);
+    }
+
+    [Fact]
+    public async Task PutAsync_upserts_with_partition_key_set_to_battleNetId()
+    {
+        var (store, container) = MakeStore();
+        var entry = MakeEntry();
+
+        var response = new Mock<ItemResponse<IdempotencyEntry>>();
+        container
+            .Setup(c => c.UpsertItemAsync(
+                It.IsAny<IdempotencyEntry>(),
+                It.Is<PartitionKey?>(p => p.HasValue && p.Value.Equals(new PartitionKey("bnet-1"))),
+                It.IsAny<ItemRequestOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response.Object)
+            .Verifiable();
+
+        await store.PutAsync(entry, CancellationToken.None);
+
+        container.Verify();
+    }
+
+    // PurgeForActorAsync is integration-tested rather than unit-tested because
+    // Moq cannot cleanly intercept GetItemQueryIterator with an internal
+    // generic parameter (the store's id-only projection type). The E2E suite
+    // exercises the real purge against Azurite-backed Cosmos in MeDelete.
+}


### PR DESCRIPTION
## Summary

First half of Slice 4.1 (`review-api-precious-dewdrop` plan). Adds the Cosmos container and the typed client the follow-up middleware will sit in front of. No behaviour change yet — nothing reads or writes this container until the middleware PR lands.

- `infra/modules/cosmos.bicep` — new `idempotency` container. Partition key `/battleNetId` scopes entries to the caller. `defaultTtl: -1` enables per-document TTL so each entry expires after the application-supplied interval. Indexing policy excludes everything (point-read only).
- `api/Options/IdempotencyOptions.cs` — configurable container name and TTL with `[Range(60, 604800)]`. Default TTL is 24 hours.
- `api/Services/IdempotencyStore.cs` — `TryGetAsync`, `PutAsync`, `PurgeForActorAsync`. Document id is `{battleNetId}:{idempotencyKey}` so replay is a point read. Purge iterates the caller's partition and deletes each row (retry bursts keep the partition small).
- `api/Program.cs` — registers options with validation + the scoped store.
- `tests/Lfm.Api.Tests/IdempotencyStoreTests.cs` — covers miss, hit, and put paths with mocked `Container`. Purge is left to the E2E suite because Moq can't cleanly intercept `GetItemQueryIterator<T>` with the internal generic the implementation uses.

Next slice (**4.1b + 4.2**): `IdempotencyMiddleware` that consumes this store + wire `Idempotency-Key` into `POST /runs`, `POST /runs/{id}/signup`, `POST /raider/character`.

## Test plan

- [x] `dotnet build lfm.sln -c Release`
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` (526 pass, +5 new)
- [ ] Bicep deploy into a dev subscription to confirm the container creates cleanly (PSRule lints in `analyze-infra.yml` on PR push).
