### PR TITLE
Retire obsolete documentation refresh

### DIFF
--- a/docs/threat-models/README.md
+++ b/docs/threat-models/README.md
@@ -1,0 +1,104 @@
+# Threat Models
+
+STRIDE threat models for LFM's distinct trust boundaries. Each file is one
+boundary, one trust transition. Documents are claude-facing first (intended to
+inform code review and secure design choices) but kept readable for any reviewer.
+
+## Why this directory exists
+
+Per the rubric in
+`souroldgeezer-audit/docs/security-reference/devsecops.md` § 7 principle 10,
+**threat modelling is part of the diff**. A design change that introduces a new
+trust boundary without a threat model is incomplete. Per § 3, "what to threat
+model" includes:
+
+- Every new external interface (HTTP, queue, webhook, RPC, file upload, WebSocket).
+- Every new trust boundary (process, network, tenant, service account, build host).
+- Every elevation-of-privilege path (admin endpoints, impersonation, sudo, role
+  assumption).
+- Every data flow that crosses a classification boundary (PII, secrets, regulated
+  data).
+- Every design change to authentication, authorization, session management,
+  cryptography, or audit logging.
+
+If a PR matches one of those, it must ship a threat-model diff in the same PR —
+either updating an existing file under this directory or adding a new one. The
+positive signal in § 5.3 #12 is exactly this: "threat model updated in the same PR
+as the architectural change it covers."
+
+## Current models (mapped to trust boundaries)
+
+| File | Boundary |
+|---|---|
+| [`battlenet-oauth-callback.md`](battlenet-oauth-callback.md) | Unauthenticated browser → `/api/battlenet/callback` (PKCE auth-code completion + session cookie issuance). |
+| [`session-cookie-api.md`](session-cookie-api.md) | Browser holding `lfm_session` → `[RequireAuth]` API endpoints. |
+| [`cosmos-partition-key-authz.md`](cosmos-partition-key-authz.md) | Authenticated handlers → Cosmos data plane; `/battleNetId` partition isolation. |
+| [`keyvault-data-protection-wrap.md`](keyvault-data-protection-wrap.md) | Functions app → Key Vault for the DP-wrap key, admin-allowlist secret, Blizzard credentials. |
+| [`admin-privilege-boundary.md`](admin-privilege-boundary.md) | Authenticated regular user → site-admin endpoints (`/admin/runs/migrate-schema`, `/wow/reference/refresh`, `/guild/admin`). |
+| [`blizzard-outbound-api.md`](blizzard-outbound-api.md) | Functions app → Blizzard OAuth + Profile + Game Data APIs. |
+| [`run-signup-peer-permission.md`](run-signup-peer-permission.md) | Authenticated user A → run document owned by user B (signup roster mutations). |
+| [`e2e-login-bypass.md`](e2e-login-bypass.md) | E2E test runner → arbitrary session cookie via the compile-and-runtime-gated `/api/e2e/login` endpoint. |
+
+## Coverage map for `api/Functions/*.cs`
+
+| Function | Covered by |
+|---|---|
+| `BattleNetLoginFunction`, `BattleNetCallbackFunction` | `battlenet-oauth-callback.md` |
+| `BattleNetLogoutFunction` | `session-cookie-api.md` (cookie clearing path) |
+| `BattleNetCharactersFunction`, `BattleNetCharactersRefreshFunction`, `BattleNetCharacterPortraitsFunction` | `blizzard-outbound-api.md` (outbound), `session-cookie-api.md` (cookie supplies user token); portrait detail in `character-portrait-fetch.md` (backlog) |
+| `MeFunction`, `MeUpdateFunction`, `MeDeleteFunction` | `session-cookie-api.md` + `cosmos-partition-key-authz.md` |
+| `GuildFunction` (GET / PATCH) | `cosmos-partition-key-authz.md` (partition + IGuildPermissions) |
+| `GuildAdminFunction` | `admin-privilege-boundary.md` |
+| `RaiderCharacterAddFunction`, `RaiderCharacterEnrichFunction`, `RaiderCharacterFunction`, `RaiderCleanupFunction` | `blizzard-outbound-api.md` + `cosmos-partition-key-authz.md` |
+| `RunsListFunction`, `RunsDetailFunction` | `cosmos-partition-key-authz.md` |
+| `RunsCreateFunction`, `RunsUpdateFunction`, `RunsDeleteFunction` | `cosmos-partition-key-authz.md` (data plane); run-creator ownership gap noted in that file's Elevation row |
+| `RunsSignupFunction`, `RunsCancelSignupFunction` | `run-signup-peer-permission.md` |
+| `RunsMigrateSchemaFunction` | `admin-privilege-boundary.md` |
+| `WowReferenceRefreshFunction`, `WowReferenceRefreshTimerFunction` | `admin-privilege-boundary.md` (write side); read side in `reference-data-integrity.md` (backlog) |
+| `WowReferenceExpansionsFunction`, `WowReferenceInstancesFunction`, `WowReferenceSpecializationsFunction` | `reference-data-integrity.md` (backlog) |
+| `PrivacyContactFunction` | not yet modelled — see backlog |
+| `HealthFunction` | not modelled — public diagnostic, no state |
+| `CorsPreflightFunction` | `session-cookie-api.md` (origin allowlist) |
+| `E2ELoginFunction` | `e2e-login-bypass.md` |
+
+## Backlog (medium-priority gaps; add when touched)
+
+These represent boundaries where the existing models flag the surface in their
+"Out of Scope" sections, with a one-paragraph charter ready to expand into a full
+file when a PR touches the relevant code:
+
+- **`reference-data-integrity.md`** — admin / timer writes blob; every authenticated
+  user reads. A tampered `index.json` poisons every browser's instance + spec
+  pickers. No content-hash, no signature.
+- **`idempotency-replay-cache.md`** — Cosmos-backed `(battleNetId, idempotency-key)`
+  replay cache. ID-construction edge cases, `UpsertItemAsync` race on concurrent
+  writes, `originalCreatedAt` leakage in replay hint, RU pressure on free-tier.
+- **`audit-log-pii-pipeline.md`** — `IActorHasher` HMAC pipeline.
+  `AuditOptions.HashSalt` is **not yet wired in `infra/modules/functions.bicep`**,
+  so deployed environments emit plaintext `battleNetId` to App Insights. Salt
+  rotation breaks historical attribution. `AuditEvent.cs` doc-comment misstates
+  GDPR PII status.
+- **`character-portrait-fetch.md`** — caller-supplied `(charRegion, realm, name)` →
+  cross-region `*.api.blizzard.com/...`. SSRF blocked by allowlist, but legacy
+  `PortraitCache` entries are not re-validated; batch amplification not capped.
+- **`cors-proxy-trust.md`** — `Origin` allowlist + `X-Forwarded-For` trust scoping.
+  Non-browser callers (no `Origin`) bypass CORS; cold-start scale-out resets
+  per-instance rate-limit buckets; `TrustedProxyAddresses` IP-format mismatch
+  silently falls back.
+- **`privacy-contact-anti-scraping.md`** — `/api/privacy-contact/email` returns a
+  split address; rate-limited separately. Currently just a one-paragraph note in
+  the function's own doc-comment.
+
+## Process: when adding or changing a boundary
+
+1. **Detect**: ask whether the change matches any item in
+   "what to threat model" above.
+2. **Choose**: edit an existing file if the change is within an existing boundary,
+   or add a new file under this directory if it's a new boundary.
+3. **Diff**: include the threat-model change in the **same PR** as the code /
+   IaC change. Reviewers should reject PRs that match § 3 criteria but lack a
+   threat-model diff.
+4. **Drift**: if a code reference moves, the line ranges in this directory go
+   stale silently. The April 2026 refresh corrected ~50 stale references that had
+   accumulated in eight days; the prevention is the per-PR habit above, not a
+   periodic sweep.

--- a/docs/threat-models/admin-privilege-boundary.md
+++ b/docs/threat-models/admin-privilege-boundary.md
@@ -1,0 +1,98 @@
+# Threat Model: Admin Privilege Boundary
+
+## Introduction
+
+This document covers the trust boundary between an authenticated regular user and the
+site-admin endpoints that execute privileged, application-wide operations:
+`POST /api/admin/runs/migrate-schema`, `POST /api/wow/reference/refresh`, and
+`GET /api/guild/admin`. Admin identity is determined by membership in the
+`site-admin-battle-net-ids` Key Vault secret, evaluated by `SiteAdminService` with a
+10-second in-memory cache. An attacker who acquires admin status — through compromise,
+mis-grant, or a window in the cache TTL — can mutate every run document, overwrite
+every reference-data blob the SPA consumes, or read every guild's full configuration.
+
+## Data Flow
+
+```
+Auth'd Browser           Function Handler              SiteAdminService           Key Vault
+      |                         |                            |                       |
+      |--POST /api/admin/runs/migrate-schema (cookie)-->     |                       |
+      |                  [boundary: user trust -> admin trust]
+      |                         |--principal=GetPrincipal()  |                       |
+      |                         |--IsAdminAsync(principal)-->|                       |
+      |                         |                            |--cache hit? (<=10s)   |
+      |                         |                            |  yes -> return       |
+      |                         |                            |  no  -> SecretClient->|
+      |                         |                            |<--ids list-----------|
+      |                         |<--true / false-------------|                       |
+      |                         |  if false -> 403           |                       |
+      |                         |--RunsRepository.MigrateSchemaAsync()->             |
+      |                         |  (SELECT * FROM c, full document overwrite,        |
+      |                         |   no IfMatchEtag, every partition)                 |
+      |<--200 / NDJSON progress-|                                                    |
+```
+
+## Trust Boundaries Crossed
+
+- **Authenticated user → admin trust zone**: every admin endpoint resolves the
+  session principal first (via the standard `[RequireAuth]` chain), then calls
+  `ISiteAdminService.IsAdminAsync(principal.BattleNetId, ct)`; only on a true result
+  does the handler execute the privileged operation.
+- **Functions MI → Key Vault for the admin allowlist**: `KeyVaultSecretResolver`
+  reads `site-admin-battle-net-ids`. The same `Key Vault Secrets User` role that
+  unwraps the Data Protection key reads this secret (see
+  `keyvault-data-protection-wrap.md`).
+- **Admin handler → Cosmos / Blob**: privileged writes that bypass per-user
+  partition isolation. `RunsMigrateSchemaFunction` writes every document in the
+  `runs` container; `WowReferenceRefreshFunction` writes every blob under
+  `wow/reference/`.
+
+## STRIDE Table
+
+| Category | Threat | Current mitigation | Residual risk |
+|---|---|---|---|
+| **Spoofing** | Attacker exploits the 10-second cache TTL: after the operator removes a Battle.net id from the secret, the attacker still gets one admin-decision window per Functions instance. | `CacheTtl = TimeSpan.FromSeconds(10)`; cache is per-instance, so revocation propagates within ~10 s on each warm instance. Operator can recycle the Functions app to invalidate every cache atomically. | Medium — silent revocation lag of up to 10 s plus existing in-flight requests. No way to force-flush from outside Azure. |
+| **Tampering — schema migration** | `RunsRepository.MigrateSchemaAsync` runs a full `SELECT * FROM c` over the runs container and `ReplaceItemAsync`s every result without `IfMatchEtag`. A bug in `RunModeResolver` or in any future migration logic could overwrite arbitrary live runs racing with concurrent user PUT/PATCH operations. | Access gated by `IsAdminAsync`. Intended as a one-shot post-deploy operation; not part of any business flow. | Medium — admin-only and expected to be one-shot, but no optimistic concurrency on the migration writes. A retry loop or a buggy migration silently clobbers user edits in flight. Document the operation as "drain user traffic before invoking" in the runbook. |
+| **Tampering — reference data** | `WowReferenceRefreshFunction` writes every `wow/reference/{kind}/{slug}` blob and the matching `index.json`. A compromised admin or a flaw in `ReferenceSync` could replace `index.json` with a manifest that points to attacker-controlled instance/spec data. The SPA consumes this for instance and specialization pickers. | Admin-gated. Blob writes go through `BlobReferenceClient` over RBAC (`allowSharedKeyAccess: false`). The blob source data comes from the Blizzard Game Data API via `BlizzardGameDataClient`. | Medium — see `reference-data-integrity.md` (backlog) for the full read-side blast radius. There is no integrity hash or signature verification on `index.json`. |
+| **Repudiation** | Admin denies having triggered a destructive admin action. | `AuditMiddleware` records function entry / exit. Per-handler `AuditLog.Emit` writes admin actions with the actor id (HMAC-hashed via `IActorHasher` when `AuditOptions.HashSalt` is set). KV `categoryGroup: audit` records the secret read on every cache refill. | Medium — no document-diff audit on `MigrateSchemaAsync`; logs say "admin X invoked migrate" but not "admin X overwrote document Y from value A to B." App Insights ingestion is best-effort. **Audit hash salt is not yet wired in IaC** (see `keyvault-data-protection-wrap.md` and `audit-log-pii-pipeline.md` backlog). |
+| **Information disclosure — guild admin** | `GuildAdminFunction` returns any guild document by caller-supplied `guildId` query parameter. An admin compromise leaks every guild's roster, mode preferences, and creator id. | Admin-gated. No further authorization within the handler — admin is trusted to read any guild. | Medium — single-factor admin compromise = full read of all guild configurations. Acceptable for the current trust model (admin role is intentionally privileged) but worth documenting as the blast radius of admin compromise. |
+| **Denial of service — refresh storm** | An admin (or a successful CSRF / replay against an admin session) repeatedly calls `POST /api/wow/reference/refresh`; each call drives a full sweep of the Blizzard Game Data API plus ~500 blob writes. There is no idempotency key or de-duplication on this endpoint. | Admin-gated. `BlizzardRateLimiter` throttles outbound calls; `RateLimitMiddleware` applies origin rate limits to the inbound endpoint. | Medium — exhausts Blizzard's per-app rate window and the storage write quota; recovery requires waiting for both. Acceptable mitigation in a hobby-cost stance; would warrant idempotency-key + 202 Accepted for any production use. |
+| **Elevation of privilege** | A non-admin acquires admin status via cache mis-population (e.g., the admin secret returns extra ids after a malformed update). | `KeyVaultSecretResolver` reads the secret as a single string; `SiteAdminService` parses by line and trims; ids list seeded from the cleartext secret only. Fail-open-to-empty on KV error (no admin granted on read failure). | Low — failure modes default to "no admin," not "all admin." A malformed write to the secret is operator error; KV soft-delete preserves the previous version for recovery. |
+
+## Key Code References
+
+- `api/Services/SiteAdminService.cs:15` — "When KeyVaultUrl is not configured,
+  IsAdminAsync always returns false."
+- `api/Services/SiteAdminService.cs:24` — `CacheTtl = TimeSpan.FromSeconds(10)`.
+- `api/Services/SiteAdminService.cs:32-67` — `IsAdminAsync` flow: TTL check, KV read,
+  fail-open-to-empty on error.
+- `api/Services/KeyVaultSecretResolver.cs` — singleton `SecretClient` constructed
+  with `DefaultAzureCredential`; reads `site-admin-battle-net-ids`.
+- `api/Functions/RunsMigrateSchemaFunction.cs:44` — admin gate.
+- `api/Functions/RunsMigrateSchemaFunction.cs:38, 71` — primary + `/api/v1/` route
+  registrations.
+- `api/Repositories/RunsRepository.cs:191-224` — `MigrateSchemaAsync` —
+  `SELECT * FROM c`, full-document `ReplaceItemAsync` per result, no `IfMatchEtag`.
+- `api/Functions/WowReferenceRefreshFunction.cs:65` — admin gate.
+- `api/Functions/WowReferenceRefreshFunction.cs:38` — comment confirming the
+  repo-wide pattern: `AuthorizationLevel.Anonymous` at the host trigger,
+  `[RequireAuth]` at the policy layer.
+- `api/Functions/GuildAdminFunction.cs:32` — admin gate.
+- `api/Services/ReferenceSync.cs` — orchestrates Blizzard pulls + blob writes;
+  consumed only by `WowReferenceRefreshFunction` and the timer.
+
+## Out of Scope
+
+- The Battle.net OAuth callback that issues the session a user later promotes via
+  admin allowlist — covered by `battlenet-oauth-callback.md`.
+- The Cosmos partition-key boundary admin operations bypass — `cosmos-partition-key-authz.md`
+  flags the schema migration's data-plane footprint; this model owns the privilege
+  decision.
+- The Key Vault role-grant blast radius (one role covers DP key + admin allowlist
+  + Blizzard credentials) — covered by `keyvault-data-protection-wrap.md`.
+- The reference-data **read** path (every authenticated user fetches `index.json`)
+  — covered by `reference-data-integrity.md` (backlog).
+- The Blizzard outbound API surface that admin refresh exercises — covered by
+  `blizzard-outbound-api.md`.
+- The audit-log pipeline (HMAC actor hashing, salt rotation, App Insights ingestion)
+  — covered by `audit-log-pii-pipeline.md` (backlog).

