### PR TITLE
5.3 Hash AuditActorId before structured logging

### DIFF
--- a/api/Audit/AuditLog.cs
+++ b/api/Audit/AuditLog.cs
@@ -1,18 +1,47 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
+using Lfm.Api.Services;
 using Microsoft.Extensions.Logging;
 
 namespace Lfm.Api.Audit;
 
+/// <summary>
+/// Writes audit events as structured logs. Actor identifiers are passed
+/// through an <see cref="IActorHasher"/> before emission so the plaintext
+/// battleNetId never reaches Application Insights.
+///
+/// <para>
+/// The hasher is an ambient static dependency installed once from
+/// <c>Program.cs</c> via <see cref="ConfigureHasher"/>. The default is an
+/// <see cref="IdentityActorHasher"/> that returns the raw id — fine for
+/// unit tests, which assert on the plaintext value. Production wiring
+/// swaps to an <see cref="HmacActorHasher"/> keyed from
+/// <c>AuditOptions.HashSalt</c>, so any deployed environment logs hex
+/// digests instead of plaintext.
+/// </para>
+/// </summary>
 public static class AuditLog
 {
+    private static IActorHasher _hasher = new IdentityActorHasher();
+
+    /// <summary>
+    /// Installs the hasher used for every subsequent <see cref="Emit"/>
+    /// call. Called once at startup from <c>Program.cs</c>; never from
+    /// application code paths.
+    /// </summary>
+    public static void ConfigureHasher(IActorHasher hasher)
+    {
+        _hasher = hasher;
+    }
+
     public static void Emit(ILogger logger, AuditEvent evt)
     {
+        var actor = _hasher.Hash(evt.ActorId);
         logger.LogInformation(
             "Audit: {AuditAction} actor={AuditActorId} target={AuditTargetId} result={AuditResult} detail={AuditDetail}",
             evt.Action,
-            evt.ActorId,
+            actor,
             evt.TargetId ?? "-",
             evt.Result,
             evt.Detail ?? "-");

--- a/api/Options/AuditOptions.cs
+++ b/api/Options/AuditOptions.cs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+namespace Lfm.Api.Options;
+
+/// <summary>
+/// Audit-log privacy knobs. The only setting today is the salt used to
+/// hash actor battleNetIds before they reach Application Insights. Produced
+/// hashes are a stable HMAC-SHA-256 hex string bound to the configured
+/// salt — correlatable across log entries within a deployment but not
+/// reversible to the plaintext battleNetId.
+/// </summary>
+public sealed class AuditOptions
+{
+    public const string SectionName = "Audit";
+
+    /// <summary>
+    /// HMAC key for hashing actor identifiers. Produce with
+    /// <c>openssl rand -base64 32</c>, store in Key Vault, and wire to this
+    /// setting via a <c>@Microsoft.KeyVault(...)</c> reference in Bicep.
+    /// Leaving this empty disables hashing — actor ids are logged as
+    /// plaintext. Acceptable in local dev; MUST be set in any deployed
+    /// environment that ingests logs to App Insights.
+    /// </summary>
+    public string HashSalt { get; init; } = string.Empty;
+}

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -80,6 +80,8 @@ builder.Services.AddOptions<PrivacyContactOptions>()
     .Bind(builder.Configuration.GetSection(PrivacyContactOptions.SectionName))
     .ValidateDataAnnotations()
     .ValidateOnStart();
+builder.Services.AddOptions<AuditOptions>()
+    .Bind(builder.Configuration.GetSection(AuditOptions.SectionName));
 builder.Services.AddOptions<RequestSizeLimitOptions>()
     .Bind(builder.Configuration.GetSection(RequestSizeLimitOptions.SectionName))
     .ValidateDataAnnotations()
@@ -174,6 +176,20 @@ builder.Services.AddSingleton<Lfm.Api.Services.ISiteAdminService, Lfm.Api.Servic
 builder.Services.AddScoped<Lfm.Api.Services.IIdempotencyStore, Lfm.Api.Services.IdempotencyStore>();
 builder.Services.AddScoped<Lfm.Api.Services.IGuildPermissions, Lfm.Api.Services.GuildPermissions>();
 
+// Audit-log actor hasher. If a salt is configured we HMAC-hash every
+// AuditActorId before it reaches Application Insights; otherwise (local
+// dev, tests) we fall back to logging the raw id. Selected here so the
+// singleton can be disposed with the process.
+builder.Services.AddSingleton<Lfm.Api.Services.IActorHasher>(sp =>
+{
+    var auditOpts = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<AuditOptions>>().Value;
+    if (string.IsNullOrEmpty(auditOpts.HashSalt))
+    {
+        return new Lfm.Api.Services.IdentityActorHasher();
+    }
+    return new Lfm.Api.Services.HmacActorHasher(auditOpts.HashSalt);
+});
+
 // Shared Blizzard rate limiter: gates all outbound Blizzard API traffic at ~80 req/s
 // sustained to stay well under the 100 req/s upstream limit, with 200-slot queue.
 builder.Services.AddSingleton<Lfm.Api.Services.IBlizzardRateLimiter>(_ => new Lfm.Api.Services.BlizzardRateLimiter());
@@ -261,4 +277,13 @@ else
 
 builder.Services.AddSingleton<ISessionCipher, DataProtectionSessionCipher>();
 
-builder.Build().Run();
+var app = builder.Build();
+
+// Install the audit-log actor hasher before the host starts firing handlers.
+// The static AuditLog service picks up the DI-selected hasher (HMAC in any
+// deployed environment where AuditOptions.HashSalt is set, Identity in tests
+// and local dev) so every subsequent AuditLog.Emit call hashes the actor id.
+Lfm.Api.Audit.AuditLog.ConfigureHasher(
+    app.Services.GetRequiredService<Lfm.Api.Services.IActorHasher>());
+
+app.Run();

--- a/api/Services/IActorHasher.cs
+++ b/api/Services/IActorHasher.cs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Lfm.Api.Services;
+
+/// <summary>
+/// Maps raw actor identifiers (battleNetIds) to an opaque, stable,
+/// non-reversible hash suitable for telemetry. Instances are injected into
+/// <see cref="Audit.AuditLog"/> at startup and used for the structured
+/// <c>AuditActorId</c> property emitted to Application Insights.
+/// </summary>
+public interface IActorHasher
+{
+    /// <summary>
+    /// Returns the hashed representation of <paramref name="actorId"/>.
+    /// Empty or null input is returned verbatim as <c>"-"</c> so downstream
+    /// log fields never carry an empty string.
+    /// </summary>
+    string Hash(string? actorId);
+}
+
+/// <summary>
+/// No-op hasher for tests and local dev: returns the raw actor id. All
+/// existing structural log assertions continue to pass because they expect
+/// the plaintext battleNetId on <c>AuditActorId</c>.
+/// </summary>
+public sealed class IdentityActorHasher : IActorHasher
+{
+    public string Hash(string? actorId) =>
+        string.IsNullOrEmpty(actorId) ? "-" : actorId;
+}
+
+/// <summary>
+/// HMAC-SHA-256 hasher keyed by a configured salt. Produces a deterministic
+/// lowercase hex string per actor, so repeated events for the same user
+/// correlate in App Insights while the plaintext battleNetId never leaves
+/// the application.
+/// </summary>
+public sealed class HmacActorHasher : IActorHasher, IDisposable
+{
+    private readonly HMACSHA256 _hmac;
+
+    public HmacActorHasher(string salt)
+    {
+        if (string.IsNullOrEmpty(salt))
+            throw new ArgumentException("Salt must not be empty.", nameof(salt));
+        _hmac = new HMACSHA256(Encoding.UTF8.GetBytes(salt));
+    }
+
+    public string Hash(string? actorId)
+    {
+        if (string.IsNullOrEmpty(actorId))
+            return "-";
+        var bytes = _hmac.ComputeHash(Encoding.UTF8.GetBytes(actorId));
+        return Convert.ToHexStringLower(bytes);
+    }
+
+    public void Dispose() => _hmac.Dispose();
+}

--- a/tests/Lfm.Api.Tests/Audit/AuditLogTests.cs
+++ b/tests/Lfm.Api.Tests/Audit/AuditLogTests.cs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Audit;
+using Lfm.Api.Services;
+using Xunit;
+
+namespace Lfm.Api.Tests.Audit;
+
+/// <summary>
+/// Regression tests for the actor-hashing behaviour installed by
+/// <see cref="AuditLog.ConfigureHasher"/>. These tests are collection-serial
+/// because <see cref="AuditLog"/> holds the hasher as a static field; running
+/// them in parallel with other tests that inspect audit output would race.
+/// </summary>
+[Collection(nameof(AuditLogHasherCollection))]
+public class AuditLogTests : IDisposable
+{
+    public AuditLogTests()
+    {
+        // Snapshot — not exposed, so we reinstall the default (identity) after.
+    }
+
+    public void Dispose()
+    {
+        // Restore the identity hasher so tests in other files continue to see
+        // the plaintext actor id they assert on today.
+        AuditLog.ConfigureHasher(new IdentityActorHasher());
+    }
+
+    [Fact]
+    public void Emit_logs_hashed_actor_when_HmacHasher_installed()
+    {
+        using var hasher = new HmacActorHasher("audit-test-salt");
+        AuditLog.ConfigureHasher(hasher);
+
+        var logger = new TestLogger<AuditLogTests>();
+        AuditLog.Emit(logger, new AuditEvent("test.action", "bnet-42", "target-7", "success", null));
+
+        var entry = Assert.Single(logger.Entries);
+        var actorId = (string)entry.Properties["AuditActorId"]!;
+        Assert.Equal(64, actorId.Length);
+        Assert.Matches("^[0-9a-f]+$", actorId);
+        Assert.NotEqual("bnet-42", actorId);
+    }
+
+    [Fact]
+    public void Emit_logs_raw_actor_under_IdentityHasher_default()
+    {
+        AuditLog.ConfigureHasher(new IdentityActorHasher());
+
+        var logger = new TestLogger<AuditLogTests>();
+        AuditLog.Emit(logger, new AuditEvent("test.action", "bnet-42", null, "success", null));
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal("bnet-42", entry.Properties["AuditActorId"]);
+    }
+}
+
+[CollectionDefinition(nameof(AuditLogHasherCollection), DisableParallelization = true)]
+public sealed class AuditLogHasherCollection
+{
+    // Marker — mutating the AuditLog static hasher must not run in parallel
+    // with any other audit-log assertions. xUnit collections that opt in via
+    // [Collection(nameof(AuditLogHasherCollection))] are serialized.
+}

--- a/tests/Lfm.Api.Tests/Services/ActorHasherTests.cs
+++ b/tests/Lfm.Api.Tests/Services/ActorHasherTests.cs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Services;
+using Xunit;
+
+namespace Lfm.Api.Tests.Services;
+
+public class ActorHasherTests
+{
+    [Fact]
+    public void IdentityHasher_returns_raw_id()
+    {
+        var hasher = new IdentityActorHasher();
+
+        Assert.Equal("bnet-1", hasher.Hash("bnet-1"));
+    }
+
+    [Fact]
+    public void IdentityHasher_substitutes_empty_with_dash()
+    {
+        var hasher = new IdentityActorHasher();
+
+        Assert.Equal("-", hasher.Hash(""));
+        Assert.Equal("-", hasher.Hash(null));
+    }
+
+    [Fact]
+    public void HmacHasher_produces_lowercase_hex_sha256_length()
+    {
+        using var hasher = new HmacActorHasher("super-secret-salt");
+
+        var result = hasher.Hash("bnet-42");
+
+        Assert.Equal(64, result.Length); // 32 bytes → 64 hex chars
+        Assert.Matches("^[0-9a-f]+$", result);
+    }
+
+    [Fact]
+    public void HmacHasher_is_deterministic_per_salt()
+    {
+        using var a = new HmacActorHasher("salt-one");
+        using var b = new HmacActorHasher("salt-one");
+
+        Assert.Equal(a.Hash("bnet-42"), b.Hash("bnet-42"));
+    }
+
+    [Fact]
+    public void HmacHasher_produces_distinct_output_per_salt()
+    {
+        using var a = new HmacActorHasher("salt-one");
+        using var b = new HmacActorHasher("salt-two");
+
+        Assert.NotEqual(a.Hash("bnet-42"), b.Hash("bnet-42"));
+    }
+
+    [Fact]
+    public void HmacHasher_substitutes_empty_with_dash()
+    {
+        using var hasher = new HmacActorHasher("salt");
+
+        Assert.Equal("-", hasher.Hash(""));
+        Assert.Equal("-", hasher.Hash(null));
+    }
+
+    [Fact]
+    public void HmacHasher_rejects_empty_salt()
+    {
+        Assert.Throws<ArgumentException>(() => new HmacActorHasher(""));
+    }
+}


### PR DESCRIPTION
## Summary

Slice 5.3 of the `review-api-precious-dewdrop` plan — pushes actor ids through an HMAC before they reach Application Insights so the plaintext battleNetId never leaves the application.

- `api/Services/IActorHasher.cs` — `IdentityActorHasher` (raw pass-through, tests / local dev) and `HmacActorHasher` (HMAC-SHA-256, lowercase hex output, keyed by the configured salt).
- `api/Options/AuditOptions.cs` — `HashSalt` setting. Empty = identity hasher; non-empty = HMAC.
- `api/Audit/AuditLog.cs` — ambient static hasher installed once at startup via `ConfigureHasher`. Every subsequent `Emit` passes `ActorId` through the hasher before the structured `AuditActorId` property is written. Default stays identity so all 23 existing call sites and their test assertions keep working; prod wiring flips it to HMAC.
- `api/Program.cs` — registers the hasher (HMAC when salt configured, Identity otherwise) and installs it on `AuditLog` right before `app.Run()`.
- Tests: a new `Services/ActorHasherTests` covers the HMAC primitive (determinism-per-salt, cross-salt distinctness, hex format, 64-char output, empty-salt rejection); a new `Audit/AuditLogTests` serialised into a disabled-parallelism collection covers the ambient-hasher swap so tests that modify it can't race other audit assertions.

Fixes **SAD-sec-pii-in-telemetry** (code-side half — D0.4 chose salted-hash only, so Slice 5.4's telemetry-purge workflow is deliberately out of scope).

## Follow-up

A small Bicep change will wire `AuditOptions.HashSalt` through a Key Vault reference (`@Microsoft.KeyVault(VaultName=…;SecretName=audit-hash-salt)`) and ensure the Functions app's managed identity has the existing `Key Vault Secrets User` role (it already does, for Battle.net secrets). That deploy change is additive and does not block shipping this PR — with no salt configured the handler logs raw ids (current behaviour), and installing the salt in a follow-up deploy flips every subsequent audit event to HMAC output.

## Test plan

- [x] `dotnet build lfm.sln -c Release`
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` (545 pass, +9 new)
- [ ] Manual: configure `Audit:HashSalt`, POST `/api/runs`, verify the emitted `AuditActorId` in App Insights is a 64-char lowercase hex string.
