### PR TITLE
7.1a Establish /api/v1/ alias pattern + health rollout

### DIFF
--- a/api/Functions/HealthFunction.cs
+++ b/api/Functions/HealthFunction.cs
@@ -29,6 +29,17 @@ public class HealthFunction(CosmosClient cosmos, IOptions<CosmosOptions> cosmosO
     }
 
     /// <summary>
+    /// <c>/api/v1/health</c> alias for <see cref="Live"/>. See
+    /// <c>docs/api-versioning.md</c> — <c>/v1/</c> is the new canonical prefix;
+    /// the unprefixed route is retained for one release so existing SPA bundles
+    /// keep working during the deploy window.
+    /// </summary>
+    [Function("health-v1")]
+    public IActionResult LiveV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "v1/health")] HttpRequest req)
+        => Live(req);
+
+    /// <summary>
     /// Readiness probe — validates that this instance can talk to Cosmos.
     /// Response contract:
     ///   - 200 OK with <see cref="HealthResponse"/> (status="ready") on success.
@@ -57,6 +68,15 @@ public class HealthFunction(CosmosClient cosmos, IOptions<CosmosOptions> cosmosO
             };
         }
     }
+
+    /// <summary>
+    /// <c>/api/v1/health/ready</c> alias for <see cref="Ready"/>.
+    /// </summary>
+    [Function("health-ready-v1")]
+    public Task<IActionResult> ReadyV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "v1/health/ready")] HttpRequest req,
+        CancellationToken ct)
+        => Ready(req, ct);
 
     internal static HealthResponse Build() => new("ok", DateTimeOffset.UtcNow);
 }

--- a/docs/api-versioning.md
+++ b/docs/api-versioning.md
@@ -1,0 +1,77 @@
+# API versioning
+
+## What this is
+
+The Lfm API canonicalised every route under `/api/v1/...` in Phase 7 of the
+`review-api-precious-dewdrop` remediation plan. The pre-existing unprefixed
+routes (`/api/runs`, `/api/me`, etc.) are kept as aliases for one release to
+cover the SPA-deploy gap (older `wwwroot` bundles that haven't been re-published
+yet still need to work).
+
+## The alias pattern
+
+Every HTTP function carries two `[Function]` declarations — one on the canonical
+`v1/...` route and one on the legacy unprefixed route. Example:
+
+```csharp
+public class HealthFunction(CosmosClient cosmos, IOptions<CosmosOptions> cosmosOpts, ILogger<HealthFunction> logger)
+{
+    [Function("health")]
+    public IActionResult Live(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "health")] HttpRequest req)
+        => new OkObjectResult(Build());
+
+    [Function("health-v1")]
+    public IActionResult LiveV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "v1/health")] HttpRequest req)
+        => Live(req);
+}
+```
+
+Rules:
+
+1. The canonical method stays where it is; all existing logic lives there.
+2. The v1 alias is a thin delegation — `=> Live(req)` — no logic duplication.
+3. The `[Function]` id gets a `-v1` suffix so both declarations can coexist in
+   the same host (`[Function]` ids must be unique).
+4. New endpoints added from this point on land under `v1/` as their primary
+   route and never get a legacy alias.
+
+## Rollout staging
+
+Phase 7 lands in family-per-PR increments so each branch stays reviewable:
+
+| PR | Scope | Endpoints |
+|---|---|---|
+| 7.1a | Health family + this docs page | `/health`, `/health/ready` |
+| 7.1b | Me / Guild / Privacy | `/me`, `/guild`, `/guild/admin`, `/privacy-contact/email` |
+| 7.1c | Runs family | `/runs`, `/runs/{id}`, `/runs/{id}/signup`, `/admin/runs/migrate-schema` |
+| 7.1d | Raider + BattleNet + WoW reference + Admin | `/raider/*`, `/battlenet/*`, `/wow/reference/*` |
+| 7.1e | SPA flip + openapi servers bump + README | Consumer cutover |
+
+Each PR is small and does not break backwards compatibility. The SPA flip in
+7.1e is the coordination point where the client starts issuing `/api/v1/...`
+requests; after one full release cycle the legacy routes can be removed in a
+follow-up PR (not part of this plan — tracked as technical debt at that point).
+
+## When to retain the alias
+
+The alias is a **migration aid**, not a long-term contract. Remove the legacy
+route once:
+
+- The SPA build has been on `/api/v1/...` for at least one deploy cycle.
+- App Insights traffic on the unprefixed routes is effectively zero (check
+  `requests | where url !startswith "/api/v1/"` over the last 7 days).
+- Any documented consumer (the OpenAPI contract at `api/openapi.yaml`) has
+  been updated to list only `/api/v1/` as the server.
+
+Until all three are true, keep the alias in place.
+
+## Why alias-by-second-function rather than middleware rewrite
+
+The Azure Functions isolated worker dispatches routes at the host layer
+(before our `IFunctionsWorkerMiddleware` runs). Rewriting `/api/x` to
+`/api/v1/x` from the worker middleware would fire *after* route matching,
+too late to help. Declaring both routes in parallel is the idiomatic
+approach and keeps the route table explicit — both routes show up in the
+Functions host's startup log and in any `az functionapp function list` dump.