--- a/docs/threat-models/battlenet-oauth-callback.md
+++ b/docs/threat-models/battlenet-oauth-callback.md
@@ -3,11 +3,12 @@
 ## Introduction
 
 This document covers the trust boundary between an unauthenticated browser and the
-`GET /api/battlenet/callback` endpoint that completes the Battle.net PKCE
-authorization-code flow and issues the application session cookie. An attacker who
-can influence this boundary before the session is established may attempt to forge a
-login, replay a stolen authorization code, fix the session to a known value, redirect
-the user to a malicious host, or gain a valid session for a victim account.
+`GET /api/battlenet/callback` (and the equivalent `/api/v1/battlenet/callback` alias)
+endpoint that completes the Battle.net PKCE authorization-code flow and issues the
+application session cookie. An attacker who can influence this boundary before the
+session is established may attempt to forge a login, replay a stolen authorization code,
+fix the session to a known value, redirect the user to a malicious host, or gain a
+valid session for a victim account.
 
 ## Data Flow
 
@@ -49,31 +50,39 @@ Browser                    Functions API               Battle.net OAuth
 |---|---|---|---|
 | **Spoofing** | Attacker submits a stolen `code` without the corresponding `login_state` cookie. | State is sealed with `IDataProtector` (purpose `Lfm.OAuth.LoginState.v1`); mismatch → `RejectWithClearedCookie`. PKCE `codeVerifier` is bound to the code. | Low — stolen code is useless without the cookie, which is `HttpOnly`; PKCE prevents server-side code injection. |
 | **Tampering** | Attacker modifies the `state` query parameter or the `login_state` cookie. | `login_state` payload is authenticated-encrypted by `IDataProtector`; any tampering causes `Unprotect` to throw → reject. State comparison is strict equality (`loginState.Value.state != urlState`). | Low — AEAD protects integrity; SHA-256 comparison is not vulnerable to timing attacks in the reject path. |
-| **Repudiation** | Attacker denies having logged in or disputes which account authenticated. | `AuditLog.Emit` writes `login.success` and `login.failure` events including `battleNetId`; App Insights + Log Analytics retain them. | Low — structured audit trail exists. No non-repudiation signature on individual events. |
+| **Repudiation** | Attacker denies having logged in or disputes which account authenticated. | `AuditLog.Emit` writes `login.success` and `login.failure` events including the actor id; `IActorHasher` HMAC-hashes the id when `AuditOptions.HashSalt` is configured (production). App Insights + Log Analytics retain the structured events. | Medium — when the salt is configured, attribution requires reproducing the HMAC; if the salt is rotated or lost, historical events become permanently unlinkable to real Battle.net accounts. **Note:** `Audit__HashSalt` is **not** wired in `infra/modules/functions.bicep` today, so deployed environments fall back to `IdentityActorHasher` and emit plaintext `battleNetId` — a separate Bicep fix is required before the mitigation here is real. |
 | **Information disclosure** | Error paths leak state details or the authorization code to attacker-controlled infrastructure. | All error paths call `RejectWithClearedCookie`, which redirects to `/auth/failure` and logs only a generic `detail` string internally. `code` and tokens are never echoed to the client. | Low — no 200-body response on error; `detail` string is not in the redirect URL. |
-| **Denial of service** | Attacker floods `/api/battlenet/callback` to exhaust token-exchange quota with Battle.net or trigger Functions cold-starts. | `RateLimitMiddleware` is registered in the pipeline ahead of this function. | Medium — rate limit is in-memory per-instance; distributed DoS still possible. Battle.net has its own rate limits on the token endpoint. |
+| **Denial of service** | Attacker floods `/api/battlenet/callback` to exhaust the Battle.net token-exchange quota or trigger Functions cold-starts. | `RateLimitMiddleware` is registered ahead of this function and treats `battlenet-callback` as the strict auth tier (`AuthFunctions` set). `RequestSizeLimitMiddleware` runs even earlier and bounds payload size. | Medium — origin-only rate limiter; per-instance in-memory state. Battle.net has its own rate limits on the token endpoint. |
+| **Denial of service (v1 alias)** | Attacker floods `/api/v1/battlenet/callback`; the v1 function id `battlenet-callback-v1` is **not** in `RateLimitMiddleware.AuthFunctions`, so the request falls through to the read tier with a higher ceiling, bypassing the auth-tier limit. | None — the v1 alias is unprotected at the auth-tier boundary; the read-tier ceiling still applies. | **High — exploitable today.** Fix: add `"battlenet-login-v1"` and `"battlenet-callback-v1"` to the `AuthFunctions` set in `api/Middleware/RateLimitMiddleware.cs`. Tracked separately as a code fix; not a doc-only finding. |
 | **Elevation of privilege** | Open-redirect via the `redirect` post-login parameter allows attacker to redirect victim to phishing site after authentication. | `BattleNetLoginFunction.IsValidRedirect` enforces the redirect must start with `/` and must not start with `//` (protocol-relative). Final redirect is always `{AppBaseUrl}{redirect}`, so destination is bounded by the API's configured `AppBaseUrl`. | Low — the restriction is explicit and unit-testable. Absolute-URL payloads are silently dropped. |
 
 ## Key Code References
 
-- `api/Functions/BattleNetCallbackFunction.cs:54-60` — checks for missing `login_state`
+- `api/Functions/BattleNetCallbackFunction.cs:54-63` — checks for missing `login_state`
   cookie and state query param; rejects if either is absent or state does not match.
-- `api/Functions/BattleNetCallbackFunction.cs:71` — PKCE code exchange: passes
+- `api/Functions/BattleNetCallbackFunction.cs:74` — PKCE code exchange: passes
   `codeVerifier` from the decrypted cookie to `ExchangeCodeAsync`.
-- `api/Functions/BattleNetCallbackFunction.cs:118-125` — session cookie set with
-  `HttpOnly`, `Secure`, `SameSite=Lax`.
-- `api/Functions/BattleNetCallbackFunction.cs:133-136` — post-login redirect bounded
+- `api/Functions/BattleNetCallbackFunction.cs:121-128` — session cookie set with
+  `HttpOnly`, `Secure`, `SameSite=Lax`, plus `Expires`.
+- `api/Functions/BattleNetCallbackFunction.cs:136-138` — post-login redirect bounded
   by `AppBaseUrl + postLoginRedirect`.
-- `api/Functions/BattleNetLoginFunction.cs:63-66` — `IsValidRedirect` guard rejecting
+- `api/Functions/BattleNetCallbackFunction.cs:146-150` — `/api/v1/battlenet/callback`
+  alias (function id `battlenet-callback-v1`) delegating to the same `Run` handler.
+- `api/Functions/BattleNetLoginFunction.cs:76-79` — `IsValidRedirect` guard rejecting
   protocol-relative and absolute-URL redirect values.
-- `api/Services/BlizzardOAuthClient.cs:105-113` — `ProtectLoginState` seals state +
+- `api/Middleware/RateLimitMiddleware.cs:21-22` — `AuthFunctions` set used by the
+  rate limiter to choose the strict auth-tier ceiling. Currently misses the `-v1`
+  aliases (see DoS row above).
+- `api/Services/BlizzardOAuthClient.cs:108-117` — `ProtectLoginState` seals state +
   verifier into an AEAD payload using `IDataProtector`.
-- `api/Services/BlizzardOAuthClient.cs:117-139` — `UnprotectLoginState` verifies
+- `api/Services/BlizzardOAuthClient.cs:120-142` — `UnprotectLoginState` verifies
   integrity; returns `null` on any tamper or expiry.
-- `api/Services/BlizzardOAuthClient.cs:202-206` — `ComputeCodeChallenge` implements
+- `api/Services/BlizzardOAuthClient.cs:205-209` — `ComputeCodeChallenge` implements
   the PKCE S256 transform: `base64url(SHA-256(verifier))`.
