### PR TITLE
7.1e Flip SPA, OpenAPI, and docs to /api/v1/ (final slice)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,25 @@ so handler annotations stay synchronised with `api/openapi.yaml`
 without exposing a Swagger UI or live-schema endpoint to production
 traffic.
 
+### Versioning and the /api/v1/ alias window
+
+`/api/v1/…` is the canonical HTTP surface from Phase 7 onward. The
+OpenAPI contract, the first-party SPA, and every new consumer target
+`/api/v1/…`.
+
+The original unprefixed routes (`/api/runs`, `/api/me`, etc.) are kept
+as **aliases** — each canonical handler carries a second
+`[Function("xxx-v1")]` declaration at `Route = "v1/…"` that delegates
+to the same method, so both route tables hit identical code. The
+alias is a migration aid: forks or older SPA bundles that predate the
+cut-over keep working during a deploy window. The legacy routes will
+be removed in a follow-up release once App Insights traffic on the
+unprefixed paths is effectively zero. See
+[`docs/api-versioning.md`](docs/api-versioning.md) for the rollout
+design, retirement criteria, and why two `[Function]` declarations
+beats middleware-level route rewriting for the Azure Functions
+isolated worker.
+
 ## Notes
 
 Use standard C# conventions: 4-space indentation. Run `dotnet format` before committing. Keep commits short and imperative.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -74,7 +74,7 @@ paths:
   # Health
   # ─────────────────────────────────────────────────────────────────────────
 
-  /api/health:
+  /api/v1/health:
     get:
       tags: [Health]
       summary: Liveness probe.
@@ -95,7 +95,7 @@ paths:
                 live:
                   value: { status: ok, timestamp: '2026-04-24T00:00:00Z' }
 
-  /api/health/ready:
+  /api/v1/health/ready:
     get:
       tags: [Health]
       summary: Readiness probe.
@@ -125,7 +125,7 @@ paths:
   # Auth (Battle.net OAuth)
   # ─────────────────────────────────────────────────────────────────────────
 
-  /api/battlenet/login:
+  /api/v1/battlenet/login:
     get:
       tags: [Auth]
       summary: Start Battle.net OAuth login.
@@ -147,7 +147,7 @@ paths:
             Location:
               schema: { type: string, format: uri }
 
-  /api/battlenet/callback:
+  /api/v1/battlenet/callback:
     get:
       tags: [Auth]
       summary: Battle.net OAuth callback.
@@ -172,7 +172,7 @@ paths:
         '400':
           $ref: '#/components/responses/ProblemBadRequest'
 
-  /api/battlenet/logout:
+  /api/v1/battlenet/logout:
     get:
       tags: [Auth]
       summary: Clear the session cookie.
@@ -186,7 +186,7 @@ paths:
   # Me
   # ─────────────────────────────────────────────────────────────────────────
 
-  /api/me:
+  /api/v1/me:
     get:
       tags: [Me]
       summary: Logged-in user's profile.
@@ -256,7 +256,7 @@ paths:
   # Privacy
   # ─────────────────────────────────────────────────────────────────────────
 
-  /api/privacy-contact/email:
+  /api/v1/privacy-contact/email:
     get:
       tags: [Privacy]
       summary: Privacy contact email (click-to-reveal).
@@ -282,7 +282,7 @@ paths:
   # Guild
   # ─────────────────────────────────────────────────────────────────────────
 
-  /api/guild:
+  /api/v1/guild:
     get:
       tags: [Guild]
       summary: Current user's guild home view.
@@ -341,7 +341,7 @@ paths:
         '412':
           $ref: '#/components/responses/ProblemPreconditionFailed'
 
-  /api/guild/admin:
+  /api/v1/guild/admin:
     get:
       tags: [Guild]
       summary: Guild admin view (raw roster + rank setup).
@@ -363,7 +363,7 @@ paths:
   # Runs
   # ─────────────────────────────────────────────────────────────────────────
 
-  /api/runs:
+  /api/v1/runs:
     get:
       tags: [Runs]
       summary: List runs visible to the caller.
@@ -411,7 +411,7 @@ paths:
         '403':
           $ref: '#/components/responses/ProblemForbidden'
 
-  /api/runs/{id}:
+  /api/v1/runs/{id}:
     parameters:
       - in: path
         name: id
@@ -488,7 +488,7 @@ paths:
         '404':
           $ref: '#/components/responses/ProblemNotFound'
 
-  /api/runs/{id}/signup:
+  /api/v1/runs/{id}/signup:
     parameters:
       - in: path
         name: id
@@ -538,7 +538,7 @@ paths:
   # Raider Characters
   # ─────────────────────────────────────────────────────────────────────────
 
-  /api/raider/character:
+  /api/v1/raider/character:
     post:
       tags: [Raider Characters]
       summary: Add a WoW character to my raider profile.
@@ -561,7 +561,7 @@ paths:
         '429':
           $ref: '#/components/responses/ProblemTooManyRequests'
 
