### PR TITLE
Stop caching anonymous auth state on transient null

### DIFF
--- a/app/Lfm.App.Core/Auth/AppAuthenticationStateProvider.cs
+++ b/app/Lfm.App.Core/Auth/AppAuthenticationStateProvider.cs
@@ -26,8 +26,10 @@ public sealed class AppAuthenticationStateProvider(IMeClient meClient, ILocaleSe
         var me = await meClient.GetAsync(CancellationToken.None);
         if (me is null)
         {
-            _cached = new AuthenticationState(new ClaimsPrincipal(new ClaimsIdentity()));
-            return _cached;
+            // Do not cache the anonymous result — a transient network failure
+            // or cold-start race must not cement the user as anonymous for the
+            // rest of the session. Let the next call retry MeClient.
+            return new AuthenticationState(new ClaimsPrincipal(new ClaimsIdentity()));
         }
 
         // Apply the user's persisted locale preference (overrides browser detection).

--- a/tests/Lfm.App.Core.Tests/Auth/AppAuthenticationStateProviderTests.cs
+++ b/tests/Lfm.App.Core.Tests/Auth/AppAuthenticationStateProviderTests.cs
@@ -158,6 +158,29 @@ public class AppAuthenticationStateProviderTests
     }
 
     [Fact]
+    public async Task GetAuthenticationStateAsync_does_not_cache_anonymous_state_so_next_call_retries()
+    {
+        // Regression: a transient null from MeClient (cold-start race, brief
+        // network blip) used to cement the user as anonymous for the session.
+        // The provider must NOT cache the anonymous result; the next call
+        // must re-hit MeClient so a recovered backend produces an authenticated
+        // state without requiring NotifyStateChanged or a full SPA reload.
+        var meClient = new Mock<IMeClient>();
+        meClient.SetupSequence(c => c.GetAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MeResponse?)null)
+            .ReturnsAsync(MakeMe());
+        var sut = new AppAuthenticationStateProvider(meClient.Object, Mock.Of<ILocaleService>());
+
+        var first = await sut.GetAuthenticationStateAsync();
+        Assert.False(first.User.Identity!.IsAuthenticated);
+
+        var second = await sut.GetAuthenticationStateAsync();
+        Assert.True(second.User.Identity!.IsAuthenticated);
+
+        meClient.Verify(c => c.GetAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    [Fact]
     public async Task NotifyStateChanged_fires_AuthenticationStateChanged_event()
     {
         var meClient = new Mock<IMeClient>();


### PR DESCRIPTION
## Summary

`AppAuthenticationStateProvider.GetAuthenticationStateAsync` cached the anonymous result when `MeClient.GetAsync` returned `null`. A transient null — Functions cold-start race, brief network blip, momentary 401/503 — would silently cement the user as anonymous for the rest of the SPA session. Recovery required either `NotifyStateChanged` (nothing in the app called it on a transient null) or a full SPA reload.

The fix: when `me` is `null`, return the anonymous state but do **not** assign `_cached`, so the next call re-hits `MeClient`. The successful-fetch path still caches normally.

From the 2026-04-29 bug-hunt backlog (item #3).

## Change

- `app/Lfm.App.Core/Auth/AppAuthenticationStateProvider.cs:27-31` — drop the `_cached =` assignment on the null path; return without caching.
- `tests/Lfm.App.Core.Tests/Auth/AppAuthenticationStateProviderTests.cs` — new regression test `GetAuthenticationStateAsync_does_not_cache_anonymous_state_so_next_call_retries`. Uses `SetupSequence` so the first call returns null and the second returns a real `MeResponse`; asserts the second call sees an authenticated state and that `MeClient.GetAsync` was invoked **exactly twice** (vs. once with the cache).

## Env / schema changes
None.

## Test plan
- [x] `dotnet build lfm.sln -c Release` — clean
- [x] `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release` — 181/181 passed (was 180; +1 new)
- [x] `dotnet format lfm.sln --verify-no-changes` — clean
- [x] Pin-the-bug check: temporarily reverted the production fix; the new test failed (`Assert.True(second.User.Identity!.IsAuthenticated)` → False because `_cached` returned the anonymous state) → restoring the fix turns it green
- [x] Existing `GetAuthenticationStateAsync_caches_result_across_calls` still passes (the authenticated path still caches via `_cached = new AuthenticationState(...)` at the bottom of the method)
- [x] Commit SSH-signed
- [ ] CI green