-- `api/Program.cs:16-21` — middleware registration order: CORS, security headers,
-  rate limit, audit, auth, auth-policy.
+- `api/Program.cs:20-30` — middleware registration order: CORS, security headers,
+  request-size limit, rate limit, audit, auth, auth-policy, idempotency.
+- `api/Program.cs:183-191` — `IActorHasher` DI registration; `HmacActorHasher` when
+  `AuditOptions.HashSalt` is set, else `IdentityActorHasher` (plaintext fallback).
 
 ## Out of Scope
 
@@ -81,3 +90,6 @@ Browser                    Functions API               Battle.net OAuth
 - Battle.net account takeover or vulnerabilities in Battle.net's own OAuth server.
 - PKCE downgrade attacks at the Battle.net authorization server (outside our control);
   we always send `code_challenge_method=S256`.
+- The Blizzard `client_credentials` flow (used by reference-data refresh) shares the
+  same `Blizzard__ClientId` / `Blizzard__ClientSecret` as the user-flow; covered by
+  `blizzard-outbound-api.md`.

--- a/docs/threat-models/blizzard-outbound-api.md
+++ b/docs/threat-models/blizzard-outbound-api.md
@@ -1,0 +1,132 @@
+# Threat Model: Blizzard Outbound API
+
+## Introduction
+
+This document covers the trust boundary between the Functions app and Blizzard's
+external APIs: the OAuth endpoints (`*.battle.net/oauth/...`) and the Profile + Game
+Data APIs (`*.api.blizzard.com/...`). Three flows cross this boundary:
+
+1. **Authorization Code + PKCE** for end-user login (covered in
+   `battlenet-oauth-callback.md`); the resulting `access_token` is forwarded to
+   Profile API calls on the user's behalf.
+2. **Client Credentials** for the Game Data API used by `WowReferenceRefreshFunction`
+   and the timer; `BlizzardGameDataClient` requests a fresh token per `SyncAllAsync`
+   invocation using `Blizzard__ClientId` + `Blizzard__ClientSecret`.
+3. **Profile API requests with the user's access token** for character lists,
+   character refresh, and portrait fetches; the token comes from
+   `SessionPrincipal.AccessToken` inside the encrypted session cookie.
+
+An attacker who can intercept these flows, exfiltrate the long-lived client secret,
+manipulate Blizzard's response to throttle the entire LFM API, or extract a user's
+WoW access token from a stolen session cookie can forge upstream calls, deny
+service to all users, or read the victim's WoW profile data.
+
+## Data Flow
+
+```
+Functions Instance              Blizzard OAuth                Blizzard API
+       |                              |                            |
+       | A. Authorization Code (per-user)                           |
+       |--POST /oauth/token (Basic clientId:clientSecret)---------->|
+       |<--access_token (user-scoped)-------------------------------|
+       | (token is then stored INSIDE the encrypted session cookie) |
+       |                                                            |
+       | B. Profile API (per-user)                                  |
+       |--BlizzardRateLimiter.Acquire()                             |
+       |--GET /profile/user/wow + Authorization: Bearer <userToken>--|
+       |<--profile JSON--------------------------------------------|
+       |                                                            |
+       | C. Client Credentials (admin/timer)                        |
+       |--POST /oauth/token grant_type=client_credentials----------->|
+       |  Basic clientId:clientSecret                               |
+       |<--access_token (app-scoped)--------------------------------|
+       |                                                            |
+       | D. Game Data API (admin/timer)                             |
+       |--BlizzardRateLimiter.Acquire()                             |
+       |--GET /data/wow/... + Authorization: Bearer <appToken>------>|
+       |<--reference JSON-------------------------------------------|
+       |                                                            |
+       | E. Throttled (any flow)                                    |
+       |<--429 + Retry-After: <seconds>-----------------------------|
+       |--BlizzardRateLimitHandler reads Retry-After                |
+       |--limiter.PauseUntil(now + retryAfter)                      |
+       |  (pauses the SHARED limiter for ALL outbound traffic)      |
+```
+
+## Trust Boundaries Crossed
+
+- **Functions MI / app secrets → Blizzard OAuth**: client credentials live in Key
+  Vault and are injected via `@Microsoft.KeyVault(...)` references. The
+  client-credentials flow trades them for a short-lived app token at every
+  `SyncAllAsync` invocation.
+- **User session cookie → Blizzard Profile API**: `SessionPrincipal.AccessToken` is
+  serialised into the encrypted session cookie. Every Profile API request inside an
+  authenticated handler reads the token from the principal and forwards it as a
+  Bearer header.
+- **External API responses → in-process rate limiter**: `BlizzardRateLimitHandler`
+  reads upstream `Retry-After` headers from 429 responses and applies them via
+  `IBlizzardRateLimiter.PauseUntil`. The limiter is process-wide.
+- **Functions instance → Blizzard regional endpoints**: outbound calls target
+  `https://{region}.battle.net/...` or `https://{region}.api.blizzard.com/...`,
+  selected from `Blizzard__Region` plus per-character overrides for cross-region
+  portrait fetches.
+
+## STRIDE Table
+
+| Category | Threat | Current mitigation | Residual risk |
+|---|---|---|---|
+| **Spoofing** | Attacker exfiltrates `Blizzard__ClientSecret` and impersonates the LFM app for client-credentials calls. | Stored in Key Vault and resolved by the Functions platform via `@Microsoft.KeyVault(...)` references; no in-code literal. The same `Key Vault Secrets User` role grant on the Functions MI is the only read path. | Medium — secret is long-lived (rotated on operator demand, not automatically). A Functions MI compromise reveals it; rotation cadence is undocumented. The same secret powers both the user PKCE flow and the admin client-credentials flow, so rotation must coordinate both. |
+| **Tampering — adversarial Retry-After** | Blizzard (or a network path positioned between LFM and Blizzard) returns a 429 with `Retry-After: 999999` (or a future `Retry-After` Date), pausing `BlizzardRateLimiter` for far longer than intended. Every outbound call from every authenticated user goes through this single shared limiter. | `BlizzardRateLimitHandler.SendAsync` falls back to `TimeSpan.FromSeconds(1)` only when both `Delta` and `Date` parsing fail — *any* parseable upstream value is honoured verbatim. | **Medium-High** — exploitable as a self-inflicted DoS amplifier whenever the upstream is degraded. Bound the maximum pause (e.g., `Math.Min(retryAfter, MaxPause)` with `MaxPause = 60s`); flag as a code-fix follow-up. |
+| **Repudiation** | LFM cannot prove an outbound Blizzard request was made by us versus an attacker who stole `ClientSecret`. | Application Insights captures every outbound dependency call with the W3C `traceparent` header (the `IHttpClientFactory` typed clients propagate `Activity.Current`). Blizzard's own audit trail records the calling client id. | Low — within LFM's logs, every outbound call is correlated to an inbound trace. Outside LFM (post-secret-exfiltration replay), only Blizzard's logs distinguish the actor. |
+| **Information disclosure — user access token in cookie** | An attacker who steals an `lfm_session` cookie obtains the embedded WoW `AccessToken` and reads the victim's WoW profile data directly from Blizzard, bypassing LFM entirely. | Cookie is `HttpOnly`, AEAD-encrypted, and bound to the DP key ring (see `session-cookie-api.md` and `keyvault-data-protection-wrap.md`). The cookie is not transmitted on cross-site requests (`SameSite=Lax`). | Medium — XSS or any code path that exfiltrates the cookie also exposes the WoW token. The token's lifetime tracks Blizzard's issuance (24 h by default) — short, but not zero. The session cookie's `MaxAge` exceeds the token's; an expired token in a still-valid cookie returns Blizzard 401 on profile calls. |
+| **Information disclosure — client_credentials token caching** | `BlizzardGameDataClient.GetClientCredentialsTokenAsync` requests a new token on every `SyncAllAsync` rather than caching for the token's `expires_in` window. Token is exchanged on the wire each invocation. | TLS protects the token in flight. The token is never persisted server-side; only held for the duration of the sync. | Low-Medium — extra outbound traffic, marginally larger attack window for in-flight interception. Acceptable for the current invocation cadence (manual or weekly). Cache to KV-resolved `IDistributedCache` if invocation frequency rises. |
+| **Denial of service — outbound throttle starvation** | Blizzard rate-limits LFM's app id (100 req/s per app); concurrent Functions instances each run their own `BlizzardRateLimiter` configured for ~80 req/s and have no cross-instance coordination. Under scale-out, the combined outbound rate exceeds the upstream cap, triggering per-instance 429s and shared `PauseUntil` calls. | `BlizzardRateLimiter` is a singleton **per Functions instance**, not per app. Each instance throttles itself locally; the combined fleet does not. | Medium — under multi-instance scale-out the outbound budget is over-spent and the resulting 429s degrade every user. The free-tier plan limits scale-out so this is a depth-in-defence concern, not exploitable today. Distributed limiter (e.g., Redis-backed) would close this if scale-out becomes routine. |
+| **Elevation of privilege** | Attacker persuades the user to authorise a wider `scope` set during PKCE login, then uses the resulting token against richer Profile API endpoints. | `BattleNetLoginFunction` sends `scope=wow.profile` only; the user-consent screen on Blizzard reflects exactly that scope. | Low — request scope is hard-coded server-side; an attacker cannot alter it without compromising the Functions binary or its config. |
+
+## Key Code References
+
+- `api/Services/BlizzardOAuthClient.cs:108-117` — `ProtectLoginState` (PKCE flow A
+  setup; covered in detail by `battlenet-oauth-callback.md`).
+- `api/Services/BlizzardOAuthClient.cs:145-178` — `ExchangeCodeAsync` — Basic-auth
+  POST to the Battle.net token endpoint with the user's authorization code.
+- `api/Services/BlizzardOAuthClient.cs:180-198` — `GetUserInfoAsync` — Bearer-auth
+  GET to the userinfo endpoint with the user's token.
+- `api/Services/BlizzardGameDataClient.cs:44-68` — `GetClientCredentialsTokenAsync`
+  — POST `grant_type=client_credentials` with `Authorization: Basic
+  base64(clientId:clientSecret)`. No token caching across calls.
+- `api/Services/BlizzardProfileClient.cs` — Bearer-auth GETs to the Profile API
+  using the user's token.
+- `api/Services/CharacterPortraitService.cs` — fetches from
+  `https://{charRegion}.api.blizzard.com/...` (see `character-portrait-fetch.md`,
+  backlog, for the SSRF / region allowlist details).
+- `api/Services/BlizzardRateLimiter.cs:36` — `PauseUntil(DateTimeOffset until)`;
+  shared in-process limiter.
+- `api/Services/BlizzardRateLimitHandler.cs:16-36` — `SendAsync` honours upstream
+  `Retry-After` (Delta or Date) verbatim with no upper bound; pauses the shared
+  limiter on any 429 from Blizzard.
+- `api/Program.cs:195-196` — `BlizzardRateLimiter` registered as singleton;
+  `BlizzardRateLimitHandler` registered as transient `DelegatingHandler`.
+- `api/Program.cs:201-237` — `IHttpClientFactory` registrations for
+  `CharacterPortraitService`, `BlizzardOAuthClient`, `BlizzardProfileClient`,
+  `BlizzardGameDataClient`. All chain `BlizzardRateLimitHandler` and
+  `AddStandardResilienceHandler` (retry + circuit breaker + timeout per
+  `Microsoft.Extensions.Http.Resilience`).
+- `api/Auth/SessionPrincipal.cs:13-17` — `AccessToken` field embedded in the
+  encrypted session cookie; the value forwarded to Profile API calls.
+- `infra/modules/functions.bicep:111-112` — `Blizzard__ClientId` and
+  `Blizzard__ClientSecret` resolved via `@Microsoft.KeyVault(...)` references.
+
+## Out of Scope
+
+- The PKCE login + callback flow itself — covered by `battlenet-oauth-callback.md`.
+- Storage of the user's access token in the session cookie — covered by
+  `session-cookie-api.md`.
+- The Key Vault role grant that resolves `Blizzard__ClientSecret` — covered by
+  `keyvault-data-protection-wrap.md`.
+- Admin authorization for the timer / refresh function that drives the
+  client-credentials flow — covered by `admin-privilege-boundary.md`.
+- The downstream effect of a tampered Game Data response on every browser (manifests
+  in blob serving wrong instance / spec data) — covered by
+  `reference-data-integrity.md` (backlog).
+- Cross-region URL construction in `CharacterPortraitService` and the SSRF /
+  cache-poisoning surface — covered by `character-portrait-fetch.md` (backlog).

