### PR TITLE
Add AGENTS guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Agent Instructions
+
+`CLAUDE.md` is the authoritative repository guidance for agentic work in this
+repo.
+
+Before making changes, read and follow [CLAUDE.md](CLAUDE.md). Treat it as the
+source of truth for repository structure, workflow, verification, tool usage,
+configuration, security, testing, infrastructure, API contracts, and
+documentation conventions.
+
+When `CLAUDE.md` names Claude-specific tools or skills, use the equivalent
+capability in your agent runtime when available. If there is no equivalent,
+follow the stated intent as closely as your environment allows.
+
+Keep this file thin. Update `CLAUDE.md` for repository guidance changes, and
+only update `AGENTS.md` if the delegation behavior itself changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Hobby project. Prefer free tiers: Cosmos DB free tier, Functions Flex Consumptio
 2. Work in `claude/<short-slug>` via `git switch -c`. Always use `git -C` with absolute paths.
 3. Keep changesets small: commits ≤ 5 files / ≤ 250 lines; branches ≤ 30 files / ≤ 900 lines vs `main`. Thresholds guide planning, not design. Commit partial finishes; split into subtasks if exceeding.
 4. Merge strategy: rebase-and-merge. Use `superpowers:finishing-a-development-branch` to close a branch.
-5. Before claiming complete: `superpowers:verification-before-completion`. Non-trivial tasks: `superpowers:requesting-code-review` before merging.
+5. Before claiming complete: `superpowers:verification-before-completion`. Non-trivial tasks: `superpowers:requesting-code-review` before merging. For documentation-only changes that cannot affect build output, targeted documentation verification is sufficient; state when the full build is intentionally skipped.
 6. Commit messages: short, imperative — e.g. `Fix docker`, `Add runs route`.
 7. PR descriptions: explain the change, list env/schema changes, include screenshots for UI work.
 8. No `Co-Authored-By` trailers. AI usage acknowledged in `README.md`.
@@ -52,7 +52,8 @@ Do not commit populated `.env` files or real credentials. See `example.env` for 
 
 If `scripts/pre-push` is installed as a git hook (see Mandatory Git Workflow item 12), the format / build / vulnerable-package commands below run automatically on `git push`. Otherwise run them manually before claiming work complete.
 
-- Run `dotnet build lfm.sln -c Release` before claiming work complete.
+- Run `dotnet build lfm.sln -c Release` before claiming work complete for code, project, dependency, configuration, infrastructure, or generated-asset changes.
+- Documentation-only changes that cannot affect build output may use targeted verification instead: review the changed files and run `git diff --check` against the changed documentation. State that the full build was intentionally skipped because the change is docs-only.
 - Per-project tests: `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` / `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release` / `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release`.
 - Format check: `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`. **Run `dotnet format lfm.sln` before committing C# changes** — CI format check fails on whitespace.
 - Bundle size check: `./scripts/check-bundle-size.sh ./publish/app/wwwroot 5` (after publish).


### PR DESCRIPTION
## Summary
- Add a thin `AGENTS.md` that delegates agent instructions to `CLAUDE.md`.
- Clarify `CLAUDE.md` verification guidance for docs-only changes.

## Test Plan
- [x] Reviewed `AGENTS.md` and `CLAUDE.md` diffs.
- [x] Ran `git diff --cached --check` before commit.
- [x] Skipped full `.NET` build intentionally because this is a documentation-only change that cannot affect build output.