### PR TITLE
7.1d /api/v1/ aliases on the remaining endpoint families

### DIFF
--- a/api/Functions/BattleNetCallbackFunction.cs
+++ b/api/Functions/BattleNetCallbackFunction.cs
@@ -139,6 +139,16 @@ public class BattleNetCallbackFunction(
         return new RedirectResult(destination, permanent: false);
     }
 
+    /// <summary>
+    /// <c>/api/v1/battlenet/callback</c> alias for <see cref="Run"/>. See
+    /// <c>docs/api-versioning.md</c>.
+    /// </summary>
+    [Function("battlenet-callback-v1")]
+    public Task<IActionResult> RunV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "v1/battlenet/callback")] HttpRequest req,
+        CancellationToken cancellationToken)
+        => Run(req, cancellationToken);
+
     // ---------------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------------

--- a/api/Functions/BattleNetCharacterPortraitsFunction.cs
+++ b/api/Functions/BattleNetCharacterPortraitsFunction.cs
@@ -78,4 +78,16 @@ public class BattleNetCharacterPortraitsFunction(
         var response = await portraitService.ResolveAsync(raider, requests, accessToken, cancellationToken);
         return new OkObjectResult(response);
     }
+
+    /// <summary>
+    /// <c>/api/v1/battlenet/character-portraits</c> alias for <see cref="Run"/>.
+    /// See <c>docs/api-versioning.md</c>.
+    /// </summary>
+    [Function("battlenet-character-portraits-v1")]
+    [RequireAuth]
+    public Task<IActionResult> RunV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "v1/battlenet/character-portraits")] HttpRequest req,
+        FunctionContext ctx,
+        CancellationToken cancellationToken)
+        => Run(req, ctx, cancellationToken);
 }

--- a/api/Functions/BattleNetCharactersFunction.cs
+++ b/api/Functions/BattleNetCharactersFunction.cs
@@ -57,6 +57,18 @@ public class BattleNetCharactersFunction(
         return new OkObjectResult(characters);
     }
 
+    /// <summary>
+    /// <c>/api/v1/battlenet/characters</c> alias for <see cref="Run"/>. See
+    /// <c>docs/api-versioning.md</c>.
+    /// </summary>
+    [Function("battlenet-characters-v1")]
+    [RequireAuth]
+    public Task<IActionResult> RunV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "v1/battlenet/characters")] HttpRequest req,
+        FunctionContext ctx,
+        CancellationToken cancellationToken)
+        => Run(req, ctx, cancellationToken);
+
     // ---------------------------------------------------------------------------
     // Internal helpers — internal for unit-test access
     // ---------------------------------------------------------------------------

--- a/api/Functions/BattleNetCharactersRefreshFunction.cs
+++ b/api/Functions/BattleNetCharactersRefreshFunction.cs
@@ -105,6 +105,18 @@ public class BattleNetCharactersRefreshFunction(
         return new OkObjectResult(characters);
     }
 
+    /// <summary>
+    /// <c>/api/v1/battlenet/characters/refresh</c> alias for <see cref="Run"/>.
+    /// See <c>docs/api-versioning.md</c>.
+    /// </summary>
+    [Function("battlenet-characters-refresh-v1")]
+    [RequireAuth]
+    public Task<IActionResult> RunV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "v1/battlenet/characters/refresh")] HttpRequest req,
+        FunctionContext ctx,
+        CancellationToken cancellationToken)
+        => Run(req, ctx, cancellationToken);
+
     // ---------------------------------------------------------------------------
     // Internal helpers — internal for unit-test access
     // ---------------------------------------------------------------------------

--- a/api/Functions/BattleNetLoginFunction.cs
+++ b/api/Functions/BattleNetLoginFunction.cs
@@ -55,6 +55,16 @@ public class BattleNetLoginFunction(IBlizzardOAuthClient oauthClient)
         return new RedirectResult(authUrl, permanent: false);
     }
 
+    /// <summary>
+    /// <c>/api/v1/battlenet/login</c> alias for <see cref="Run"/>. See
+    /// <c>docs/api-versioning.md</c>.
+    /// </summary>
+    [Function("battlenet-login-v1")]
+    public IActionResult RunV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "v1/battlenet/login")] HttpRequest req,
+        CancellationToken cancellationToken)
+        => Run(req, cancellationToken);
+
     // ---------------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------------

