### PR TITLE
7.1b /api/v1/ aliases on Me, Guild, Privacy families

### DIFF
--- a/api/Functions/GuildAdminFunction.cs
+++ b/api/Functions/GuildAdminFunction.cs
@@ -42,4 +42,16 @@ public class GuildAdminFunction(IGuildRepository guildRepo, ISiteAdminService si
 
         return new OkObjectResult(GuildMapper.MapToDto(guildDoc));
     }
+
+    /// <summary>
+    /// <c>/api/v1/guild/admin</c> alias for <see cref="Run"/>. See
+    /// <c>docs/api-versioning.md</c>.
+    /// </summary>
+    [Function("guild-admin-get-v1")]
+    [RequireAuth]
+    public Task<IActionResult> RunV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "v1/guild/admin")] HttpRequest req,
+        FunctionContext ctx,
+        CancellationToken cancellationToken)
+        => Run(req, ctx, cancellationToken);
 }

--- a/api/Functions/GuildFunction.cs
+++ b/api/Functions/GuildFunction.cs
@@ -75,6 +75,18 @@ public class GuildFunction(IGuildRepository guildRepo, IRaidersRepository raider
         return new OkObjectResult(GuildMapper.MapToDto(guildDoc));
     }
 
+    /// <summary>
+    /// <c>/api/v1/guild</c> alias for <see cref="GuildGet"/>. See
+    /// <c>docs/api-versioning.md</c>.
+    /// </summary>
+    [Function("guild-get-v1")]
+    [RequireAuth]
+    public Task<IActionResult> GuildGetV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "v1/guild")] HttpRequest req,
+        FunctionContext ctx,
+        CancellationToken cancellationToken)
+        => GuildGet(req, ctx, cancellationToken);
+
     // ------------------------------------------------------------------
     // PATCH /api/guild
     // ------------------------------------------------------------------
@@ -184,6 +196,18 @@ public class GuildFunction(IGuildRepository guildRepo, IRaidersRepository raider
 
         return new OkObjectResult(GuildMapper.MapToDto(persisted));
     }
+
+    /// <summary>
+    /// <c>/api/v1/guild</c> PATCH alias for <see cref="GuildUpdate"/>. See
+    /// <c>docs/api-versioning.md</c>.
+    /// </summary>
+    [Function("guild-update-v1")]
+    [RequireAuth]
+    public Task<IActionResult> GuildUpdateV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "patch", Route = "v1/guild")] HttpRequest req,
+        FunctionContext ctx,
+        CancellationToken cancellationToken)
+        => GuildUpdate(req, ctx, cancellationToken);
 
     /// <summary>
     /// Returns the caller's <c>If-Match</c> ETag when present and non-wildcard.

--- a/api/Functions/MeDeleteFunction.cs
+++ b/api/Functions/MeDeleteFunction.cs
@@ -50,4 +50,16 @@ public class MeDeleteFunction(
         // TS returns status 200 with { deleted: true }.
         return new OkObjectResult(new { deleted = true });
     }
+
+    /// <summary>
+    /// <c>/api/v1/me</c> DELETE alias for <see cref="Run"/>. See
+    /// <c>docs/api-versioning.md</c>.
+    /// </summary>
+    [Function("me-delete-v1")]
+    [RequireAuth]
+    public Task<IActionResult> RunV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "v1/me")] HttpRequest req,
+        FunctionContext ctx,
+        CancellationToken cancellationToken)
+        => Run(req, ctx, cancellationToken);
 }

--- a/api/Functions/MeFunction.cs
+++ b/api/Functions/MeFunction.cs
@@ -45,4 +45,16 @@ public class MeFunction(IRaidersRepository repo, ISiteAdminService siteAdmin)
             IsSiteAdmin: isAdmin,
             Locale: raider.Locale));
     }
+
+    /// <summary>
+    /// <c>/api/v1/me</c> alias for <see cref="Run"/>. See
+    /// <c>docs/api-versioning.md</c> for the rollout plan.
+    /// </summary>
+    [Function("me-v1")]
+    [RequireAuth]
+    public Task<IActionResult> RunV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "v1/me")] HttpRequest req,
+        FunctionContext ctx,
+        CancellationToken cancellationToken)
+        => Run(req, ctx, cancellationToken);
 }

--- a/api/Functions/MeUpdateFunction.cs
+++ b/api/Functions/MeUpdateFunction.cs
@@ -87,6 +87,18 @@ public class MeUpdateFunction(IRaidersRepository repo)
     }
 
     /// <summary>
+    /// <c>/api/v1/me</c> alias for <see cref="Run"/>. See
+    /// <c>docs/api-versioning.md</c>.
+    /// </summary>
+    [Function("me-update-v1")]
+    [RequireAuth]
+    public Task<IActionResult> RunV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "patch", Route = "v1/me")] HttpRequest req,
+        FunctionContext ctx,
+        CancellationToken cancellationToken)
+        => Run(req, ctx, cancellationToken);
+
+    /// <summary>
     /// Returns the caller's <c>If-Match</c> ETag when present and non-wildcard.
     /// A <c>*</c> wildcard is treated as "no precondition" so SPA flows that
     /// haven't captured the ETag yet remain functional during migration.

