### PR TITLE
6.1 Log Cosmos RequestCharge on every repo op

### DIFF
--- a/api/Repositories/CosmosRequestChargeLogger.cs
+++ b/api/Repositories/CosmosRequestChargeLogger.cs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging;
+
+namespace Lfm.Api.Repositories;
+
+/// <summary>
+/// Structured-logging helpers for Cosmos <c>RequestCharge</c>. Emitting the
+/// RU cost of every point-read, write, and query page into Application
+/// Insights gives an at-a-glance view of which endpoints are expensive and
+/// which partitions are hot — essential visibility on the free-tier 1000
+/// RU/s ceiling. Log structure is deliberately minimal (op, container, pk,
+/// ru) so the fields are indexable and queryable without parsing message
+/// text.
+/// </summary>
+internal static class CosmosRequestChargeLogger
+{
+    public static void LogRequestCharge<T>(this ILogger logger, ItemResponse<T> response, string op, string container, string partitionKey)
+    {
+        logger.LogInformation(
+            "Cosmos op={CosmosOp} container={CosmosContainer} pk={CosmosPartitionKey} ru={CosmosRequestCharge}",
+            op, container, partitionKey, response.RequestCharge);
+    }
+
+    public static void LogRequestCharge<T>(this ILogger logger, FeedResponse<T> response, string op, string container, string partitionKey)
+    {
+        logger.LogInformation(
+            "Cosmos op={CosmosOp} container={CosmosContainer} pk={CosmosPartitionKey} ru={CosmosRequestCharge}",
+            op, container, partitionKey, response.RequestCharge);
+    }
+
+    /// <summary>
+    /// Logs an accumulated <paramref name="requestCharge"/> for a multi-page
+    /// cross-partition query. Callers sum the per-page charges themselves
+    /// (one call per loop) and pass the total here so App Insights gets a
+    /// single row per logical query rather than one per page.
+    /// </summary>
+    public static void LogRequestChargeTotal(this ILogger logger, string op, string container, double requestCharge)
+    {
+        logger.LogInformation(
+            "Cosmos op={CosmosOp} container={CosmosContainer} pk={CosmosPartitionKey} ru={CosmosRequestCharge}",
+            op, container, "*cross-partition*", requestCharge);
+    }
+}

--- a/api/Repositories/GuildRepository.cs
+++ b/api/Repositories/GuildRepository.cs
@@ -2,12 +2,13 @@
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
 using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Lfm.Api.Options;
 
 namespace Lfm.Api.Repositories;
 
-public sealed class GuildRepository(CosmosClient client, IOptions<CosmosOptions> cosmosOpts) : IGuildRepository
+public sealed class GuildRepository(CosmosClient client, IOptions<CosmosOptions> cosmosOpts, ILogger<GuildRepository> logger) : IGuildRepository
 {
     private const string ContainerName = "guilds";
     private readonly Container _container = client.GetContainer(cosmosOpts.Value.DatabaseName, ContainerName);
@@ -20,6 +21,7 @@ public sealed class GuildRepository(CosmosClient client, IOptions<CosmosOptions>
                 guildId,
                 new PartitionKey(guildId),
                 cancellationToken: ct);
+            logger.LogRequestCharge(response, "read", ContainerName, guildId);
             return response.Resource with { ETag = response.ETag };
         }
         catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
@@ -30,10 +32,11 @@ public sealed class GuildRepository(CosmosClient client, IOptions<CosmosOptions>
 
     public async Task UpsertAsync(GuildDocument doc, CancellationToken ct)
     {
-        await _container.UpsertItemAsync(
+        var response = await _container.UpsertItemAsync(
             doc,
             new PartitionKey(doc.Id),
             cancellationToken: ct);
+        logger.LogRequestCharge(response, "upsert", ContainerName, doc.Id);
     }
 
     public async Task<GuildDocument> ReplaceAsync(GuildDocument doc, string ifMatchEtag, CancellationToken ct)
@@ -47,6 +50,7 @@ public sealed class GuildRepository(CosmosClient client, IOptions<CosmosOptions>
                 new PartitionKey(doc.Id),
                 options,
                 ct);
+            logger.LogRequestCharge(response, "replace", ContainerName, doc.Id);
             return response.Resource with { ETag = response.ETag };
         }
         catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)

