### PR TITLE
Fix software design findings

### DIFF
--- a/api/Functions/GuildFunction.cs
+++ b/api/Functions/GuildFunction.cs
@@ -12,6 +12,7 @@ using Lfm.Api.Helpers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;
+using Lfm.Api.Validation;
 using Lfm.Contracts.Guild;
 
 namespace Lfm.Api.Functions;

--- a/api/Functions/MeUpdateFunction.cs
+++ b/api/Functions/MeUpdateFunction.cs
@@ -9,6 +9,7 @@ using Lfm.Api.Auth;
 using Lfm.Api.Helpers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
+using Lfm.Api.Validation;
 using Lfm.Contracts.Me;
 
 namespace Lfm.Api.Functions;

--- a/api/Functions/RaiderCharacterAddFunction.cs
+++ b/api/Functions/RaiderCharacterAddFunction.cs
@@ -7,6 +7,7 @@ using Lfm.Api.Helpers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;
+using Lfm.Api.Validation;
 using Lfm.Contracts.Characters;
 using Lfm.Contracts.Raiders;
 using Microsoft.AspNetCore.Http;

--- a/api/Functions/RunResponseMapper.cs
+++ b/api/Functions/RunResponseMapper.cs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Helpers;
+using Lfm.Api.Repositories;
+using Lfm.Contracts.Runs;
+
+namespace Lfm.Api.Functions;
+
+internal static class RunResponseMapper
+{
+    internal static RunDetailDto ToDetail(RunDocument run, string currentBattleNetId)
+    {
+        var (difficulty, size) = RunModeResolver.Resolve(run.Difficulty, run.Size, run.ModeKey);
+        return new RunDetailDto(
+            Id: run.Id,
+            StartTime: run.StartTime,
+            SignupCloseTime: run.SignupCloseTime,
+            Description: run.Description,
+            Visibility: run.Visibility,
+            CreatorGuild: run.CreatorGuild,
+            InstanceId: run.InstanceId,
+            InstanceName: run.InstanceName,
+            Difficulty: difficulty,
+            Size: size,
+            KeystoneLevel: run.KeystoneLevel,
+            RunCharacters: run.RunCharacters
+                .Select(c => ToCharacter(c, currentBattleNetId))
+                .ToList());
+    }
+
+    internal static RunSummaryDto ToSummary(RunDocument run, string currentBattleNetId)
+    {
+        var (difficulty, size) = RunModeResolver.Resolve(run.Difficulty, run.Size, run.ModeKey);
+        return new RunSummaryDto(
+            Id: run.Id,
+            StartTime: run.StartTime,
+            SignupCloseTime: run.SignupCloseTime,
+            Description: run.Description,
+            Visibility: run.Visibility,
+            CreatorGuild: run.CreatorGuild,
+            InstanceId: run.InstanceId,
+            InstanceName: run.InstanceName,
+            RunCharacters: run.RunCharacters
+                .Select(c => ToCharacter(c, currentBattleNetId))
+                .ToList(),
+            Difficulty: difficulty,
+            Size: size,
+            KeystoneLevel: run.KeystoneLevel);
+    }
+
+    private static RunCharacterDto ToCharacter(
+        RunCharacterEntry character,
+        string currentBattleNetId) =>
+        new(
+            CharacterName: character.CharacterName,
+            CharacterRealm: character.CharacterRealm,
+            CharacterClassId: character.CharacterClassId,
+            CharacterClassName: character.CharacterClassName,
+            DesiredAttendance: character.DesiredAttendance,
+            ReviewedAttendance: character.ReviewedAttendance,
+            SpecName: character.SpecName,
+            Role: character.Role,
+            IsCurrentUser: character.RaiderBattleNetId == currentBattleNetId);
+}

--- a/api/Functions/RunsCancelSignupFunction.cs
+++ b/api/Functions/RunsCancelSignupFunction.cs
@@ -57,8 +57,6 @@ public class RunsCancelSignupFunction(
         //      return errorResponse(404, "Run not found");
         if (run.Visibility == "GUILD")
         {
-            var isCreator = run.CreatorBattleNetId == principal.BattleNetId;
-
             // Derive the caller's guild from the raider's selected character.
             var raider = await raidersRepo.GetByBattleNetIdAsync(principal.BattleNetId, ct);
             if (raider is null)
@@ -66,11 +64,7 @@ public class RunsCancelSignupFunction(
 
             var (guildId, _) = GuildResolver.FromRaider(raider);
 
-            var isGuildMember = guildId is not null
-                && run.CreatorGuildId is not null
-                && run.CreatorGuildId.ToString() == guildId;
-
-            if (!isCreator && !isGuildMember)
+            if (!RunAccessPolicy.CanView(run, principal.BattleNetId, guildId))
                 return Problem.NotFound(req.HttpContext, "run-not-found", "Run not found.");
         }
 
@@ -102,7 +96,7 @@ public class RunsCancelSignupFunction(
         AuditLog.Emit(logger, new AuditEvent("signup.cancel", principal.BattleNetId, id, "success", null));
 
         // 7. Return sanitized run — mirrors sanitizeRunDocumentForResponse.
-        return new OkObjectResult(Sanitize(persisted, principal.BattleNetId));
+        return new OkObjectResult(RunResponseMapper.ToDetail(persisted, principal.BattleNetId));
     }
 
     /// <summary>
@@ -118,37 +112,4 @@ public class RunsCancelSignupFunction(
         CancellationToken ct)
         => Run(req, id, ctx, ct);
 
-    // ------------------------------------------------------------------
-    // Sanitizer — mirrors sanitizeRunDocumentForResponse in
-    // functions/src/lib/runResponseSanitizer.ts
-    // ------------------------------------------------------------------
-
-    private static RunDetailDto Sanitize(RunDocument run, string currentBattleNetId)
-    {
-        var (difficulty, size) = Helpers.RunModeResolver.Resolve(run.Difficulty, run.Size, run.ModeKey);
-        return new RunDetailDto(
-            Id: run.Id,
-            StartTime: run.StartTime,
-            SignupCloseTime: run.SignupCloseTime,
-            Description: run.Description,
-            Visibility: run.Visibility,
-            CreatorGuild: run.CreatorGuild,
-            InstanceId: run.InstanceId,
-            InstanceName: run.InstanceName,
-            Difficulty: difficulty,
-            Size: size,
-            KeystoneLevel: run.KeystoneLevel,
-            RunCharacters: run.RunCharacters
-                .Select(c => new RunCharacterDto(
-                    CharacterName: c.CharacterName,
-                    CharacterRealm: c.CharacterRealm,
-                    CharacterClassId: c.CharacterClassId,
-                    CharacterClassName: c.CharacterClassName,
-                    DesiredAttendance: c.DesiredAttendance,
-                    ReviewedAttendance: c.ReviewedAttendance,
-                    SpecName: c.SpecName,
-                    Role: c.Role,
-                    IsCurrentUser: c.RaiderBattleNetId == currentBattleNetId))
-                .ToList());
-    }
 }

--- a/api/Functions/RunsCreateFunction.cs
+++ b/api/Functions/RunsCreateFunction.cs
@@ -12,6 +12,7 @@ using Lfm.Api.Helpers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;
+using Lfm.Api.Validation;
 using Lfm.Contracts.Runs;
 
 namespace Lfm.Api.Functions;
@@ -110,7 +111,7 @@ public class RunsCreateFunction(IRunsRepository repo, IRaidersRepository raiders
 
         AuditLog.Emit(logger, new AuditEvent("run.create", principal.BattleNetId, runId, "success", null));
 
-        return new ObjectResult(MapToDto(created)) { StatusCode = 201 };
+        return new ObjectResult(RunResponseMapper.ToDetail(created, principal.BattleNetId)) { StatusCode = 201 };
     }
 
     /// <summary>
@@ -181,25 +182,4 @@ public class RunsCreateFunction(IRunsRepository repo, IRaidersRepository raiders
             KeystoneLevel: body.KeystoneLevel);
     }
 
