### PR TITLE
Bug-hunt fixes from 2026-04-29 deep dive (Phases 2-7)

### DIFF
--- a/api/Middleware/IdempotencyMiddleware.cs
+++ b/api/Middleware/IdempotencyMiddleware.cs
@@ -154,7 +154,6 @@ public sealed class IdempotencyMiddleware : IFunctionsWorkerMiddleware
             Detail = "The original request already completed. GET the resource for its current state.",
             Instance = httpContext.Request.Path.Value,
         };
-        problem.Extensions["originalCreatedAt"] = entry.CreatedAt;
         var traceId = Activity.Current?.TraceId.ToString();
         if (!string.IsNullOrEmpty(traceId))
             problem.Extensions["traceId"] = traceId;

--- a/api/Repositories/RaidersRepository.cs
+++ b/api/Repositories/RaidersRepository.cs
@@ -85,7 +85,7 @@ public sealed class RaidersRepository(CosmosClient client, IOptions<CosmosOption
             WHERE c.lastSeenAt < @cutoff OR NOT IS_DEFINED(c.lastSeenAt)
             """;
 
-        var feedIterator = _container.GetItemQueryIterator<RaiderDocument>(
+        using var feedIterator = _container.GetItemQueryIterator<RaiderDocument>(
             new QueryDefinition(query).WithParameter("@cutoff", cutoff));
 
         var results = new List<RaiderDocument>();

--- a/api/Repositories/RunsRepository.cs
+++ b/api/Repositories/RunsRepository.cs
@@ -70,7 +70,7 @@ public sealed class RunsRepository(CosmosClient client, IOptions<CosmosOptions> 
         QueryDefinition queryDef, int top, string? continuationToken, CancellationToken ct)
     {
         var options = new QueryRequestOptions { MaxItemCount = top };
-        var feedIterator = _container.GetItemQueryIterator<RunDocument>(
+        using var feedIterator = _container.GetItemQueryIterator<RunDocument>(
             queryDef, continuationToken, options);
 
         if (!feedIterator.HasMoreResults)
@@ -160,7 +160,7 @@ public sealed class RunsRepository(CosmosClient client, IOptions<CosmosOptions> 
                OR ARRAY_CONTAINS(c.runCharacters, {"raiderBattleNetId": @battleNetId}, true)
             """;
 
-        var feedIterator = _container.GetItemQueryIterator<RunDocument>(
+        using var feedIterator = _container.GetItemQueryIterator<RunDocument>(
             new QueryDefinition(query)
                 .WithParameter("@battleNetId", battleNetId));
 
@@ -195,7 +195,7 @@ public sealed class RunsRepository(CosmosClient client, IOptions<CosmosOptions> 
         // Iterate every run document. The set is small (hobby scale), and
         // unlike ScrubRaiderAsync we don't have a cheap WHERE predicate —
         // every legacy doc needs inspection.
-        var feedIterator = _container.GetItemQueryIterator<RunDocument>("SELECT * FROM c");
+        using var feedIterator = _container.GetItemQueryIterator<RunDocument>("SELECT * FROM c");
 
         var scanned = 0;
         var migrated = 0;

--- a/api/Repositories/RunsRepository.cs
+++ b/api/Repositories/RunsRepository.cs
@@ -21,7 +21,9 @@ public sealed class RunsRepository(CosmosClient client, IOptions<CosmosOptions> 
         //   PUBLIC runs | runs created by this user | GUILD runs from the same guild
         //   Ordered by startTime ascending.
         if (!int.TryParse(guildId, out var numericGuildId))
-            return new RunsPage(Array.Empty<RunDocument>(), null);
+            throw new ArgumentException(
+                $"guildId '{guildId}' must be numeric; non-numeric values silently hide all runs from a user.",
+                nameof(guildId));
 
         const string query = """
             SELECT * FROM c

--- a/api/Services/GuildPermissions.cs
+++ b/api/Services/GuildPermissions.cs
@@ -23,27 +23,19 @@ public sealed class GuildPermissions(IGuildRepository guildRepo) : IGuildPermiss
 
         if (guild?.BlizzardRosterRaw?.Members is null) return false;
 
-        // Build lookup maps mirroring resolveMatchedGuildRanks in
+        // Build lookup map mirroring resolveMatchedGuildRanks in
         // functions/src/lib/guild-member-match.ts.
-        var rankById = new Dictionary<int, int>();
         var rankByKey = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         foreach (var member in guild.BlizzardRosterRaw.Members)
-        {
-            if (member.Character.Id.HasValue)
-                rankById[member.Character.Id.Value] = member.Rank;
             rankByKey[$"{member.Character.Realm.Slug}:{member.Character.Name}"] = member.Rank;
-        }
 
         // Walk stored characters — return true as soon as we find a rank-0 match.
         if (raider.Characters is null) return false;
         foreach (var character in raider.Characters)
         {
-            // Match by Blizzard character ID first (more reliable).
-            // StoredSelectedCharacter.SpecializationsSummary is the closest proxy
-            // for "profile summary id" in the .NET model; we use the raider's stored
-            // character name+realm as the fallback key.
+            // Match the stored character against the guild roster by realm-slug + name.
             var key = $"{character.Realm}:{character.Name}";
-            if (rankByKey.TryGetValue(key, out var rankByName) && rankByName == 0) return true;
+            if (rankByKey.TryGetValue(key, out var rank) && rank == 0) return true;
         }
 
         return false;

--- a/api/Services/IdempotencyStore.cs
+++ b/api/Services/IdempotencyStore.cs
@@ -96,7 +96,7 @@ public sealed class IdempotencyStore : IIdempotencyStore
         // by retry burst) so a cross-partition query is not needed — we just
         // enumerate the partition and delete each id we find.
         var query = new QueryDefinition("SELECT c.id FROM c");
-        var iterator = _container.GetItemQueryIterator<IdempotencyIdOnly>(
+        using var iterator = _container.GetItemQueryIterator<IdempotencyIdOnly>(
             query,
             requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(battleNetId) });
 

--- a/api/Services/KeyVaultSecretResolver.cs
+++ b/api/Services/KeyVaultSecretResolver.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
+using System.Collections.Concurrent;
 using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
 
@@ -8,13 +9,24 @@ namespace Lfm.Api.Services;
 
 /// <summary>
 /// Production <see cref="ISecretResolver"/> backed by Azure Key Vault using
-/// <see cref="DefaultAzureCredential"/>.
+/// <see cref="DefaultAzureCredential"/>. Caches one <see cref="SecretClient"/>
+/// per vault URL — both the credential probe and the underlying HttpClient
+/// are expensive to recreate.
 /// </summary>
 public sealed class KeyVaultSecretResolver : ISecretResolver
 {
+    private readonly Func<string, SecretClient> _factory;
+    private readonly ConcurrentDictionary<string, SecretClient> _clients
+        = new(StringComparer.OrdinalIgnoreCase);
+
+    public KeyVaultSecretResolver()
+        : this(url => new SecretClient(new Uri(url), new DefaultAzureCredential())) { }
+
+    internal KeyVaultSecretResolver(Func<string, SecretClient> factory) => _factory = factory;
+
     public async Task<string?> GetSecretAsync(string vaultUrl, string secretName, CancellationToken ct)
     {
-        var client = new SecretClient(new Uri(vaultUrl), new DefaultAzureCredential());
+        var client = _clients.GetOrAdd(vaultUrl, _factory);
         var secret = await client.GetSecretAsync(secretName, cancellationToken: ct);
         return secret.Value.Value;
     }

--- a/api/Services/ReferenceSync.cs
+++ b/api/Services/ReferenceSync.cs
@@ -286,16 +286,41 @@ public sealed class ReferenceSync(
     // ---------------------------------------------------------------------------
 
     /// <summary>
-    /// Simple 429-retry wrapper: sleep 1s and retry on <c>HttpStatusCode.TooManyRequests</c>,
-    /// log + skip on any other error. The shared <c>BlizzardRateLimiter</c> gates
-    /// outbound traffic to ~80 req/s so genuine 429s from Blizzard are rare, but
-    /// the retry is kept for safety.
+    /// Simple 429-retry wrapper: sleep 1s and retry on <c>HttpStatusCode.TooManyRequests</c>
+    /// up to <see cref="MaxRetries429"/> times, log + skip on any other error or once
+    /// the cap is exceeded. The shared <c>BlizzardRateLimiter</c> gates outbound
+    /// traffic to ~80 req/s so genuine 429s from Blizzard are rare; the cap
+    /// prevents a sustained outage from burning the entire Functions invocation
+    /// timeout in a tight retry loop.
     /// </summary>
-    private async Task<T?> FetchWithRetryAsync<T>(
+    private const int MaxRetries429 = 5;
+    private static readonly TimeSpan Retry429Delay = TimeSpan.FromSeconds(1);
+
+    private Task<T?> FetchWithRetryAsync<T>(
         Func<Task<T>> fetch,
         string description,
         CancellationToken ct) where T : class
+        => FetchWithRetryAsyncCore(fetch, description, MaxRetries429, Retry429Delay, logger, ct);
+
+    // Test-only seam — exposed via InternalsVisibleTo. Keeps production callers unchanged.
+    internal static Task<T?> FetchWithRetryAsyncForTests<T>(
+        Func<Task<T>> fetch,
+        string description,
+        int maxRetries,
+        TimeSpan retryDelay,
+        ILogger logger,
+        CancellationToken ct) where T : class
+        => FetchWithRetryAsyncCore(fetch, description, maxRetries, retryDelay, logger, ct);
+
+    private static async Task<T?> FetchWithRetryAsyncCore<T>(
+        Func<Task<T>> fetch,
+        string description,
+        int maxRetries,
+        TimeSpan retryDelay,
+        ILogger logger,
+        CancellationToken ct) where T : class
     {
+        var attempt = 0;
         while (true)
         {
             ct.ThrowIfCancellationRequested();
@@ -305,7 +330,14 @@ public sealed class ReferenceSync(
             }
             catch (HttpRequestException ex) when ((int?)ex.StatusCode == 429)
             {
-                await Task.Delay(TimeSpan.FromSeconds(1), ct);
+                if (attempt++ >= maxRetries)
+                {
+                    logger.LogWarning(
+                        "Skipping {Description}: 429 retry cap exceeded ({Cap} retries)",
+                        description, maxRetries);
+                    return null;
+                }
+                await Task.Delay(retryDelay, ct);
             }
             catch (Exception ex)
             {

--- a/tests/Lfm.Api.Tests/Middleware/IdempotencyMiddlewareTests.cs
+++ b/tests/Lfm.Api.Tests/Middleware/IdempotencyMiddlewareTests.cs
@@ -152,6 +152,10 @@ public class IdempotencyMiddlewareTests
         Assert.Equal(
             "https://github.com/lfm-org/lfm/errors#idempotent-replay",
             doc.RootElement.GetProperty("type").GetString());
+
+        // Wire-contract: server-internal audit timestamps must not appear in the body.
+        Assert.False(doc.RootElement.TryGetProperty("originalCreatedAt", out _),
+            "originalCreatedAt is a server audit timestamp and must not be on the wire.");
     }
 
     [Fact]

--- a/tests/Lfm.Api.Tests/RunsRepositoryGuardTests.cs
+++ b/tests/Lfm.Api.Tests/RunsRepositoryGuardTests.cs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Lfm.Api.Options;
+using Lfm.Api.Repositories;
+using Xunit;
+
+namespace Lfm.Api.Tests;
+
+public class RunsRepositoryGuardTests
+{
+    [Fact]
+    public async Task ListForGuildAsync_throws_on_non_numeric_guild_id()
+    {
+        var clientMock = new Mock<CosmosClient>(MockBehavior.Loose);
+        clientMock.Setup(c => c.GetContainer(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(new Mock<Container>(MockBehavior.Loose).Object);
+
+        var opts = Microsoft.Extensions.Options.Options.Create(new CosmosOptions
+        {
+            Endpoint = "https://test.documents.azure.com",
+            DatabaseName = "lfm-test",
+        });
+        var repo = new RunsRepository(clientMock.Object, opts, NullLogger<RunsRepository>.Instance);
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            repo.ListForGuildAsync(
+                guildId: "not-a-number",
+                battleNetId: "bnet-1",
+                top: 50,
+                continuationToken: null,
+                ct: CancellationToken.None));
+    }
+}

--- a/tests/Lfm.Api.Tests/Services/KeyVaultSecretResolverTests.cs
+++ b/tests/Lfm.Api.Tests/Services/KeyVaultSecretResolverTests.cs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Azure;
+using Azure.Security.KeyVault.Secrets;
+using Moq;
+using Xunit;
+
+namespace Lfm.Api.Tests.Services;
+
+public class KeyVaultSecretResolverTests
+{
+    [Fact]
+    public async Task GetSecretAsync_caches_one_client_per_vault_url()
+    {
+        var factoryCalls = new List<string>();
+        var clientMock = new Mock<SecretClient>();
+        // Azure.Security.KeyVault.Secrets 4.10.0 added a `SecretContentType?`
+        // parameter, so the virtual GetSecretAsync overload Moq must match has
+        // four arguments: name, version, outContentType, cancellationToken.
+        clientMock
+            .Setup(c => c.GetSecretAsync(
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<SecretContentType?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Response.FromValue(
+                SecretModelFactory.KeyVaultSecret(new SecretProperties("k"), "value"),
+                Mock.Of<Response>()));
+
+        var resolver = new Lfm.Api.Services.KeyVaultSecretResolver(url =>
+        {
+            factoryCalls.Add(url);
+            return clientMock.Object;
+        });
+
+        await resolver.GetSecretAsync("https://kv-a.vault.azure.net/", "k1", CancellationToken.None);
+        await resolver.GetSecretAsync("https://kv-a.vault.azure.net/", "k2", CancellationToken.None);
+        await resolver.GetSecretAsync("https://kv-b.vault.azure.net/", "k3", CancellationToken.None);
+
+        Assert.Equal(2, factoryCalls.Count);
+        Assert.Equal("https://kv-a.vault.azure.net/", factoryCalls[0]);
+        Assert.Equal("https://kv-b.vault.azure.net/", factoryCalls[1]);
+    }
+}

--- a/tests/Lfm.Api.Tests/Services/KeyVaultSecretResolverTests.cs
+++ b/tests/Lfm.Api.Tests/Services/KeyVaultSecretResolverTests.cs
@@ -34,12 +34,18 @@ public class KeyVaultSecretResolverTests
             return clientMock.Object;
         });
 
-        await resolver.GetSecretAsync("https://kv-a.vault.azure.net/", "k1", CancellationToken.None);
-        await resolver.GetSecretAsync("https://kv-a.vault.azure.net/", "k2", CancellationToken.None);
-        await resolver.GetSecretAsync("https://kv-b.vault.azure.net/", "k3", CancellationToken.None);
+        var v1 = await resolver.GetSecretAsync("https://kv-a.vault.azure.net/", "k1", CancellationToken.None);
+        var v2 = await resolver.GetSecretAsync("https://kv-a.vault.azure.net/", "k2", CancellationToken.None);
+        var v3 = await resolver.GetSecretAsync("https://kv-b.vault.azure.net/", "k3", CancellationToken.None);
 
+        // Cache: the factory fires once per distinct URL, in arrival order.
         Assert.Equal(2, factoryCalls.Count);
         Assert.Equal("https://kv-a.vault.azure.net/", factoryCalls[0]);
         Assert.Equal("https://kv-b.vault.azure.net/", factoryCalls[1]);
+
+        // End-to-end: the secret round-trips through the cached client.
+        Assert.Equal("value", v1);
+        Assert.Equal("value", v2);
+        Assert.Equal("value", v3);
     }
 }

--- a/tests/Lfm.Api.Tests/Services/ReferenceSyncRetryCapTests.cs
+++ b/tests/Lfm.Api.Tests/Services/ReferenceSyncRetryCapTests.cs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Net;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Lfm.Api.Tests.Services;
+
+public class ReferenceSyncRetryCapTests
+{
+    [Fact]
+    public async Task FetchWithRetryAsync_returns_null_after_cap_exceeded_on_sustained_429()
+    {
+        var calls = 0;
+        Task<string> Fetch()
+        {
+            calls++;
+            throw new HttpRequestException(
+                "Too Many Requests", inner: null, statusCode: HttpStatusCode.TooManyRequests);
+        }
+
+        var result = await Lfm.Api.Services.ReferenceSync.FetchWithRetryAsyncForTests(
+            Fetch, "test-fetch", maxRetries: 3, retryDelay: TimeSpan.Zero,
+            logger: NullLogger.Instance, ct: CancellationToken.None);
+
+        Assert.Null(result);
+        Assert.Equal(4, calls); // initial attempt + 3 retries
+    }
+}

--- a/tests/Lfm.Api.Tests/Services/ReferenceSyncRetryCapTests.cs
+++ b/tests/Lfm.Api.Tests/Services/ReferenceSyncRetryCapTests.cs
@@ -9,8 +9,15 @@ namespace Lfm.Api.Tests.Services;
 
 public class ReferenceSyncRetryCapTests
 {
-    [Fact]
-    public async Task FetchWithRetryAsync_returns_null_after_cap_exceeded_on_sustained_429()
+    // Cap semantics: maxRetries=N produces N+1 total fetch attempts (1 initial + N retries)
+    // before the cap fires. The boundary cases pin off-by-one behavior at N=0 and N=1.
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(1, 2)]
+    [InlineData(3, 4)]
+    [InlineData(5, 6)]
+    public async Task FetchWithRetryAsync_returns_null_after_cap_on_sustained_429(
+        int maxRetries, int expectedCalls)
     {
         var calls = 0;
         Task<string> Fetch()
@@ -21,10 +28,29 @@ public class ReferenceSyncRetryCapTests
         }
 
         var result = await Lfm.Api.Services.ReferenceSync.FetchWithRetryAsyncForTests(
-            Fetch, "test-fetch", maxRetries: 3, retryDelay: TimeSpan.Zero,
+            Fetch, "test-fetch", maxRetries: maxRetries, retryDelay: TimeSpan.Zero,
             logger: NullLogger.Instance, ct: CancellationToken.None);
 
         Assert.Null(result);
-        Assert.Equal(4, calls); // initial attempt + 3 retries
+        Assert.Equal(expectedCalls, calls);
+    }
+
+    [Fact]
+    public async Task FetchWithRetryAsync_returns_null_on_non_429_exception_without_retry()
+    {
+        var calls = 0;
+        Task<string> Fetch()
+        {
+            calls++;
+            throw new HttpRequestException(
+                "Server Error", inner: null, statusCode: HttpStatusCode.InternalServerError);
+        }
+
+        var result = await Lfm.Api.Services.ReferenceSync.FetchWithRetryAsyncForTests(
+            Fetch, "test-fetch", maxRetries: 5, retryDelay: TimeSpan.Zero,
+            logger: NullLogger.Instance, ct: CancellationToken.None);
+
+        Assert.Null(result);
+        Assert.Equal(1, calls);
     }
 }


### PR DESCRIPTION
## Summary

Six fixes from the 2026-04-29 deep-dive bug hunt. Phase 1 (LastSeenAt regression that would have triggered a daily silent account-wipe) was already merged separately as `5869ae3`; this PR delivers the remaining High-severity findings.

| Commit | Fix |
|--------|-----|
| `7a2224e` | **Wire-contract leak.** `IdempotencyMiddleware.WriteReplayHintAsync` was emitting `originalCreatedAt` (server audit timestamp) on the replay 4xx body. CLAUDE.md API Wire Contracts forbid server-internal audit timestamps on the wire. Drops the field; adds an absence-assertion to the existing `Replays_cached_status_on_hit_without_invoking_next` test. |
| `2721334` | **Reliability.** `ReferenceSync.FetchWithRetryAsync` retried 429 forever. A sustained Blizzard 429 outage would burn the entire 10-min Functions invocation timeout. Adds `MaxRetries429 = 5` (5 retries → 6 total calls, ~5–6 s ceiling per resource), with an `internal` test seam exposing the cap. New unit test `ReferenceSyncRetryCapTests`. |
| `e149be0` | **Defensive contract.** `RunsRepository.ListForGuildAsync` silently returned an empty page on a non-numeric `guildId` while `RunsCreateFunction` happily accepted the same string — a silent visibility hole. Now throws `ArgumentException` with a descriptive message. New unit test `RunsRepositoryGuardTests` using a Moq'd `CosmosClient`. |
| `09747c3` | **Dead-code removal.** `GuildPermissions.IsAdminAsync` built a `rankById` map that was never read, with a misleading comment claiming an "ID-first match" path that didn't exist. Removes the dead map and corrects the comment. Behavior-preserving (existing 27 GuildPermissions tests pass unchanged). |
| `1776bed` | **Resource hygiene.** Five Cosmos `FeedIterator` declarations leaked the underlying HTTP response stream on cancellation/exception paths. Added `using var` to all five sites in `RaidersRepository`, `RunsRepository` (3 sites), and `IdempotencyStore`. No behavior change on the happy path. |
| `401ff14` | **SDK lifetime.** `KeyVaultSecretResolver` constructed a fresh `SecretClient` + `DefaultAzureCredential` on every `GetSecretAsync` call, defeating credential probing reuse and `HttpClient` lifetime management. Now caches one `SecretClient` per vault URL via `ConcurrentDictionary`. DI registration was already `AddSingleton`. New unit test `KeyVaultSecretResolverTests` using a Moq'd factory. |

Diff totals: 11 files, +180 / −26 lines (≤ 30 files / ≤ 900 lines per branch).

## Env / schema changes
None.

## Test plan
- [x] `dotnet build lfm.sln -c Release` — 0 warnings, 0 errors
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` — **712 passed, 0 failed, 0 skipped**
- [x] `dotnet format lfm.sln --verify-no-changes` — clean
- [x] All 6 commits SSH-signed
- [ ] CI green
- [ ] Idempotent-replay smoke (POST → POST same key → confirm response body lacks `originalCreatedAt`)
- [ ] Verify ReferenceSync still completes in normal conditions (single 429 → retry succeeds; existing `SyncInstancesAsync_retries_after_429_and_still_writes_manifest_entry` covers this)

## Notes for reviewer
- One bug-hunt finding from the original plan was **downgraded** during execution: the speculative "realm-slug mismatch locks out guild masters" claim. After verifying that stored `StoredSelectedCharacter.Realm` is set as `body.Realm.ToLowerInvariant()` (matching Blizzard's slug shape for clients that send slugs — the standard pattern), no production repro path was identified. Phase 5 was reduced to the verifiable dead-code removal. If a real GM lockout is reported, revisit with a repro.
- Several lower-priority bug-hunt findings remain in the plan's Backlog section and are not part of this PR (frontend lifecycle, infra hardcodes, Y1→FC1 SKU, `runs` container indexing, etc.).