-  /api/raider/characters/{id}:
+  /api/v1/raider/characters/{id}:
     parameters:
       - in: path
         name: id
@@ -582,7 +582,7 @@ paths:
         '404':
           $ref: '#/components/responses/ProblemNotFound'
 
-  /api/raider/characters/{id}/enrich:
+  /api/v1/raider/characters/{id}/enrich:
     parameters:
       - in: path
         name: id
@@ -614,7 +614,7 @@ paths:
   # Battle.net Profile
   # ─────────────────────────────────────────────────────────────────────────
 
-  /api/battlenet/characters:
+  /api/v1/battlenet/characters:
     get:
       tags: [Battle.net Profile]
       summary: Logged-in user's WoW characters.
@@ -639,7 +639,7 @@ paths:
         '404':
           $ref: '#/components/responses/ProblemNotFound'
 
-  /api/battlenet/characters/refresh:
+  /api/v1/battlenet/characters/refresh:
     post:
       tags: [Battle.net Profile]
       summary: Refresh the cached character list from Blizzard.
@@ -657,7 +657,7 @@ paths:
         '429':
           $ref: '#/components/responses/ProblemTooManyRequests'
 
-  /api/battlenet/character-portraits:
+  /api/v1/battlenet/character-portraits:
     post:
       tags: [Battle.net Profile]
       summary: Resolve portrait URLs for a batch of characters.
@@ -684,7 +684,7 @@ paths:
   # WoW Reference
   # ─────────────────────────────────────────────────────────────────────────
 
-  /api/wow/reference/expansions:
+  /api/v1/wow/reference/expansions:
     get:
       tags: [WoW Reference]
       summary: Blizzard journal expansions (manifest).
@@ -698,7 +698,7 @@ paths:
                 type: array
                 items: { $ref: '#/components/schemas/ExpansionDto' }
 
-  /api/wow/reference/instances:
+  /api/v1/wow/reference/instances:
     get:
       tags: [WoW Reference]
       summary: Blizzard journal instances (manifest).
@@ -712,7 +712,7 @@ paths:
                 type: array
                 items: { $ref: '#/components/schemas/InstanceDto' }
 
-  /api/wow/reference/specializations:
+  /api/v1/wow/reference/specializations:
     get:
       tags: [WoW Reference]
       summary: WoW specializations (manifest).
@@ -726,7 +726,7 @@ paths:
                 type: array
                 items: { $ref: '#/components/schemas/SpecializationDto' }
 
-  /api/wow/reference/refresh:
+  /api/v1/wow/reference/refresh:
     post:
       tags: [WoW Reference, Admin]
       summary: Rebuild the reference-data manifests from Blizzard (admin only).
@@ -753,7 +753,7 @@ paths:
   # Admin
   # ─────────────────────────────────────────────────────────────────────────
 
-  /api/admin/runs/migrate-schema:
+  /api/v1/admin/runs/migrate-schema:
     post:
       tags: [Admin]
       summary: Backfill typed mode fields on legacy run documents.

--- a/app/Layout/MainLayout.razor
+++ b/app/Layout/MainLayout.razor
@@ -205,7 +205,7 @@
         // implementation was silently eaten by HttpClient timeouts on cold
         // Functions starts and left the session alive (issue #53).
         var apiBase = Config["ApiBaseUrl"]?.TrimEnd('/') ?? string.Empty;
-        Nav.NavigateTo($"{apiBase}/api/battlenet/logout", forceLoad: true);
+        Nav.NavigateTo($"{apiBase}/api/v1/battlenet/logout", forceLoad: true);
     }
 
     public void Dispose()