-    // ------------------------------------------------------------------
-    // Mapping helper — projects the stored RunDocument to its wire DTO.
-    // ------------------------------------------------------------------
-
-    private static RunDetailDto MapToDto(RunDocument doc)
-    {
-        var (difficulty, size) = RunModeResolver.Resolve(doc.Difficulty, doc.Size, doc.ModeKey);
-        return new RunDetailDto(
-            Id: doc.Id,
-            StartTime: doc.StartTime,
-            SignupCloseTime: doc.SignupCloseTime,
-            Description: doc.Description,
-            Visibility: doc.Visibility,
-            CreatorGuild: doc.CreatorGuild,
-            InstanceId: doc.InstanceId,
-            InstanceName: doc.InstanceName,
-            RunCharacters: [],
-            Difficulty: difficulty,
-            Size: size,
-            KeystoneLevel: doc.KeystoneLevel);
-    }
 }

--- a/api/Functions/RunsDeleteFunction.cs
+++ b/api/Functions/RunsDeleteFunction.cs
@@ -48,7 +48,7 @@ public class RunsDeleteFunction(IRunsRepository repo, IRaidersRepository raiders
         // 2. Permission check — mirrors runs-delete.ts:
         //    Creator can always delete. Non-creator must be in the same guild with
         //    canDeleteGuildRuns permission.
-        var isCreator = existing.CreatorBattleNetId == principal.BattleNetId;
+        var isCreator = RunAccessPolicy.IsCreator(existing, principal.BattleNetId);
         if (!isCreator)
         {
             // Load the raider and derive guild info from the selected character.
@@ -59,9 +59,7 @@ public class RunsDeleteFunction(IRunsRepository repo, IRaidersRepository raiders
 
             var (guildId, _) = GuildResolver.FromRaider(raider);
 
-            if (existing.Visibility != "GUILD"
-                || existing.CreatorGuildId is null
-                || guildId != existing.CreatorGuildId.ToString())
+            if (!RunAccessPolicy.IsGuildPeer(existing, principal.BattleNetId, guildId))
             {
                 AuditLog.Emit(logger, new AuditEvent("run.delete", principal.BattleNetId, id, "failure", "not creator"));
                 return Problem.Forbidden(

--- a/api/Functions/RunsDetailFunction.cs
+++ b/api/Functions/RunsDetailFunction.cs
@@ -47,8 +47,6 @@ public class RunsDetailFunction(IRunsRepository repo, IRaidersRepository raiders
         //     return errorResponse(404, "Run not found");
         if (run.Visibility == "GUILD")
         {
-            var isCreator = run.CreatorBattleNetId == principal.BattleNetId;
-
             // Derive the caller's guild from their raider's selected character so
             // that guild membership is always taken from the stored character data
             // (principal.GuildId is a legacy session field that is no longer populated).
@@ -58,11 +56,7 @@ public class RunsDetailFunction(IRunsRepository repo, IRaidersRepository raiders
 
             var (guildId, _) = GuildResolver.FromRaider(raider);
 
-            var isGuildMember = guildId is not null
-                && run.CreatorGuildId is not null
-                && run.CreatorGuildId.ToString() == guildId;
-
-            if (!isCreator && !isGuildMember)
+            if (!RunAccessPolicy.CanView(run, principal.BattleNetId, guildId))
                 return Problem.NotFound(req.HttpContext, "run-not-found", "Run not found.");
         }
 
@@ -73,7 +67,7 @@ public class RunsDetailFunction(IRunsRepository repo, IRaidersRepository raiders
         if (!string.IsNullOrEmpty(run.ETag))
             req.HttpContext.Response.Headers.ETag = run.ETag;
 
-        return new OkObjectResult(Sanitize(run, principal.BattleNetId));
+        return new OkObjectResult(RunResponseMapper.ToDetail(run, principal.BattleNetId));
     }
 
     /// <summary>
@@ -89,41 +83,4 @@ public class RunsDetailFunction(IRunsRepository repo, IRaidersRepository raiders
         CancellationToken ct)
         => Run(req, id, ctx, ct);
 
-    // ------------------------------------------------------------------
-    // Sanitizer — mirrors sanitizeRunDocumentForResponse in
-    // functions/src/lib/runResponseSanitizer.ts
-    // ------------------------------------------------------------------
-
-    private static RunDetailDto Sanitize(RunDocument run, string currentBattleNetId)
-    {
-        var (difficulty, size) = Helpers.RunModeResolver.Resolve(run.Difficulty, run.Size, run.ModeKey);
-        return new RunDetailDto(
-            Id: run.Id,
-            StartTime: run.StartTime,
-            SignupCloseTime: run.SignupCloseTime,
-            Description: run.Description,
-            Visibility: run.Visibility,
-            CreatorGuild: run.CreatorGuild,
-            InstanceId: run.InstanceId,
-            InstanceName: run.InstanceName,
-            Difficulty: difficulty,
-            Size: size,
-            KeystoneLevel: run.KeystoneLevel,
-            RunCharacters: run.RunCharacters
-                .Select(c => SanitizeCharacter(c, currentBattleNetId))
-                .ToList());
-    }
-
-    private static RunCharacterDto SanitizeCharacter(
-        RunCharacterEntry character, string currentBattleNetId) =>
-        new RunCharacterDto(
-            CharacterName: character.CharacterName,
-            CharacterRealm: character.CharacterRealm,
-            CharacterClassId: character.CharacterClassId,
-            CharacterClassName: character.CharacterClassName,
-            DesiredAttendance: character.DesiredAttendance,
-            ReviewedAttendance: character.ReviewedAttendance,
-            SpecName: character.SpecName,
-            Role: character.Role,
-            IsCurrentUser: character.RaiderBattleNetId == currentBattleNetId);
 }

--- a/api/Functions/RunsListFunction.cs
+++ b/api/Functions/RunsListFunction.cs
@@ -56,7 +56,7 @@ public class RunsListFunction(IRunsRepository repo, IRaidersRepository raidersRe
             : await repo.ListForUserAsync(principal.BattleNetId, top, continuationToken, ct);
 
         var dtos = page.Items
-            .Select(r => Sanitize(r, principal.BattleNetId))
+            .Select(r => RunResponseMapper.ToSummary(r, principal.BattleNetId))
             .ToList();
 
         return new OkObjectResult(new RunsListResponse(dtos, page.ContinuationToken));
@@ -91,41 +91,4 @@ public class RunsListFunction(IRunsRepository repo, IRaidersRepository raidersRe
         return string.IsNullOrEmpty(value) ? null : value;
     }
 
-    // ------------------------------------------------------------------
-    // Sanitizer — mirrors sanitizeRunDocumentForResponse in
-    // functions/src/lib/runResponseSanitizer.ts
-    // ------------------------------------------------------------------
-
-    private static RunSummaryDto Sanitize(RunDocument run, string currentBattleNetId)
-    {
-        var (difficulty, size) = Helpers.RunModeResolver.Resolve(run.Difficulty, run.Size, run.ModeKey);
-        return new RunSummaryDto(
-            Id: run.Id,
-            StartTime: run.StartTime,
-            SignupCloseTime: run.SignupCloseTime,
-            Description: run.Description,
-            Visibility: run.Visibility,
-            CreatorGuild: run.CreatorGuild,
-            InstanceId: run.InstanceId,
-            InstanceName: run.InstanceName,
-            RunCharacters: run.RunCharacters
-                .Select(c => SanitizeCharacter(c, currentBattleNetId))
-                .ToList(),
-            Difficulty: difficulty,
-            Size: size,
-            KeystoneLevel: run.KeystoneLevel);
-    }
-
-    private static RunCharacterDto SanitizeCharacter(
-        RunCharacterEntry character, string currentBattleNetId) =>
-        new RunCharacterDto(
-            CharacterName: character.CharacterName,
-            CharacterRealm: character.CharacterRealm,
-            CharacterClassId: character.CharacterClassId,
-            CharacterClassName: character.CharacterClassName,
-            DesiredAttendance: character.DesiredAttendance,
-            ReviewedAttendance: character.ReviewedAttendance,
-            SpecName: character.SpecName,
-            Role: character.Role,
-            IsCurrentUser: character.RaiderBattleNetId == currentBattleNetId);
 }

--- a/api/Functions/RunsSignupFunction.cs
+++ b/api/Functions/RunsSignupFunction.cs
@@ -12,6 +12,7 @@ using Lfm.Api.Helpers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;
+using Lfm.Api.Validation;
 using Lfm.Contracts.Runs;
 using Lfm.Contracts.WoW;
 
@@ -144,12 +145,7 @@ public class RunsSignupFunction(
             // 4c. Visibility check for GUILD runs — mirrors runs-signup.ts.
             if (run.Visibility == "GUILD")
             {
-                var isCreator = run.CreatorBattleNetId == principal.BattleNetId;
-                var isGuildMember = callerGuildId is not null
-                    && run.CreatorGuildId is not null
-                    && run.CreatorGuildId.ToString() == callerGuildId;
-
-                if (!isCreator && !isGuildMember)
+                if (!RunAccessPolicy.CanView(run, principal.BattleNetId, callerGuildId))
                     return Problem.NotFound(req.HttpContext, "run-not-found", "Run not found.");
 
                 var canSignup = await guildPermissions.CanSignupGuildRunsAsync(raider, ct);
@@ -226,7 +222,7 @@ public class RunsSignupFunction(
 
                 AuditLog.Emit(logger, new AuditEvent("signup.create", principal.BattleNetId, id, "success", null));
 
-                return new OkObjectResult(Sanitize(persisted, principal.BattleNetId));
+                return new OkObjectResult(RunResponseMapper.ToDetail(persisted, principal.BattleNetId));
             }
             catch (ConcurrencyConflictException)
             {
@@ -255,37 +251,4 @@ public class RunsSignupFunction(
         CancellationToken ct)
         => Run(req, id, ctx, ct);
 
-    // ------------------------------------------------------------------
-    // Sanitizer — mirrors sanitizeRunDocumentForResponse in
-    // functions/src/lib/runResponseSanitizer.ts
-    // ------------------------------------------------------------------
-
-    private static RunDetailDto Sanitize(RunDocument run, string currentBattleNetId)
-    {
-        var (difficulty, size) = Helpers.RunModeResolver.Resolve(run.Difficulty, run.Size, run.ModeKey);
-        return new RunDetailDto(
-            Id: run.Id,
-            StartTime: run.StartTime,
-            SignupCloseTime: run.SignupCloseTime,
-            Description: run.Description,
-            Visibility: run.Visibility,
-            CreatorGuild: run.CreatorGuild,
-            InstanceId: run.InstanceId,
-            InstanceName: run.InstanceName,
-            Difficulty: difficulty,
-            Size: size,
-            KeystoneLevel: run.KeystoneLevel,
-            RunCharacters: run.RunCharacters
-                .Select(c => new RunCharacterDto(
-                    CharacterName: c.CharacterName,
-                    CharacterRealm: c.CharacterRealm,
-                    CharacterClassId: c.CharacterClassId,
-                    CharacterClassName: c.CharacterClassName,
-                    DesiredAttendance: c.DesiredAttendance,
-                    ReviewedAttendance: c.ReviewedAttendance,
-                    SpecName: c.SpecName,
-                    Role: c.Role,
-                    IsCurrentUser: c.RaiderBattleNetId == currentBattleNetId))
-                .ToList());
-    }
 }

--- a/api/Functions/RunsUpdateFunction.cs
+++ b/api/Functions/RunsUpdateFunction.cs
@@ -12,6 +12,7 @@ using Lfm.Api.Helpers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;
+using Lfm.Api.Validation;
 using Lfm.Contracts.Runs;
 
 namespace Lfm.Api.Functions;
@@ -84,12 +85,10 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
         // 3. Permission check — mirrors runs-update.ts:
         //    Creator can always edit. Non-creator must be in the same guild with
         //    canCreateGuildRuns permission.
-        var isCreator = existing.CreatorBattleNetId == principal.BattleNetId;
+        var isCreator = RunAccessPolicy.IsCreator(existing, principal.BattleNetId);
         if (!isCreator)
         {
-            if (existing.Visibility != "GUILD"
-                || existing.CreatorGuildId is null
-                || guildId != existing.CreatorGuildId.ToString())
+            if (!RunAccessPolicy.IsGuildPeer(existing, principal.BattleNetId, guildId))
             {
                 AuditLog.Emit(logger, new AuditEvent("run.update", principal.BattleNetId, id, "failure", "not creator"));
                 return Problem.Forbidden(
@@ -276,7 +275,7 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
         if (!string.IsNullOrEmpty(persisted.ETag))
             req.HttpContext.Response.Headers.ETag = persisted.ETag;
 
-        return new OkObjectResult(MapToDto(persisted, principal.BattleNetId));
+        return new OkObjectResult(RunResponseMapper.ToDetail(persisted, principal.BattleNetId));
     }
 
     /// <summary>
@@ -292,36 +291,4 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
         CancellationToken ct)
         => Run(req, id, ctx, ct);
 
-    // ------------------------------------------------------------------
-    // Mapping helper — projects the stored RunDocument to its wire DTO.
-    // ------------------------------------------------------------------
-
-    private static RunDetailDto MapToDto(RunDocument doc, string currentBattleNetId)
-    {
-        var (difficulty, size) = RunModeResolver.Resolve(doc.Difficulty, doc.Size, doc.ModeKey);
-        return new RunDetailDto(
-            Id: doc.Id,
-            StartTime: doc.StartTime,
-            SignupCloseTime: doc.SignupCloseTime,
-            Description: doc.Description,
-            Visibility: doc.Visibility,
-            CreatorGuild: doc.CreatorGuild,
-            InstanceId: doc.InstanceId,
-            InstanceName: doc.InstanceName,
-            Difficulty: difficulty,
-            Size: size,
-            KeystoneLevel: doc.KeystoneLevel,
-            RunCharacters: doc.RunCharacters
-                .Select(c => new RunCharacterDto(
-                    CharacterName: c.CharacterName,
-                    CharacterRealm: c.CharacterRealm,
-                    CharacterClassId: c.CharacterClassId,
-                    CharacterClassName: c.CharacterClassName,
-                    DesiredAttendance: c.DesiredAttendance,
-                    ReviewedAttendance: c.ReviewedAttendance,
-                    SpecName: c.SpecName,
-                    Role: c.Role,
-                    IsCurrentUser: c.RaiderBattleNetId == currentBattleNetId))
-                .ToList());
-    }
 }

--- a/api/Services/RunAccessPolicy.cs
+++ b/api/Services/RunAccessPolicy.cs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Repositories;
+
+namespace Lfm.Api.Services;
+
+internal static class RunAccessPolicy
+{
+    internal static bool CanView(RunDocument run, string currentBattleNetId, string? callerGuildId) =>
+        run.Visibility != "GUILD"
+        || IsCreator(run, currentBattleNetId)
+        || IsSameGuild(run, callerGuildId);
+
+    internal static bool IsGuildPeer(RunDocument run, string currentBattleNetId, string? callerGuildId) =>
+        run.Visibility == "GUILD"
+        && !IsCreator(run, currentBattleNetId)
+        && IsSameGuild(run, callerGuildId);
+
+    internal static bool IsCreator(RunDocument run, string currentBattleNetId) =>
+        run.CreatorBattleNetId == currentBattleNetId;
+
+    private static bool IsSameGuild(RunDocument run, string? callerGuildId) =>
+        callerGuildId is not null
+        && run.CreatorGuildId is not null
+        && run.CreatorGuildId.ToString() == callerGuildId;
+}

--- a/api/Validation/RequestValidators.cs
+++ b/api/Validation/RequestValidators.cs
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Text.RegularExpressions;
+using FluentValidation;
+using Lfm.Contracts.Guild;
+using Lfm.Contracts.Me;
+using Lfm.Contracts.Raiders;
+using Lfm.Contracts.Runs;
+
+namespace Lfm.Api.Validation;
+
+public sealed class CreateRunRequestValidator : AbstractValidator<CreateRunRequest>
+{
+    private static readonly HashSet<string> ValidVisibilities =
+        new(StringComparer.Ordinal) { "PUBLIC", "GUILD" };
+
+    internal static readonly HashSet<string> ValidDifficulties =
+        new(StringComparer.Ordinal)
+        {
+            "LFR", "NORMAL", "HEROIC", "MYTHIC", "MYTHIC_KEYSTONE",
+        };
+
+    internal const string MythicKeystone = "MYTHIC_KEYSTONE";
+
+    public CreateRunRequestValidator()
+    {
+        RuleFor(x => x.StartTime)
+            .NotEmpty().WithMessage("startTime is required")
+            .MaximumLength(64).WithMessage("startTime must be at most 64 characters");
+
+        RuleFor(x => x.SignupCloseTime)
+            .MaximumLength(64).WithMessage("signupCloseTime must be at most 64 characters");
+
+        RuleFor(x => x.Difficulty)
+            .NotEmpty().WithMessage("difficulty is required");
+        RuleFor(x => x.Difficulty)
+            .Must(d => d is null || ValidDifficulties.Contains(d))
+            .WithMessage("difficulty must be one of LFR, NORMAL, HEROIC, MYTHIC, MYTHIC_KEYSTONE");
+
+        RuleFor(x => x.Size)
+            .NotNull().WithMessage("size is required");
+        RuleFor(x => x.Size)
+            .InclusiveBetween(1, 40).When(x => x.Size.HasValue)
+            .WithMessage("size must be between 1 and 40");
+
+        RuleFor(x => x.Visibility)
+            .NotEmpty().WithMessage("visibility is required")
+            .Must(v => v is null || ValidVisibilities.Contains(v))
+            .WithMessage("visibility must be PUBLIC or GUILD");
+
+        RuleFor(x => x)
+            .Must(x => x.InstanceId.HasValue || x.Difficulty == MythicKeystone)
+            .WithMessage("instanceId is required for non-Mythic+ runs");
+
+        RuleFor(x => x.KeystoneLevel)
+            .InclusiveBetween(2, 30).When(x => x.KeystoneLevel.HasValue)
+            .WithMessage("keystoneLevel must be between 2 and 30");
+        RuleFor(x => x)
+            .Must(x => x.Difficulty == MythicKeystone || x.KeystoneLevel is null)
+            .WithMessage("keystoneLevel is only valid for Mythic+ runs");
+        RuleFor(x => x)
+            .Must(x => x.Difficulty != MythicKeystone || x.InstanceId.HasValue || x.KeystoneLevel.HasValue)
+            .WithMessage("keystoneLevel is required when no specific dungeon is selected");
+
+        RuleFor(x => x.InstanceName)
+            .MaximumLength(128).WithMessage("instanceName must be at most 128 characters");
+
+        RuleFor(x => x.Description)
+            .MaximumLength(2000).WithMessage("description must be at most 2000 characters");
+    }
+}
+
+public sealed class UpdateRunRequestValidator : AbstractValidator<UpdateRunRequest>
+{
+    private static readonly HashSet<string> ValidVisibilities =
+        new(StringComparer.Ordinal) { "PUBLIC", "GUILD" };
+
+    public UpdateRunRequestValidator()
+    {
+        RuleFor(x => x.Visibility)
+            .Must(v => v is null || ValidVisibilities.Contains(v))
+            .WithMessage("visibility must be PUBLIC or GUILD");
+
+        RuleFor(x => x.StartTime)
+            .MaximumLength(64).WithMessage("startTime must be at most 64 characters");
+
+        RuleFor(x => x.SignupCloseTime)
+            .MaximumLength(64).WithMessage("signupCloseTime must be at most 64 characters");
+
+        RuleFor(x => x.Difficulty)
+            .Must(d => d is null || CreateRunRequestValidator.ValidDifficulties.Contains(d))
+            .WithMessage("difficulty must be one of LFR, NORMAL, HEROIC, MYTHIC, MYTHIC_KEYSTONE");
+
+        RuleFor(x => x.Size)
+            .InclusiveBetween(1, 40).When(x => x.Size.HasValue)
+            .WithMessage("size must be between 1 and 40");
+
+        RuleFor(x => x.KeystoneLevel)
+            .InclusiveBetween(2, 30).When(x => x.KeystoneLevel.HasValue)
+            .WithMessage("keystoneLevel must be between 2 and 30");
+
+        RuleFor(x => x.InstanceName)
+            .MaximumLength(128).WithMessage("instanceName must be at most 128 characters");
+
+        RuleFor(x => x.Description)
+            .MaximumLength(2000).WithMessage("description must be at most 2000 characters");
+    }
+}
+
+public sealed class SignupRequestValidator : AbstractValidator<SignupRequest>
+{
+    private static readonly HashSet<string> ValidAttendances =
+        new(StringComparer.Ordinal) { "IN", "OUT", "BENCH", "LATE", "AWAY" };
+
+    public SignupRequestValidator()
+    {
+        RuleFor(x => x.CharacterId)
+            .NotEmpty().WithMessage("characterId is required");
+
+        RuleFor(x => x.DesiredAttendance)
+            .NotEmpty().WithMessage("desiredAttendance is required")
+            .Must(v => v is not null && ValidAttendances.Contains(v))
+            .WithMessage("desiredAttendance must be one of: IN, OUT, BENCH, LATE, AWAY");
+    }
+}
+
+public partial class AddCharacterRequestValidator : AbstractValidator<AddCharacterRequest>
+{
+    private static readonly HashSet<string> ValidRegions = ["eu", "us", "kr", "tw", "cn"];
+
+    [GeneratedRegex("^[a-z0-9-]+$")]
+    private static partial Regex RealmPattern();
+
+    [GeneratedRegex(@"^[a-zA-Z\u00C0-\u00FF]+$")]
+    private static partial Regex NamePattern();
+
+    public AddCharacterRequestValidator()
+    {
+        RuleFor(x => x.Region)
+            .NotEmpty().WithMessage("region is required")
+            .Must(r => r is not null && ValidRegions.Contains(r))
+            .WithMessage("region must be one of: eu, us, kr, tw, cn");
+
+        RuleFor(x => x.Realm)
+            .NotEmpty().WithMessage("realm is required")
+            .MaximumLength(64).WithMessage("realm must be at most 64 characters")
+            .Must(r => r is not null && RealmPattern().IsMatch(r))
+            .WithMessage("realm must be a valid slug (lowercase, alphanumeric, hyphens)");
+
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("name is required")
+            .MinimumLength(2).WithMessage("name must be at least 2 characters")
+            .MaximumLength(12).WithMessage("name must be at most 12 characters")
+            .Must(n => n is not null && NamePattern().IsMatch(n))
+            .WithMessage("name must contain only letters");
+    }
+}
+
+public sealed class UpdateMeRequestValidator : AbstractValidator<UpdateMeRequest>
+{
+    private static readonly string[] SupportedLocales = ["en", "fi"];
+
+    public UpdateMeRequestValidator()
+    {
+        RuleFor(x => x.Locale)
+            .NotEmpty()
+            .WithMessage("locale is required")
+            .Must(l => l is not null && SupportedLocales.Contains(l))
+            .WithMessage($"Invalid locale. Supported: {string.Join(", ", SupportedLocales)}");
+    }
+}
+
+public sealed class UpdateGuildRequestValidator : AbstractValidator<UpdateGuildRequest>
+{
+    private static readonly string[] AllowedLocales =
+        ["fi", "en-gb", "de", "fr", "es", "sv", "da", "nb"];
+
+    public UpdateGuildRequestValidator()
+    {
+        RuleFor(x => x.Timezone)
+            .NotEmpty()
+            .WithMessage("timezone is required")
+            .MaximumLength(64).WithMessage("timezone must be at most 64 characters");
+
+        RuleFor(x => x.Locale)
+            .NotEmpty()
+            .WithMessage("locale is required")
+            .Must(l => l is not null && AllowedLocales.Contains(
+                l.Replace('_', '-'), StringComparer.OrdinalIgnoreCase))
+            .WithMessage($"Invalid locale. Supported: {string.Join(", ", AllowedLocales)}");
+
+        RuleFor(x => x.Slogan)
+            .MaximumLength(200).WithMessage("slogan must be at most 200 characters");
+    }
+}

--- a/app/Lfm.App.Core/packages.lock.json
+++ b/app/Lfm.App.Core/packages.lock.json
@@ -38,11 +38,6 @@
           "Microsoft.Extensions.Options": "10.0.7"
         }
       },
-      "FluentValidation": {
-        "type": "Transitive",
-        "resolved": "12.1.1",
-        "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
-      },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -181,10 +176,7 @@
         "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
       },
       "lfm.contracts": {
-        "type": "Project",
-        "dependencies": {
-          "FluentValidation": "[12.1.1, )"
-        }
+        "type": "Project"
       }
     }
   }

--- a/app/packages.lock.json
+++ b/app/packages.lock.json
@@ -109,11 +109,6 @@
         "resolved": "10.0.4",
         "contentHash": "6PVJDzxzz2gvKLSWKHNrmmHfoDcTNJixKMHXDf2Ztv8bvpLiIsDe4QahFvnVcWtZ74nIlaOKU2sR+nYk+/K2bg=="
       },
-      "FluentValidation": {
-        "type": "Transitive",
-        "resolved": "12.1.1",
-        "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
-      },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -371,10 +366,7 @@
         }
       },
       "lfm.contracts": {
-        "type": "Project",
-        "dependencies": {
-          "FluentValidation": "[12.1.1, )"
-        }
+        "type": "Project"
       }
     },
     "net10.0/browser-wasm": {}