--- a/api/Functions/PrivacyContactFunction.cs
+++ b/api/Functions/PrivacyContactFunction.cs
@@ -53,4 +53,13 @@ public class PrivacyContactFunction(IOptions<PrivacyContactOptions> options)
         return new OkObjectResult(new PrivacyEmailResponse(Local: local, Domain: domain, Email: email));
 #pragma warning restore CS0618
     }
+
+    /// <summary>
+    /// <c>/api/v1/privacy-contact/email</c> alias for <see cref="GetEmail"/>.
+    /// See <c>docs/api-versioning.md</c>.
+    /// </summary>
+    [Function("privacy-email-v1")]
+    public IActionResult GetEmailV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "v1/privacy-contact/email")] HttpRequest req)
+        => GetEmail(req);
 }

--- a/tests/Lfm.Api.Tests/FunctionAuthorizationContractTests.cs
+++ b/tests/Lfm.Api.Tests/FunctionAuthorizationContractTests.cs
@@ -43,6 +43,7 @@ public class FunctionAuthorizationContractTests
         "health-ready-v1",
         // Public privacy contact — the SPA reveals this only on user click.
         "privacy-email",
+        "privacy-email-v1",
         // Catch-all OPTIONS preflight handler — short-circuited by CorsMiddleware.
         "cors-preflight",
     };

--- a/tests/Lfm.Api.Tests/MeFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/MeFunctionTests.cs
@@ -104,6 +104,43 @@ public class MeFunctionTests
     }
 
     [Fact]
+    public async Task RunV1_delegates_to_canonical_Run_handler()
+    {
+        // Alias contract: /api/v1/me is a thin delegation; if a future
+        // refactor drifts the two paths this test fails fast.
+        var principal = new SessionPrincipal(
+            BattleNetId: "bnet-1",
+            BattleTag: "Player#1234",
+            GuildId: null,
+            GuildName: null,
+            IssuedAt: DateTimeOffset.UtcNow,
+            ExpiresAt: DateTimeOffset.UtcNow.AddHours(1));
+
+        var raider = new RaiderDocument(
+            Id: "bnet-1",
+            BattleNetId: "bnet-1",
+            SelectedCharacterId: "char-1",
+            Locale: "en");
+
+        var repo = new Mock<IRaidersRepository>();
+        repo.Setup(r => r.GetByBattleNetIdAsync("bnet-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(raider);
+
+        var siteAdmin = new Mock<ISiteAdminService>();
+        siteAdmin.Setup(s => s.IsAdminAsync("bnet-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var fn = new MeFunction(repo.Object, siteAdmin.Object);
+        var ctx = MakeFunctionContext(principal);
+
+        var result = await fn.RunV1(new DefaultHttpContext().Request, ctx, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var me = Assert.IsType<MeResponse>(ok.Value);
+        Assert.Equal("bnet-1", me.BattleNetId);
+    }
+
+    [Fact]
     public async Task Response_carries_etag_header_mirroring_cosmos_etag()
     {
         var principal = new SessionPrincipal(

--- a/tests/Lfm.Api.Tests/PrivacyContactFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/PrivacyContactFunctionTests.cs
@@ -60,6 +60,20 @@ public class PrivacyContactFunctionTests
     }
 
     [Fact]
+    public void GetEmailV1_delegates_to_canonical_GetEmail_handler()
+    {
+        // Alias contract: /api/v1/privacy-contact/email is a thin delegation.
+        var fn = MakeFunction("privacy@example.com");
+
+        var result = fn.GetEmailV1(new DefaultHttpContext().Request);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var body = Assert.IsType<PrivacyEmailResponse>(ok.Value);
+        Assert.Equal("privacy", body.Local);
+        Assert.Equal("example.com", body.Domain);
+    }
+
+    [Fact]
     public void GetEmail_returns_404_when_address_is_malformed()
     {
         // The Options validator normally rejects at startup, but a defensive


### PR DESCRIPTION
## Summary

Second PR of the Slice 7.1 rollout. Applies the alias pattern established in PR #141 + [docs/api-versioning.md](docs/api-versioning.md) to the Me, Guild, and Privacy families. Each handler gains one thin `[Function("xxx-v1")]` method with `Route = "v1/..."` that delegates to the canonical method; no logic is duplicated.

- `MeFunction` → `me-v1` at `v1/me`
- `MeUpdateFunction` → `me-update-v1` at `v1/me` (PATCH)
- `MeDeleteFunction` → `me-delete-v1` at `v1/me` (DELETE)
- `GuildFunction` → `guild-get-v1` at `v1/guild`, `guild-update-v1` at `v1/guild` (PATCH)
- `GuildAdminFunction` → `guild-admin-get-v1` at `v1/guild/admin`
- `PrivacyContactFunction` → `privacy-email-v1` at `v1/privacy-contact/email`

`FunctionAuthorizationContractTests.AnonymousAllowList` grows by one entry (`privacy-email-v1`) to match the canonical route's public-reveal posture; every other alias inherits `[RequireAuth]` from the declaring type. Alias delegation is pinned by two new smoke tests — one on Me, one on Privacy — representing the two authorization shapes in this slice.

Fixes the Me/Guild/Privacy slice of **SAD-contract-no-versioning**.

## Test plan

- [x] `dotnet build lfm.sln -c Release`
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` (558 pass, +2 new alias tests + the contract test automatically discovers the new function ids)
- [ ] Manual: `curl http://localhost:7071/api/v1/me -H "Cookie: session=…"` returns the same body as `GET /api/me` with the same ETag header.
