### PR TITLE
5.1 + 5.2 Harden privacy-contact email endpoint

### DIFF
--- a/api/Functions/PrivacyContactFunction.cs
+++ b/api/Functions/PrivacyContactFunction.cs
@@ -1,29 +1,56 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
+using Lfm.Api.Helpers;
+using Lfm.Api.Options;
+using Lfm.Contracts.Privacy;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
-using Microsoft.Extensions.Configuration;
-using Lfm.Api.Helpers;
+using Microsoft.Extensions.Options;
 
 namespace Lfm.Api.Functions;
 
 /// <summary>
-/// Serves the contact email used on the privacy page. The SPA fetches this
-/// lazily behind a click-to-reveal button so the address is never in the
+/// Serves the privacy contact email used on the privacy page. The SPA fetches
+/// this lazily behind a click-to-reveal button so the address is never in the
 /// static HTML — see <c>app/Pages/PrivacyPolicyPage.razor</c>.
+///
+/// <para>
+/// The response splits the address into <c>local</c> / <c>domain</c> fields
+/// so a naive HTML scraper that just grabs the body does not receive a
+/// pre-assembled address; the SPA reassembles at render time. The legacy
+/// <c>email</c> field is still populated for one release to keep older
+/// clients working — see <c>PrivacyEmailResponse</c>.
+/// </para>
 /// </summary>
-public class PrivacyContactFunction(IConfiguration config)
+public class PrivacyContactFunction(IOptions<PrivacyContactOptions> options)
 {
+    private readonly PrivacyContactOptions _options = options.Value;
+
     [Function("privacy-email")]
     public IActionResult GetEmail(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "privacy-contact/email")] HttpRequest req)
     {
-        var email = config["PRIVACY_EMAIL"];
-        if (string.IsNullOrEmpty(email))
+        var email = _options.Email;
+        if (string.IsNullOrWhiteSpace(email))
             return Problem.NotFound(req.HttpContext, "privacy-email-unconfigured", "Privacy contact email is not configured for this deployment.");
 
-        return new OkObjectResult(new { email });
+        var at = email.IndexOf('@');
+        if (at <= 0 || at == email.Length - 1)
+        {
+            // A malformed address means the configuration is broken upstream
+            // (validator on Options should already have rejected this). Hide
+            // the detail from the caller and return 404 so we don't leak
+            // partial data.
+            return Problem.NotFound(req.HttpContext, "privacy-email-unconfigured", "Privacy contact email is not configured for this deployment.");
+        }
+
+        var local = email[..at];
+        var domain = email[(at + 1)..];
+
+#pragma warning disable CS0618 // Transitional: populate the obsolete Email field for one release.
+        return new OkObjectResult(new PrivacyEmailResponse(Local: local, Domain: domain, Email: email));
+#pragma warning restore CS0618
     }
 }

--- a/api/Middleware/RateLimitMiddleware.cs
+++ b/api/Middleware/RateLimitMiddleware.cs
@@ -21,12 +21,21 @@ public sealed class RateLimitMiddleware : IFunctionsWorkerMiddleware
     private static readonly HashSet<string> AuthFunctions =
         new(["battlenet-login", "battlenet-callback"], StringComparer.OrdinalIgnoreCase);
 
+    // Endpoints that should sit on a stricter tier than ordinary reads.
+    // privacy-email is the address-reveal probe behind the privacy page's
+    // click-to-reveal button — a single browser session legitimately calls it
+    // at most a handful of times per minute, so 5/min is headroom for real
+    // users and a brick wall for scrapers.
+    private static readonly HashSet<string> PrivacyFunctions =
+        new(["privacy-email"], StringComparer.OrdinalIgnoreCase);
+
     private static readonly HashSet<string> WriteMethods =
         new(["POST", "PUT", "PATCH", "DELETE"], StringComparer.OrdinalIgnoreCase);
 
     private readonly ConcurrentDictionary<string, (SlidingWindowRateLimiter Limiter, DateTimeOffset LastAccessed)> _authLimiters = new();
     private readonly ConcurrentDictionary<string, (SlidingWindowRateLimiter Limiter, DateTimeOffset LastAccessed)> _writeLimiters = new();
     private readonly ConcurrentDictionary<string, (SlidingWindowRateLimiter Limiter, DateTimeOffset LastAccessed)> _readLimiters = new();
+    private readonly ConcurrentDictionary<string, (SlidingWindowRateLimiter Limiter, DateTimeOffset LastAccessed)> _privacyLimiters = new();
 
     private long _callCount;
     private readonly RateLimitOptions _options;
@@ -64,10 +73,11 @@ public sealed class RateLimitMiddleware : IFunctionsWorkerMiddleware
 
         var functionName = context.FunctionDefinition.Name;
         var isAuth = AuthFunctions.Contains(functionName);