--- a/shared/Lfm.Contracts/Guild/UpdateGuildRequest.cs
+++ b/shared/Lfm.Contracts/Guild/UpdateGuildRequest.cs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
-using FluentValidation;
-
 namespace Lfm.Contracts.Guild;
 
 /// <summary>
@@ -24,34 +22,3 @@ public sealed record UpdateGuildRequest(
     string? Locale,
     string? Slogan,
     IReadOnlyList<UpdateGuildRankPermission>? RankPermissions);
-
-/// <summary>
-/// Validates UpdateGuildRequest.
-/// Allowed locales mirror the TypeScript ALLOWED_LOCALES constant in
-/// <c>functions/src/lib/guild/settings.ts</c>.
-/// Timezone validation is a non-empty string check only; full IANA zone
-/// validation is deferred to the service layer (runtime zone DB required).
-/// </summary>
-public sealed class UpdateGuildRequestValidator : AbstractValidator<UpdateGuildRequest>
-{
-    private static readonly string[] AllowedLocales =
-        ["fi", "en-gb", "de", "fr", "es", "sv", "da", "nb"];
-
-    public UpdateGuildRequestValidator()
-    {
-        RuleFor(x => x.Timezone)
-            .NotEmpty()
-            .WithMessage("timezone is required")
-            .MaximumLength(64).WithMessage("timezone must be at most 64 characters");
-
-        RuleFor(x => x.Locale)
-            .NotEmpty()
-            .WithMessage("locale is required")
-            .Must(l => l is not null && AllowedLocales.Contains(
-                l.Replace('_', '-'), StringComparer.OrdinalIgnoreCase))
-            .WithMessage($"Invalid locale. Supported: {string.Join(", ", AllowedLocales)}");
-
-        RuleFor(x => x.Slogan)
-            .MaximumLength(200).WithMessage("slogan must be at most 200 characters");
-    }
-}

