### PR TITLE
7.1c /api/v1/ aliases on the Runs family

### DIFF
--- a/api/Functions/RunsCancelSignupFunction.cs
+++ b/api/Functions/RunsCancelSignupFunction.cs
@@ -105,6 +105,19 @@ public class RunsCancelSignupFunction(
         return new OkObjectResult(Sanitize(persisted, principal.BattleNetId));
     }
 
+    /// <summary>
+    /// <c>/api/v1/runs/{id}/signup</c> DELETE alias for <see cref="Run"/>. See
+    /// <c>docs/api-versioning.md</c>.
+    /// </summary>
+    [Function("runs-cancel-signup-v1")]
+    [RequireAuth]
+    public Task<IActionResult> RunV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "v1/runs/{id}/signup")] HttpRequest req,
+        string id,
+        FunctionContext ctx,
+        CancellationToken ct)
+        => Run(req, id, ctx, ct);
+
     // ------------------------------------------------------------------
     // Sanitizer — mirrors sanitizeRunDocumentForResponse in
     // functions/src/lib/runResponseSanitizer.ts

--- a/api/Functions/RunsCreateFunction.cs
+++ b/api/Functions/RunsCreateFunction.cs
@@ -113,6 +113,18 @@ public class RunsCreateFunction(IRunsRepository repo, IRaidersRepository raiders
         return new ObjectResult(MapToDto(created)) { StatusCode = 201 };
     }
 
+    /// <summary>
+    /// <c>/api/v1/runs</c> POST alias for <see cref="Run"/>. See
+    /// <c>docs/api-versioning.md</c>.
+    /// </summary>
+    [Function("runs-create-v1")]
+    [RequireAuth]
+    public Task<IActionResult> RunV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "v1/runs")] HttpRequest req,
+        FunctionContext ctx,
+        CancellationToken ct)
+        => Run(req, ctx, ct);
+
     // ------------------------------------------------------------------
     // Document builder — mirrors buildRunDocument in runs-create.ts
     // ------------------------------------------------------------------

--- a/api/Functions/RunsDeleteFunction.cs
+++ b/api/Functions/RunsDeleteFunction.cs
@@ -89,4 +89,17 @@ public class RunsDeleteFunction(IRunsRepository repo, IRaidersRepository raiders
         // TS returns status 200 with { deleted: true }.
         return new OkObjectResult(new { deleted = true });
     }
+
+    /// <summary>
+    /// <c>/api/v1/runs/{id}</c> DELETE alias for <see cref="Run"/>. See
+    /// <c>docs/api-versioning.md</c>.
+    /// </summary>
+    [Function("runs-delete-v1")]
+    [RequireAuth]
+    public Task<IActionResult> RunV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "v1/runs/{id}")] HttpRequest req,
+        string id,
+        FunctionContext ctx,
+        CancellationToken ct)
+        => Run(req, id, ctx, ct);
 }

--- a/api/Functions/RunsDetailFunction.cs
+++ b/api/Functions/RunsDetailFunction.cs
@@ -76,6 +76,19 @@ public class RunsDetailFunction(IRunsRepository repo, IRaidersRepository raiders
         return new OkObjectResult(Sanitize(run, principal.BattleNetId));
     }
 
+    /// <summary>
+    /// <c>/api/v1/runs/{id}</c> alias for <see cref="Run"/>. See
+    /// <c>docs/api-versioning.md</c>.
+    /// </summary>
+    [Function("runs-detail-v1")]
+    [RequireAuth]
+    public Task<IActionResult> RunV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "v1/runs/{id}")] HttpRequest req,
+        string id,
+        FunctionContext ctx,
+        CancellationToken ct)
+        => Run(req, id, ctx, ct);
+
     // ------------------------------------------------------------------
     // Sanitizer — mirrors sanitizeRunDocumentForResponse in
     // functions/src/lib/runResponseSanitizer.ts

--- a/api/Functions/RunsListFunction.cs
+++ b/api/Functions/RunsListFunction.cs
@@ -62,6 +62,18 @@ public class RunsListFunction(IRunsRepository repo, IRaidersRepository raidersRe
         return new OkObjectResult(new RunsListResponse(dtos, page.ContinuationToken));
     }
 
+    /// <summary>
+    /// <c>/api/v1/runs</c> alias for <see cref="Run"/>. See
+    /// <c>docs/api-versioning.md</c>.
+    /// </summary>
+    [Function("runs-list-v1")]
+    [RequireAuth]
+    public Task<IActionResult> RunV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "v1/runs")] HttpRequest req,
+        FunctionContext ctx,
+        CancellationToken ct)
+        => Run(req, ctx, ct);
+
     private static int ParseTop(HttpRequest req)
     {
         if (!req.Query.TryGetValue("top", out var raw) || raw.Count == 0)

--- a/api/Functions/RunsMigrateSchemaFunction.cs
+++ b/api/Functions/RunsMigrateSchemaFunction.cs
@@ -60,4 +60,16 @@ public class RunsMigrateSchemaFunction(
 
         return new OkObjectResult(result);
     }
+
+    /// <summary>
+    /// <c>/api/v1/admin/runs/migrate-schema</c> alias for <see cref="Run"/>.
+    /// See <c>docs/api-versioning.md</c>.
+    /// </summary>
+    [Function("runs-migrate-schema-v1")]
+    [RequireAuth]
+    public Task<IActionResult> RunV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "v1/admin/runs/migrate-schema")] HttpRequest req,
+        FunctionContext ctx,
+        CancellationToken ct)
+        => Run(req, ctx, ct);
 }