--- a/app/Lfm.App.Core/Services/BattleNetClient.cs
+++ b/app/Lfm.App.Core/Services/BattleNetClient.cs
@@ -20,7 +20,7 @@ public sealed class BattleNetClient(IHttpClientFactory factory) : IBattleNetClie
         var http = factory.CreateClient("api");
         try
         {
-            var response = await http.GetAsync("api/battlenet/characters", ct);
+            var response = await http.GetAsync("api/v1/battlenet/characters", ct);
             if (response.StatusCode == HttpStatusCode.NoContent)
                 return new CharactersFetchResult.NeedsRefresh();
             if (!response.IsSuccessStatusCode)
@@ -41,7 +41,7 @@ public sealed class BattleNetClient(IHttpClientFactory factory) : IBattleNetClie
         var http = factory.CreateClient("api");
         try
         {
-            var response = await http.PostAsync("api/battlenet/characters/refresh", null, ct);
+            var response = await http.PostAsync("api/v1/battlenet/characters/refresh", null, ct);
             if (!response.IsSuccessStatusCode)
                 return null;
             return await response.Content.ReadFromJsonAsync<List<CharacterDto>>(JsonOptions, ct);
@@ -59,7 +59,7 @@ public sealed class BattleNetClient(IHttpClientFactory factory) : IBattleNetClie
         var http = factory.CreateClient("api");
         try
         {
-            var response = await http.PostAsJsonAsync("api/battlenet/character-portraits", requests, ct);
+            var response = await http.PostAsJsonAsync("api/v1/battlenet/character-portraits", requests, ct);
             if (!response.IsSuccessStatusCode)
                 return null;
             var result = await response.Content.ReadFromJsonAsync<PortraitResponse>(JsonOptions, ct);

--- a/app/Lfm.App.Core/Services/ExpansionsClient.cs
+++ b/app/Lfm.App.Core/Services/ExpansionsClient.cs
@@ -11,7 +11,7 @@ public sealed class ExpansionsClient(IHttpClientFactory factory) : IExpansionsCl
     public async Task<IReadOnlyList<ExpansionDto>> ListAsync(CancellationToken ct)
     {
         var http = factory.CreateClient("api");
-        var items = await http.GetFromJsonAsync<List<ExpansionDto>>("api/wow/reference/expansions", ct);
+        var items = await http.GetFromJsonAsync<List<ExpansionDto>>("api/v1/wow/reference/expansions", ct);
         return items ?? [];
     }
 }

--- a/app/Lfm.App.Core/Services/GuildClient.cs
+++ b/app/Lfm.App.Core/Services/GuildClient.cs
@@ -13,7 +13,7 @@ public sealed class GuildClient(IHttpClientFactory factory) : IGuildClient
         var http = factory.CreateClient("api");
         try
         {
-            return await http.GetFromJsonAsync<GuildDto>("api/guild", ct);
+            return await http.GetFromJsonAsync<GuildDto>("api/v1/guild", ct);
         }
         catch (HttpRequestException)
         {
@@ -30,7 +30,7 @@ public sealed class GuildClient(IHttpClientFactory factory) : IGuildClient
         // server-issued value. A future slice will capture the ETag on the
         // preceding GET /api/guild and echo it here for full optimistic
         // concurrency. `*` matches any non-deleted resource per RFC 9110.
-        using var patch = new HttpRequestMessage(HttpMethod.Patch, "api/guild")
+        using var patch = new HttpRequestMessage(HttpMethod.Patch, "api/v1/guild")
         {
             Content = JsonContent.Create(request),
         };

--- a/app/Lfm.App.Core/Services/InstancesClient.cs
+++ b/app/Lfm.App.Core/Services/InstancesClient.cs
@@ -11,7 +11,7 @@ public sealed class InstancesClient(IHttpClientFactory factory) : IInstancesClie
     public async Task<IReadOnlyList<InstanceDto>> ListAsync(CancellationToken ct)
     {
         var http = factory.CreateClient("api");
-        var items = await http.GetFromJsonAsync<List<InstanceDto>>("api/wow/reference/instances", ct);
+        var items = await http.GetFromJsonAsync<List<InstanceDto>>("api/v1/wow/reference/instances", ct);
         return items ?? [];
     }
 }

--- a/app/Lfm.App.Core/Services/MeClient.cs
+++ b/app/Lfm.App.Core/Services/MeClient.cs
@@ -14,7 +14,7 @@ public sealed class MeClient(IHttpClientFactory factory) : IMeClient
         var http = factory.CreateClient("api");
         try
         {
-            return await http.GetFromJsonAsync<MeResponse>("api/me", ct);
+            return await http.GetFromJsonAsync<MeResponse>("api/v1/me", ct);
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)
         {
@@ -32,7 +32,7 @@ public sealed class MeClient(IHttpClientFactory factory) : IMeClient
             // server-issued value. A future slice will capture the ETag on the
             // preceding GET /api/me and echo it here for full optimistic
             // concurrency. `*` matches any non-deleted resource per RFC 9110.
-            using var patch = new HttpRequestMessage(HttpMethod.Patch, "api/me")
+            using var patch = new HttpRequestMessage(HttpMethod.Patch, "api/v1/me")
             {
                 Content = JsonContent.Create(request),
             };
@@ -53,7 +53,7 @@ public sealed class MeClient(IHttpClientFactory factory) : IMeClient
         var http = factory.CreateClient("api");
         try
         {
-            var response = await http.PutAsync($"api/raider/characters/{id}", content: null, ct);
+            var response = await http.PutAsync($"api/v1/raider/characters/{id}", content: null, ct);
             return response.IsSuccessStatusCode;
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)
@@ -67,7 +67,7 @@ public sealed class MeClient(IHttpClientFactory factory) : IMeClient
         var http = factory.CreateClient("api");
         try
         {
-            var response = await http.DeleteAsync("api/me", ct);
+            var response = await http.DeleteAsync("api/v1/me", ct);
             return response.IsSuccessStatusCode;
         }
         catch (HttpRequestException)
@@ -81,7 +81,7 @@ public sealed class MeClient(IHttpClientFactory factory) : IMeClient
         var http = factory.CreateClient("api");
         try
         {
-            var response = await http.PostAsync($"api/raider/characters/{id}/enrich", content: null, ct);
+            var response = await http.PostAsync($"api/v1/raider/characters/{id}/enrich", content: null, ct);
             if (!response.IsSuccessStatusCode) return null;
             return await response.Content.ReadFromJsonAsync<CharacterDto>(cancellationToken: ct);
         }

--- a/app/Lfm.App.Core/Services/RunsClient.cs
+++ b/app/Lfm.App.Core/Services/RunsClient.cs
@@ -18,20 +18,20 @@ public sealed class RunsClient(IHttpClientFactory factory) : IRunsClient
         // consumes only the first page — a future "load more" feature will need
         // a ListAsync overload that exposes ContinuationToken.
         var http = factory.CreateClient("api");
-        var response = await http.GetFromJsonAsync<RunsListResponse>("api/runs", ct);
+        var response = await http.GetFromJsonAsync<RunsListResponse>("api/v1/runs", ct);
         return response?.Items ?? [];
     }
 
     public async Task<RunDetailDto?> GetAsync(string id, CancellationToken ct)
     {
         var http = factory.CreateClient("api");
-        return await http.GetFromJsonAsync<RunDetailDto>($"api/runs/{Uri.EscapeDataString(id)}", ct);
+        return await http.GetFromJsonAsync<RunDetailDto>($"api/v1/runs/{Uri.EscapeDataString(id)}", ct);
     }
 
     public async Task<RunDetailWithEtag?> GetWithEtagAsync(string id, CancellationToken ct)
     {
         var http = factory.CreateClient("api");
-        using var response = await http.GetAsync($"api/runs/{Uri.EscapeDataString(id)}", ct);
+        using var response = await http.GetAsync($"api/v1/runs/{Uri.EscapeDataString(id)}", ct);
         if (!response.IsSuccessStatusCode) return null;
 
         var dto = await response.Content.ReadFromJsonAsync<RunDetailDto>(ct);
@@ -44,7 +44,7 @@ public sealed class RunsClient(IHttpClientFactory factory) : IRunsClient
     public async Task<RunDetailDto?> CreateAsync(CreateRunRequest request, CancellationToken ct)
     {
         var http = factory.CreateClient("api");
-        var response = await http.PostAsJsonAsync("api/runs", request, ct);
+        var response = await http.PostAsJsonAsync("api/v1/runs", request, ct);
         if (!response.IsSuccessStatusCode) return null;
         return await response.Content.ReadFromJsonAsync<RunDetailDto>(ct);
     }
@@ -54,7 +54,7 @@ public sealed class RunsClient(IHttpClientFactory factory) : IRunsClient
     {
         var http = factory.CreateClient("api");
 
-        using var httpRequest = new HttpRequestMessage(HttpMethod.Put, $"api/runs/{Uri.EscapeDataString(id)}")
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Put, $"api/v1/runs/{Uri.EscapeDataString(id)}")
         {
             Content = JsonContent.Create(request),
         };
@@ -78,14 +78,14 @@ public sealed class RunsClient(IHttpClientFactory factory) : IRunsClient
     public async Task<bool> DeleteAsync(string id, CancellationToken ct)
     {
         var http = factory.CreateClient("api");
-        var response = await http.DeleteAsync($"api/runs/{Uri.EscapeDataString(id)}", ct);
+        var response = await http.DeleteAsync($"api/v1/runs/{Uri.EscapeDataString(id)}", ct);
         return response.IsSuccessStatusCode;
     }
 
     public async Task<RunDetailDto?> SignupAsync(string runId, SignupRequest request, CancellationToken ct)
     {
         var http = factory.CreateClient("api");
-        var response = await http.PostAsJsonAsync($"api/runs/{Uri.EscapeDataString(runId)}/signup", request, ct);
+        var response = await http.PostAsJsonAsync($"api/v1/runs/{Uri.EscapeDataString(runId)}/signup", request, ct);
         if (!response.IsSuccessStatusCode) return null;
         return await response.Content.ReadFromJsonAsync<RunDetailDto>(ct);
     }
@@ -93,7 +93,7 @@ public sealed class RunsClient(IHttpClientFactory factory) : IRunsClient
     public async Task<RunDetailDto?> CancelSignupAsync(string runId, CancellationToken ct)
     {
         var http = factory.CreateClient("api");
-        var response = await http.DeleteAsync($"api/runs/{Uri.EscapeDataString(runId)}/signup", ct);
+        var response = await http.DeleteAsync($"api/v1/runs/{Uri.EscapeDataString(runId)}/signup", ct);
         if (!response.IsSuccessStatusCode) return null;
         return await response.Content.ReadFromJsonAsync<RunDetailDto>(ct);
     }

--- a/app/Lfm.App.Core/Services/WowReferenceAdminClient.cs
+++ b/app/Lfm.App.Core/Services/WowReferenceAdminClient.cs
@@ -25,7 +25,7 @@ public sealed class WowReferenceAdminClient(IHttpClientFactory factory) : IWowRe
 
         // ResponseHeadersRead — return as soon as the headers arrive so we
         // can start reading NDJSON lines while the server is still producing them.
-        using var response = await http.PostAsync("api/wow/reference/refresh", content: null, ct);
+        using var response = await http.PostAsync("api/v1/wow/reference/refresh", content: null, ct);
         response.EnsureSuccessStatusCode();
 
         await using var stream = await response.Content.ReadAsStreamAsync(ct);

--- a/app/Pages/LandingPage.razor
+++ b/app/Pages/LandingPage.razor
@@ -40,6 +40,6 @@
     private void NavigateToLogin()
     {
         var apiBase = Config["ApiBaseUrl"]?.TrimEnd('/') ?? string.Empty;
-        Nav.NavigateTo($"{apiBase}/api/battlenet/login", forceLoad: true);
+        Nav.NavigateTo($"{apiBase}/api/v1/battlenet/login", forceLoad: true);
     }
 }

--- a/app/Pages/LoginPage.razor
+++ b/app/Pages/LoginPage.razor
@@ -19,6 +19,6 @@
     {
         var redirect = string.IsNullOrEmpty(Redirect) ? "/runs" : Redirect;
         var apiBase = Config["ApiBaseUrl"]?.TrimEnd('/') ?? string.Empty;
-        Nav.NavigateTo($"{apiBase}/api/battlenet/login?redirect={Uri.EscapeDataString(redirect)}", forceLoad: true);
+        Nav.NavigateTo($"{apiBase}/api/v1/battlenet/login?redirect={Uri.EscapeDataString(redirect)}", forceLoad: true);
     }
 }

--- a/app/Pages/PrivacyPolicyPage.razor
+++ b/app/Pages/PrivacyPolicyPage.razor
@@ -113,7 +113,7 @@
         try
         {
             var http = HttpFactory.CreateClient("api");
-            var result = await http.GetFromJsonAsync<Lfm.Contracts.Privacy.PrivacyEmailResponse>("api/privacy-contact/email");
+            var result = await http.GetFromJsonAsync<Lfm.Contracts.Privacy.PrivacyEmailResponse>("api/v1/privacy-contact/email");
             if (result is null || string.IsNullOrEmpty(result.Local) || string.IsNullOrEmpty(result.Domain))
             {
                 _state = RevealState.Error;

--- a/tests/Lfm.Api.Tests/Openapi/OpenApiContractTests.cs
+++ b/tests/Lfm.Api.Tests/Openapi/OpenApiContractTests.cs
@@ -65,32 +65,32 @@ public class OpenApiContractTests
         var result = await OpenApiDocument.LoadAsync(SpecPath, CreateSettings());
 
         Assert.NotNull(result.Document!.Paths);
-        Assert.Contains("/api/health", result.Document.Paths.Keys);
-        Assert.Contains("/api/health/ready", result.Document.Paths.Keys);
+        Assert.Contains("/api/v1/health", result.Document.Paths.Keys);
+        Assert.Contains("/api/v1/health/ready", result.Document.Paths.Keys);
     }
 
     [Theory]
-    [InlineData("/api/me")]
-    [InlineData("/api/guild")]
-    [InlineData("/api/guild/admin")]
-    [InlineData("/api/runs")]
-    [InlineData("/api/runs/{id}")]
-    [InlineData("/api/runs/{id}/signup")]
-    [InlineData("/api/raider/character")]
-    [InlineData("/api/raider/characters/{id}")]
-    [InlineData("/api/raider/characters/{id}/enrich")]
-    [InlineData("/api/battlenet/login")]
-    [InlineData("/api/battlenet/callback")]
-    [InlineData("/api/battlenet/logout")]
-    [InlineData("/api/battlenet/characters")]
-    [InlineData("/api/battlenet/characters/refresh")]
-    [InlineData("/api/battlenet/character-portraits")]
-    [InlineData("/api/wow/reference/expansions")]
-    [InlineData("/api/wow/reference/instances")]
-    [InlineData("/api/wow/reference/specializations")]
-    [InlineData("/api/wow/reference/refresh")]
-    [InlineData("/api/admin/runs/migrate-schema")]
-    [InlineData("/api/privacy-contact/email")]
+    [InlineData("/api/v1/me")]
+    [InlineData("/api/v1/guild")]
+    [InlineData("/api/v1/guild/admin")]
+    [InlineData("/api/v1/runs")]
+    [InlineData("/api/v1/runs/{id}")]
+    [InlineData("/api/v1/runs/{id}/signup")]
+    [InlineData("/api/v1/raider/character")]
+    [InlineData("/api/v1/raider/characters/{id}")]
+    [InlineData("/api/v1/raider/characters/{id}/enrich")]
+    [InlineData("/api/v1/battlenet/login")]
+    [InlineData("/api/v1/battlenet/callback")]
+    [InlineData("/api/v1/battlenet/logout")]
+    [InlineData("/api/v1/battlenet/characters")]
+    [InlineData("/api/v1/battlenet/characters/refresh")]
+    [InlineData("/api/v1/battlenet/character-portraits")]
+    [InlineData("/api/v1/wow/reference/expansions")]
+    [InlineData("/api/v1/wow/reference/instances")]
+    [InlineData("/api/v1/wow/reference/specializations")]
+    [InlineData("/api/v1/wow/reference/refresh")]
+    [InlineData("/api/v1/admin/runs/migrate-schema")]
+    [InlineData("/api/v1/privacy-contact/email")]
     public async Task Spec_documents_public_endpoint(string path)
     {
         var result = await OpenApiDocument.LoadAsync(SpecPath, CreateSettings());

--- a/tests/Lfm.App.Core.Tests/Services/BattleNetClientTests.cs
+++ b/tests/Lfm.App.Core.Tests/Services/BattleNetClientTests.cs
@@ -48,7 +48,7 @@ public class BattleNetClientTests
         Assert.Equal(2, cached.Characters.Count);
         Assert.Equal("Char-A", cached.Characters[0].Name);
         Assert.Equal(HttpMethod.Get, handler.LastRequest!.Method);
-        Assert.Equal("/api/battlenet/characters", handler.LastRequest.RequestUri!.PathAndQuery);
+        Assert.Equal("/api/v1/battlenet/characters", handler.LastRequest.RequestUri!.PathAndQuery);
     }
 
     [Fact]
@@ -144,7 +144,7 @@ public class BattleNetClientTests
         var single = Assert.Single(result!);
         Assert.Equal("Refreshed", single.Name);
         Assert.Equal(HttpMethod.Post, handler.LastRequest!.Method);
-        Assert.Equal("/api/battlenet/characters/refresh", handler.LastRequest.RequestUri!.PathAndQuery);
+        Assert.Equal("/api/v1/battlenet/characters/refresh", handler.LastRequest.RequestUri!.PathAndQuery);
     }
 
     [Fact]
@@ -200,7 +200,7 @@ public class BattleNetClientTests
         Assert.Equal(2, result!.Count);
         Assert.Equal("https://render.example/p1.jpg", result["eu-silvermoon-sourgeezer"]);
         Assert.Equal(HttpMethod.Post, handler.LastRequest!.Method);
-        Assert.Equal("/api/battlenet/character-portraits", handler.LastRequest.RequestUri!.PathAndQuery);
+        Assert.Equal("/api/v1/battlenet/character-portraits", handler.LastRequest.RequestUri!.PathAndQuery);
         Assert.NotNull(handler.LastRequest.Content);
         Assert.Equal("application/json", handler.LastRequest.Content!.Headers.ContentType!.MediaType);
     }