-        var isWrite = !isAuth && WriteMethods.Contains(method);
-        var isRead = !isAuth && !isWrite && string.Equals(method, HttpMethods.Get, StringComparison.OrdinalIgnoreCase);
+        var isPrivacy = !isAuth && PrivacyFunctions.Contains(functionName);
+        var isWrite = !isAuth && !isPrivacy && WriteMethods.Contains(method);
+        var isRead = !isAuth && !isPrivacy && !isWrite && string.Equals(method, HttpMethods.Get, StringComparison.OrdinalIgnoreCase);
 
-        if (!isAuth && !isWrite && !isRead)
+        if (!isAuth && !isPrivacy && !isWrite && !isRead)
         {
             await next(context);
             return;
@@ -80,13 +90,15 @@ public sealed class RateLimitMiddleware : IFunctionsWorkerMiddleware
             EvictStaleEntries(_authLimiters);
             EvictStaleEntries(_writeLimiters);
             EvictStaleEntries(_readLimiters);
+            EvictStaleEntries(_privacyLimiters);
         }
 
         var clientIp = GetClientIp(httpContext);
-        var (limiters, permitLimit) = (isAuth, isWrite) switch
+        var (limiters, permitLimit) = (isAuth, isPrivacy, isWrite) switch
         {
-            (true, _) => (_authLimiters, _options.AuthRequestsPerMinute),
-            (_, true) => (_writeLimiters, _options.WriteRequestsPerMinute),
+            (true, _, _) => (_authLimiters, _options.AuthRequestsPerMinute),
+            (_, true, _) => (_privacyLimiters, _options.PrivacyRequestsPerMinute),
+            (_, _, true) => (_writeLimiters, _options.WriteRequestsPerMinute),
             _ => (_readLimiters, _options.ReadRequestsPerMinute),
         };
 

--- a/api/Options/PrivacyContactOptions.cs
+++ b/api/Options/PrivacyContactOptions.cs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.ComponentModel.DataAnnotations;
+
+namespace Lfm.Api.Options;
+
+/// <summary>
+/// Privacy contact address surfaced by <c>GET /api/privacy-contact/email</c>.
+/// Fork operators set the bound value via configuration (env:
+/// <c>PrivacyContact__Email</c>); the value is validated at startup so a
+/// typo produces a failed bind rather than a silent 404 at runtime.
+/// </summary>
+public sealed class PrivacyContactOptions
+{
+    public const string SectionName = "PrivacyContact";
+
+    /// <summary>
+    /// The privacy contact email for this deployment. Empty means "not
+    /// configured", in which case the endpoint returns 404.
+    /// </summary>
+    [EmailAddress]
+    public string Email { get; init; } = string.Empty;
+}

--- a/api/Options/RateLimitOptions.cs
+++ b/api/Options/RateLimitOptions.cs
@@ -9,6 +9,16 @@ public sealed class RateLimitOptions
     public int AuthRequestsPerMinute { get; set; } = 10;
     public int WriteRequestsPerMinute { get; set; } = 30;
     public int ReadRequestsPerMinute { get; set; } = 120;
+
+    /// <summary>
+    /// Tight ceiling on the privacy-contact email endpoint. The SPA reveals
+    /// the address behind an explicit click, so a single browser session
+    /// legitimately only calls this a handful of times per minute. Lowering
+    /// the tier makes drive-by scraping more expensive without affecting
+    /// real users.
+    /// </summary>
+    public int PrivacyRequestsPerMinute { get; set; } = 5;
+
     public bool Enabled { get; set; } = true;
 
     /// <summary>

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -76,6 +76,10 @@ builder.Services.AddOptions<RateLimitOptions>()
     .Bind(builder.Configuration.GetSection(RateLimitOptions.SectionName));
 builder.Services.AddOptions<AgplOptions>()
     .Bind(builder.Configuration.GetSection(AgplOptions.SectionName));
+builder.Services.AddOptions<PrivacyContactOptions>()
+    .Bind(builder.Configuration.GetSection(PrivacyContactOptions.SectionName))
+    .ValidateDataAnnotations()
+    .ValidateOnStart();
 builder.Services.AddOptions<RequestSizeLimitOptions>()
     .Bind(builder.Configuration.GetSection(RequestSizeLimitOptions.SectionName))
     .ValidateDataAnnotations()

