### PR TITLE
Revise AGENTS guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,19 @@
 # Agent Instructions
 
-`CLAUDE.md` is the authoritative repository guidance for agentic work in this
-repo.
+Repository guidance for agentic work is centralized in [CLAUDE.md](CLAUDE.md).
 
-Before making changes, read and follow [CLAUDE.md](CLAUDE.md). Treat it as the
-source of truth for repository structure, workflow, verification, tool usage,
-configuration, security, testing, infrastructure, API contracts, and
-documentation conventions.
+Before changing files in this repo:
 
-When `CLAUDE.md` names Claude-specific tools or skills, use the equivalent
-capability in your agent runtime when available. If there is no equivalent,
-follow the stated intent as closely as your environment allows.
+1. Read [CLAUDE.md](CLAUDE.md).
+2. Treat it as the source of truth for repository structure, workflow,
+   verification, tool usage, configuration, security, testing, infrastructure,
+   API contracts, and documentation conventions.
+3. When it names Claude-specific tools or skills, use the closest equivalent in
+   your agent runtime. If no equivalent exists, preserve the intent as closely
+   as possible and state the limitation in your response.
 
-Keep this file thin. Update `CLAUDE.md` for repository guidance changes, and
-only update `AGENTS.md` if the delegation behavior itself changes.
+For delegated or parallel agent work, pass along the same instruction: read and
+follow [CLAUDE.md](CLAUDE.md) before making changes.
+
+Keep this file thin. Put repository guidance changes in [CLAUDE.md](CLAUDE.md).
+Update `AGENTS.md` only when this delegation behavior changes.


### PR DESCRIPTION
## Summary
- Clarify that CLAUDE.md is the centralized source of truth for agentic repository guidance.
- Spell out how non-Claude runtimes should map Claude-specific tools or state limitations.
- Add explicit delegation guidance for parallel or delegated agents.

## Test Plan
- [x] `git -C /home/souroldgeezer/repos/lfm diff --check -- AGENTS.md`
- [x] Full build intentionally skipped because this is a documentation-only change.