--- a/shared/Lfm.Contracts/Lfm.Contracts.csproj
+++ b/shared/Lfm.Contracts/Lfm.Contracts.csproj
@@ -6,7 +6,4 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RootNamespace>Lfm.Contracts</RootNamespace>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="12.1.1" />
-  </ItemGroup>
 </Project>

--- a/shared/Lfm.Contracts/Me/UpdateMeRequest.cs
+++ b/shared/Lfm.Contracts/Me/UpdateMeRequest.cs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
-using FluentValidation;
-
 namespace Lfm.Contracts.Me;
 
 /// <summary>
@@ -10,20 +8,3 @@ namespace Lfm.Contracts.Me;
 /// Fields mirror the TypeScript handler at functions/src/functions/me-update.ts.
 /// </summary>
 public sealed record UpdateMeRequest(string? Locale);
-
-/// <summary>
-/// Validates UpdateMeRequest. Supported locales mirror the TS SUPPORTED_LOCALES constant.
-/// </summary>
-public sealed class UpdateMeRequestValidator : AbstractValidator<UpdateMeRequest>
-{
-    private static readonly string[] SupportedLocales = ["en", "fi"];
-
-    public UpdateMeRequestValidator()
-    {
-        RuleFor(x => x.Locale)
-            .NotEmpty()
-            .WithMessage("locale is required")
-            .Must(l => l is not null && SupportedLocales.Contains(l))
-            .WithMessage($"Invalid locale. Supported: {string.Join(", ", SupportedLocales)}");
-    }
-}

