### PR TITLE
Catch JSDisconnectedException in MainLayout locale handler

### DIFF
--- a/app/Layout/MainLayout.razor
+++ b/app/Layout/MainLayout.razor
@@ -192,8 +192,16 @@
 
     private async void HandleLocaleChanged()
     {
-        await JS.InvokeVoidAsync("lfmSetDocumentLang", LocaleService.CurrentLocale);
-        await InvokeAsync(StateHasChanged);
+        // async void crosses JS interop; an unhandled exception escapes to
+        // the SynchronizationContext and can crash the WASM circuit. Mirror
+        // the OnAfterRenderAsync handling for the same teardown failure mode.
+        try
+        {
+            await JS.InvokeVoidAsync("lfmSetDocumentLang", LocaleService.CurrentLocale);
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (Microsoft.JSInterop.JSDisconnectedException) { /* JS channel disposed during teardown. */ }
+        catch (TaskCanceledException) { /* Render disposed mid-await. */ }
     }
 
     private void HandleLogout()

--- a/tests/Lfm.App.Tests/LayoutTests.cs
+++ b/tests/Lfm.App.Tests/LayoutTests.cs
@@ -5,6 +5,7 @@ using Bunit;
 using Bunit.TestDoubles;
 using Lfm.App.Layout;
 using Lfm.App.Services;
+using Lfm.App.i18n;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -170,5 +171,40 @@ public class LayoutTests : ComponentTestBase
         Assert.Equal("-1", main.GetAttribute("tabindex"));
         // The FocusOnNavigate component with Selector="h1" must be gone — focus is now driven by MainLayout's LocationChanged handler.
         Assert.DoesNotContain("FocusOnNavigate", cut.Markup);
+    }
+
+    [Fact]
+    public void MainLayout_Locale_Change_Survives_JSDisconnectedException()
+    {
+        // Regression: HandleLocaleChanged is `async void` and crosses JS interop.
+        // An unhandled JSDisconnectedException during teardown would escape to
+        // the SynchronizationContext and crash the WASM circuit. The handler
+        // must catch it.
+        this.AddAuthorization();
+        // Render first (under default Loose JSInterop, the initial-render
+        // lfmSetDocumentLang call succeeds), then arm the exception for the
+        // subsequent locale-change call.
+        var cut = Render<MainLayout>(p =>
+            p.Add(x => x.Body, builder => builder.AddContent(0, "page content")));
+
+        JSInterop.SetupVoid("lfmSetDocumentLang", "fi")
+            .SetException(new Microsoft.JSInterop.JSDisconnectedException("test: channel disposed"));
+
+        var localeService = Services.GetRequiredService<ILocaleService>();
+
+        // Triggering the locale change fires HandleLocaleChanged. The handler
+        // is async void; without the try/catch, the JSDisconnectedException
+        // raised by the test's strict JSInterop setup propagates out of the
+        // event invocation. With the fix it is swallowed.
+        Exception? caught = null;
+        try
+        {
+            localeService.SetLocale("fi");
+        }
+        catch (Exception ex)
+        {
+            caught = ex;
+        }
+        Assert.Null(caught);
     }
 }


### PR DESCRIPTION
## Summary

`MainLayout.HandleLocaleChanged` is `async void` (required because it's wired to a sync `Action` event). It awaits two things — `JS.InvokeVoidAsync("lfmSetDocumentLang", ...)` and `InvokeAsync(StateHasChanged)` — with no exception handling. An unhandled `JSDisconnectedException` from the JS interop call escapes to the SynchronizationContext and can crash the WASM circuit during teardown (e.g., user closes the tab while a locale toggle is in flight).

The same file already handles `JSDisconnectedException` in `OnAfterRenderAsync` for the `_mainRef.FocusAsync` call ([app/Layout/MainLayout.razor:188-189](app/Layout/MainLayout.razor#L188-L189)). This mirrors that pattern.

From the 2026-04-29 bug-hunt backlog (item #2).

## Change

- `app/Layout/MainLayout.razor:193-197` — wrap the body in `try { ... } catch (JSDisconnectedException) { } catch (TaskCanceledException) { }`.
- `tests/Lfm.App.Tests/LayoutTests.cs` — new bUnit regression test `MainLayout_Locale_Change_Survives_JSDisconnectedException`. Verified to **fail without the fix** (the JSDisconnectedException escapes through `HandleLocaleChanged`'s async-void) and **pass with the fix**.

## Env / schema changes
None.

## Test plan
- [x] `dotnet build lfm.sln -c Release` — clean
- [x] `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release` — 182/182 passed
- [x] `dotnet format lfm.sln --verify-no-changes` — clean
- [x] Pin-the-bug check: temporarily reverted the production fix; the new test failed with `JSDisconnectedException: test: channel disposed` → restoring the fix turns it green
- [x] Commit SSH-signed
- [ ] CI green