### PR TITLE
Reset CreateRunPage submit flag in finally

### DIFF
--- a/app/Pages/CreateRunPage.razor
+++ b/app/Pages/CreateRunPage.razor
@@ -464,7 +464,6 @@
             if (created is null)
             {
                 _inlineError = new RunError(RunErrorKind.Unknown, [Loc["createRun.failed"].Value]);
-                _submitting = false;
                 return;
             }
 
@@ -473,6 +472,9 @@
         catch (Exception ex)
         {
             _inlineError = RunErrorParser.Network(ex);
+        }
+        finally
+        {
             _submitting = false;
         }
     }

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -566,6 +566,71 @@ public class RunsPagesTests : ComponentTestBase
         Assert.Empty(cut.FindAll("#expansion-select"));
     }
 
+    // Regression: HandleSubmit's `_submitting` flag must reset on every exit
+    // path, including the success path that navigates away. The original
+    // implementation only reset on early-return + catch, leaving the flag
+    // stuck `true` after a successful create. Today `Nav.NavigateTo` disposes
+    // the page so the stale flag is unobservable, but a future refactor that
+    // replaces navigation with an inline success state (toast + reset form)
+    // would silently leave the submit button disabled forever. Mirror the
+    // EditRunPage `try/finally { _saving = false; }` pattern.
+    [Fact]
+    public void CreateRunPage_HandleSubmit_Resets_Submitting_Flag_On_Success_Path()
+    {
+        var runsClient = new Mock<IRunsClient>();
+        runsClient.Setup(c => c.CreateAsync(It.IsAny<CreateRunRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeDetail());
+
+        var instancesClient = new Mock<IInstancesClient>();
+        instancesClient.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        Services.AddSingleton(instancesClient.Object);
+
+        var expansionsClient = new Mock<IExpansionsClient>();
+        expansionsClient.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new ExpansionDto(505, "The War Within")]);
+        Services.AddSingleton(expansionsClient.Object);
+
+        var guildClient = new Mock<IGuildClient>();
+        guildClient.Setup(c => c.GetAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GuildDto?)null);
+        Services.AddSingleton(guildClient.Object);
+
+        Services.AddSingleton(runsClient.Object);
+
+        var cut = Render<CreateRunPage>();
+
+        // The default form state after load is M+ + any-dungeon with start
+        // time auto-set to next Thursday 20:00. Only the keystone level is
+        // required to make CanSubmit return true.
+        cut.WaitForAssertion(() =>
+            Assert.Contains(Loc("createRun.submit"), cut.Markup));
+        cut.Find("#keylevel-input").Input("10");
+
+        var submitButton = cut.FindAll("fluent-button")
+            .First(b => b.TextContent.Contains(Loc("createRun.submit"), StringComparison.Ordinal));
+        submitButton.Click();
+
+        // Verify the success path actually ran.
+        cut.WaitForAssertion(() =>
+            runsClient.Verify(c => c.CreateAsync(
+                It.IsAny<CreateRunRequest>(),
+                It.IsAny<CancellationToken>()),
+                Times.Once));
+
+        // The flag is private; reflection is the cheapest way to pin the
+        // post-condition without coupling to incidental markup. The button's
+        // disabled state is a downstream signal but it's also influenced by
+        // CanSubmit, so reading the field directly avoids ambiguity.
+        var instance = cut.Instance;
+        var field = typeof(CreateRunPage).GetField(
+            "_submitting",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        cut.WaitForAssertion(() =>
+            Assert.False((bool)field!.GetValue(instance)!));
+    }
+
     // ── EditRunPage ──────────────────────────────────────────────────────────
 
     private Mock<IRunsClient> WireEditRunServices(


### PR DESCRIPTION
## Summary

`CreateRunPage.HandleSubmit` set `_submitting = true` at the top, but only reset it on the early-return + catch paths. The success path called `Nav.NavigateTo(...)` and exited without resetting.

In current Blazor WASM behavior the navigation disposes the page component, so the stale flag is moot in production. But the code is asymmetric and brittle:

1. Inconsistent with the analogous [`EditRunPage.HandleSave`](app/Pages/EditRunPage.razor) which already uses `try/finally { _saving = false; }`.
2. A future refactor that replaces navigation with an inline success state (toast + reset form, etc.) would silently leave the submit button disabled forever — silent UX regression.

This is a defensive consistency fix from the 2026-04-29 bug-hunt backlog.

## Change

- `app/Pages/CreateRunPage.razor:441-478` — `try/finally { _submitting = false; }`, removing the two ad-hoc resets.
- `tests/Lfm.App.Tests/RunsPagesTests.cs` — new bUnit regression test `CreateRunPage_HandleSubmit_Resets_Submitting_Flag_On_Success_Path` that pins the flag-reset on the success path via reflection (button-disabled state alone wouldn't catch a future regression because `CanSubmit` also gates the button).

Diff: 2 files, +68/−1.

## Env / schema changes
None.

## Test plan
- [x] `dotnet build lfm.sln -c Release` — 0 warnings, 0 errors
- [x] `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release` — 181/181 passed
- [x] `dotnet format lfm.sln --verify-no-changes` — clean
- [x] Commit SSH-signed
- [ ] CI green