--- a/docs/threat-models/cosmos-partition-key-authz.md
+++ b/docs/threat-models/cosmos-partition-key-authz.md
@@ -49,38 +49,61 @@ Auth'd Browser         Function Handler          Repository Layer           Cosm
 
 | Category | Threat | Current mitigation | Residual risk |
 |---|---|---|---|
-| **Spoofing** | Attacker sends `?battleNetId=victim` in a query string and a repository method uses that value as the partition key instead of the session principal. | `RaidersRepository.GetByBattleNetIdAsync` and `UpsertAsync` are only called from handlers that supply `principal.BattleNetId` from the verified session, not from request parameters. | Medium — not enforced at the repository API level; a future handler calling the repository with a request-supplied ID would introduce BOLA silently. |
-| **Tampering** | Attacker submits an `ETag`-free PUT to overwrite another user's run document. | `RunsRepository.UpdateAsync` passes `IfMatchEtag = run.ETag` to Cosmos, providing optimistic concurrency. `DeleteAsync` operates by `run.Id` + `PartitionKey(run.Id)` and should only be called after ownership is verified by the handler. | Medium — ownership check is in function handlers, not in repository methods; no enforce-at-repo pattern. |
-| **Repudiation** | Attacker denies having modified a document; write audit trail is absent. | Cosmos diagnostic settings (`DataPlaneRequests`, `QueryRuntimeStatistics`) are forwarded to Log Analytics. `AuditMiddleware` logs requests at the HTTP layer. | Medium — Cosmos diagnostic logs capture operation type and resource but not full document diff. No application-level write audit. |
-| **Information disclosure** | Cross-partition query in `ListExpiredAsync` returns all raiders; attacker with Functions MI compromise could read all user profiles. | `disableLocalAuth: true` in `cosmos.bicep` prevents key-based access. Only the Functions MI with Built-in Data Contributor role can query. Network access is restricted to Azure datacenter IPs (`ipRules: [{0.0.0.0}]`). | Medium — the `{0.0.0.0}` IP rule permits all Azure-datacenter traffic, not just the single Functions app. Any other Azure resource in the same region could reach the Cosmos endpoint. |
-| **Denial of service** | Attacker triggers many cross-partition queries to exhaust the 1,000 RU/s free-tier throughput. | Runs container has a composite index optimizing the `visibility + creatorGuild + startTime` query. Raiders container only exposes the cleanup query as cross-partition. | Medium — no per-user RU cap; a single authenticated user could trigger many concurrent cross-partition queries and impact all users. |
-| **Elevation of privilege** | Attacker exploits a BOLA flaw where `GetByIdAsync` (runs container) returns a document without verifying `creatorBattleNetId` matches the session. | `RunsRepository.GetByIdAsync` is a pure point-read by `id`; handler code must validate ownership before exposing the document. The repository has no knowledge of the calling user. | Medium — authorization is handler-responsibility, not repository-enforced. No centralized ownership-check helper currently exists. |
+| **Spoofing** | Attacker sends `?battleNetId=victim` in a query string and a repository method uses that value as the partition key instead of the session principal. | `RaidersRepository.GetByBattleNetIdAsync`, `UpsertAsync`, and `ReplaceAsync` are only called from handlers that supply `principal.BattleNetId` from the verified session, not from request parameters. The `idempotency` container follows the same pattern: `IdempotencyMiddleware` derives the `battleNetId` from `ctx.GetPrincipal()`. | Medium — not enforced at the repository API level; a future handler calling any of these repositories with a request-supplied id would introduce BOLA silently. |
+| **Tampering** | Attacker submits an `ETag`-free PUT/PATCH to overwrite another user's run, raider, or guild document. | Every `ReplaceAsync` overload — `RaidersRepository`, `RunsRepository`, `GuildRepository` — passes an `IfMatchEtag` to Cosmos and translates 412 to a `ConcurrencyConflictException`. Handlers honour `If-Match` on `PUT /runs/{id}`, `PATCH /me`, `PATCH /guild`. | Low — write-fencing is now repo-level for the user-write paths. The outstanding gap is **ownership** (is the caller the document's owner), not **fencing** (is the etag current). |
+| **Tampering — admin migration** | `RunsMigrateSchemaFunction` runs `SELECT * FROM c` over the runs container and unconditionally `ReplaceItemAsync`s every result without `IfMatchEtag`. A bug in `RunModeResolver` or in the admin gate could overwrite arbitrary live runs. | Access gated by `ISiteAdminService.IsAdminAsync`. Intended as a one-shot post-deploy operation. | Medium — admin-only and single-shot, but no optimistic concurrency on the migration writes. Detailed coverage in `admin-privilege-boundary.md`. |
+| **Repudiation** | Attacker denies having modified a document; write audit trail is absent. | Cosmos diagnostic settings (`DataPlaneRequests`, `QueryRuntimeStatistics`) forwarded to Log Analytics. `CosmosRequestChargeLogger` emits structured per-op logs (operation, container, partition key, RU charge) on every call. `AuditMiddleware` logs HTTP function start/end; per-handler `AuditLog.Emit` records mutating actions with the actor id HMAC-hashed via `IActorHasher`. | Medium — Cosmos diagnostic logs capture operation type and resource but not full document diff. Actor ids in audit logs are HMAC-pseudonymized when `AuditOptions.HashSalt` is set; **today the salt is not wired in `infra/modules/functions.bicep`, so actor ids surface as plaintext until that gap is closed.** |
+| **Information disclosure** | Cross-partition query in `ListExpiredAsync` returns all raiders; attacker with Functions MI compromise could read all user profiles. | `disableLocalAuth: true` on the Cosmos account prevents key-based access. Only the Functions MI with Built-in Data Contributor role can query. Network access is restricted to Azure datacenter IPs (`ipRules: [0.0.0.0]`). The cleanup query projects only `id` and `battleNetId`. | Medium — the `0.0.0.0` IP rule permits all Azure-datacenter traffic, not just the single Functions app. Any other Azure resource in the same region could reach the Cosmos endpoint. |
+| **Information disclosure — admin / scrub queries** | `RunsRepository.ScrubRaiderAsync` (account-deletion cascade) and `RunsRepository.MigrateSchemaAsync` (admin one-shot) execute the broadest cross-partition reads in the codebase. `MigrateSchemaAsync` returns full `RunDocument` payloads with no projection. | Both paths are gated: scrub runs only from `MeDeleteFunction` for the caller's own `battleNetId`; migrate runs only from `RunsMigrateSchemaFunction` after `ISiteAdminService` admit. | Medium — admin compromise plus `MigrateSchemaAsync` reveals every run's full content. See `admin-privilege-boundary.md`. |
+| **Denial of service** | Attacker triggers many cross-partition queries to exhaust the 1,000 RU/s free-tier throughput. | Runs container has a composite index optimising the `visibility + creatorGuild + startTime` query. Raiders container only exposes the cleanup query as cross-partition. `CosmosRequestChargeLogger` makes runaway-cost queries observable post-hoc. | Medium — no per-user RU cap; a single authenticated user could trigger many concurrent cross-partition queries and impact all users. |
+| **Elevation of privilege** | Attacker exploits a BOLA flaw where `GetByIdAsync` (runs container) returns a document without verifying `creatorBattleNetId` matches the session. | `RunsRepository.GetByIdAsync` is a pure point-read by `id`; handler code must validate ownership before exposing the document. `IGuildPermissions` provides a centralised authorisation helper for guild-scoped operations (signup, run create, run delete by guild rank). | Medium — `IGuildPermissions` covers guild-scope authorisation; **run-creator ownership** (is the caller the run's `creatorBattleNetId`?) is still scattered across handlers with no central helper. Account-deletion cascade through `MeDeleteFunction` is its own write-flow within the partition boundary. |
 
 ## Key Code References
 
-- `api/Program.cs:98-100` — Cosmos client construction: uses `DefaultAzureCredential`
-  when `AuthKey` is absent (production path), falling back to key for local dev.
-- `api/Repositories/RaidersRepository.cs:16-20` — point-read uses caller-supplied
-  `battleNetId` as both the document ID and the `PartitionKey`; isolation holds only
-  if the caller provides `principal.BattleNetId`.
-- `api/Repositories/RaidersRepository.cs:29-33` — `UpsertAsync` uses
-  `raider.BattleNetId` as partition key; the document's own field governs placement.
-- `api/Repositories/RaidersRepository.cs:51-71` — `ListExpiredAsync` is a
-  cross-partition query; it projects only `id` and `battleNetId` to limit data exposure.
-- `api/Repositories/RunsRepository.cs:12-33` — `ListForGuildAsync` cross-partition
-  query filters by `@battleNetId` and `@guildId`; both come from the session principal
-  in the calling handler.
-- `api/Repositories/RunsRepository.cs:95-112` — `UpdateAsync` enforces optimistic
-  concurrency via `IfMatchEtag`; no explicit owner check at the repository level.
-- `api/Repositories/GuildRepository.cs:12-25` — `GetAsync` point-read by `guildId`
+- `api/Program.cs:110-145` — Cosmos client construction (singleton): uses
+  `DefaultAzureCredential` when `AuthKey` is absent (production path), falling back
+  to key for local dev / emulator. SDK retry policy capped at 9 attempts / 30 s for
+  rate-limited requests.
+- `api/Program.cs:171-173` — repository registrations (`IRaidersRepository`,
+  `IRunsRepository`, `IGuildRepository`).
+- `api/Program.cs:176-177` — `IIdempotencyStore` and `IGuildPermissions` registrations.
+- `api/Repositories/RaidersRepository.cs:16-31` — `GetByBattleNetIdAsync` point-read
+  uses caller-supplied `battleNetId` as both id and `PartitionKey`; isolation holds
+  only if the caller provides `principal.BattleNetId`. Logs RU charge.
+- `api/Repositories/RaidersRepository.cs:33-40` — `UpsertAsync` partitioned on
+  `raider.BattleNetId`.
+- `api/Repositories/RaidersRepository.cs:42-60` — `ReplaceAsync` enforces
+  `IfMatchEtag`, throws `ConcurrencyConflictException` on 412.
+- `api/Repositories/RaidersRepository.cs:62-76` — `DeleteAsync`.
+- `api/Repositories/RaidersRepository.cs:78-101` — `ListExpiredAsync` cross-partition
+  query, projects only `id` and `battleNetId`.
+- `api/Repositories/RunsRepository.cs:17-41` — `ListForGuildAsync` cross-partition
+  query, filters by `@battleNetId` and `@guildId` from the session principal.
+- `api/Repositories/RunsRepository.cs:112-133` — `UpdateAsync(run, ifMatchEtag, ct)` —
+  caller may pass an explicit `If-Match`, otherwise falls back to `run.ETag`. Throws
+  `ConcurrencyConflictException` on 412.
+- `api/Repositories/RunsRepository.cs:151-188` — `ScrubRaiderAsync` cross-partition
+  account-deletion cascade.
+- `api/Repositories/RunsRepository.cs:191-224` — `MigrateSchemaAsync` admin one-shot:
+  `SELECT * FROM c` over the entire `runs` container, full-document writes without
+  ETag.
+- `api/Repositories/CosmosRequestChargeLogger.cs` — structured RU/op logger invoked
+  by every repository.
+- `api/Repositories/ConcurrencyConflictException.cs` — translation of Cosmos 412 to
+  a domain exception consumed by handlers as `Problem.Conflict(...)`.
+- `api/Repositories/GuildRepository.cs:16-31` — `GetAsync` point-read by `guildId`
   partition key; guilds are not user-private resources, so no per-user check applies.
-- `infra/modules/cosmos.bicep:28-29` — `disableLocalAuth: true` and
+- `infra/modules/cosmos.bicep:31-32` — `disableLocalAuth: true` and
   `disableKeyBasedMetadataWriteAccess: true` enforce managed-identity-only access.
-- `infra/modules/cosmos.bicep:48-55` — `raiders` container partition key `/battleNetId`
-  defines the isolation boundary.
-- `infra/modules/cosmos.bicep:77-84` — `runs` container partition key `/id` (run ID,
-  not user ID); user isolation on runs is query-level, not partition-level.
-- `infra/modules/functions.bicep:148-157` — Cosmos Built-in Data Contributor role
+- `infra/modules/cosmos.bicep:33-35` — `ipRules: [0.0.0.0]` (Azure-datacenter-only).
+- `infra/modules/cosmos.bicep:51-58` — `raiders` container, partition key
+  `/battleNetId` (the user-isolation boundary).
+- `infra/modules/cosmos.bicep:80-100` — `runs` container, partition key `/id` (run id,
+  not user id); user isolation on runs is query-level, not partition-level. Composite
+  index for the guild-list query.
+- `infra/modules/cosmos.bicep:130-146` — `idempotency` container, partition key
+  `/battleNetId` (same isolation pattern as raiders; covered by the Spoofing row).
+- `infra/modules/functions.bicep:154-168` — Cosmos Built-in Data Contributor role
   granted to Functions MI; scope is the account, not a single container.
 
 ## Out of Scope
@@ -90,3 +113,11 @@ Auth'd Browser         Function Handler          Repository Layer           Cosm
   only.
 - The session cookie that supplies `BattleNetId` to the handler — covered by
   `session-cookie-api.md`.
+- Admin-driven mass mutation paths (`RunsMigrateSchemaFunction`, the admin scrub flow)
+  — full coverage in `admin-privilege-boundary.md`; this model only flags the data-plane
+  surface.
+- Idempotency replay-cache semantics, TTL, and key-collision concerns — covered by
+  `idempotency-replay-cache.md` (backlog).
+- Static reference-data containers (`ExpansionsRepository`, `InstancesRepository`,
+  `SpecializationsRepository`) — these are blob-backed, not Cosmos-backed; covered by
+  `reference-data-integrity.md` (backlog).

--- a/docs/threat-models/e2e-login-bypass.md
+++ b/docs/threat-models/e2e-login-bypass.md
@@ -1,0 +1,108 @@
+# Threat Model: E2E Login Bypass
+
+## Introduction
+
+This document covers the trust boundary at `GET /api/e2e/login` — a deliberate
+authentication-bypass endpoint that issues a valid encrypted session cookie for an
+arbitrary, caller-supplied `battleNetId` without going through Battle.net OAuth.
+The endpoint exists so Playwright E2E tests can stand up a logged-in browser
+session against the in-process stack without depending on a real Blizzard account.
+
+The endpoint is gated by **two independent controls**:
+
+1. **Compile gate** — wrapped in `#if E2E ... #endif`. The `E2E` preprocessor symbol
+   is only defined when MSBuild is invoked with `E2ETest=true`. Production builds
+   do not set the property; the function is not in the deployed binary at all.
+2. **Runtime gate** — even when compiled in, the handler returns 404 unless the
+   `E2E_TEST_MODE` environment variable equals `"true"`.
+
+Both gates must fail simultaneously for the bypass to be reachable. The threat
+model exists to keep that contract visible — a regression in either gate is a full
+authentication bypass.
+
+## Data Flow
+
+```
+Browser / Test Runner          Functions API                Encrypted Cookie
+       |                              |                            |
+       |--GET /api/e2e/login?battleNetId=test-bnet-id-admin-->     |
+       |                   [boundary: unauthenticated -> arbitrary identity]
+       |                              |--#if E2E? (compile-time)   |
+       |                              |  no  -> function absent    |
+       |                              |  yes -> next gate          |
+       |                              |--E2E_TEST_MODE == "true"?  |
+       |                              |  no  -> 404 problem+json   |
+       |                              |  yes -> next step          |
+       |                              |--principal=SessionPrincipal|
+       |                              |  (arbitrary battleNetId    |
+       |                              |   from query string)       |
+       |                              |--cipher.Protect(principal) |
+       |<--Set-Cookie: lfm_session----|                            |
+       |<--302 to redirect-----------|                            |
+```
+
+## Trust Boundaries Crossed
+
+- **Build pipeline → deployable artifact**: setting `E2ETest=true` (or anything
+  that injects the `E2E` symbol) controls whether the function class even exists
+  in the compiled assembly. CI / CD configuration is part of the trust boundary.
+- **Process environment → handler reachability**: `E2E_TEST_MODE` is read from
+  `Environment.GetEnvironmentVariable`. App-settings injection is the trust
+  boundary.
+- **Caller-supplied `battleNetId` → encrypted cookie**: when both gates pass, the
+  handler accepts any string as the principal id, including `test-bnet-id-admin`
+  (the admin fixture used by E2E tests).
+
+## STRIDE Table
+
+| Category | Threat | Current mitigation | Residual risk |
+|---|---|---|---|
+| **Spoofing** | Caller passes `?battleNetId=test-bnet-id-admin` and is issued a session cookie that satisfies `SiteAdminService` if `test-bnet-id-admin` is in `site-admin-battle-net-ids`. | Both gates must pass. In production neither is intended to be true — the symbol is absent and the env-var is unset. | High **only** if both gates fail; Low under the intended posture. The threat is the gate regression, not the endpoint logic. |
+| **Tampering — CI mis-configuration** | A future change to `Lfm.Api.csproj` or a CI step accidentally sets `E2ETest=true` for the production build. The function ships in production; only the env-var stops the bypass. | The `<PropertyGroup Condition="'$(E2ETest)' == 'true'">` predicate is explicit; the property is not set anywhere in `.github/workflows/deploy.yml`. | Medium — a single `dotnet build /p:E2ETest=true` in the wrong workflow defeats the compile gate. Should be linted by a CI assertion that the production build does NOT define `E2E`. |
+| **Tampering — env-var mis-injection** | A production app-setting `E2E_TEST_MODE=true` is committed (e.g. via a copy-paste from local dev) or forced via Azure portal override. The runtime gate fails open. | The deploy IaC (`infra/modules/functions.bicep`) does not list `E2E_TEST_MODE` in the `appSettings` block — it cannot be set through Bicep. Manual portal overrides are the only injection path. | Medium — a control-plane action by a privileged operator can flip it. App-setting drift detection on the Functions resource would close this. |
+| **Repudiation** | Test traffic from the bypass is indistinguishable from real traffic in App Insights. | The function emits its own structured log entry on each invocation; the issued cookie's `IssuedAt` is the same shape as a normal one. There is no `IsTestPrincipal` field on `SessionPrincipal`. | Low for the test environment (operator knows tests are running). High if the bypass were ever reached in production, since logs would not flag it as anomalous. Acceptable because the prerequisites for production reachability are already covered above. |
+| **Information disclosure** | The redirect parameter (`?redirect=...`) accepts any path that starts with `/` OR with `blizzard.AppBaseUrl`. A fully-qualified URL not matching `AppBaseUrl` falls back to `AppBaseUrl`. | Validation is two-armed: relative paths under `/` are accepted as-is; absolute URLs must match `AppBaseUrl`. | Low — the function is dev-only; the validator is consistent with the production callback's rules. |
+| **Denial of service** | Unlimited `GET /api/e2e/login` calls in test creating arbitrary cookies. | None within the function. `RateLimitMiddleware` does not list `e2e-login` in `AuthFunctions`, so it falls through to the read tier. | Low for the test environment (intentional). High if the bypass were ever reached in production (unlimited session minting). Acceptable under the gate-not-failed assumption. |
+| **Elevation of privilege** | The bypass issues `test-bnet-id-admin`. If `site-admin-battle-net-ids` ever contains `test-bnet-id-admin` in production (operator error), a leaked bypass becomes a privileged session. | Operationally — `site-admin-battle-net-ids` should never contain test fixtures in production. No technical control prevents the operator from setting it. | Medium under operator error; Low under correct operations. Document in the admin runbook. |
+
+## Key Code References
+
+- `api/Lfm.Api.csproj:14-16` — conditional `<DefineConstants>` setting that adds
+  the `E2E` symbol only when `E2ETest=true` is passed to MSBuild.
+- `api/Functions/E2ELoginFunction.cs:4` — `#if E2E` (compile gate).
+- `api/Functions/E2ELoginFunction.cs:24` — `[HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "e2e/login")]`.
+- `api/Functions/E2ELoginFunction.cs:26-29` — runtime gate:
+  `if (!string.Equals(Environment.GetEnvironmentVariable("E2E_TEST_MODE"), "true", StringComparison.OrdinalIgnoreCase))
+  return Problem.NotFound(...)`.
+- `api/Functions/E2ELoginFunction.cs:34` — accepts arbitrary `battleNetId` from
+  the query string with `"test-bnet-id"` as the default.
+- `api/Functions/E2ELoginFunction.cs:37-50` — switches on the id to inject a
+  matching `GuildId` / `GuildName` for known fixtures (`test-bnet-id-admin`,
+  `test-bnet-id-member`).
+- `api/Functions/E2ELoginFunction.cs:52-59` — sets `lfm_session` cookie with
+  `Secure = false` (because E2E runs over `http://localhost`).
+- `api/Functions/E2ELoginFunction.cs:62-74` — redirect validation; relative paths
+  accepted, absolute URLs only when matching `AppBaseUrl`.
+- `tests/Lfm.E2E/...` — Playwright tests that drive the endpoint; the only
+  intended consumer.
+
+## Out of Scope
+
+- The production OAuth flow that the bypass intentionally circumvents — covered
+  by `battlenet-oauth-callback.md`.
+- The session cookie shape itself — covered by `session-cookie-api.md`.
+- The admin-allowlist secret that determines which test fixture reaches privileged
+  paths — covered by `admin-privilege-boundary.md`.
+- The Cosmos partition-key isolation that test sessions exercise — covered by
+  `cosmos-partition-key-authz.md`. (Test-issued sessions still go through the
+  normal partition-key boundary; nothing about the bypass weakens that.)
+
+## Recommended hardening (follow-up tasks, not part of this model)
+
+- Add a CI assertion that `dotnet build` (production target) produces a binary
+  whose `E2ELoginFunction` type does not exist — prevents the "compile gate
+  silently disabled" regression.
+- Add an IaC drift-detection rule that fails if `E2E_TEST_MODE` ever appears in
+  the production Function App's `appSettings`.
+- Tag the test-fixture session with an `IsTestPrincipal=true` claim so any future
+  log scrub can trivially distinguish bypass-issued sessions from real ones.

--- a/docs/threat-models/keyvault-data-protection-wrap.md
+++ b/docs/threat-models/keyvault-data-protection-wrap.md
@@ -9,6 +9,11 @@ cookie encryption and the OAuth `login_state` cookie. An attacker who can extrac
 rotate, or block access to this Key Vault key can forge session cookies, forge OAuth
 state, decrypt existing cookies, or deny authentication to all users.
 
+The boundary now also covers two adjacent KV-resolved secrets that share the same role
+assignment: `site-admin-battle-net-ids` (read by `KeyVaultSecretResolver` /
+`SiteAdminService`) and the `Blizzard__ClientId` / `Blizzard__ClientSecret` pair
+(resolved by the Functions platform via `@Microsoft.KeyVault(...)` references).
+
 ## Data Flow
 
 ```
@@ -28,6 +33,13 @@ Functions Instance          Azure Blob Storage           Azure Key Vault
        |--IDataProtector.Protect(payload)                       |
        |  (uses in-memory key ring — NO per-request KV call)    |
        |                                                        |
+       | admin allowlist refresh (every 10s cache TTL)          |
+       |--SecretClient.GetSecretAsync("site-admin-battle-net-ids")->|
+       |<--secret value-----------------------------------------|
+       |                                                        |
+       | platform startup (slot resolves @Microsoft.KeyVault)   |
+       |   for Blizzard__ClientId / __ClientSecret              |
+       |                                                        |
        | key rotation (90-day lifetime)                         |
        |--new key generated, wrapped with KV RSA key----------->|
        |--new encrypted XML written to blob----------------->   |
@@ -38,9 +50,10 @@ Functions Instance          Azure Blob Storage           Azure Key Vault
 - **Functions MI to Key Vault**: `DefaultAzureCredential` presents the system-assigned
   managed identity token; Key Vault RBAC (`Key Vault Secrets User` role) controls
   access. The RSA wrap/unwrap operations (`wrapKey`, `unwrapKey`) are the privileged
-  operations.
+  cryptographic operations; secret reads (`get`) are the privileged secret operations.
 - **Functions MI to Blob Storage**: the key ring XML blob is persisted to and read from
-  a storage account; blob access uses the Functions MI via `Blob Data Owner` role.
+  a storage account; blob access uses the Functions MI via `Blob Data Owner` role on
+  the storage account scope.
 - **Key ring in memory to Data Protection API**: once unwrapped at startup, the key
   material lives in the process memory of each Functions instance; memory-level
   isolation is the only boundary.
@@ -49,44 +62,80 @@ Functions Instance          Azure Blob Storage           Azure Key Vault
 
 | Category | Threat | Current mitigation | Residual risk |
 |---|---|---|---|
-| **Spoofing** | Attacker spoofs the Functions identity to obtain `unwrapKey` permission on the Key Vault key. | System-assigned managed identity; no client secret to leak. RBAC is scoped to the specific Key Vault resource in Bicep. Token issuance and validation is handled by Azure AD. | Low — requires compromise of the Azure control plane or the Functions runtime itself. |
-| **Tampering** | Attacker overwrites the blob containing the encrypted key ring XML to inject a known key. | Blob storage is accessed only by the Functions MI (`Blob Data Owner`). Key Vault `enablePurgeProtection: true` prevents deletion of the wrapping key. CanNotDelete lock prevents accidental KV removal. | Medium — an attacker with Storage `Blob Data Owner` access (e.g. via compromised MI) could replace the blob. There is no blob integrity check (e.g. KV-signed hash) beyond the Key Vault wrapping. |
-| **Repudiation** | Attacker extracts a Data Protection key and later claims the session was forged by the application. | Key Vault audit logs (`categoryGroup: audit`) are streamed to Log Analytics via diagnostic settings. Key Vault access logs record every `unwrapKey` and `wrapKey` operation with caller identity. | Low — KV audit log provides non-repudiation for KV operations; no log of which sessions were issued using which key. |
-| **Information disclosure** | Attacker reads the encrypted key ring blob and separately obtains the KV private key material to decrypt it offline. | KV key operations are server-side: the private RSA key never leaves Key Vault. The `unwrapKey` operation returns only the symmetric AES key, not the RSA private key. Key Vault HSM is not used (standard SKU) — key material is software-protected at rest. | Medium — standard SKU means the RSA private key is software-protected, not in an HSM. A sufficiently privileged Azure principal with `Key Vault Crypto Officer` or higher could export the key. |
-| **Denial of service** | Attacker revokes the Functions MI's Key Vault access or deletes/disables the `dataprotection` key, preventing session establishment. | CanNotDelete resource lock on the Key Vault (`kvLock`). `enablePurgeProtection: true` prevents immediate permanent deletion. Key is configured for `wrapKey`/`unwrapKey` only. | Medium — a control-plane action (role assignment removal) could revoke access without triggering the lock. Existing in-memory key rings would continue to work until the Functions instance restarts. |
-| **Elevation of privilege** | Attacker obtains the in-memory Data Protection key (e.g., via memory dump, process injection) and uses it to forge session cookies for arbitrary users. | Key ring lives in process memory only after the `unwrapKey` call at startup/rotation; it is not persisted in cleartext anywhere. Functions is a managed PaaS service. `SetApplicationName("Lfm")` scopes the protector so keys are not usable across different applications. | High — once a Functions instance is running, the symmetric key is in memory. A sufficiently privileged attacker with remote code execution on the Functions host can extract it. This is the highest residual risk in this boundary. |
+| **Spoofing** | Attacker spoofs the Functions identity to obtain `unwrapKey` permission on the Key Vault key. | System-assigned managed identity; no client secret to leak. RBAC scoped to the Key Vault resource. Token issuance and validation handled by Azure AD. | Low — requires compromise of the Azure control plane or the Functions runtime itself. |
+| **Tampering** | Attacker overwrites the blob containing the encrypted key ring XML to inject a known key. | Blob storage account has `allowSharedKeyAccess: false` (`infra/modules/storage.bicep:24`), so all writes go through RBAC; the only role grant is `Blob Data Owner` on the Functions MI. Key Vault `enablePurgeProtection: true` prevents deletion of the wrapping key. CanNotDelete lock prevents accidental KV removal. | Medium — the **same** `Blob Data Owner` role grant covers the DP key blob, the `AzureWebJobsStorage` runtime blobs, and the `wow` reference-data container. A compromised Functions MI can tamper with all three; there is no per-container blob RBAC scoping today. There is no blob integrity check (e.g. a KV-signed hash) beyond Key Vault wrapping. |
+| **Repudiation** | Attacker extracts a Data Protection key and later claims the session was forged by the application. | Key Vault diagnostic settings (`categoryGroup: audit`) stream every `wrapKey` / `unwrapKey` / secret-read call with caller identity to Log Analytics. | Low — KV audit log provides non-repudiation for KV operations; no log of which sessions were issued using which key. |
+| **Information disclosure** | Attacker reads the encrypted key ring blob and separately obtains the KV private key material to decrypt it offline. | KV key operations are server-side: the private RSA key never leaves Key Vault. The `unwrapKey` operation returns only the symmetric AES key. Standard SKU (software-protected at rest); no HSM. | Medium — standard SKU means the RSA private key is software-protected, not in an HSM. A sufficiently privileged Azure principal with `Key Vault Crypto Officer` or higher could export the key. |
+| **Information disclosure — secret blast radius** | The single `Key Vault Secrets User` role grant on the Functions MI now covers more than the `dataprotection` key: it also reads `site-admin-battle-net-ids` (via `KeyVaultSecretResolver` → `SiteAdminService`) and resolves `battlenet-client-id` / `battlenet-client-secret` (via `@Microsoft.KeyVault(...)` app-setting references). | Same RBAC role assignment governs all four; Azure RBAC does not support per-secret scoping under a single role. All four are intended to be read by the Functions MI. | Medium — a compromised Functions MI gains read access to **every current and future secret** in the vault, not just the wrapping key. New secrets added to this vault inherit the same exposure. |
+| **Denial of service** | Attacker revokes the Functions MI's Key Vault access or deletes/disables the `dataprotection` key, preventing session establishment. | CanNotDelete resource lock on the Key Vault. `enablePurgeProtection: true` prevents immediate permanent deletion. Key is configured for `wrapKey`/`unwrapKey` only. | Medium — a control-plane action (role assignment removal) could revoke access without triggering the lock. Existing in-memory key rings would continue to work until the Functions instance restarts. |
+| **Elevation of privilege** | Attacker obtains the in-memory Data Protection key (e.g., via memory dump, process injection) and uses it to forge session cookies for arbitrary users. | Key ring lives in process memory only after the `unwrapKey` call at startup/rotation; never persisted in cleartext. Functions is a managed PaaS service. `SetApplicationName("Lfm")` scopes the protector so keys are not usable across applications. Child protectors split purposes (`Lfm.Session.v1`, `Lfm.OAuth.LoginState.v1`). | High — once a Functions instance is running, the symmetric key is in memory. A sufficiently privileged attacker with remote code execution on the Functions host can extract it. This is the highest residual risk on this boundary. |
 
 ## Key Code References
 
-- `api/Program.cs:167-169` — `AddDataProtection()` with `SetApplicationName("Lfm")`
-  and `SetDefaultKeyLifetime(90 days)`.
-- `api/Program.cs:171-178` — production path: `PersistKeysToAzureBlobStorage` +
-  `ProtectKeysWithAzureKeyVault` using `DefaultAzureCredential`; the KV key URI is
-  versionless to allow automatic key rotation.
-- `api/Program.cs:179-186` — local/E2E fallback: keys persisted to `$TMPDIR/lfm-dp-keys`
-  with no encryption; ephemeral sessions acceptable for dev/test.
-- `api/Auth/DataProtectionSessionCipher.cs:8-9` — creates a child `IDataProtector`
-  with purpose `Lfm.Session.v1`; the root ring key is unwrapped at startup, not per-call.
-- `api/Services/BlizzardOAuthClient.cs:37` — `login_state` cookie uses a separate child
-  protector with purpose `Lfm.OAuth.LoginState.v1`; same root key ring, different
-  purpose isolation.
-- `infra/modules/keyvault.bicep:13-37` — Key Vault provisioned with `enableRbacAuthorization`,
-  `enableSoftDelete`, `enablePurgeProtection`, `softDeleteRetentionInDays: 90`.
-- `infra/modules/keyvault.bicep:39-46` — `CanNotDelete` management lock on the Key Vault.
-- `infra/modules/keyvault.bicep:59-67` — `dataprotection` RSA-2048 key restricted to
+- `api/Program.cs:174` — `KeyVaultSecretResolver` registered as `ISecretResolver`
+  singleton; resolves admin allowlist secret.
+- `api/Program.cs:175` — `SiteAdminService` (consumer) registered.
+- `api/Program.cs:241-276` — Data Protection setup block.
+  - `:257-259` — `AddDataProtection()` with `SetApplicationName("Lfm")` and 90-day key
+    lifetime.
+  - `:261-268` — production path: `PersistKeysToAzureBlobStorage` (URI from
+    `Storage__DataProtectionBlobUri`) + `ProtectKeysWithAzureKeyVault` (URI from
+    `Auth__DataProtectionKeyUri`) using `DefaultAzureCredential`. The KV key URI is
+    versionless to allow automatic key rotation.
+  - `:270-276` — local/E2E fallback: keys persisted to `$TMPDIR/lfm-dp-keys` with no
+    encryption; ephemeral sessions acceptable for dev/test.
+- `api/Program.cs:286-287` — `AuditLog.ConfigureHasher` installs the DI-selected
+  `IActorHasher` (HMAC when `AuditOptions.HashSalt` is set, identity otherwise) so
+  every audit event hashes the actor id before reaching App Insights.
+- `api/Auth/DataProtectionSessionCipher.cs:11-12` — child `IDataProtector` with
+  purpose `Lfm.Session.v1`; root ring key is unwrapped at startup, not per-call.
+- `api/Services/BlizzardOAuthClient.cs:40` — `login_state` cookie uses a separate
+  child protector with purpose `Lfm.OAuth.LoginState.v1`; same root key ring,
+  different purpose isolation.
+- `api/Services/KeyVaultSecretResolver.cs` — singleton `SecretClient` constructed with
+  `DefaultAzureCredential`; reads `site-admin-battle-net-ids`.
+- `api/Services/SiteAdminService.cs` — 10-second in-memory cache of admin id list;
+  fail-open-to-empty on KV error.
+- `infra/modules/keyvault.bicep:16-39` — Key Vault provisioned with
+  `enableRbacAuthorization`, `enableSoftDelete`, `enablePurgeProtection`,
+  `softDeleteRetentionInDays: 90`.
+- `infra/modules/keyvault.bicep:42-49` — `CanNotDelete` management lock.
+- `infra/modules/keyvault.bicep:51-59` — diagnostic settings (`categoryGroup: audit`)
+  forwarding KV operation logs to Log Analytics.
+- `infra/modules/keyvault.bicep:62-70` — `dataprotection` RSA-2048 key restricted to
   `wrapKey` and `unwrapKey` operations only.
-- `infra/modules/keyvault.bicep:71` — versionless key URI output used by `functions.bicep`
-  as `dataProtectionKeyUri`.
-- `infra/modules/functions.bicep:132-141` — `Key Vault Secrets User` role
-  (`4633458b-17de-408a-b874-0445c86b69e6`) granted to the Functions MI on the KV scope.
-- `infra/modules/functions.bicep:115` — `Auth__DataProtectionKeyUri` app setting
-  receives the versionless KV key URI via Bicep parameter.
+- `infra/modules/keyvault.bicep:74` — versionless key URI output used by
+  `functions.bicep` as `dataProtectionKeyUri`.
+- `infra/modules/storage.bicep:23-26` — `allowSharedKeyAccess: false`,
+  `allowBlobPublicAccess: false`, `minimumTlsVersion: 'TLS1_2'`,
+  `supportsHttpsTrafficOnly: true` — closes the shared-key write path on the storage
+  account that holds the DP key blob.
+- `infra/modules/functions.bicep:118` — `Auth__DataProtectionKeyUri` app setting.
+- `infra/modules/functions.bicep:122` — `Storage__DataProtectionBlobUri` app setting.
+- `infra/modules/functions.bicep:144-152` — `Key Vault Secrets User` role
+  (`4633458b-17de-408a-b874-0445c86b69e6`) granted to the Functions MI on the KV
+  scope. **One role assignment, vault-wide; per-secret scoping is not possible under
+  RBAC.**
+
+## Known gap (not yet fixed in code or IaC)
+
+`AuditOptions.HashSalt` is bound from the `Audit` configuration section
+(`Program.cs:83-84`) but there is no `Audit__HashSalt` app-setting entry in
+`infra/modules/functions.bicep` and no `@Microsoft.KeyVault(...)` reference for it.
+Until that wiring is added, deployed environments fall back to
+`IdentityActorHasher` and emit plaintext `battleNetId` (PII) into App Insights. The
+fix is a Bicep change adding a Key Vault reference for `Audit__HashSalt`; it is
+**not** a documentation issue — flagged here so it is visible alongside the rest of
+the KV trust-boundary inventory. See `audit-log-pii-pipeline.md` (backlog) for the
+full pipeline view.
 
 ## Out of Scope
 
-- Network-level Key Vault access controls (VNet service endpoints, private endpoints) —
-  not applicable at Consumption plan free tier; `defaultAction: Allow` is a known
+- Network-level Key Vault access controls (VNet service endpoints, private endpoints)
+  — not applicable at Consumption plan free tier; `defaultAction: Allow` is a known
   accepted trade-off documented in `keyvault.bicep`.
 - Key Vault Premium / HSM upgrade path for hardware-protected key material.
 - Rotation procedures and runbook for manual emergency key rotation after a suspected
   key compromise.
+- The admin allowlist authorization itself (cache TTL, fail-open behaviour) — covered
+  by `admin-privilege-boundary.md`.

--- a/docs/threat-models/run-signup-peer-permission.md
+++ b/docs/threat-models/run-signup-peer-permission.md
@@ -1,0 +1,117 @@
+# Threat Model: Run Signup and Peer Permission
+
+## Introduction
+
+This document covers the trust boundary between two authenticated users where one
+mutates the other's run document via the signup roster. Run documents are
+partitioned by run id, not by user, so partition isolation does **not** isolate
+users on this resource. Authorization is policy-only, evaluated at the handler
+layer through `IGuildPermissions` (rank checks against the cached guild roster
+inside the run's owning guild).
+
+`POST /api/runs/{id}/signup` and `DELETE /api/runs/{id}/signup` are the two writes
+across this boundary. The combination is the source of the canonical
+**resignup-bypass** weakness: cancelling a signup and re-creating it discards any
+prior `ReviewedAttendance` decision the run owner had set.
+
+## Data Flow
+
+```
+Auth'd Browser (Caller A)            Functions API                      Cosmos DB (runs)
+       |                                   |                                    |
+       |--POST /api/runs/{id}/signup------>|                                    |
+       |    body: { CharacterId, ... }     |                                    |
+       |                       [boundary: caller A -> roster on run owned by B]
+       |                                   |--Auth: principal=A                  |
+       |                                   |--Read raider(A)-------->Cosmos(raiders)
+       |                                   |--Read run(id)----------------------->|
+       |                                   |<--RunDocument {RunCharacters[], ...}-|
+       |                                   |--Visibility check                   |
+       |                                   |    GUILD -> guildPermissions        |
+       |                                   |        .CanSignupGuildRunsAsync(A)  |
+       |                                   |--existingIndex = find A in roster   |
+       |                                   |--reviewedAttendance =               |
+       |                                   |    existing >=0 ? entry.Reviewed    |
+       |                                   |                 : "IN"              |
+       |                                   |--Replace run(if-match etag)-------->|
+       |<--200 + sanitised RunCharacters---|                                    |
+       |                                                                        |
+       |--DELETE /api/runs/{id}/signup---->|                                    |
+       |                                   |--remove A's entry from roster       |
+       |                                   |--Replace run(if-match etag)-------->|
+       |                                                                        |
+       | A re-POSTs with same character id                                      |
+       |--POST /api/runs/{id}/signup------>|                                    |
+       |                                   |--existingIndex = -1 (just removed)  |
+       |                                   |--reviewedAttendance = "IN" (reset)  |
+```
+
+## Trust Boundaries Crossed
+
+- **Caller A → run owned by B**: A signs up to a run B created. The mutation
+  attaches a `RunCharacterEntry` with `RaiderBattleNetId = principal.BattleNetId`
+  to B's run document.
+- **Cached guild roster → permission decision**: `IGuildPermissions` reads
+  `GuildDocument.Roster` (populated by a separate enrichment path) and matches the
+  caller's character to a rank entry. Roster freshness is its own concern — a
+  former member who has not been removed from the cached roster still satisfies
+  `CanSignupGuildRunsAsync`.
+- **Optimistic-concurrency loop → user-perceived semantics**: signup retries up to
+  3 times on `ConcurrencyConflictException`. Two simultaneous signups for the same
+  user race; the loser retries.
+
+## STRIDE Table
+
+| Category | Threat | Current mitigation | Residual risk |
+|---|---|---|---|
+| **Spoofing** | Caller A signs up using caller B's character id (`body.CharacterId` references a character that lives on B's `RaiderDocument`). | The handler loads the caller's own `RaiderDocument` by `principal.BattleNetId` and looks up `body.CharacterId` *within that raider's character list*; if the id is not on the caller's raider, the handler returns 404 `signup-not-found-character`. A's session cannot reach B's character ids. | Low — character ownership is enforced at handler layer. |
+| **Tampering — resignup attendance reset** | Run owner B sets A's `ReviewedAttendance` to `"OUT"` (rejected). A cancels their signup (`DELETE /signup`) then re-signs up (`POST /signup`); on the re-signup, `existingIndex < 0` so `reviewedAttendance` defaults to `"IN"`, silently reversing B's rejection. | None server-side. The flow is a legitimate user editing their signup; the cancel + resign path is allowed for self-edit. There is no per-`(runId, raiderBattleNetId)` history of prior reviewed-attendance decisions. | **High — exploitable today.** Fix: the resignup path must preserve any existing-or-prior `OUT` decision. Options: (a) keep the entry on cancel but mark `Cancelled = true`, so `existingIndex >= 0` on resignup; (b) maintain a per-run rejection list separate from the roster; (c) require run-owner re-approval after cancel. Tracked as a code fix, not a doc-only finding. |
+| **Tampering — concurrent roster writes** | Two simultaneous signup attempts for the same caller produce a 412 from Cosmos; the lose-side retries. | `RunsRepository.UpdateAsync` enforces `IfMatchEtag` and throws `ConcurrencyConflictException`; handler retries up to 3 times before returning 409 problem+json. | Low — bounded retries, no infinite loop. Acceptable user experience under contention. |
+| **Repudiation** | A run owner disputes whether a signup or cancel happened. | `AuditLog.Emit("signup.create" / "signup.cancel", principal.BattleNetId, runId, ...)` records every mutation through this boundary. Cosmos `_etag` history is implicit (not preserved between writes). | Medium — App Insights ingestion is best-effort. No per-document audit of the *content* of each roster mutation (e.g. which entry was added, removed, or re-`IN`-ified). Forensics on the resignup-bypass requires correlating the cancel + create pair. |
+| **Information disclosure — guild run roster leakage** | All authenticated callers who can list the run (`GET /runs` or `GET /runs/{id}`) see the full sanitised roster: every signup's character name, class, spec, role, `DesiredAttendance`, `ReviewedAttendance`. For GUILD-scoped runs, "all callers" means "all guild members." | `RaiderBattleNetId` is stripped from the wire DTO via `Sanitize`. Other identifying fields stay. | Low-Medium — by design (a sign-up sheet that members cannot see is not useful). The `ReviewedAttendance` value reveals who the run owner has accepted vs rejected, which is sensitive social information; documented as an accepted trade-off. |
+| **Denial of service** | Caller floods POST/DELETE on a single run id; each operation reads + replaces the entire run document. | `RateLimitMiddleware` applies the standard origin rate limit. ETag-based optimistic concurrency means concurrent floods just lose retries. | Medium — consumes RU on the runs container; in the free-tier 1000 RU/s budget, sustained flooding from one user could starve others. Currently no per-user RU cap. |
+| **Elevation of privilege — guild rank bypass** | An ex-guild member whose Blizzard guild membership has lapsed but whose `GuildDocument.Roster` cache has not been refreshed still passes `CanSignupGuildRunsAsync` and signs up. | `GuildPermissions` documents the dependency on roster freshness; the roster is refreshed by a separate enrichment flow. The permission helper already returns `false` when roster is absent (`GuildPermissions.cs:59` comment). | Medium — depends on roster-refresh cadence (currently driven by user-triggered enrichment). A staleness window is unavoidable without active push from Blizzard. Documented constraint. |
+
+## Key Code References
+
+- `api/Functions/RunsSignupFunction.cs:29` — handler doc-comment outlining the
+  permission flow.
+- `api/Functions/RunsSignupFunction.cs:144-156` — visibility check + GUILD rank
+  gate via `IGuildPermissions.CanSignupGuildRunsAsync`.
+- `api/Functions/RunsSignupFunction.cs:166-175` — roster lookup by
+  `RaiderBattleNetId == principal.BattleNetId`.
+- `api/Functions/RunsSignupFunction.cs:177-179` — entryId reused if existing; new
+  GUID otherwise.
+- `api/Functions/RunsSignupFunction.cs:181-183` — **the resignup-bypass:**
+  `reviewedAttendance = existingIndex >= 0 ? existing.ReviewedAttendance : "IN"`.
+- `api/Functions/RunsSignupFunction.cs:185-201` — `RunCharacterEntry` construction.
+- `api/Functions/RunsCancelSignupFunction.cs:21-27` — handler doc; cancel removes
+  the entry rather than marking it cancelled.
+- `api/Functions/RunsCancelSignupFunction.cs:55-61` — visibility check for GUILD
+  runs.
+- `api/Functions/RunsCancelSignupFunction.cs:97-102` — repository update + audit
+  emit.
+- `api/Services/GuildPermissions.cs:102-144` — `CanSignupGuildRunsAsync` —
+  matches caller's character to a rank entry in the cached roster.
+- `api/Services/GuildPermissions.cs:59-66, 109-116, 158-165` — staleness comment:
+  returns `false` when roster is absent or stale.
+- `api/Repositories/RunsRepository.cs:112-133` — `UpdateAsync(run, ifMatchEtag)`
+  throws `ConcurrencyConflictException` on 412; consumed by the 3-attempt retry
+  loop in the signup handler.
+- `shared/Lfm.Contracts/RunCharacterEntry.cs` — DTO; `ReviewedAttendance` field is
+  the persistence shape carrying the bypass.
+
+## Out of Scope
+
+- The Cosmos partition-key boundary on the `runs` container — covered by
+  `cosmos-partition-key-authz.md`.
+- The session cookie that supplies the principal — covered by
+  `session-cookie-api.md`.
+- Run creation and deletion authorization (run-creator ownership) — covered
+  partially by `cosmos-partition-key-authz.md`'s Elevation row; this model
+  intentionally focuses on the roster mutation flows.
+- Guild roster freshness / Blizzard-side membership state — driven by a separate
+  enrichment path (`BattleNetCharactersRefreshFunction`); covered indirectly by
+  `blizzard-outbound-api.md`.
+- Privacy / consent for displaying `ReviewedAttendance` to other guild members —
+  product-level decision, accepted trade-off documented above.

--- a/docs/threat-models/session-cookie-api.md
+++ b/docs/threat-models/session-cookie-api.md
@@ -9,6 +9,24 @@ authenticated access as the victim; an attacker who can bypass the auth check ga
 access to protected resources without any credentials at all. The session cookie is the
 sole credential for all authenticated API calls.
 
+## Repo-wide auth pattern (read this first)
+
+Every Function in `api/Functions/*.cs` declares `AuthorizationLevel.Anonymous` at the
+host trigger. **This is intentional and is not an anonymous endpoint.** Authentication
+and authorization are enforced inside the worker by the middleware chain, specifically:
+
+1. `AuthMiddleware` — decrypts the `lfm_session` cookie, validates expiry, and stores
+   the resulting `SessionPrincipal` in `HttpContext.Items[SessionKeys.Principal]`.
+2. `AuthPolicyMiddleware` — checks for `[RequireAuth]` on the function method or class
+   via cached reflection; returns 401 problem+json if a principal is required and
+   absent.
+
+Any reviewer scanning for `AuthorizationLevel.Function` / `Admin` etc. will find none;
+that is the deliberate pattern, not a SAD-G-anonymous-private finding. Three endpoints
+are *genuinely* anonymous (login, callback, logout, health, privacy-contact, the
+CORS preflight catch-all, and the E2E-only login bypass when compiled in); every other
+function is gated by `[RequireAuth]`.
+
 ## Data Flow
 
 ```
@@ -18,11 +36,13 @@ Browser                    Functions API (middleware chain)         Cosmos DB
   |                   [boundary: browser session -> API trust zone]
   |                              |--CorsMiddleware (origin check)       |
   |                              |--SecurityHeadersMiddleware           |
-  |                              |--RateLimitMiddleware                 |
-  |                              |--AuditMiddleware                     |
+  |                              |--RequestSizeLimitMiddleware (413)    |
+  |                              |--RateLimitMiddleware (429)           |
+  |                              |--AuditMiddleware (timing only)       |
   |                              |--AuthMiddleware (Unprotect cookie)   |
   |                              |--AuthPolicyMiddleware (RequireAuth?) |
   |                              |    if no principal -> 401            |
+  |                              |--IdempotencyMiddleware (replay?)     |
   |                              |--Function handler (uses principal)   |
   |                              |--ReadItemAsync(battleNetId, pk)----->|
   |                              |<--RaiderDocument--------------------|
@@ -44,36 +64,56 @@ Browser                    Functions API (middleware chain)         Cosmos DB
 
 | Category | Threat | Current mitigation | Residual risk |
 |---|---|---|---|
-| **Spoofing** | Attacker forges a session cookie to log in as another user. | `DataProtectionSessionCipher.Unprotect` uses AEAD (AES-256-CBC + HMAC-SHA256 by default) via `IDataProtector`; forgery without the key is infeasible. Key is wrapped by Key Vault. | Low — depends on key confidentiality (see `keyvault-data-protection-wrap.md`). |
-| **Tampering** | Attacker replays an expired but otherwise valid cookie. | `AuthMiddleware` checks `principal.ExpiresAt > DateTimeOffset.UtcNow` after unprotecting; expired sessions are silently dropped. | Low — clock-skew window is negligible (UTC comparison, no tolerance added). |
-| **Repudiation** | Attacker claims they did not make a state-changing API call. | `AuditMiddleware` is registered in the pipeline ahead of function handlers and logs request method, path, and (after auth) the principal identity. App Insights + Log Analytics retain logs. | Medium — audit events are best-effort; if App Insights ingestion is delayed or dropped, the record is lost. No tamper-evident log store. |
-| **Information disclosure** | XSS in the frontend steals the session cookie. | Cookie is set `HttpOnly=true`, preventing JavaScript access. `SecurityHeadersMiddleware` adds `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, and a restrictive `Content-Security-Policy`. `Strict-Transport-Security` prevents HTTP downgrade. | Medium — CSP on the API response is `default-src 'none'; frame-ancestors 'none'`, but the Blazor WASM SPA's own CSP headers are managed by Static Web Apps and are not visible in this repo; a weak SPA CSP could enable XSS on the frontend origin. |
-| **Denial of service** | Attacker sends many requests with invalid cookies to force repeated `Unprotect` operations. | `RateLimitMiddleware` is registered before `AuthMiddleware` and can throttle per-IP. | Medium — rate limiter is in-process; under heavy load from many IPs it provides limited protection. |
-| **Elevation of privilege** | Attacker bypasses `[RequireAuth]` by reaching a function handler before `AuthPolicyMiddleware` runs. | `AuthPolicyMiddleware` is the last middleware before the handler; it uses reflection-based caching to check for `RequireAuthAttribute` on the method or class. 401 is returned immediately if principal is absent. | Low — middleware is registered in correct order in `Program.cs`. Risk materialises only if registration order is changed. |
+| **Spoofing** | Attacker forges a session cookie to log in as another user. | `DataProtectionSessionCipher.Unprotect` uses AEAD via `IDataProtector`; forgery without the key is infeasible. Key is wrapped by Key Vault. | Low — depends on key confidentiality (see `keyvault-data-protection-wrap.md`). |
+| **Tampering** | Attacker replays an expired but otherwise valid cookie. | `AuthMiddleware` checks `principal.ExpiresAt + ClockSkew > UtcNow` after unprotecting, where `ClockSkew = 30s`. State-changing endpoints additionally honour `If-Match` ETags (`PUT /runs/{id}`, `PATCH /me`, `PATCH /guild`) so a replayed cookie within the skew window cannot bypass optimistic concurrency. | Low — replay window is bounded to the configured 30 s skew; `If-Match` prevents lost-update on concurrent writes. |
+| **Repudiation** | Attacker denies having made a state-changing API call. | `AuditMiddleware` records function name, invocation id, and elapsed time on every request. Per-handler `AuditLog.Emit` records mutating actions; `IActorHasher` HMAC-hashes the actor id when `AuditOptions.HashSalt` is set. App Insights + Log Analytics retain logs. | Medium — `AuditMiddleware` does **not** log the principal identity; only per-handler `AuditLog.Emit` calls capture the actor, and the actor is hashed. App Insights ingestion is best-effort. **Today the salt is not wired in `infra/modules/functions.bicep`**, so deployed environments emit plaintext `battleNetId` until that gap is closed; covered separately by `audit-log-pii-pipeline.md` (backlog). |
+| **Information disclosure** | XSS in the frontend steals the session cookie. | Cookie is `HttpOnly=true`. `SecurityHeadersMiddleware` adds `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy`, `Strict-Transport-Security`, `Content-Security-Policy: default-src 'none'; frame-ancestors 'none'`, plus build-id headers `X-Source-Code` and `X-Source-Commit`, plus a default `Cache-Control: private, no-store` fallback for any handler that did not set its own. Every problem+json error body carries a `traceId` extension. | Medium — CSP on the API response is restrictive; the Blazor WASM SPA's own CSP headers are managed by Static Web Apps and are not visible in this repo. The `traceId` exposed in error responses is a non-secret W3C trace identifier; it is a minor request fingerprint, not a credential. |
+| **Denial of service** | Attacker sends many requests with invalid cookies to force repeated `Unprotect` operations, or floods the API with oversized payloads. | `RequestSizeLimitMiddleware` (default 64 KiB cap, 413 problem+json) runs ahead of rate-limit, auth, and handler — bounding compute exposure on oversized inputs. `RateLimitMiddleware` runs next; 429 responses include `Retry-After: 60`. `X-Forwarded-For` is only honoured from configured `TrustedProxyAddresses`, so direct callers cannot forge fresh per-IP buckets. | Medium — per `serverless-api-design §3.10`, edge rate-limiting (Front Door / API Management) is the **primary** defence; the in-process middleware here is a fallback. SWA Free tier provides no edge rate-limit, so this is an accepted trade-off for the current cost stance. `RateLimit-Limit` / `RateLimit-Remaining` / `RateLimit-Reset` informational headers are not emitted on success responses (§3.10 deviation; minor for a hobby project with first-party clients only). |
+| **Elevation of privilege** | Attacker bypasses `[RequireAuth]` by reaching a function handler before `AuthPolicyMiddleware` runs. | `AuthPolicyMiddleware` runs immediately before the handler. `IdempotencyMiddleware` runs after `AuthPolicyMiddleware` and only operates on already-authenticated callers (anonymous requests bypass idempotency state writes entirely). Reflection-based attribute lookup is cached in a `ConcurrentDictionary` to avoid per-request overhead. | Low — registration order in `Program.cs:20-30` keeps `AuthPolicyMiddleware` immediately before the handler; risk materialises only if registration order is changed. |
 
 ## Key Code References
 
-- `api/Middleware/AuthMiddleware.cs:17-24` — reads the session cookie by configured
-  name, calls `cipher.Unprotect`, validates `ExpiresAt`, and stores the principal in
-  `context.Items`.
-- `api/Middleware/AuthPolicyMiddleware.cs:15-23` — checks `context.TryGetPrincipal()`;
-  returns 401 if null and the function is decorated with `[RequireAuth]`.
-- `api/Middleware/AuthPolicyMiddleware.cs:27-40` — reflection-based attribute lookup
+- `api/Middleware/AuthMiddleware.cs:18` — `ClockSkew = TimeSpan.FromSeconds(30)`
+  constant; consumed by the expiry check.
+- `api/Middleware/AuthMiddleware.cs:22-36` — reads the session cookie by configured
+  name, calls `cipher.Unprotect`, validates `ExpiresAt + ClockSkew > UtcNow`, and
+  stores the principal in `context.Items`.
+- `api/Middleware/AuthPolicyMiddleware.cs:16-28` — checks `context.TryGetPrincipal()`;
+  returns 401 problem+json if null and the function is decorated with `[RequireAuth]`.
+- `api/Middleware/AuthPolicyMiddleware.cs:30-43` — reflection-based attribute lookup
   cached in `ConcurrentDictionary` to avoid per-request reflection overhead.
-- `api/Middleware/SecurityHeadersMiddleware.cs:22-26` — adds `X-Content-Type-Options`,
-  `X-Frame-Options`, `Referrer-Policy`, `Strict-Transport-Security`, and `CSP` headers
-  to every HTTP response.
-- `api/Auth/DataProtectionSessionCipher.cs:8-14` — cipher creates the `IDataProtector`
-  with purpose string `Lfm.Session.v1`; `Protect` serializes the principal to JSON then
-  AEAD-encrypts it.
-- `api/Auth/SessionPrincipal.cs:11-14` — `AccessToken` field stores the Battle.net
-  OAuth token inside the encrypted session cookie; leaking the cookie exposes the token.
-- `api/Auth/RequireAuthAttribute.cs:7-8` — marker attribute targeting method or class;
-  `Inherited = true` so subclasses inherit the requirement.
-- `api/Program.cs:16-21` — canonical middleware registration order that must be
-  preserved to maintain the security chain.
-- `api/Program.cs:167-178` — Data Protection key ring configured with KV wrap and blob
-  persistence; session cookie integrity depends on this key ring.
+- `api/Middleware/SecurityHeadersMiddleware.cs:41-58` — adds all response headers.
+  Lines 41-47 emit `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`,
+  `Strict-Transport-Security`, `Content-Security-Policy`, plus build-id headers
+  `X-Source-Code`, `X-Source-Commit`. Lines 55-58 add a default
+  `Cache-Control: private, no-store` for any response that did not set its own.
+- `api/Middleware/RequestSizeLimitMiddleware.cs` — 64 KiB body cap; emits 413
+  problem+json with `traceId`.
+- `api/Middleware/RateLimitMiddleware.cs:21-22` — `AuthFunctions` set governing the
+  strict auth-tier ceiling.
+- `api/Middleware/RateLimitMiddleware.cs:114` — `Retry-After: 60` on 429 response.
+- `api/Middleware/RateLimitMiddleware.cs:124-147` — `GetClientIp` honours
+  `X-Forwarded-For` only from `TrustedProxyAddresses`.
+- `api/Middleware/IdempotencyMiddleware.cs` — runs after `AuthPolicyMiddleware`; the
+  replay cache is partitioned per `battleNetId` derived from the session principal,
+  not from request parameters.
+- `api/Auth/DataProtectionSessionCipher.cs:11-12` — cipher creates the
+  `IDataProtector` with purpose string `Lfm.Session.v1`; `Protect` serialises the
+  principal to JSON then AEAD-encrypts it.
+- `api/Auth/SessionPrincipal.cs:13-17` — `AccessToken` field stores the Battle.net
+  OAuth token inside the encrypted session cookie; leaking the cookie exposes the
+  token (see `blizzard-outbound-api.md`).
+- `api/Auth/RequireAuthAttribute.cs:10-11` — marker attribute targeting method or
+  class; `Inherited = true` so subclasses inherit the requirement.
+- `api/Program.cs:20-30` — canonical middleware registration order
+  (CORS → SecurityHeaders → RequestSizeLimit → RateLimit → Audit → Auth → AuthPolicy
+  → Idempotency). Must be preserved to maintain the security chain.
+- `api/Program.cs:42-52` — `AddProblemDetails` registration; every problem+json body
+  includes the W3C `traceId` extension via the customizer.
+- `api/Program.cs:254-276` — Data Protection key ring configured with KV wrap and
+  blob persistence; session cookie integrity depends on this key ring.
+- `api/Program.cs:286-287` — `AuditLog.ConfigureHasher` installs the DI-selected
+  `IActorHasher`.
 
 ## Out of Scope
 
@@ -83,3 +123,8 @@ Browser                    Functions API (middleware chain)         Cosmos DB
   `keyvault-data-protection-wrap.md`.
 - The OAuth flow that issues the cookie in the first place — covered by
   `battlenet-oauth-callback.md`.
+- `IdempotencyMiddleware` / `IdempotencyStore` semantics, TTL, and replay correctness
+  — covered by `idempotency-replay-cache.md` (backlog).
+- E2E test-only login bypass — covered by `e2e-login-bypass.md`. The bypass is
+  compile-guarded behind `#if E2E` and runtime-gated by `E2E_TEST_MODE=true`; it
+  does not exist in production binaries.


### PR DESCRIPTION
This PR description was removed after repository history was rewritten to remove retired documentation. See current `main` for the active project state.