--- a/tests/Lfm.App.Core.Tests/Services/ExpansionsClientTests.cs
+++ b/tests/Lfm.App.Core.Tests/Services/ExpansionsClientTests.cs
@@ -35,7 +35,7 @@ public class ExpansionsClientTests
         Assert.Equal(68, result[0].Id);
         Assert.Equal("The War Within", result[1].Name);
         Assert.Equal(HttpMethod.Get, handler.LastRequest!.Method);
-        Assert.Equal("/api/wow/reference/expansions", handler.LastRequest.RequestUri!.PathAndQuery);
+        Assert.Equal("/api/v1/wow/reference/expansions", handler.LastRequest.RequestUri!.PathAndQuery);
     }
 
     [Fact]

--- a/tests/Lfm.App.Core.Tests/Services/GuildClientTests.cs
+++ b/tests/Lfm.App.Core.Tests/Services/GuildClientTests.cs
@@ -56,7 +56,7 @@ public class GuildClientTests
         Assert.NotNull(result);
         Assert.Equal("Stormchasers", result!.Guild!.Name);
         Assert.Equal(HttpMethod.Get, handler.LastRequest!.Method);
-        Assert.Equal("/api/guild", handler.LastRequest.RequestUri!.PathAndQuery);
+        Assert.Equal("/api/v1/guild", handler.LastRequest.RequestUri!.PathAndQuery);
     }
 
     [Fact]