--- a/api/Functions/BattleNetLogoutFunction.cs
+++ b/api/Functions/BattleNetLogoutFunction.cs
@@ -62,4 +62,14 @@ public class BattleNetLogoutFunction(
         // Redirect to the home page.
         return new RedirectResult(_blizzardOpts.AppBaseUrl, permanent: false);
     }
+
+    /// <summary>
+    /// <c>/api/v1/battlenet/logout</c> alias for <see cref="Run"/>. See
+    /// <c>docs/api-versioning.md</c>.
+    /// </summary>
+    [Function("battlenet-logout-v1")]
+    public IActionResult RunV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "v1/battlenet/logout")] HttpRequest req,
+        FunctionContext ctx)
+        => Run(req, ctx);
 }

--- a/api/Functions/RaiderCharacterAddFunction.cs
+++ b/api/Functions/RaiderCharacterAddFunction.cs
@@ -177,6 +177,18 @@ public class RaiderCharacterAddFunction(
             Character: dto));
     }
 
+    /// <summary>
+    /// <c>/api/v1/raider/character</c> alias for <see cref="Run"/>. See
+    /// <c>docs/api-versioning.md</c>.
+    /// </summary>
+    [Function("raider-character-add-v1")]
+    [RequireAuth]
+    public Task<IActionResult> RunV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "v1/raider/character")] HttpRequest req,
+        FunctionContext ctx,
+        CancellationToken ct)
+        => Run(req, ctx, ct);
+
     // ---------------------------------------------------------------------------
     // Internal helpers — internal for unit-test access
     // ---------------------------------------------------------------------------

--- a/api/Functions/RaiderCharacterEnrichFunction.cs
+++ b/api/Functions/RaiderCharacterEnrichFunction.cs
@@ -135,4 +135,17 @@ public sealed class RaiderCharacterEnrichFunction(
 
         return new OkObjectResult(RaiderCharacterAddFunction.MapToCharacterDto(stored));
     }
+
+    /// <summary>
+    /// <c>/api/v1/raider/characters/{id}/enrich</c> alias for <see cref="Run"/>.
+    /// See <c>docs/api-versioning.md</c>.
+    /// </summary>
+    [Function("raider-character-enrich-v1")]
+    [RequireAuth]
+    public Task<IActionResult> RunV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "v1/raider/characters/{id}/enrich")] HttpRequest req,
+        string id,
+        FunctionContext ctx,
+        CancellationToken ct)
+        => Run(req, id, ctx, ct);
 }

--- a/api/Functions/RaiderCharacterFunction.cs
+++ b/api/Functions/RaiderCharacterFunction.cs
@@ -70,4 +70,17 @@ public class RaiderCharacterFunction(IRaidersRepository repo, ILogger<RaiderChar
         // 4. Return updated selection.
         return new OkObjectResult(new UpdateCharacterResponse(SelectedCharacterId: id));
     }
+
+    /// <summary>
+    /// <c>/api/v1/raider/characters/{id}</c> alias for <see cref="Run"/>. See
+    /// <c>docs/api-versioning.md</c>.
+    /// </summary>
+    [Function("raider-character-v1")]
+    [RequireAuth]
+    public Task<IActionResult> RunV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "v1/raider/characters/{id}")] HttpRequest req,
+        string id,
+        FunctionContext ctx,
+        CancellationToken ct)
+        => Run(req, id, ctx, ct);
 }

--- a/api/Functions/WowReferenceExpansionsFunction.cs
+++ b/api/Functions/WowReferenceExpansionsFunction.cs
@@ -20,4 +20,15 @@ public class WowReferenceExpansionsFunction(IExpansionsRepository repo)
         var items = await repo.ListAsync(ct);
         return new OkObjectResult(items);
     }
+
+    /// <summary>
+    /// <c>/api/v1/wow/reference/expansions</c> alias for <see cref="Run"/>.
+    /// See <c>docs/api-versioning.md</c>.
+    /// </summary>
+    [Function("wow-reference-expansions-v1")]
+    [RequireAuth]
+    public Task<IActionResult> RunV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "v1/wow/reference/expansions")] HttpRequest req,
+        CancellationToken ct)
+        => Run(req, ct);
 }

--- a/api/Functions/WowReferenceInstancesFunction.cs
+++ b/api/Functions/WowReferenceInstancesFunction.cs
@@ -20,4 +20,15 @@ public class WowReferenceInstancesFunction(IInstancesRepository repo)
         var items = await repo.ListAsync(ct);
         return new OkObjectResult(items);
     }
