### PR TITLE
Use ShellCheck in pre-push

### DIFF
--- a/scripts/archi-render.sh
+++ b/scripts/archi-render.sh
@@ -94,8 +94,8 @@ strip_optional_quotes() {
 expand_home() {
   local path="$1"
   case "$path" in
-    "~") printf '%s' "$HOME" ;;
-    "~/"*) printf '%s/%s' "$HOME" "${path#"~/"}" ;;
+    \~) printf '%s' "$HOME" ;;
+    \~/*) printf '%s/%s' "$HOME" "${path#\~/}" ;;
     *) printf '%s' "$path" ;;
   esac
 }

--- a/scripts/check-bundle-size.sh
+++ b/scripts/check-bundle-size.sh
@@ -34,7 +34,7 @@ for asset in "${assets[@]}"; do
     size=$(brotli --quality=11 --stdout "$asset" | wc -c)
   fi
   total_bytes=$(( total_bytes + size ))
-  printf '%10d  %s\n' "$size" "${asset#$PUBLISH_DIR/}" >> "$tmp_breakdown"
+  printf '%10d  %s\n' "$size" "${asset#"$PUBLISH_DIR"/}" >> "$tmp_breakdown"
 done
 
 budget_bytes=$(( BUDGET_MB * 1024 * 1024 ))

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -7,6 +7,26 @@ set -euo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
+shell_scripts=(
+  scripts/archi-render.sh
+  scripts/check-bundle-size.sh
+  scripts/claude/stop-devsecops-audit.sh
+  scripts/claude/stop-responsive-audit.sh
+  scripts/claude/stop-test-audit.sh
+  scripts/install-codex-skills.sh
+  scripts/pre-commit
+  scripts/pre-push
+  scripts/run-tests-parallel.sh
+  scripts/wait-api-ready.sh
+)
+
+echo "[pre-push] Shell script lint..."
+if command -v shellcheck >/dev/null 2>&1; then
+  shellcheck "${shell_scripts[@]}"
+else
+  echo "[pre-push] shellcheck not found; skipping optional shell lint."
+fi
+
 echo "[pre-push] Format check..."
 dotnet format lfm.sln --verify-no-changes --no-restore --severity error
 


### PR DESCRIPTION
## Summary
- Run ShellCheck from `scripts/pre-push` when it is installed, while keeping it optional for local contributors.
- Fix current ShellCheck findings in the architecture render and bundle-size scripts.

## Test Plan
- `shellcheck scripts/archi-render.sh scripts/check-bundle-size.sh scripts/claude/stop-devsecops-audit.sh scripts/claude/stop-responsive-audit.sh scripts/claude/stop-test-audit.sh scripts/install-codex-skills.sh scripts/pre-commit scripts/pre-push scripts/run-tests-parallel.sh scripts/wait-api-ready.sh`
- `bash -n scripts/archi-render.sh scripts/check-bundle-size.sh scripts/claude/stop-devsecops-audit.sh scripts/claude/stop-responsive-audit.sh scripts/claude/stop-test-audit.sh scripts/install-codex-skills.sh scripts/pre-commit scripts/pre-push scripts/run-tests-parallel.sh scripts/wait-api-ready.sh`
- `git diff --check`
- `./scripts/pre-push`