@@ -98,7 +98,7 @@ public class GuildClientTests
         Assert.NotNull(result);
         Assert.Equal("Stormchasers Reborn", result!.Guild!.Name);
         Assert.Equal(HttpMethod.Patch, handler.LastRequest!.Method);
-        Assert.Equal("/api/guild", handler.LastRequest.RequestUri!.PathAndQuery);
+        Assert.Equal("/api/v1/guild", handler.LastRequest.RequestUri!.PathAndQuery);
         Assert.Equal("application/json", handler.LastRequest.Content!.Headers.ContentType!.MediaType);
     }
 

--- a/tests/Lfm.App.Core.Tests/Services/InstancesClientTests.cs
+++ b/tests/Lfm.App.Core.Tests/Services/InstancesClientTests.cs
@@ -35,7 +35,7 @@ public class InstancesClientTests
         Assert.Equal("1234:raid", result[0].Id);
         Assert.Equal("Operation: Mechagon", result[1].Name);
         Assert.Equal(HttpMethod.Get, handler.LastRequest!.Method);
-        Assert.Equal("/api/wow/reference/instances", handler.LastRequest.RequestUri!.PathAndQuery);
+        Assert.Equal("/api/v1/wow/reference/instances", handler.LastRequest.RequestUri!.PathAndQuery);
     }
 
     [Fact]