--- a/shared/Lfm.Contracts/Raiders/AddCharacterRequest.cs
+++ b/shared/Lfm.Contracts/Raiders/AddCharacterRequest.cs
@@ -1,41 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
-using System.Text.RegularExpressions;
-using FluentValidation;
-
 namespace Lfm.Contracts.Raiders;
 
 public sealed record AddCharacterRequest(string? Region, string? Realm, string? Name);
-
-public partial class AddCharacterRequestValidator : AbstractValidator<AddCharacterRequest>
-{
-    private static readonly HashSet<string> ValidRegions = ["eu", "us", "kr", "tw", "cn"];
-
-    [GeneratedRegex("^[a-z0-9-]+$")]
-    private static partial Regex RealmPattern();
-
-    [GeneratedRegex(@"^[a-zA-Z\u00C0-\u00FF]+$")]
-    private static partial Regex NamePattern();
-
-    public AddCharacterRequestValidator()
-    {
-        RuleFor(x => x.Region)
-            .NotEmpty().WithMessage("region is required")
-            .Must(r => r is not null && ValidRegions.Contains(r))
-            .WithMessage("region must be one of: eu, us, kr, tw, cn");
-
-        RuleFor(x => x.Realm)
-            .NotEmpty().WithMessage("realm is required")
-            .MaximumLength(64).WithMessage("realm must be at most 64 characters")
-            .Must(r => r is not null && RealmPattern().IsMatch(r))
-            .WithMessage("realm must be a valid slug (lowercase, alphanumeric, hyphens)");
-
-        RuleFor(x => x.Name)
-            .NotEmpty().WithMessage("name is required")
-            .MinimumLength(2).WithMessage("name must be at least 2 characters")
-            .MaximumLength(12).WithMessage("name must be at most 12 characters")
-            .Must(n => n is not null && NamePattern().IsMatch(n))
-            .WithMessage("name must contain only letters");
-    }
-}