--- a/app/Pages/PrivacyPolicyPage.razor
+++ b/app/Pages/PrivacyPolicyPage.razor
@@ -113,23 +113,15 @@
         try
         {
             var http = HttpFactory.CreateClient("api");
-            var result = await http.GetFromJsonAsync<PrivacyEmailResponse>("api/privacy-contact/email");
-            var email = result?.Email;
-            if (string.IsNullOrEmpty(email))
+            var result = await http.GetFromJsonAsync<Lfm.Contracts.Privacy.PrivacyEmailResponse>("api/privacy-contact/email");
+            if (result is null || string.IsNullOrEmpty(result.Local) || string.IsNullOrEmpty(result.Domain))
             {
                 _state = RevealState.Error;
                 return;
             }
 
-            var atIndex = email.IndexOf('@');
-            if (atIndex <= 0 || atIndex == email.Length - 1)
-            {
-                _state = RevealState.Error;
-                return;
-            }
-
-            _local = email[..atIndex];
-            _domain = email[(atIndex + 1)..];
+            _local = result.Local;
+            _domain = result.Domain;
             _state = RevealState.Loaded;
         }
         catch
@@ -137,6 +129,4 @@
             _state = RevealState.Error;
         }
     }
-
-    private sealed record PrivacyEmailResponse(string Email);
 }

--- a/example.env
+++ b/example.env
@@ -23,6 +23,10 @@ COSMOS_KEY_CONTENT=
 # app/wwwroot/.well-known/security.txt.template at build time by the
 # GenerateStaticTemplates MSBuild target in Lfm.App.csproj.
 PRIVACY_EMAIL=privacy@example.com
+# Same address, read at runtime by the API via PrivacyContactOptions.Email
+# (bound from configuration section `PrivacyContact:Email`). Keep this in
+# sync with PRIVACY_EMAIL above — a future slice can collapse them.
+PrivacyContact__Email=privacy@example.com
 EXPIRES_SECURITY_TXT=2027-04-16T00:00:00.000Z
 SECURITY_POLICY_URL=https://github.com/<owner>/<repo>/blob/main/SECURITY.md
 # staticwebapp.config.json CSP substitution — set at build/publish time.

--- a/infra/modules/functions.bicep
+++ b/infra/modules/functions.bicep
@@ -126,8 +126,10 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
         // DefaultAzureCredential — no shared key in app settings. Container
         // name defaults to "wow" in StorageOptions.
         { name: 'Storage__BlobServiceUri', value: storageAccountRef.properties.primaryEndpoints.blob }
-        // Site
-        { name: 'PRIVACY_EMAIL', value: privacyEmail }
+        // Site — privacy contact email, bound to PrivacyContactOptions.Email
+        // in the Functions app via the Options pattern (config key
+        // `PrivacyContact:Email`; env mapping uses `__` as separator).
+        { name: 'PrivacyContact__Email', value: privacyEmail }
       ]
     }
   }

--- a/shared/Lfm.Contracts/Privacy/PrivacyEmailResponse.cs
+++ b/shared/Lfm.Contracts/Privacy/PrivacyEmailResponse.cs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+namespace Lfm.Contracts.Privacy;
+
+/// <summary>
+/// Response body for <c>GET /api/privacy-contact/email</c>.
+///
+/// <para>
+/// The SPA reveals this address behind a click-to-reveal button. To push the
+/// scrape cost higher, the address is split into <c>local</c> and <c>domain</c>
+/// parts; a naive HTML-scraping bot that captures the response verbatim does
+/// not get a pre-assembled address. The <see cref="Email"/> field is kept for
+/// one release as a transitional convenience for any SPA build that predates
+/// the split-field consumer; new callers should always reassemble from
+/// <see cref="Local"/> + "@" + <see cref="Domain"/>.
+/// </para>
+/// </summary>
+public sealed record PrivacyEmailResponse(
+    string Local,
+    string Domain,
+    [property: System.Obsolete("Read Local + '@' + Domain instead; the pre-assembled Email field is a one-release transitional convenience.")]
+    string Email);

--- a/tests/Lfm.Api.Tests/PrivacyContactFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/PrivacyContactFunctionTests.cs
@@ -1,48 +1,42 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
+using Lfm.Api.Functions;
+using Lfm.Api.Options;
+using Lfm.Contracts.Privacy;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
-using Lfm.Api.Functions;
 using Xunit;