--- a/tests/Lfm.App.Core.Tests/Services/MeClientTests.cs
+++ b/tests/Lfm.App.Core.Tests/Services/MeClientTests.cs
@@ -42,7 +42,7 @@ public class MeClientTests
         Assert.Equal("Stormchasers", result.GuildName);
         Assert.Equal("en", result.Locale);
         Assert.Equal(HttpMethod.Get, handler.LastRequest!.Method);
-        Assert.Equal("/api/me", handler.LastRequest.RequestUri!.PathAndQuery);
+        Assert.Equal("/api/v1/me", handler.LastRequest.RequestUri!.PathAndQuery);
     }
 
     [Fact]
@@ -92,7 +92,7 @@ public class MeClientTests
         Assert.NotNull(result);
         Assert.Equal("fi", result!.Locale);
         Assert.Equal(HttpMethod.Patch, handler.LastRequest!.Method);
-        Assert.Equal("/api/me", handler.LastRequest.RequestUri!.PathAndQuery);
+        Assert.Equal("/api/v1/me", handler.LastRequest.RequestUri!.PathAndQuery);
         Assert.Equal("application/json", handler.LastRequest.Content!.Headers.ContentType!.MediaType);
     }
 
@@ -146,7 +146,7 @@ public class MeClientTests
 
         Assert.True(result);
         Assert.Equal(HttpMethod.Delete, handler.LastRequest!.Method);