--- a/shared/Lfm.Contracts/Runs/CreateRunRequest.cs
+++ b/shared/Lfm.Contracts/Runs/CreateRunRequest.cs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
-using FluentValidation;
-
 namespace Lfm.Contracts.Runs;
 
 /// <summary>
@@ -18,69 +16,3 @@ public sealed record CreateRunRequest(
     string? Difficulty,
     int? Size,
     int? KeystoneLevel = null);
-
-public sealed class CreateRunRequestValidator : AbstractValidator<CreateRunRequest>
-{
-    private static readonly HashSet<string> ValidVisibilities =
-        new(StringComparer.Ordinal) { "PUBLIC", "GUILD" };
-
-    internal static readonly HashSet<string> ValidDifficulties =
-        new(StringComparer.Ordinal)
-        {
-            "LFR", "NORMAL", "HEROIC", "MYTHIC", "MYTHIC_KEYSTONE",
-        };
-
-    internal const string MythicKeystone = "MYTHIC_KEYSTONE";
-
-    public CreateRunRequestValidator()
-    {
-        RuleFor(x => x.StartTime)
-            .NotEmpty().WithMessage("startTime is required")
-            .MaximumLength(64).WithMessage("startTime must be at most 64 characters");
-
-        RuleFor(x => x.SignupCloseTime)
-            .MaximumLength(64).WithMessage("signupCloseTime must be at most 64 characters");
-
-        RuleFor(x => x.Difficulty)
-            .NotEmpty().WithMessage("difficulty is required");
-        RuleFor(x => x.Difficulty)
-            .Must(d => d is null || ValidDifficulties.Contains(d))
-            .WithMessage("difficulty must be one of LFR, NORMAL, HEROIC, MYTHIC, MYTHIC_KEYSTONE");
-
-        RuleFor(x => x.Size)
-            .NotNull().WithMessage("size is required");
-        RuleFor(x => x.Size)
-            .InclusiveBetween(1, 40).When(x => x.Size.HasValue)
-            .WithMessage("size must be between 1 and 40");
-
-        RuleFor(x => x.Visibility)
-            .NotEmpty().WithMessage("visibility is required")
-            .Must(v => v is null || ValidVisibilities.Contains(v))
-            .WithMessage("visibility must be PUBLIC or GUILD");
-
-        // InstanceId is required unless the run is a Mythic+ session — M+
-        // runs may be dungeon-agnostic ("Any dungeon").
-        RuleFor(x => x)
-            .Must(x => x.InstanceId.HasValue || x.Difficulty == MythicKeystone)
-            .WithMessage("instanceId is required for non-Mythic+ runs");
-
-        // KeystoneLevel is only valid on Mythic+ runs, and it becomes required
-        // when no specific instance is selected — a dungeon-less M+ run needs
-        // the level to mean anything.
-        RuleFor(x => x.KeystoneLevel)
-            .InclusiveBetween(2, 30).When(x => x.KeystoneLevel.HasValue)
-            .WithMessage("keystoneLevel must be between 2 and 30");
-        RuleFor(x => x)
-            .Must(x => x.Difficulty == MythicKeystone || x.KeystoneLevel is null)
-            .WithMessage("keystoneLevel is only valid for Mythic+ runs");
-        RuleFor(x => x)
-            .Must(x => x.Difficulty != MythicKeystone || x.InstanceId.HasValue || x.KeystoneLevel.HasValue)
-            .WithMessage("keystoneLevel is required when no specific dungeon is selected");
-
-        RuleFor(x => x.InstanceName)
-            .MaximumLength(128).WithMessage("instanceName must be at most 128 characters");
-
-        RuleFor(x => x.Description)
-            .MaximumLength(2000).WithMessage("description must be at most 2000 characters");
-    }
-}

