### PR TITLE
Retry auth state probe after sign-in

### DIFF
--- a/api/Program.cs
+++ b/api/Program.cs
@@ -152,7 +152,9 @@ builder.Services.AddSingleton<BlobContainerClient>(sp =>
     var opts = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<StorageOptions>>().Value;
     if (!string.IsNullOrEmpty(opts.BlobConnectionString))
     {
-        var service = new BlobServiceClient(opts.BlobConnectionString);
+        var service = new BlobServiceClient(
+            opts.BlobConnectionString,
+            new BlobClientOptions(BlobClientOptions.ServiceVersion.V2025_11_05));
         return service.GetBlobContainerClient(opts.WowContainerName);
     }
     if (!string.IsNullOrEmpty(opts.BlobServiceUri))
@@ -173,7 +175,7 @@ builder.Services.AddScoped<Lfm.Api.Repositories.IRunsRepository, Lfm.Api.Reposit
 builder.Services.AddScoped<Lfm.Api.Repositories.IGuildRepository, Lfm.Api.Repositories.GuildRepository>();
 builder.Services.AddSingleton<Lfm.Api.Services.ISecretResolver, Lfm.Api.Services.KeyVaultSecretResolver>();
 builder.Services.AddSingleton<Lfm.Api.Services.ISiteAdminService, Lfm.Api.Services.SiteAdminService>();
-builder.Services.AddScoped<Lfm.Api.Services.IIdempotencyStore, Lfm.Api.Services.IdempotencyStore>();
+builder.Services.AddSingleton<Lfm.Api.Services.IIdempotencyStore, Lfm.Api.Services.IdempotencyStore>();
 builder.Services.AddScoped<Lfm.Api.Services.IGuildPermissions, Lfm.Api.Services.GuildPermissions>();
 
 // Audit-log actor hasher. If a salt is configured we HMAC-hash every

--- a/app/Lfm.App.Core/Services/MeClient.cs
+++ b/app/Lfm.App.Core/Services/MeClient.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
+using System.Net;
 using System.Net.Http.Json;
 using Lfm.Contracts.Characters;
 using Lfm.Contracts.Me;
@@ -9,18 +10,60 @@ namespace Lfm.App.Services;
 
 public sealed class MeClient(IHttpClientFactory factory) : IMeClient
 {
+    private const int GetMeMaxAttempts = 4;
+
     public async Task<MeResponse?> GetAsync(CancellationToken ct)
     {
         var http = factory.CreateClient("api");
-        try
+        for (var attempt = 1; attempt <= GetMeMaxAttempts; attempt++)
         {
-            return await http.GetFromJsonAsync<MeResponse>("api/v1/me", ct);
+            try
+            {
+                using var response = await http.GetAsync("api/v1/me", ct);
+                if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+                    return null;
+                if (response.IsSuccessStatusCode)
+                    return await response.Content.ReadFromJsonAsync<MeResponse>(cancellationToken: ct);
+                if (!IsTransientStatus(response.StatusCode) || attempt == GetMeMaxAttempts)
+                    return null;
+            }
+            catch (Exception ex) when (IsTransientGetException(ex, ct) && attempt < GetMeMaxAttempts)
+            {
+                // Retry below.
+            }
+            catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)
+            {
+                return null;
+            }
+
+            try
+            {
+                await Task.Delay(GetMeRetryDelay(attempt), ct);
+            }
+            catch (OperationCanceledException)
+            {
+                return null;
+            }
         }
-        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)
-        {
-            return null;
-        }
+
+        return null;
     }
+
+    private static bool IsTransientStatus(HttpStatusCode statusCode)
+        => statusCode is
+            HttpStatusCode.RequestTimeout or
+            HttpStatusCode.TooManyRequests or
+            HttpStatusCode.InternalServerError or
+            HttpStatusCode.BadGateway or
+            HttpStatusCode.ServiceUnavailable or
+            HttpStatusCode.GatewayTimeout;
+
+    private static bool IsTransientGetException(Exception ex, CancellationToken ct)
+        => !ct.IsCancellationRequested &&
+           ex is HttpRequestException or TaskCanceledException or OperationCanceledException;
+
+    private static TimeSpan GetMeRetryDelay(int attempt)
+        => TimeSpan.FromMilliseconds(100 * Math.Pow(2, attempt - 1));
 
     public async Task<UpdateMeResponse?> UpdateAsync(UpdateMeRequest request, CancellationToken ct)
     {

--- a/tests/Lfm.App.Core.Tests/Services/MeClientTests.cs
+++ b/tests/Lfm.App.Core.Tests/Services/MeClientTests.cs
@@ -53,7 +53,7 @@ public class MeClientTests
         var result = await client.GetAsync(CancellationToken.None);
 
         Assert.Null(result);
-        Assert.Equal(1, handler.CallCount);
+        Assert.Equal(4, handler.CallCount);
     }
 
     [Fact]