-        Assert.Equal("/api/me", handler.LastRequest.RequestUri!.PathAndQuery);
+        Assert.Equal("/api/v1/me", handler.LastRequest.RequestUri!.PathAndQuery);
     }
 
     [Fact]
@@ -182,7 +182,7 @@ public class MeClientTests
 
         Assert.True(result);
         Assert.Equal(HttpMethod.Put, handler.LastRequest!.Method);
-        Assert.Equal("/api/raider/characters/eu-silvermoon-arthas", handler.LastRequest.RequestUri!.PathAndQuery);
+        Assert.Equal("/api/v1/raider/characters/eu-silvermoon-arthas", handler.LastRequest.RequestUri!.PathAndQuery);
     }
 
     [Fact]
@@ -228,7 +228,7 @@ public class MeClientTests
         Assert.Equal("Sourgeezer", result!.Name);
         Assert.Equal("silvermoon", result.Realm);
         Assert.Equal(HttpMethod.Post, handler.LastRequest!.Method);
-        Assert.Equal("/api/raider/characters/eu-silvermoon-sourgeezer/enrich", handler.LastRequest.RequestUri!.PathAndQuery);
+        Assert.Equal("/api/v1/raider/characters/eu-silvermoon-sourgeezer/enrich", handler.LastRequest.RequestUri!.PathAndQuery);
     }
 
     [Fact]

--- a/tests/Lfm.App.Core.Tests/Services/RunsClientTests.cs
+++ b/tests/Lfm.App.Core.Tests/Services/RunsClientTests.cs
@@ -83,7 +83,7 @@ public class RunsClientTests
         Assert.Equal(2, result.Count);
         Assert.Equal("run-a", result[0].Id);
         Assert.Equal(HttpMethod.Get, handler.LastRequest!.Method);
-        Assert.Equal("/api/runs", handler.LastRequest.RequestUri!.PathAndQuery);
+        Assert.Equal("/api/v1/runs", handler.LastRequest.RequestUri!.PathAndQuery);
     }
 
     [Fact]
@@ -122,7 +122,7 @@ public class RunsClientTests
         await client.GetAsync("run with spaces/and?weird", CancellationToken.None);
 
         var path = handler.LastRequest!.RequestUri!.PathAndQuery;
-        Assert.StartsWith("/api/runs/", path);
+        Assert.StartsWith("/api/v1/runs/", path);
         Assert.Contains("%2F", path);
         Assert.DoesNotContain(" ", path);
         Assert.DoesNotContain("?weird", path);
@@ -149,7 +149,7 @@ public class RunsClientTests
 
         Assert.NotNull(result);
         Assert.Equal(HttpMethod.Post, handler.LastRequest!.Method);
-        Assert.Equal("/api/runs", handler.LastRequest.RequestUri!.PathAndQuery);
+        Assert.Equal("/api/v1/runs", handler.LastRequest.RequestUri!.PathAndQuery);
         Assert.NotNull(handler.LastRequest.Content);
         Assert.Equal("application/json", handler.LastRequest.Content!.Headers.ContentType!.MediaType);
     }