--- a/tests/Lfm.Api.Tests/FunctionAuthorizationContractTests.cs
+++ b/tests/Lfm.Api.Tests/FunctionAuthorizationContractTests.cs
@@ -37,6 +37,10 @@ public class FunctionAuthorizationContractTests
         // Health probes — App Service Health Check / external monitors.
         "health",
         "health-ready",
+        // /api/v1/ aliases for the probes — alias contract mirrors the canonical
+        // route's anonymous accessibility. See docs/api-versioning.md.
+        "health-v1",
+        "health-ready-v1",
         // Public privacy contact — the SPA reveals this only on user click.
         "privacy-email",
         // Catch-all OPTIONS preflight handler — short-circuited by CorsMiddleware.

--- a/tests/Lfm.Api.Tests/HealthFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/HealthFunctionTests.cs
@@ -47,6 +47,37 @@ public class HealthFunctionTests
         Assert.True(body.Timestamp <= after);
     }
 
+    [Fact]
+    public void LiveV1_returns_the_same_response_as_Live()
+    {
+        // Alias contract: the /api/v1/health handler is a thin delegation to
+        // the canonical Live() method. If a future refactor extracts logic
+        // into only the legacy entry point, this test catches the drift.
+        var (fn, _) = CreateReadyFunction();
+
+        var result = fn.LiveV1(new DefaultHttpContext().Request);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Equal(200, ok.StatusCode);
+        var body = Assert.IsType<HealthResponse>(ok.Value);
+        Assert.Equal("ok", body.Status);
+    }
+
+    [Fact]
+    public async Task ReadyV1_returns_the_same_response_as_Ready()
+    {
+        var (fn, mockDb) = CreateReadyFunction();
+        mockDb.Setup(d => d.ReadAsync(It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DatabaseResponse)null!);
+
+        var result = await fn.ReadyV1(new DefaultHttpContext().Request, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Equal(200, ok.StatusCode);
+        var body = Assert.IsType<HealthResponse>(ok.Value);
+        Assert.Equal("ready", body.Status);
+    }
+
     private static (HealthFunction fn, Mock<Database> mockDb) CreateReadyFunction()
     {
         var mockDb = new Mock<Database>();


### PR DESCRIPTION
## Summary

First PR of the Slice 7.1 rollout (`review-api-precious-dewdrop` plan). Establishes the `/api/v1/` alias pattern and applies it to the health family as a self-contained proof of concept. Subsequent PRs mechanically apply the same pattern to every other endpoint family without re-negotiating the shape.

- `HealthFunction` gains two extra `[Function]` declarations — `health-v1` at `Route = "v1/health"` and `health-ready-v1` at `Route = "v1/health/ready"`. Each alias method is a thin delegation to the canonical handler (`=> Live(req)` etc.). No logic duplication.
- `docs/api-versioning.md` (new) documents the pattern, the rollout staging (Me/Guild/Privacy → Runs → Raider/BattleNet/WoW reference → SPA flip), and the retirement criteria for the legacy routes.
- `HealthFunctionTests` pins both aliases via dedicated tests, so a future refactor that accidentally diverges the two paths fails fast.
- `FunctionAuthorizationContractTests` allow-list grows two entries (`health-v1`, `health-ready-v1`) — the contract test insists every function is either `[RequireAuth]` or in the explicit allow list.

Fixes part of **SAD-contract-no-versioning**; remaining families shipped in follow-up PRs 7.1b–7.1e.

## Why two `[Function]` declarations rather than route rewriting

The Azure Functions isolated worker does route matching at the host layer, before `IFunctionsWorkerMiddleware` runs. A middleware that rewrites `/api/x` → `/api/v1/x` would execute too late to redirect the dispatch. Declaring both routes in parallel is idiomatic, shows up in the Functions host startup log, and keeps the route table explicit for `az functionapp function list` inspection.

## Test plan

- [x] `dotnet build lfm.sln -c Release`
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` (549 pass, +2 new alias tests)
- [ ] Manual: `curl http://localhost:7071/api/v1/health` and `curl http://localhost:7071/api/v1/health/ready` both return the same bodies as their unprefixed counterparts.