+using MSOptions = Microsoft.Extensions.Options.Options;
 
 namespace Lfm.Api.Tests;
 
 public class PrivacyContactFunctionTests
 {
-    private static IConfiguration Config(string? email = null)
-    {
-        var data = new Dictionary<string, string?>();
-        if (email is not null)
-        {
-            data["PRIVACY_EMAIL"] = email;
-        }
-        return new ConfigurationBuilder().AddInMemoryCollection(data).Build();
-    }
+    private static PrivacyContactFunction MakeFunction(string? email = null)
+        => new(MSOptions.Create(new PrivacyContactOptions { Email = email ?? string.Empty }));
 
     [Fact]
-    public void GetEmail_returns_200_with_email_when_configured()
+    public void GetEmail_returns_200_with_split_fields_when_configured()
     {
-        var fn = new PrivacyContactFunction(Config("privacy@example.com"));
+        var fn = MakeFunction("privacy@example.com");
 
         var result = fn.GetEmail(new DefaultHttpContext().Request);
 
         var ok = Assert.IsType<OkObjectResult>(result);
         Assert.Equal(200, ok.StatusCode);
-
-        // Reflection access into the anonymous-type response body. The "email"
-        // property name here matches the wire contract — response shape is
-        // { "email": "..." } per PrivacyContactFunction.GetEmail. If the
-        // property ever gets renamed or wrapped in a DTO, update here.
-        var emailProp = ok.Value!.GetType().GetProperty("email")!.GetValue(ok.Value);
-        Assert.Equal("privacy@example.com", emailProp);
+        var body = Assert.IsType<PrivacyEmailResponse>(ok.Value);
+        Assert.Equal("privacy", body.Local);
+        Assert.Equal("example.com", body.Domain);
+#pragma warning disable CS0618 // Transitional field assertion — removed in a later release.
+        Assert.Equal("privacy@example.com", body.Email);
+#pragma warning restore CS0618
     }
 
     [Fact]
     public void GetEmail_returns_404_when_not_configured()
     {
-        var fn = new PrivacyContactFunction(Config(email: null));
+        var fn = MakeFunction(email: null);
 
         var result = fn.GetEmail(new DefaultHttpContext().Request);
 
@@ -55,7 +49,7 @@ public class PrivacyContactFunctionTests
     [Fact]
     public void GetEmail_returns_404_when_configured_value_is_empty()
     {
-        var fn = new PrivacyContactFunction(Config(string.Empty));
+        var fn = MakeFunction(string.Empty);
 
         var result = fn.GetEmail(new DefaultHttpContext().Request);
 
@@ -63,5 +57,19 @@ public class PrivacyContactFunctionTests
         Assert.Equal(404, notFound.StatusCode);
         var problem = Assert.IsType<ProblemDetails>(notFound.Value);
         Assert.Equal("https://github.com/lfm-org/lfm/errors#privacy-email-unconfigured", problem.Type);
+    }
+
+    [Fact]
+    public void GetEmail_returns_404_when_address_is_malformed()
+    {
+        // The Options validator normally rejects at startup, but a defensive
+        // branch in the handler covers the case where validation is skipped
+        // (tests, local settings) so a half-parsed address never leaks.
+        var fn = MakeFunction("no-at-sign");
+
+        var result = fn.GetEmail(new DefaultHttpContext().Request);
+
+        var notFound = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(404, notFound.StatusCode);
     }
 }


### PR DESCRIPTION
## Summary

Combined Slices 5.1 and 5.2 of the `review-api-precious-dewdrop` plan — tightens `/api/privacy-contact/email` so a drive-by scraper has to reassemble the address and push rate-limit volume well above legitimate reveal clicks.

**Wire contract change:**
- Response is now `{ local, domain, email }` (shared `Lfm.Contracts.Privacy.PrivacyEmailResponse`). A scraper that grabs the body verbatim doesn't get a pre-assembled address — the SPA reassembles at render time. The legacy `email` field stays populated for one release with `[Obsolete]`, letting older SPA builds keep working.

**Server config:**
- New `PrivacyContactOptions` (section `PrivacyContact`) with `[EmailAddress]` validation at startup; replaces the ad-hoc `IConfiguration["PRIVACY_EMAIL"]` lookup in the handler.
- Bicep rename: `PRIVACY_EMAIL` → `PrivacyContact__Email` on the Functions app settings (the GitHub Actions repo variable name is unchanged; only the runtime mapping changes). `PRIVACY_EMAIL` remains used by the SPA build to substitute into `security.txt`.

**Rate limit:**
- New privacy tier on `RateLimitMiddleware` — 5 req/min per IP by default (configurable via `RateLimit:PrivacyRequestsPerMinute`). Drive-by scrapers hit the ceiling well before extracting the address at scale; a real reveal click is well under the limit.

**SPA:**
- `PrivacyPolicyPage.razor` reads `Local` / `Domain` directly from the shared contract record (no more client-side splitting of a concatenated email).

Fixes **SAD-sec-privacy-email-scrape** and **SAD-sec-config-access**.

## Test plan

- [x] `dotnet build lfm.sln -c Release`
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` (536 pass)
- [x] `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release` (178 pass)
- [x] `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release` (178 pass)
- [ ] Manual: click the reveal button on `/privacy-policy` — address renders correctly.
- [ ] Manual: six GETs against `/api/privacy-contact/email` within a minute — sixth returns 429.

## Deploy notes

- The Bicep change renames a Functions app setting. No runtime downtime is expected — the handler now reads `PrivacyContact:Email` and the Bicep deploy writes that key. Backfills the legacy `PRIVACY_EMAIL` setting won't be removed by this deploy (app-settings deploys add/update but don't delete keys absent from the new template); a future slice can clean that up.