@@ -196,7 +196,7 @@ public class RunsClientTests
 
         Assert.NotNull(result);
         Assert.Equal(HttpMethod.Post, handler.LastRequest!.Method);
-        Assert.Equal("/api/runs/run-1/signup", handler.LastRequest.RequestUri!.PathAndQuery);
+        Assert.Equal("/api/v1/runs/run-1/signup", handler.LastRequest.RequestUri!.PathAndQuery);
     }
 
     [Fact]
@@ -217,7 +217,7 @@ public class RunsClientTests
 
         Assert.NotNull(result);
         Assert.Equal(HttpMethod.Put, handler.LastRequest!.Method);
-        Assert.Equal("/api/runs/run-1", handler.LastRequest.RequestUri!.PathAndQuery);
+        Assert.Equal("/api/v1/runs/run-1", handler.LastRequest.RequestUri!.PathAndQuery);
         Assert.Equal("application/json", handler.LastRequest.Content!.Headers.ContentType!.MediaType);
         Assert.Equal("\"etag-v1\"", handler.LastRequest.Headers.IfMatch.Single().Tag);
     }
@@ -285,7 +285,7 @@ public class RunsClientTests
         Assert.NotNull(result);
         Assert.Equal("run-1", result!.Id);
         Assert.Equal(HttpMethod.Delete, handler.LastRequest!.Method);
-        Assert.Equal("/api/runs/run-1/signup", handler.LastRequest.RequestUri!.PathAndQuery);
+        Assert.Equal("/api/v1/runs/run-1/signup", handler.LastRequest.RequestUri!.PathAndQuery);
     }
 
     [Fact]
@@ -306,7 +306,7 @@ public class RunsClientTests
         await client.CancelSignupAsync("run with spaces/and?weird", CancellationToken.None);
 
         var path = handler.LastRequest!.RequestUri!.PathAndQuery;
-        Assert.StartsWith("/api/runs/", path);
+        Assert.StartsWith("/api/v1/runs/", path);
         Assert.EndsWith("/signup", path);
         Assert.Contains("%2F", path);
         Assert.DoesNotContain(" ", path);

--- a/tests/Lfm.App.Tests/AuthPagesTests.cs
+++ b/tests/Lfm.App.Tests/AuthPagesTests.cs
@@ -31,7 +31,7 @@ public class AuthPagesTests : ComponentTestBase
         cut.Find("fluent-button").Click();
 
         var entry = Assert.Single(nav.History);
-        Assert.StartsWith("http://localhost:7071/api/battlenet/login", entry.Uri);
+        Assert.StartsWith("http://localhost:7071/api/v1/battlenet/login", entry.Uri);
         Assert.Contains("redirect=%2Fruns", entry.Uri);
         Assert.True(entry.Options.ForceLoad);
     }


### PR DESCRIPTION
## Summary

The final slice of the `review-api-precious-dewdrop` remediation plan. Every consumer now targets `/api/v1/…` as the canonical URL; the unprefixed `/api/…` routes stay registered as aliases through the second `[Function(…)]` declarations shipped in PRs 141–144.

**SPA HTTP clients flipped to `/api/v1/…`:**
- `MeClient`, `GuildClient`, `RunsClient`, `BattleNetClient`, `ExpansionsClient`, `InstancesClient`, `WowReferenceAdminClient` — all literal `"api/…"` / `$"api/…"` paths rewritten.

**Razor navigation paths flipped:**
- `LoginPage`, `LandingPage` → `/api/v1/battlenet/login`
- `MainLayout` → `/api/v1/battlenet/logout`
- `PrivacyPolicyPage` → `/api/v1/privacy-contact/email`

**OpenAPI contract:**
- Every path key in `api/openapi.yaml` moves from `/api/…` to `/api/v1/…`. The `servers` block is unchanged — the version is encoded in the path, keeping `/api/health`-shape backwards-compat documentation in the Git history if ever needed.

**Docs:**
- `README.md` gains a short "Versioning and the /api/v1/ alias window" block under "API Contract" explaining that the old routes remain as transitional aliases and pointing at [`docs/api-versioning.md`](docs/api-versioning.md) for the rollout design and retirement criteria.

**Tests updated:**
- `RunsClientTests`, `MeClientTests`, `GuildClientTests`, `BattleNetClientTests`, `ExpansionsClientTests`, `InstancesClientTests`, `AuthPagesTests` — path-assertion strings bulk-flipped.
- `OpenApiContractTests` — `InlineData` and `Contains` assertions bulk-flipped to the `/api/v1/` path keys.

Closes the last open bullet under **SAD-contract-no-versioning**. With this PR merged, the plan's checklist is fully executed.

## Test plan

- [x] `dotnet build lfm.sln -c Release`
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` (580 pass)
- [x] `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release` (178 pass)
- [x] `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release` (178 pass)
- [ ] Manual smoke: load the SPA, log in via Battle.net, create a run, view privacy policy → all succeed over `/api/v1/…` with no network errors in DevTools.