--- a/api/Functions/RunsSignupFunction.cs
+++ b/api/Functions/RunsSignupFunction.cs
@@ -232,6 +232,19 @@ public class RunsSignupFunction(
             "Concurrent modification, please retry.");
     }
 
+    /// <summary>
+    /// <c>/api/v1/runs/{id}/signup</c> POST alias for <see cref="Run"/>. See
+    /// <c>docs/api-versioning.md</c>.
+    /// </summary>
+    [Function("runs-signup-v1")]
+    [RequireAuth]
+    public Task<IActionResult> RunV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "v1/runs/{id}/signup")] HttpRequest req,
+        string id,
+        FunctionContext ctx,
+        CancellationToken ct)
+        => Run(req, id, ctx, ct);
+
     // ------------------------------------------------------------------
     // Sanitizer — mirrors sanitizeRunDocumentForResponse in
     // functions/src/lib/runResponseSanitizer.ts

--- a/api/Functions/RunsUpdateFunction.cs
+++ b/api/Functions/RunsUpdateFunction.cs
@@ -279,6 +279,19 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
         return new OkObjectResult(MapToDto(persisted, principal.BattleNetId));
     }
 
+    /// <summary>
+    /// <c>/api/v1/runs/{id}</c> PUT alias for <see cref="Run"/>. See
+    /// <c>docs/api-versioning.md</c>.
+    /// </summary>
+    [Function("runs-update-v1")]
+    [RequireAuth]
+    public Task<IActionResult> RunV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "v1/runs/{id}")] HttpRequest req,
+        string id,
+        FunctionContext ctx,
+        CancellationToken ct)
+        => Run(req, id, ctx, ct);
+
     // ------------------------------------------------------------------
     // Mapping helper — projects the stored RunDocument to its wire DTO.
     // ------------------------------------------------------------------

--- a/tests/Lfm.Api.Tests/RunsDetailFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RunsDetailFunctionTests.cs
@@ -99,6 +99,31 @@ public class RunsDetailFunctionTests
             Role: "HEALER");
 
     // ------------------------------------------------------------------
+    // v1 alias contract — /api/v1/runs/{id} is a thin delegation
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task RunV1_delegates_to_canonical_Run_handler()
+    {
+        var principal = MakePrincipal(battleNetId: "bnet-1", guildId: "12345");
+        var doc = MakeRunDoc(id: "run-1", visibility: "PUBLIC", etag: "\"v1-etag\"");
+
+        var repo = new Mock<IRunsRepository>();
+        repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(doc);
+
+        var raidersRepo = new Mock<IRaidersRepository>();
+        var fn = new RunsDetailFunction(repo.Object, raidersRepo.Object);
+        var ctx = MakeFunctionContext(principal);
+
+        var request = new DefaultHttpContext().Request;
+        var result = await fn.RunV1(request, "run-1", ctx, CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Equal("\"v1-etag\"", request.HttpContext.Response.Headers.ETag.ToString());
+    }
+
+    // ------------------------------------------------------------------
     // Test 1: Happy path — returns sanitized run detail for authenticated user
     // ------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Third PR of the Slice 7.1 rollout. Applies the alias pattern established in PR #141 + [docs/api-versioning.md](docs/api-versioning.md) to every handler under the Runs umbrella. Each handler gains one thin `[Function("xxx-v1")]` method with `Route = "v1/..."` delegating to the canonical method; no logic is duplicated.

- `RunsListFunction` → `runs-list-v1` at `v1/runs`
- `RunsCreateFunction` → `runs-create-v1` at `v1/runs` (POST)
- `RunsDetailFunction` → `runs-detail-v1` at `v1/runs/{id}`
- `RunsUpdateFunction` → `runs-update-v1` at `v1/runs/{id}` (PUT)
- `RunsDeleteFunction` → `runs-delete-v1` at `v1/runs/{id}` (DELETE)
- `RunsSignupFunction` → `runs-signup-v1` at `v1/runs/{id}/signup` (POST)
- `RunsCancelSignupFunction` → `runs-cancel-signup-v1` at `v1/runs/{id}/signup` (DELETE)
- `RunsMigrateSchemaFunction` → `runs-migrate-schema-v1` at `v1/admin/runs/migrate-schema` (POST)

All eight handlers already carry `[RequireAuth]` on the declaring type, so `AnonymousAllowList` is unchanged — the contract test auto-discovers the new function ids. `RunsDetail`'s alias smoke test pins delegation across a path-parameter route (covers the shape shared by `runs/{id}`, `runs/{id}/signup`, and their PUT/DELETE siblings).

Fixes the Runs slice of **SAD-contract-no-versioning**. Next PR (7.1d) covers Raider + BattleNet + WoW Reference + Admin families.

## Test plan

- [x] `dotnet build lfm.sln -c Release`
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` (567 pass, +1 new alias smoke test; the contract test automatically discovers the 8 new function ids)