--- a/shared/Lfm.Contracts/Runs/SignupRequest.cs
+++ b/shared/Lfm.Contracts/Runs/SignupRequest.cs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
-using FluentValidation;
-
 namespace Lfm.Contracts.Runs;
 
 /// <summary>
@@ -14,20 +12,3 @@ public sealed record SignupRequest(
     string? CharacterId,
     string? DesiredAttendance,
     int? SpecId);
-
-public sealed class SignupRequestValidator : AbstractValidator<SignupRequest>
-{
-    private static readonly HashSet<string> ValidAttendances =
-        new(StringComparer.Ordinal) { "IN", "OUT", "BENCH", "LATE", "AWAY" };
-
-    public SignupRequestValidator()
-    {
-        RuleFor(x => x.CharacterId)
-            .NotEmpty().WithMessage("characterId is required");
-
-        RuleFor(x => x.DesiredAttendance)
-            .NotEmpty().WithMessage("desiredAttendance is required")
-            .Must(v => v is not null && ValidAttendances.Contains(v))
-            .WithMessage("desiredAttendance must be one of: IN, OUT, BENCH, LATE, AWAY");
-    }
-}

--- a/shared/Lfm.Contracts/Runs/UpdateRunRequest.cs
+++ b/shared/Lfm.Contracts/Runs/UpdateRunRequest.cs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
-using FluentValidation;
-
 namespace Lfm.Contracts.Runs;
 
 /// <summary>
@@ -19,41 +17,3 @@ public sealed record UpdateRunRequest(
     string? Difficulty = null,
     int? Size = null,
     int? KeystoneLevel = null);
-
-public sealed class UpdateRunRequestValidator : AbstractValidator<UpdateRunRequest>
-{
-    private static readonly HashSet<string> ValidVisibilities =
-        new(StringComparer.Ordinal) { "PUBLIC", "GUILD" };
-
-    public UpdateRunRequestValidator()
-    {
-        // All fields are optional on update, but if provided they must be valid.
-        RuleFor(x => x.Visibility)
-            .Must(v => v is null || ValidVisibilities.Contains(v))
-            .WithMessage("visibility must be PUBLIC or GUILD");
-
-        RuleFor(x => x.StartTime)
-            .MaximumLength(64).WithMessage("startTime must be at most 64 characters");
-
-        RuleFor(x => x.SignupCloseTime)
-            .MaximumLength(64).WithMessage("signupCloseTime must be at most 64 characters");
-
-        RuleFor(x => x.Difficulty)
-            .Must(d => d is null || CreateRunRequestValidator.ValidDifficulties.Contains(d))
-            .WithMessage("difficulty must be one of LFR, NORMAL, HEROIC, MYTHIC, MYTHIC_KEYSTONE");
-
-        RuleFor(x => x.Size)
-            .InclusiveBetween(1, 40).When(x => x.Size.HasValue)
-            .WithMessage("size must be between 1 and 40");
-
-        RuleFor(x => x.KeystoneLevel)
-            .InclusiveBetween(2, 30).When(x => x.KeystoneLevel.HasValue)
-            .WithMessage("keystoneLevel must be between 2 and 30");
-
-        RuleFor(x => x.InstanceName)
-            .MaximumLength(128).WithMessage("instanceName must be at most 128 characters");
-
-        RuleFor(x => x.Description)
-            .MaximumLength(2000).WithMessage("description must be at most 2000 characters");
-    }
-}

--- a/shared/Lfm.Contracts/packages.lock.json
+++ b/shared/Lfm.Contracts/packages.lock.json
@@ -1,13 +1,6 @@
 {
   "version": 1,
   "dependencies": {
-    "net10.0": {
-      "FluentValidation": {
-        "type": "Direct",
-        "requested": "[12.1.1, )",
-        "resolved": "12.1.1",
-        "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
-      }
-    }
+    "net10.0": {}
   }
 }

--- a/tests/Lfm.Api.Tests/ContractsProjectDesignTests.cs
+++ b/tests/Lfm.Api.Tests/ContractsProjectDesignTests.cs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Xml.Linq;
+using Xunit;
+
+namespace Lfm.Api.Tests;
+
+public class ContractsProjectDesignTests
+{
+    [Fact]
+    public void Shared_contracts_project_has_no_validation_framework_dependency()
+    {
+        var projectPath = Path.Combine(FindRepositoryRoot(), "shared", "Lfm.Contracts", "Lfm.Contracts.csproj");
+        var project = XDocument.Load(projectPath);
+
+        var packageReferences = project.Descendants("PackageReference")
+            .Select(e => e.Attribute("Include")?.Value)
+            .Where(v => !string.IsNullOrWhiteSpace(v))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        Assert.DoesNotContain("FluentValidation", packageReferences);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "lfm.sln")))
+                return directory.FullName;
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not find repository root from test output directory.");
+    }
+}