@@ -64,13 +64,40 @@ public class MeClientTests
         var result = await client.GetAsync(CancellationToken.None);
 
         Assert.Null(result);
-        Assert.Equal(1, handler.CallCount);
+        Assert.Equal(4, handler.CallCount);
     }
 
     [Fact]
     public async Task GetAsync_returns_null_on_5xx_status()
     {
         var (client, handler) = MakeClient(new StubHttpMessageHandler(HttpStatusCode.ServiceUnavailable));
+
+        var result = await client.GetAsync(CancellationToken.None);
+
+        Assert.Null(result);
+        Assert.Equal(4, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task GetAsync_retries_transient_503_and_returns_me_response()
+    {
+        var responses = new Queue<HttpResponseMessage>([
+            new HttpResponseMessage(HttpStatusCode.ServiceUnavailable),
+            StubHttpMessageHandler.CreateJsonResponse(HttpStatusCode.OK, MakeMeResponse())
+        ]);
+        var (client, handler) = MakeClient(new StubHttpMessageHandler(_ => responses.Dequeue()));
+
+        var result = await client.GetAsync(CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal("player#1234", result!.BattleNetId);
+        Assert.Equal(2, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task GetAsync_does_not_retry_401()
+    {
+        var (client, handler) = MakeClient(new StubHttpMessageHandler(HttpStatusCode.Unauthorized));
 
         var result = await client.GetAsync(CancellationToken.None);
 

--- a/tests/Lfm.App.Core.Tests/Services/StubHttpMessageHandler.cs
+++ b/tests/Lfm.App.Core.Tests/Services/StubHttpMessageHandler.cs
@@ -34,6 +34,9 @@ public sealed class StubHttpMessageHandler : HttpMessageHandler
     public static StubHttpMessageHandler Throws(Exception exception) =>
         new(_ => throw exception);
 
+    public static HttpResponseMessage CreateJsonResponse(HttpStatusCode statusCode, object body) =>
+        CreateResponse(statusCode, body);
+
     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         LastRequest = request;

--- a/tests/Lfm.E2E/Infrastructure/StackFixture.cs
+++ b/tests/Lfm.E2E/Infrastructure/StackFixture.cs
@@ -48,14 +48,14 @@ public class StackFixture : IAsyncLifetime
         .Build();
 
     // Version tag + manifest-list digest, matching the Cosmos pin above. The
-    // :3.28.0 tag documents which Azurite release the digest corresponds to;
+    // :3.35.0 tag documents which Azurite release the digest corresponds to;
     // the @sha256: digest (on the multi-arch manifest list) guarantees the
     // same bytes every run and still resolves to the correct platform
     // manifest (linux/amd64 on CI, linux/arm64 on Apple-silicon dev). Bump
     // both together when upgrading.
     private readonly AzuriteContainer _azurite = new AzuriteBuilder(
-        "mcr.microsoft.com/azure-storage/azurite:3.28.0"
-        + "@sha256:b2edf4c05060390f368fef3dde4b82981b7125c763a3c6fdeb16e74b20094375")
+        "mcr.microsoft.com/azure-storage/azurite:3.35.0"
+        + "@sha256:647c63a91102a9d8e8000aab803436e1fc85fbb285e7ce830a82ee5d6661cf37")
         .WithPortBinding(10000, 10000)
         .WithPortBinding(10001, 10001)
         .WithPortBinding(10002, 10002)
@@ -173,6 +173,7 @@ public class StackFixture : IAsyncLifetime
                     "WireMock OAuth stub did not return a base URL after start"),
                 ["Cors__AllowedOrigins__0"] = $"http://localhost:{_appPort}",
                 ["PRIVACY_EMAIL"] = "privacy@e2e.test",
+                ["PrivacyContact__Email"] = "privacy@e2e.test",
             },
             _apiOutput);
 

--- a/tests/Lfm.E2E/Seeds/WowReferenceSeed.cs
+++ b/tests/Lfm.E2E/Seeds/WowReferenceSeed.cs
@@ -23,7 +23,9 @@ public static class WowReferenceSeed
 
     public static async Task SeedAsync(string blobConnectionString)
     {
-        var service = new BlobServiceClient(blobConnectionString);
+        var service = new BlobServiceClient(
+            blobConnectionString,
+            new BlobClientOptions(BlobClientOptions.ServiceVersion.V2025_11_05));
         var container = service.GetBlobContainerClient(ContainerName);
         await container.CreateIfNotExistsAsync();
 

--- a/tests/Lfm.E2E/Specs/AuthCallbackSpec.cs
+++ b/tests/Lfm.E2E/Specs/AuthCallbackSpec.cs
@@ -40,7 +40,7 @@ public class AuthCallbackSpec(AuthCallbackFixture fixture, ITestOutputHelper out
     // See AuthSpec for the rationale on the WASM patterns — this spec
     // exercises the same cold-start Blazor bundle download path.
     protected override string[] IgnoredConsolePatterns =>
-        ["401", "/api/me", "MONO_WASM", ".wasm", "mono_download_assets"];
+        ["401", "503", "/api/me", "MONO_WASM", ".wasm", "mono_download_assets"];
 
     public override async Task InitializeAsync()
     {
@@ -82,14 +82,50 @@ public class AuthCallbackSpec(AuthCallbackFixture fixture, ITestOutputHelper out
 
         // Wait for the browser to land back on the app after the full OAuth
         // redirect chain. The default post-login redirect is /runs.
-        await Page!.WaitForURLAsync(
+        await Assertions.Expect(Page!).ToHaveURLAsync(
             new System.Text.RegularExpressions.Regex(@"/runs(\?|$)"),
             new() { Timeout = 30000 });
 
         // Assert the user is signed in — the Sign Out button is only rendered
         // inside <AuthorizeView><Authorized>, so its presence proves the auth
         // cookie the real callback set is being honoured by the Blazor client.
-        var navBar = new NavBar(Page);
+        var navBar = new NavBar(Page!);
         await Assertions.Expect(navBar.SignOutButton).ToBeVisibleAsync(new() { Timeout = 15000 });
+    }
+
+    [Fact]
+    public async Task ProductionCallback_TransientMe503AfterCallback_RetriesAndShowsSignedIn()
+    {
+        var loginPage = new LoginPage(Page!);
+
+        await loginPage.GotoAsync(fixture.Stack.AppBaseUrl);
+        await Assertions.Expect(loginPage.SignInButton).ToBeVisibleAsync(new() { Timeout = 30000 });
+
+        var meFailuresInjected = 0;
+        await Page!.RouteAsync("**/api/v1/me", async route =>
+        {
+            if (meFailuresInjected == 0)
+            {
+                meFailuresInjected++;
+                await route.FulfillAsync(new()
+                {
+                    Status = 503,
+                    ContentType = "text/plain",
+                    Body = "Service Unavailable"
+                });
+                return;
+            }
+
+            await route.ContinueAsync();
+        });
+
+        await loginPage.ClickSignInAsync();
+        await Assertions.Expect(Page!).ToHaveURLAsync(
+            new System.Text.RegularExpressions.Regex(@"/runs(\?|$)"),
+            new() { Timeout = 30000 });
+
+        var navBar = new NavBar(Page!);
+        await Assertions.Expect(navBar.SignOutButton).ToBeVisibleAsync(new() { Timeout = 15000 });
+        Assert.Equal(1, meFailuresInjected);
     }
 }


### PR DESCRIPTION
## Summary
- Retry transient `GET /api/v1/me` failures so a temporary 503 after OAuth callback does not leave the SPA cached as anonymous until reload.
- Add unit coverage for transient `/api/v1/me` retries and a browser E2E regression that injects a post-callback 503.
- Repair E2E harness drift needed for auth callback coverage: Azurite pin/API version, privacy contact env, and idempotency store middleware lifetime.

## Test Plan
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- [x] `dotnet build lfm.sln -c Release`
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` (707 passed)
- [x] `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release` (180 passed)
- [x] `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release` (180 passed)
- [x] `LFM_E2E_CHROMIUM_PATH=/home/souroldgeezer/repos/lfm/.chrome/chrome dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --filter FullyQualifiedName~AuthCallbackSpec` (2 passed)
- [x] `git diff --check`