--- a/api/Repositories/RaidersRepository.cs
+++ b/api/Repositories/RaidersRepository.cs
@@ -2,12 +2,13 @@
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
 using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Lfm.Api.Options;
 
 namespace Lfm.Api.Repositories;
 
-public sealed class RaidersRepository(CosmosClient client, IOptions<CosmosOptions> cosmosOpts) : IRaidersRepository
+public sealed class RaidersRepository(CosmosClient client, IOptions<CosmosOptions> cosmosOpts, ILogger<RaidersRepository> logger) : IRaidersRepository
 {
     private const string ContainerName = "raiders";
     private readonly Container _container = client.GetContainer(cosmosOpts.Value.DatabaseName, ContainerName);
@@ -20,6 +21,7 @@ public sealed class RaidersRepository(CosmosClient client, IOptions<CosmosOption
                 battleNetId,
                 new PartitionKey(battleNetId),
                 cancellationToken: ct);
+            logger.LogRequestCharge(response, "read", ContainerName, battleNetId);
             return response.Resource with { ETag = response.ETag };
         }
         catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
@@ -30,10 +32,11 @@ public sealed class RaidersRepository(CosmosClient client, IOptions<CosmosOption
 
     public async Task UpsertAsync(RaiderDocument raider, CancellationToken ct)
     {
-        await _container.UpsertItemAsync(
+        var response = await _container.UpsertItemAsync(
             raider,
             new PartitionKey(raider.BattleNetId),
             cancellationToken: ct);
+        logger.LogRequestCharge(response, "upsert", ContainerName, raider.BattleNetId);
     }
 
     public async Task<RaiderDocument> ReplaceAsync(RaiderDocument raider, string ifMatchEtag, CancellationToken ct)
@@ -47,6 +50,7 @@ public sealed class RaidersRepository(CosmosClient client, IOptions<CosmosOption
                 new PartitionKey(raider.BattleNetId),
                 options,
                 ct);
+            logger.LogRequestCharge(response, "replace", ContainerName, raider.BattleNetId);
             return response.Resource with { ETag = response.ETag };
         }
         catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
@@ -59,10 +63,11 @@ public sealed class RaidersRepository(CosmosClient client, IOptions<CosmosOption
     {
         try
         {
-            await _container.DeleteItemAsync<RaiderDocument>(
+            var response = await _container.DeleteItemAsync<RaiderDocument>(
                 battleNetId,
                 new PartitionKey(battleNetId),
                 cancellationToken: ct);
+            logger.LogRequestCharge(response, "delete", ContainerName, battleNetId);
         }
         catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
         {
@@ -84,11 +89,14 @@ public sealed class RaidersRepository(CosmosClient client, IOptions<CosmosOption
             new QueryDefinition(query).WithParameter("@cutoff", cutoff));
 
         var results = new List<RaiderDocument>();
+        var totalRu = 0.0;
         while (feedIterator.HasMoreResults)
         {
             var page = await feedIterator.ReadNextAsync(ct);
+            totalRu += page.RequestCharge;
             results.AddRange(page);
         }
+        logger.LogRequestChargeTotal("list-expired", ContainerName, totalRu);
         return results;
     }
 }

--- a/api/Repositories/RunsRepository.cs
+++ b/api/Repositories/RunsRepository.cs
@@ -2,13 +2,14 @@
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
 using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Lfm.Api.Helpers;
 using Lfm.Api.Options;
 
 namespace Lfm.Api.Repositories;
 
-public sealed class RunsRepository(CosmosClient client, IOptions<CosmosOptions> cosmosOpts) : IRunsRepository
+public sealed class RunsRepository(CosmosClient client, IOptions<CosmosOptions> cosmosOpts, ILogger<RunsRepository> logger) : IRunsRepository
 {
     private const string ContainerName = "runs";
     private readonly Container _container = client.GetContainer(cosmosOpts.Value.DatabaseName, ContainerName);
@@ -74,6 +75,7 @@ public sealed class RunsRepository(CosmosClient client, IOptions<CosmosOptions> 
             return new RunsPage(Array.Empty<RunDocument>(), null);
 
         var response = await feedIterator.ReadNextAsync(ct);
+        logger.LogRequestChargeTotal("query-page", ContainerName, response.RequestCharge);
         var items = response.ToList();
         return new RunsPage(items, response.ContinuationToken);
     }
@@ -88,6 +90,7 @@ public sealed class RunsRepository(CosmosClient client, IOptions<CosmosOptions> 
                 id,
                 new PartitionKey(id),
                 cancellationToken: ct);
+            logger.LogRequestCharge(response, "read", ContainerName, id);
             return response.Resource with { ETag = response.ETag };
         }
         catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
@@ -102,6 +105,7 @@ public sealed class RunsRepository(CosmosClient client, IOptions<CosmosOptions> 
             run,
             new PartitionKey(run.Id),
             cancellationToken: ct);
+        logger.LogRequestCharge(response, "create", ContainerName, run.Id);
         return response.Resource;
     }
 
@@ -119,6 +123,7 @@ public sealed class RunsRepository(CosmosClient client, IOptions<CosmosOptions> 
                 new PartitionKey(run.Id),
                 options,
                 ct);
+            logger.LogRequestCharge(response, "replace", ContainerName, run.Id);
             return response.Resource with { ETag = response.ETag };
         }
         catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
@@ -131,10 +136,11 @@ public sealed class RunsRepository(CosmosClient client, IOptions<CosmosOptions> 
     {
         try
         {
-            await _container.DeleteItemAsync<RunDocument>(
+            var response = await _container.DeleteItemAsync<RunDocument>(
                 id,
                 new PartitionKey(id),
                 cancellationToken: ct);
+            logger.LogRequestCharge(response, "delete", ContainerName, id);
         }
         catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
         {
@@ -157,11 +163,14 @@ public sealed class RunsRepository(CosmosClient client, IOptions<CosmosOptions> 
                 .WithParameter("@battleNetId", battleNetId));
 
         var runs = new List<RunDocument>();
+        var queryRu = 0.0;
         while (feedIterator.HasMoreResults)
         {
             var page = await feedIterator.ReadNextAsync(ct);
+            queryRu += page.RequestCharge;
             runs.AddRange(page);
         }
+        logger.LogRequestChargeTotal("scrub-query", ContainerName, queryRu);
 
         // Replace each modified run. TS uses Promise.all; sequential is fine at hobby scale.
         foreach (var run in runs)
@@ -169,11 +178,12 @@ public sealed class RunsRepository(CosmosClient client, IOptions<CosmosOptions> 
             var scrubbed = ScrubRunDocument(run, battleNetId);
             if (scrubbed.Modified)
             {
-                await _container.ReplaceItemAsync(
+                var response = await _container.ReplaceItemAsync(
                     scrubbed.Run,
                     run.Id,
                     new PartitionKey(run.Id),
                     cancellationToken: ct);
+                logger.LogRequestCharge(response, "scrub-replace", ContainerName, run.Id);
             }
         }
     }
@@ -187,9 +197,11 @@ public sealed class RunsRepository(CosmosClient client, IOptions<CosmosOptions> 
 
         var scanned = 0;
         var migrated = 0;
+        var totalRu = 0.0;
         while (feedIterator.HasMoreResults)
         {
             var page = await feedIterator.ReadNextAsync(ct);
+            totalRu += page.RequestCharge;
             foreach (var run in page)
             {
                 scanned++;
@@ -198,14 +210,16 @@ public sealed class RunsRepository(CosmosClient client, IOptions<CosmosOptions> 
                 migrated++;
                 if (!dryRun)
                 {
-                    await _container.ReplaceItemAsync(
+                    var response = await _container.ReplaceItemAsync(
                         populated,
                         run.Id,
                         new PartitionKey(run.Id),
                         cancellationToken: ct);
+                    logger.LogRequestCharge(response, "migrate-replace", ContainerName, run.Id);
                 }
             }
         }
+        logger.LogRequestChargeTotal("migrate-scan", ContainerName, totalRu);
         return new RunMigrationResult(scanned, migrated, dryRun);
     }
 

--- a/tests/Lfm.Api.Tests/RunsRepositoryConcurrencyTests.cs
+++ b/tests/Lfm.Api.Tests/RunsRepositoryConcurrencyTests.cs
@@ -62,7 +62,7 @@ public class RunsRepositoryConcurrencyTests
         client.Setup(c => c.GetContainer("testdb", "runs")).Returns(container.Object);
 
         var opts = Microsoft.Extensions.Options.Options.Create(new CosmosOptions { Endpoint = "https://test.documents.azure.com", DatabaseName = "testdb" });
-        var repo = new RunsRepository(client.Object, opts);
+        var repo = new RunsRepository(client.Object, opts, Microsoft.Extensions.Logging.Abstractions.NullLogger<RunsRepository>.Instance);
 
         var run = MakeRunDoc(etag: "\"stale-etag\"");
 
@@ -79,6 +79,7 @@ public class RunsRepositoryConcurrencyTests
         var responseMock = new Mock<ItemResponse<RunDocument>>();
         responseMock.Setup(r => r.Resource).Returns(run);
         responseMock.Setup(r => r.ETag).Returns("\"new-etag\"");
+        responseMock.Setup(r => r.RequestCharge).Returns(3.14);
 
         var container = new Mock<Container>();
         container
@@ -94,7 +95,8 @@ public class RunsRepositoryConcurrencyTests
         client.Setup(c => c.GetContainer("testdb", "runs")).Returns(container.Object);
 
         var opts = Microsoft.Extensions.Options.Options.Create(new CosmosOptions { Endpoint = "https://test.documents.azure.com", DatabaseName = "testdb" });
-        var repo = new RunsRepository(client.Object, opts);
+        var logger = new TestLogger<RunsRepository>();
+        var repo = new RunsRepository(client.Object, opts, logger);
 
         var result = await repo.UpdateAsync(run, null, CancellationToken.None);
 
@@ -108,5 +110,14 @@ public class RunsRepositoryConcurrencyTests
                 It.Is<ItemRequestOptions>(o => o.IfMatchEtag == "\"my-etag\""),
                 It.IsAny<CancellationToken>()),
             Times.Once);
+
+        // Every Cosmos op must emit the four structured log fields so App
+        // Insights can aggregate RU-per-endpoint; regression guard for
+        // Slice 6.1.
+        Assert.Contains(logger.Entries, e =>
+            e.Properties.TryGetValue("CosmosOp", out var op) && (op?.ToString() == "replace")
+            && e.Properties.TryGetValue("CosmosContainer", out var container) && (container?.ToString() == "runs")
+            && e.Properties.TryGetValue("CosmosPartitionKey", out var pk) && (pk?.ToString() == "run-1")
+            && e.Properties.TryGetValue("CosmosRequestCharge", out var ru) && ((double)ru! == 3.14));
     }
 }


### PR DESCRIPTION
## Summary

Slice 6.1 of the `review-api-precious-dewdrop` plan — gives Application Insights per-endpoint RU visibility so we can see which operations approach the free-tier 1000 RU/s ceiling before callers feel it.

- New `CosmosRequestChargeLogger` extension method emits a single structured log line per Cosmos op with `CosmosOp`, `CosmosContainer`, `CosmosPartitionKey`, and `CosmosRequestCharge`. All four fields are structured properties, indexed and queryable without message parsing.
- `RunsRepository`, `RaidersRepository`, `GuildRepository` inject `ILogger<T>` and call the extension after every `ReadItemAsync`, `CreateItemAsync`, `ReplaceItemAsync`, `UpsertItemAsync`, `DeleteItemAsync`, and query page.
- Cross-partition queries (`ListExpiredAsync`, `ScrubRaiderAsync`, `MigrateSchemaAsync`, `QueryOnePageAsync`) accumulate the per-page charge and emit one combined row per logical query so App Insights gets total query cost without one row per page.
- Tests: `RunsRepositoryConcurrencyTests.UpdateAsync_passes_etag_in_request_options` extended to capture logs through a `TestLogger<RunsRepository>` and assert the four structured fields after a `ReplaceItemAsync` call.

Fixes **SAD-obs-ru-charge-unlogged**.

## Test plan

- [x] `dotnet build lfm.sln -c Release`
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` (545 pass)
- [ ] Manual: trigger `GET /api/runs/{id}` locally with `func start`, verify the console logs a `Cosmos op=read container=runs pk=…` line with the RU charge.
- [ ] Manual: after deploy, run KQL against App Insights: `traces | where customDimensions.CosmosOp != "" | summarize sum(todouble(customDimensions.CosmosRequestCharge)) by tostring(customDimensions.CosmosOp), tostring(customDimensions.CosmosContainer)` — per-endpoint RU rollup now possible.