--- a/tests/Lfm.Api.Tests/RunResponseMapperTests.cs
+++ b/tests/Lfm.Api.Tests/RunResponseMapperTests.cs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Functions;
+using Lfm.Api.Repositories;
+using Xunit;
+
+namespace Lfm.Api.Tests;
+
+public class RunResponseMapperTests
+{
+    [Fact]
+    public void ToDetail_projects_run_document_without_exposing_raider_ids()
+    {
+        var doc = MakeRunDoc(runCharacters: [
+            MakeCharacterEntry("entry-own", "Ownchar", "bnet-current"),
+            MakeCharacterEntry("entry-peer", "Peerchar", "bnet-peer")
+        ]);
+
+        var dto = RunResponseMapper.ToDetail(doc, "bnet-current");
+
+        Assert.Equal("run-1", dto.Id);
+        Assert.Equal("HEROIC", dto.Difficulty);
+        Assert.Equal(30, dto.Size);
+        Assert.Equal(2, dto.RunCharacters.Count);
+
+        var own = Assert.Single(dto.RunCharacters, c => c.CharacterName == "Ownchar");
+        Assert.True(own.IsCurrentUser);
+
+        var peer = Assert.Single(dto.RunCharacters, c => c.CharacterName == "Peerchar");
+        Assert.False(peer.IsCurrentUser);
+    }
+
+    [Fact]
+    public void ToSummary_projects_same_sanitized_roster_as_detail()
+    {
+        var doc = MakeRunDoc(runCharacters: [
+            MakeCharacterEntry("entry-own", "Ownchar", "bnet-current"),
+            MakeCharacterEntry("entry-peer", "Peerchar", "bnet-peer")
+        ]);
+
+        var dto = RunResponseMapper.ToSummary(doc, "bnet-current");
+
+        Assert.Equal("run-1", dto.Id);
+        Assert.Equal("HEROIC", dto.Difficulty);
+        Assert.Equal(30, dto.Size);
+        Assert.Equal(2, dto.RunCharacters.Count);
+        Assert.True(dto.RunCharacters.Single(c => c.CharacterName == "Ownchar").IsCurrentUser);
+        Assert.False(dto.RunCharacters.Single(c => c.CharacterName == "Peerchar").IsCurrentUser);
+    }
+
+    private static RunDocument MakeRunDoc(IReadOnlyList<RunCharacterEntry> runCharacters) =>
+        new(
+            Id: "run-1",
+            StartTime: "2026-06-01T19:00:00Z",
+            SignupCloseTime: "2026-06-01T18:30:00Z",
+            Description: "Test run",
+            ModeKey: "NORMAL:20",
+            Visibility: "GUILD",
+            CreatorGuild: "Test Guild",
+            CreatorGuildId: 12345,
+            InstanceId: 42,
+            InstanceName: "Test Instance",
+            CreatorBattleNetId: "bnet-creator",
+            CreatedAt: "2026-05-01T00:00:00Z",
+            Ttl: 86400,
+            RunCharacters: runCharacters,
+            Difficulty: "HEROIC",
+            Size: 30,
+            KeystoneLevel: null);
+
+    private static RunCharacterEntry MakeCharacterEntry(string id, string name, string raiderBattleNetId) =>
+        new(
+            Id: id,
+            CharacterId: id,
+            CharacterName: name,
+            CharacterRealm: "silvermoon",
+            CharacterLevel: 80,
+            CharacterClassId: 2,
+            CharacterClassName: "Paladin",
+            CharacterRaceId: 1,
+            CharacterRaceName: "Human",
+            RaiderBattleNetId: raiderBattleNetId,
+            DesiredAttendance: "IN",
+            ReviewedAttendance: "IN",
+            SpecId: 65,
+            SpecName: "Holy",
+            Role: "HEALER");
+}

--- a/tests/Lfm.Api.Tests/Runs/CreateRunRequestValidatorTests.cs
+++ b/tests/Lfm.Api.Tests/Runs/CreateRunRequestValidatorTests.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
+using Lfm.Api.Validation;
 using Lfm.Contracts.Runs;
 using Xunit;
 

--- a/tests/Lfm.Api.Tests/Services/RunAccessPolicyTests.cs
+++ b/tests/Lfm.Api.Tests/Services/RunAccessPolicyTests.cs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Repositories;
+using Lfm.Api.Services;
+using Xunit;
+
+namespace Lfm.Api.Tests.Services;
+
+public class RunAccessPolicyTests
+{
+    [Fact]
+    public void CanView_allows_public_runs_without_guild_membership()
+    {
+        var run = MakeRun(visibility: "PUBLIC", creatorBattleNetId: "creator", creatorGuildId: null);
+
+        Assert.True(RunAccessPolicy.CanView(run, "viewer", callerGuildId: null));
+    }
+
+    [Fact]
+    public void CanView_allows_guild_run_creator()
+    {
+        var run = MakeRun(visibility: "GUILD", creatorBattleNetId: "creator", creatorGuildId: 123);
+
+        Assert.True(RunAccessPolicy.CanView(run, "creator", callerGuildId: null));
+    }
+
+    [Fact]
+    public void CanView_allows_same_guild_member_for_guild_run()
+    {
+        var run = MakeRun(visibility: "GUILD", creatorBattleNetId: "creator", creatorGuildId: 123);
+
+        Assert.True(RunAccessPolicy.CanView(run, "member", callerGuildId: "123"));
+    }
+
+    [Fact]
+    public void CanView_denies_outside_member_for_guild_run()
+    {
+        var run = MakeRun(visibility: "GUILD", creatorBattleNetId: "creator", creatorGuildId: 123);
+
+        Assert.False(RunAccessPolicy.CanView(run, "outsider", callerGuildId: "999"));
+    }
+
+    [Fact]
+    public void IsGuildPeer_allows_same_guild_non_creator_only_for_guild_runs()
+    {
+        var guildRun = MakeRun(visibility: "GUILD", creatorBattleNetId: "creator", creatorGuildId: 123);
+        var publicRun = MakeRun(visibility: "PUBLIC", creatorBattleNetId: "creator", creatorGuildId: 123);
+
+        Assert.True(RunAccessPolicy.IsGuildPeer(guildRun, "peer", callerGuildId: "123"));
+        Assert.False(RunAccessPolicy.IsGuildPeer(guildRun, "creator", callerGuildId: "123"));
+        Assert.False(RunAccessPolicy.IsGuildPeer(publicRun, "peer", callerGuildId: "123"));
+    }
+
+    private static RunDocument MakeRun(
+        string visibility,
+        string? creatorBattleNetId,
+        int? creatorGuildId) =>
+        new(
+            Id: "run-1",
+            StartTime: "2026-06-01T19:00:00Z",
+            SignupCloseTime: "2026-06-01T18:30:00Z",
+            Description: "Test run",
+            ModeKey: "NORMAL:20",
+            Visibility: visibility,
+            CreatorGuild: "Test Guild",
+            CreatorGuildId: creatorGuildId,
+            InstanceId: 42,
+            InstanceName: "Test Instance",
+            CreatorBattleNetId: creatorBattleNetId,
+            CreatedAt: "2026-05-01T00:00:00Z",
+            Ttl: 86400,
+            RunCharacters: []);
+}

--- a/tests/Lfm.Api.Tests/WriteRequestLengthCapsTests.cs
+++ b/tests/Lfm.Api.Tests/WriteRequestLengthCapsTests.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
+using Lfm.Api.Validation;
 using Lfm.Contracts.Guild;
 using Lfm.Contracts.Runs;
 using Xunit;


### PR DESCRIPTION
## Summary
- Centralize run DTO projection and raider ID redaction in an API-local mapper.
- Move request validators out of shared contracts into the API boundary and refresh lockfiles.
- Extract repeated run creator/guild-peer access checks into a small run access policy helper.

## Test Plan
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release`

## Notes
- No UI or schema changes.
- Worktree remains at `.worktrees/design-findings-fix` for follow-up changes if needed.