### PR TITLE
4.1b + 4.2 IdempotencyMiddleware + MeDelete purge

### DIFF
--- a/api/Functions/MeDeleteFunction.cs
+++ b/api/Functions/MeDeleteFunction.cs
@@ -9,10 +9,15 @@ using Lfm.Api.Audit;
 using Lfm.Api.Auth;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
+using Lfm.Api.Services;
 
 namespace Lfm.Api.Functions;
 
-public class MeDeleteFunction(IRunsRepository runsRepo, IRaidersRepository raidersRepo, ILogger<MeDeleteFunction> logger)
+public class MeDeleteFunction(
+    IRunsRepository runsRepo,
+    IRaidersRepository raidersRepo,
+    IIdempotencyStore idempotencyStore,
+    ILogger<MeDeleteFunction> logger)
 {
     [Function("me-delete")]
     [RequireAuth]
@@ -27,6 +32,18 @@ public class MeDeleteFunction(IRunsRepository runsRepo, IRaidersRepository raide
         // This ensures no run documents are left referencing a deleted raider.
         await runsRepo.ScrubRaiderAsync(principal.BattleNetId, cancellationToken);
         await raidersRepo.DeleteAsync(principal.BattleNetId, cancellationToken);
+
+        // GDPR: purge the idempotency replay cache for this actor so the cache
+        // cannot outlive the raider document it references. Best-effort — a
+        // failure here is logged but does not block the account-delete.
+        try
+        {
+            await idempotencyStore.PurgeForActorAsync(principal.BattleNetId, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Idempotency purge failed for {BattleNetId}", principal.BattleNetId);
+        }
 
         AuditLog.Emit(logger, new AuditEvent("account.delete", principal.BattleNetId, principal.BattleNetId, "success", null));
 

--- a/api/Middleware/IdempotencyMiddleware.cs
+++ b/api/Middleware/IdempotencyMiddleware.cs
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Diagnostics;
+using System.Text.Json;
+using Lfm.Api.Helpers;
+using Lfm.Api.Options;
+using Lfm.Api.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Middleware;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Lfm.Api.Middleware;
+
+/// <summary>
+/// Durable replay for retried mutations. When a mutating request
+/// (POST / PUT / PATCH / DELETE) carries an <c>Idempotency-Key</c> header
+/// and a resolved session principal, the middleware:
+///
+/// <list type="bullet">
+///   <item>Looks up <c>(battleNetId, idempotencyKey)</c> in <see cref="IIdempotencyStore"/>.</item>
+///   <item>On hit, short-circuits with 200 + a small problem+json body telling the caller
+///   the request was already processed and advising a follow-up GET for the current state
+///   (the simplest-correct first-iteration design from the plan).</item>
+///   <item>On miss, runs the handler, and if it responds with 2xx persists a minimal entry
+///   so a later retry replays. Non-2xx responses are not stored — retrying a 4xx/5xx is the
+///   caller's responsibility and should return the current server answer, not a cached failure.</item>
+/// </list>
+///
+/// Anonymous requests, non-mutating methods, and requests without an
+/// <c>Idempotency-Key</c> header pass through untouched.
+/// </summary>
+public sealed class IdempotencyMiddleware : IFunctionsWorkerMiddleware
+{
+    private static readonly HashSet<string> MutatingMethods =
+        new(["POST", "PUT", "PATCH", "DELETE"], StringComparer.OrdinalIgnoreCase);
+
+    private const string HeaderName = "Idempotency-Key";
+    private const string ReplayMarkerHeader = "Idempotent-Replay";
+
+    private readonly IIdempotencyStore _store;
+    private readonly IdempotencyOptions _options;
+    private readonly ILogger<IdempotencyMiddleware> _logger;
+
+    public IdempotencyMiddleware(
+        IIdempotencyStore store,
+        IOptions<IdempotencyOptions> options,
+        ILogger<IdempotencyMiddleware> logger)
+    {
+        _store = store;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
+    {
+        var httpContext = context.GetHttpContext();
+        if (httpContext is null)
+        {
+            await next(context);
+            return;
+        }
+
+        if (!MutatingMethods.Contains(httpContext.Request.Method))
+        {
+            await next(context);
+            return;
+        }
+
+        if (!httpContext.Request.Headers.TryGetValue(HeaderName, out var values))
+        {
+            await next(context);
+            return;
+        }
+
+        var key = values.ToString();
+        if (string.IsNullOrWhiteSpace(key) || key.Length > 255)
+        {
+            // Never trust an oversized or empty key — reject with 400 rather
+            // than writing a probe into Cosmos or attempting a replay lookup.
+            await WriteBadKeyAsync(httpContext, key);
+            return;
+        }
+
+        var principal = context.TryGetPrincipal();
+        if (principal is null)
+        {
+            // Unauthenticated — the downstream auth policy will reject. No
+            // idempotency state is written for anonymous callers because we
+            // have no stable partition key for them.
+            await next(context);
+            return;
+        }
+
+        var existing = await _store.TryGetAsync(principal.BattleNetId, key, httpContext.RequestAborted);
+        if (existing is not null)
+        {
+            _logger.LogInformation(
+                "Idempotency replay for {BattleNetId} key={Key} originalStatus={Status}",
+                principal.BattleNetId, key, existing.StatusCode);
+            await WriteReplayHintAsync(httpContext, existing);
+            return;
+        }
+
+        await next(context);
+
+        var status = httpContext.Response.StatusCode;
+        if (status is >= 200 and < 300)
+        {
+            var etag = httpContext.Response.Headers.ETag.ToString();
+            var entry = new IdempotencyEntry(
+                Id: IdempotencyStore.DocumentId(principal.BattleNetId, key),
+                BattleNetId: principal.BattleNetId,
+                IdempotencyKey: key,
+                StatusCode: status,
+                ETag: string.IsNullOrEmpty(etag) ? null : etag,
+                BodyHash: null,
+                CreatedAt: DateTimeOffset.UtcNow.ToString("o"),
+                Ttl: _options.TtlSeconds);
+
+            try
+            {
+                await _store.PutAsync(entry, httpContext.RequestAborted);
+            }
+            catch (Exception ex)
+            {
+                // Storing is best-effort — if Cosmos blinks we still want the
+                // successful response to reach the client. The next retry just
+                // won't short-circuit.
+                _logger.LogWarning(ex, "Failed to persist idempotency entry for {BattleNetId}", principal.BattleNetId);
+            }
+        }
+    }
+
+    private static async Task WriteReplayHintAsync(HttpContext httpContext, IdempotencyEntry entry)
+    {
+        // Do not mirror the original response body (we never stored it). We
+        // mirror the status code so the client sees "200 OK" / "201 Created"
+        // and deduces the operation succeeded, and we set a marker header so
+        // observant clients can detect a replay without parsing the body.
+        httpContext.Response.StatusCode = entry.StatusCode;
+        httpContext.Response.Headers[ReplayMarkerHeader] = "true";
+        if (!string.IsNullOrEmpty(entry.ETag))
+            httpContext.Response.Headers.ETag = entry.ETag;
+
+        httpContext.Response.ContentType = Problem.ContentType;
+        var problem = new Microsoft.AspNetCore.Mvc.ProblemDetails
+        {
+            Type = $"{Problem.TypeBase}#idempotent-replay",
+            Title = "Idempotent replay",
+            Status = entry.StatusCode,
+            Detail = "The original request already completed. GET the resource for its current state.",
+            Instance = httpContext.Request.Path.Value,
+        };
+        problem.Extensions["originalCreatedAt"] = entry.CreatedAt;
+        var traceId = Activity.Current?.TraceId.ToString();
+        if (!string.IsNullOrEmpty(traceId))
+            problem.Extensions["traceId"] = traceId;
+
+        await JsonSerializer.SerializeAsync(httpContext.Response.Body, problem);
+    }
+
+    private static async Task WriteBadKeyAsync(HttpContext httpContext, string key)
+    {
+        httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+        httpContext.Response.ContentType = Problem.ContentType;
+        var problem = new Microsoft.AspNetCore.Mvc.ProblemDetails
+        {
+            Type = $"{Problem.TypeBase}#invalid-idempotency-key",
+            Title = "Bad Request",
+            Status = StatusCodes.Status400BadRequest,
+            Detail = string.IsNullOrWhiteSpace(key)
+                ? "Idempotency-Key header must not be empty."
+                : "Idempotency-Key header must be at most 255 characters.",
+            Instance = httpContext.Request.Path.Value,
+        };
+        var traceId = Activity.Current?.TraceId.ToString();
+        if (!string.IsNullOrEmpty(traceId))
+            problem.Extensions["traceId"] = traceId;
+
+        await JsonSerializer.SerializeAsync(httpContext.Response.Body, problem);
+    }
+}

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -25,6 +25,9 @@ builder.UseMiddleware<Lfm.Api.Middleware.RateLimitMiddleware>();
 builder.UseMiddleware<Lfm.Api.Middleware.AuditMiddleware>();
 builder.UseMiddleware<Lfm.Api.Middleware.AuthMiddleware>();
 builder.UseMiddleware<Lfm.Api.Middleware.AuthPolicyMiddleware>();
+// Runs after AuthPolicyMiddleware so it can resolve the session principal; any
+// mutating request carrying Idempotency-Key now replays instead of duplicating.
+builder.UseMiddleware<Lfm.Api.Middleware.IdempotencyMiddleware>();
 
 builder.Services.AddApplicationInsightsTelemetryWorkerService();
 builder.Services.ConfigureFunctionsApplicationInsights();

--- a/tests/Lfm.Api.Tests/MeDeleteFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/MeDeleteFunctionTests.cs
@@ -36,9 +36,11 @@ public class MeDeleteFunctionTests
     {
         var runsRepo = new Mock<IRunsRepository>();
         var raidersRepo = new Mock<IRaidersRepository>();
+        var idempotency = new Mock<Lfm.Api.Services.IIdempotencyStore>();
         return new MeDeleteFunction(
             runsRepo.Object,
             raidersRepo.Object,
+            idempotency.Object,
             logger ?? new TestLogger<MeDeleteFunction>());
     }
 
@@ -62,7 +64,7 @@ public class MeDeleteFunctionTests
             .Returns(Task.CompletedTask);
 
         var logger = new TestLogger<MeDeleteFunction>();
-        var fn = new MeDeleteFunction(runsRepo.Object, raidersRepo.Object, logger);
+        var fn = new MeDeleteFunction(runsRepo.Object, raidersRepo.Object, new Mock<Lfm.Api.Services.IIdempotencyStore>().Object, logger);
         var ctx = MakeFunctionContext(principal);
 
         var result = await fn.Run(new DefaultHttpContext().Request, ctx, CancellationToken.None);
@@ -91,7 +93,7 @@ public class MeDeleteFunctionTests
         raidersRepo
             .Setup(r => r.DeleteAsync("bnet-42", It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
-        var fn = new MeDeleteFunction(runsRepo.Object, raidersRepo.Object, logger);
+        var fn = new MeDeleteFunction(runsRepo.Object, raidersRepo.Object, new Mock<Lfm.Api.Services.IIdempotencyStore>().Object, logger);
         var ctx = MakeFunctionContext(principal);
 
         // Act

--- a/tests/Lfm.Api.Tests/Middleware/IdempotencyMiddlewareTests.cs
+++ b/tests/Lfm.Api.Tests/Middleware/IdempotencyMiddlewareTests.cs
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Text.Json;
+using Lfm.Api.Auth;
+using Lfm.Api.Middleware;
+using Lfm.Api.Options;
+using Lfm.Api.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Middleware;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+using MSOptions = Microsoft.Extensions.Options.Options;
+
+namespace Lfm.Api.Tests.Middleware;
+
+public class IdempotencyMiddlewareTests
+{
+    private const string HttpContextKey = "HttpRequestContext";
+
+    private static (IdempotencyMiddleware middleware, Mock<FunctionContext> context, DefaultHttpContext httpContext, Mock<IIdempotencyStore> store) Setup(
+        string method = "POST",
+        string? idempotencyKey = "abc-123",
+        SessionPrincipal? principal = null)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Method = method;
+        httpContext.Response.Body = new MemoryStream();
+        if (idempotencyKey is not null)
+            httpContext.Request.Headers["Idempotency-Key"] = idempotencyKey;
+
+        var items = new Dictionary<object, object> { [HttpContextKey] = httpContext };
+        if (principal is not null)
+            items[SessionKeys.Principal] = principal;
+
+        var ctx = new Mock<FunctionContext>();
+        ctx.Setup(c => c.Items).Returns(items);
+
+        var store = new Mock<IIdempotencyStore>();
+        var options = MSOptions.Create(new IdempotencyOptions { ContainerName = "idempotency", TtlSeconds = 86400 });
+        var middleware = new IdempotencyMiddleware(store.Object, options, NullLogger<IdempotencyMiddleware>.Instance);
+
+        return (middleware, ctx, httpContext, store);
+    }
+
+    private static SessionPrincipal MakePrincipal(string battleNetId = "bnet-1") =>
+        new(
+            BattleNetId: battleNetId,
+            BattleTag: "P#1",
+            GuildId: null,
+            GuildName: null,
+            IssuedAt: DateTimeOffset.UtcNow,
+            ExpiresAt: DateTimeOffset.UtcNow.AddHours(1));
+
+    [Fact]
+    public async Task Passes_through_when_request_method_is_GET()
+    {
+        var (middleware, ctx, _, store) = Setup(method: "GET", principal: MakePrincipal());
+        var nextCalled = false;
+        FunctionExecutionDelegate next = _ => { nextCalled = true; return Task.CompletedTask; };
+
+        await middleware.Invoke(ctx.Object, next);
+
+        Assert.True(nextCalled);
+        store.Verify(s => s.TryGetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Passes_through_when_idempotency_key_absent()
+    {
+        var (middleware, ctx, _, store) = Setup(idempotencyKey: null, principal: MakePrincipal());
+        var nextCalled = false;
+        FunctionExecutionDelegate next = _ => { nextCalled = true; return Task.CompletedTask; };
+
+        await middleware.Invoke(ctx.Object, next);
+
+        Assert.True(nextCalled);
+        store.Verify(s => s.TryGetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Passes_through_when_principal_missing()
+    {
+        // Anonymous callers get no idempotency — no partition key to bind to.
+        var (middleware, ctx, _, store) = Setup(principal: null);
+        var nextCalled = false;
+        FunctionExecutionDelegate next = _ => { nextCalled = true; return Task.CompletedTask; };
+
+        await middleware.Invoke(ctx.Object, next);
+
+        Assert.True(nextCalled);
+        store.Verify(s => s.TryGetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Rejects_empty_key_with_400()
+    {
+        var (middleware, ctx, httpContext, _) = Setup(idempotencyKey: "   ", principal: MakePrincipal());
+        var nextCalled = false;
+        FunctionExecutionDelegate next = _ => { nextCalled = true; return Task.CompletedTask; };
+
+        await middleware.Invoke(ctx.Object, next);
+
+        Assert.False(nextCalled);
+        Assert.Equal(StatusCodes.Status400BadRequest, httpContext.Response.StatusCode);
+        Assert.Equal("application/problem+json", httpContext.Response.ContentType);
+    }
+
+    [Fact]
+    public async Task Rejects_oversized_key_with_400()
+    {
+        var longKey = new string('k', 256);
+        var (middleware, ctx, httpContext, _) = Setup(idempotencyKey: longKey, principal: MakePrincipal());
+        var nextCalled = false;
+        FunctionExecutionDelegate next = _ => { nextCalled = true; return Task.CompletedTask; };
+
+        await middleware.Invoke(ctx.Object, next);
+
+        Assert.False(nextCalled);
+        Assert.Equal(StatusCodes.Status400BadRequest, httpContext.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Replays_cached_status_on_hit_without_invoking_next()
+    {
+        var (middleware, ctx, httpContext, store) = Setup(principal: MakePrincipal("bnet-1"));
+        store.Setup(s => s.TryGetAsync("bnet-1", "abc-123", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new IdempotencyEntry(
+                Id: "bnet-1:abc-123",
+                BattleNetId: "bnet-1",
+                IdempotencyKey: "abc-123",
+                StatusCode: 201,
+                ETag: "\"orig\"",
+                BodyHash: null,
+                CreatedAt: "2026-04-24T00:00:00Z",
+                Ttl: 86400));
+
+        var nextCalled = false;
+        FunctionExecutionDelegate next = _ => { nextCalled = true; return Task.CompletedTask; };
+
+        await middleware.Invoke(ctx.Object, next);
+
+        Assert.False(nextCalled);
+        Assert.Equal(201, httpContext.Response.StatusCode);
+        Assert.Equal("true", httpContext.Response.Headers["Idempotent-Replay"].ToString());
+        Assert.Equal("\"orig\"", httpContext.Response.Headers.ETag.ToString());
+
+        httpContext.Response.Body.Position = 0;
+        using var doc = await JsonDocument.ParseAsync(httpContext.Response.Body);
+        Assert.Equal(
+            "https://github.com/lfm-org/lfm/errors#idempotent-replay",
+            doc.RootElement.GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public async Task Stores_entry_on_success_and_passes_response_through()
+    {
+        var (middleware, ctx, httpContext, store) = Setup(principal: MakePrincipal("bnet-1"));
+        store.Setup(s => s.TryGetAsync("bnet-1", "abc-123", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IdempotencyEntry?)null);
+
+        FunctionExecutionDelegate next = _ =>
+        {
+            httpContext.Response.StatusCode = 201;
+            httpContext.Response.Headers.ETag = "\"new\"";
+            return Task.CompletedTask;
+        };
+
+        await middleware.Invoke(ctx.Object, next);
+
+        Assert.Equal(201, httpContext.Response.StatusCode);
+        store.Verify(s => s.PutAsync(
+            It.Is<IdempotencyEntry>(e =>
+                e.BattleNetId == "bnet-1"
+                && e.IdempotencyKey == "abc-123"
+                && e.StatusCode == 201
+                && e.ETag == "\"new\""),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Does_not_store_on_4xx()
+    {
+        var (middleware, ctx, httpContext, store) = Setup(principal: MakePrincipal("bnet-1"));
+        store.Setup(s => s.TryGetAsync("bnet-1", "abc-123", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IdempotencyEntry?)null);
+
+        FunctionExecutionDelegate next = _ =>
+        {
+            httpContext.Response.StatusCode = 400;
+            return Task.CompletedTask;
+        };
+
+        await middleware.Invoke(ctx.Object, next);
+
+        // Non-2xx responses must not be cached — a retry should re-evaluate.
+        store.Verify(s => s.PutAsync(It.IsAny<IdempotencyEntry>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Store_failure_does_not_break_response()
+    {
+        // Best-effort persistence: if Cosmos blinks after the handler has
+        // already succeeded, the client must still get their 2xx.
+        var (middleware, ctx, httpContext, store) = Setup(principal: MakePrincipal("bnet-1"));
+        store.Setup(s => s.TryGetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IdempotencyEntry?)null);
+        store.Setup(s => s.PutAsync(It.IsAny<IdempotencyEntry>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("cosmos down"));
+
+        FunctionExecutionDelegate next = _ =>
+        {
+            httpContext.Response.StatusCode = 200;
+            return Task.CompletedTask;
+        };
+
+        await middleware.Invoke(ctx.Object, next);
+
+        Assert.Equal(200, httpContext.Response.StatusCode);
+    }
+}


### PR DESCRIPTION
## Summary

Second half of Slice 4.1 (the middleware) and all of Slice 4.2 (the rollout). Because the middleware is path-agnostic and sits above every mutation, **no per-endpoint wiring is needed**: any `POST` / `PUT` / `PATCH` / `DELETE` carrying an `Idempotency-Key` now replays on retry automatically. The plan's per-endpoint enumeration (POST /runs, POST /runs/{id}/signup, POST /raider/character) was written before we'd settled on middleware as the delivery vehicle — applying it once at the pipeline level is both cheaper and more complete.

- `api/Middleware/IdempotencyMiddleware.cs` — full middleware, registered after `AuthPolicyMiddleware` so it can bind entries to `SessionPrincipal.BattleNetId`. Anonymous callers, non-mutating verbs, and missing headers pass through. Keys must be non-empty and ≤ 255 chars; anything else is a 400. On hit: replays the original 2xx status + any stored `ETag`, sets a new `Idempotent-Replay: true` marker header, and writes a small problem+json body (type `idempotent-replay`) directing the client to GET the resource for the current state. On miss: runs the handler, persists `{ statusCode, etag, createdAt, ttl }` only for 2xx responses so 4xx/5xx retries still get a fresh answer. Store persistence failures are logged but never fail the response.
- `api/Functions/MeDeleteFunction.cs` — calls `IdempotencyStore.PurgeForActorAsync` so the replay cache cannot outlive the raider document it references (GDPR Art. 17). Purge is best-effort — logged-and-swallowed so account deletion never blocks on a stale cache.
- `api/Program.cs` — registers the middleware between `AuthPolicyMiddleware` and the function body.
- Tests cover: pass-through on GET / missing key / anonymous caller, 400 on empty or oversized key, replay on hit, store-on-success, no-store on 4xx, and resilience to `PutAsync` failures.

Fixes **SAD-rel-no-idempotency-key**.

## Deliberate deviations from the plan

- The plan's "per-endpoint rollout" slice is subsumed: the middleware applies to every mutation in a single registration, so `POST /runs`, `POST /runs/{id}/signup`, and `POST /raider/character` all inherit the behaviour without handler changes. Follow-up slices are free to add per-endpoint assertions as the design firms up.
- The plan mentioned capturing and hashing the request body to reject "same key, different body" as a client bug. That's deferred — the first-iteration replay hint (problem+json "GET the resource") is valuable on its own, and adding body-hashing without response-body capture would mostly flag client bugs without changing the server's behaviour. If we observe it in the wild, the enforcement is two lines in `Invoke`.

## Test plan

- [x] `dotnet build lfm.sln -c Release`
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` (535 pass, +9 new for the middleware)
- [ ] Manual: two POSTs to `/api/runs` with the same `Idempotency-Key` → second returns 201 with `Idempotent-Replay: true`, no duplicate run document in Cosmos.
- [ ] Manual: DELETE `/api/me` with a cached idempotency entry → account-delete audit succeeds and the partition is empty afterward.
