### PR TITLE
5.5 SPA Source link + SPDX attribution fix

### DIFF
--- a/app/Layout/MainLayout.razor
+++ b/app/Layout/MainLayout.razor
@@ -88,10 +88,16 @@
         @Body
     </main>
 
-    <!-- Footer with privacy link and language toggle -->
+    <!-- Footer with privacy link, AGPL §13 source link, and language toggle.
+         The "Source" anchor discharges the AGPL §13 obligation to prominently
+         offer the Corresponding Source to every user interacting over the
+         network. Fork operators: override SourceRepositoryUrl in
+         appsettings.json to point at your modified source repository. -->
     <footer style="border-top:1px solid var(--neutral-stroke-rest);padding:8px 16px">
         <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="8" Wrap="true" Style="align-items:center;justify-content:center">
             <FluentAnchor Href="/privacy">@Loc["footer.privacyPolicy"]</FluentAnchor>
+            <span>|</span>
+            <FluentAnchor Href="@_sourceUrl" Target="_blank" rel="noopener external">@Loc["footer.source"]</FluentAnchor>
             <span>|</span>
             <FluentButton Appearance="Appearance.Stealth"
                           OnClick="@(() => LocaleService.SetLocale("en"))"
@@ -108,11 +114,14 @@
 </div>
 
 @code {
+    private const string DefaultSourceRepositoryUrl = "https://github.com/lfm-org/lfm";
+
     private bool _showMobileMenu;
     private bool _navigated;
     private ElementReference _mainRef;
     private string _themeIcon = "\u2600\ufe0f";
     private string _themeTooltip = string.Empty;
+    private string _sourceUrl = DefaultSourceRepositoryUrl;
 
     protected override void OnInitialized()
     {
@@ -120,6 +129,15 @@
         ThemeService.OnChange += OnThemeChanged;
         LocaleService.OnLocaleChanged += HandleLocaleChanged;
         UpdateThemeDisplay();
+
+        // Resolve the AGPL source URL from config. Fork operators override
+        // SourceRepositoryUrl in appsettings.json (or via environment) to
+        // satisfy AGPL \u00a713 on their deployment.
+        var configured = Config["SourceRepositoryUrl"];
+        if (!string.IsNullOrWhiteSpace(configured))
+        {
+            _sourceUrl = configured;
+        }
     }
 
     private void UpdateThemeDisplay()

--- a/app/wwwroot/appsettings.json
+++ b/app/wwwroot/appsettings.json
@@ -1,5 +1,6 @@
 {
   "ApiBaseUrl": "http://localhost:7183",
+  "SourceRepositoryUrl": "https://github.com/lfm-org/lfm",
   "Logging": {
     "LogLevel": {
       "Default": "Warning",

--- a/app/wwwroot/locales/en.json
+++ b/app/wwwroot/locales/en.json
@@ -242,6 +242,7 @@
     "notFound.body": "Sorry, the content you are looking for does not exist.",
 
     "footer.privacyPolicy": "Privacy Notice",
+    "footer.source": "Source",
     "nav.toggleMenu": "Toggle navigation menu",
 
     "theme.switchToLight": "Switch to light mode",

--- a/app/wwwroot/locales/fi.json
+++ b/app/wwwroot/locales/fi.json
@@ -221,6 +221,7 @@
     "notFound.title": "Ei l\u00f6ytynyt",
     "notFound.body": "Sivua ei l\u00f6ydy.",
     "footer.privacyPolicy": "Tietosuojaseloste",
+    "footer.source": "Lähdekoodi",
     "nav.toggleMenu": "Vaihda navigointivalikko",
     "theme.switchToLight": "Vaihda vaaleaan tilaan",
     "theme.switchToDark": "Vaihda tummaan tilaan",

--- a/scripts/archi-render.sh
+++ b/scripts/archi-render.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-FileCopyrightText: 2026 Sour Old Geezer
+# SPDX-FileCopyrightText: 2026 LFM contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
 # Render every view in an ArchiMate OEF XML file as a PNG using Archi's


### PR DESCRIPTION
## Summary

Slice 5.5 of the `review-api-precious-dewdrop` plan — discharges the AGPL §13 obligation in the SPA's footer and fixes an attribution glitch you spotted in `scripts/archi-render.sh`.

**AGPL §13 source link:**
- `MainLayout.razor` footer now includes a `Source` anchor alongside the privacy link. Opens in a new tab with `rel="noopener external"`.
- `appsettings.json` gains `SourceRepositoryUrl: "https://github.com/lfm-org/lfm"`. Fork operators override this setting (or the equivalent environment variable) to point at their own modified source repository.
- `footer.source` added to `en.json` ("Source") and `fi.json` ("Lähdekoodi").

**SPDX attribution fix:**
- `scripts/archi-render.sh` line 2 now reads `# SPDX-FileCopyrightText: 2026 LFM contributors`, matching every other file in the repo. The previous value (`Sour Old Geezer`) appears to have been a copy-paste slip when the script was first committed.

## Test plan

- [x] `dotnet build lfm.sln -c Release`
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- [x] `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release` (178 pass)
- [ ] Manual: load any page, confirm the Source link appears in the footer and navigates to the GitHub repo in a new tab.