+
+    /// <summary>
+    /// <c>/api/v1/wow/reference/instances</c> alias for <see cref="Run"/>.
+    /// See <c>docs/api-versioning.md</c>.
+    /// </summary>
+    [Function("wow-reference-instances-v1")]
+    [RequireAuth]
+    public Task<IActionResult> RunV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "v1/wow/reference/instances")] HttpRequest req,
+        CancellationToken ct)
+        => Run(req, ct);
 }

--- a/api/Functions/WowReferenceRefreshFunction.cs
+++ b/api/Functions/WowReferenceRefreshFunction.cs
@@ -127,6 +127,18 @@ public class WowReferenceRefreshFunction(
         return new EmptyResult();
     }
 
+    /// <summary>
+    /// <c>/api/v1/wow/reference/refresh</c> alias for <see cref="Run"/>.
+    /// See <c>docs/api-versioning.md</c>.
+    /// </summary>
+    [Function("wow-reference-refresh-v1")]
+    [RequireAuth]
+    public Task<IActionResult> RunV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "v1/wow/reference/refresh")] HttpRequest req,
+        FunctionContext ctx,
+        CancellationToken ct)
+        => Run(req, ctx, ct);
+
     private static async Task WriteNdjsonLineAsync(HttpResponse response, object envelope, CancellationToken ct)
     {
         await JsonSerializer.SerializeAsync(response.Body, envelope, envelope.GetType(), JsonOptions, ct);

--- a/api/Functions/WowReferenceSpecializationsFunction.cs
+++ b/api/Functions/WowReferenceSpecializationsFunction.cs
@@ -20,4 +20,15 @@ public class WowReferenceSpecializationsFunction(ISpecializationsRepository repo
         var items = await repo.ListAsync(ct);
         return new OkObjectResult(items);
     }
+
+    /// <summary>
+    /// <c>/api/v1/wow/reference/specializations</c> alias for <see cref="Run"/>.
+    /// See <c>docs/api-versioning.md</c>.
+    /// </summary>
+    [Function("wow-reference-specializations-v1")]
+    [RequireAuth]
+    public Task<IActionResult> RunV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "v1/wow/reference/specializations")] HttpRequest req,
+        CancellationToken ct)
+        => Run(req, ct);
 }

--- a/tests/Lfm.Api.Tests/FunctionAuthorizationContractTests.cs
+++ b/tests/Lfm.Api.Tests/FunctionAuthorizationContractTests.cs
@@ -29,11 +29,14 @@ public class FunctionAuthorizationContractTests
     {
         // Login flow — caller has no session yet by definition.
         "battlenet-login",
+        "battlenet-login-v1",
         "battlenet-callback",
+        "battlenet-callback-v1",
         // Logout is idempotent and non-destructive: a stale nav / bookmark /
         // double-click should land on the home page, not a 401 error page.
         // See #53 and BattleNetLogoutFunction XML summary for rationale.
         "battlenet-logout",
+        "battlenet-logout-v1",
         // Health probes — App Service Health Check / external monitors.
         "health",
         "health-ready",


### PR DESCRIPTION
## Summary

Fourth PR of the Slice 7.1 rollout. Closes out the API-side alias rollout — every HTTP handler in the Functions project now has a `/api/v1/...` alias delegating to its canonical method. Next (and final) PR is the SPA flip + OpenAPI servers bump + README.

**Families covered (13 handlers):**
- Auth: `BattleNetLoginFunction`, `BattleNetCallbackFunction`, `BattleNetLogoutFunction`
- Battle.net profile: `BattleNetCharactersFunction`, `BattleNetCharactersRefreshFunction`, `BattleNetCharacterPortraitsFunction`
- Raider characters: `RaiderCharacterAddFunction`, `RaiderCharacterFunction`, `RaiderCharacterEnrichFunction`
- WoW reference: `WowReferenceExpansionsFunction`, `WowReferenceInstancesFunction`, `WowReferenceSpecializationsFunction`, `WowReferenceRefreshFunction`

Each handler gains one thin `[Function("xxx-v1")]` method at `Route = "v1/..."` delegating to the canonical handler — no logic duplication.

`FunctionAuthorizationContractTests.AnonymousAllowList` grows three entries (`battlenet-login-v1`, `battlenet-callback-v1`, `battlenet-logout-v1`) so the contract test accepts the anonymous auth-flow aliases. Every other alias inherits `[RequireAuth]` from the declaring type.

Fixes the remaining API-side of **SAD-contract-no-versioning**.

## Test plan

- [x] `dotnet build lfm.sln -c Release`
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` (580 pass; contract test auto-discovered 13 new function ids)
