### PR TITLE
Lowercase CharactersPage CharKey to match server canonical id

### DIFF
--- a/app/Pages/CharactersPage.razor
+++ b/app/Pages/CharactersPage.razor
@@ -441,6 +441,13 @@
         }
     }
 
+    // Lowercases all three components so the key is identical to
+    // RunsPage.CharacterId, MeClient.SelectCharacterAsync URL paths, and
+    // CharacterPortraitService's normalized response keys (region/realm/name
+    // are normalised to lowercase server-side). A mixed-case key here used
+    // to silently miss the active-character badge (when SelectedCharacterId
+    // came back from the server in lowercase) and the portrait dictionary
+    // lookup (server returns lowercase-keyed entries).
     private static string CharKey(CharacterDto c) =>
-        $"{c.Region}-{c.Realm}-{c.Name.ToLowerInvariant()}";
+        $"{c.Region.ToLowerInvariant()}-{c.Realm.ToLowerInvariant()}-{c.Name.ToLowerInvariant()}";
 }

--- a/tests/Lfm.App.Tests/CharactersPagesTests.cs
+++ b/tests/Lfm.App.Tests/CharactersPagesTests.cs
@@ -259,6 +259,42 @@ public class CharactersPagesTests : ComponentTestBase
     }
 
     [Fact]
+    public void CharactersPage_Selected_Badge_Renders_When_Server_Id_Differs_In_Case()
+    {
+        // Regression: server normalises region/realm/name to lowercase before
+        // storing me.SelectedCharacterId (see CharacterPortraitService.TryNormalise).
+        // CharKey used to be `$"{c.Region}-{c.Realm}-{c.Name.ToLowerInvariant()}"`,
+        // which for a CharacterDto whose Region/Realm came back from Blizzard in
+        // mixed case would never equal the lowercase server value, silently
+        // hiding the active-character badge across page navigations.
+        this.AddAuthorization().SetAuthorized("player#1234");
+        var mixedCase = new CharacterDto(
+            Name: "Arthas", Realm: "Silvermoon", RealmName: "Silvermoon", Level: 80,
+            Region: "EU", ClassId: 1, ClassName: "Warrior", PortraitUrl: null,
+            ActiveSpecId: 71, SpecName: "Arms");
+        var battleNet = new Mock<IBattleNetClient>();
+        battleNet.Setup(c => c.GetCharactersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CharactersFetchResult.Cached(new List<CharacterDto> { mixedCase }));
+        battleNet.Setup(c => c.GetPortraitsAsync(It.IsAny<IEnumerable<CharacterPortraitRequest>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IDictionary<string, string>?)null);
+        var me = new Mock<IMeClient>();
+        // Server-stored SelectedCharacterId is fully lowercase.
+        me.Setup(m => m.GetAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeMeResponse(selectedCharacterId: "eu-silvermoon-arthas"));
+        Services.AddSingleton(battleNet.Object);
+        Services.AddSingleton(me.Object);
+
+        var cut = Render<CharactersPage>();
+
+        cut.WaitForAssertion(() =>
+        {
+            var card = cut.Find("[data-char-id='eu-silvermoon-arthas']");
+            Assert.Contains("outline", card.GetAttribute("style") ?? "");
+            Assert.Contains(Loc("characters.active"), cut.Markup);
+        });
+    }
+
+    [Fact]
     public void CharactersPage_Non_Selected_Card_Has_No_Outline()
     {
         this.AddAuthorization().SetAuthorized("player#1234");


### PR DESCRIPTION
## Summary

`CharactersPage.CharKey` produced `$"{c.Region}-{c.Realm}-{c.Name.ToLowerInvariant()}"` — only the name was lowercased. Three other places in the system use a fully-lowercased identifier:

- [`RunsPage.CharacterId`](app/Pages/RunsPage.razor) — `$"{character.Region.ToLowerInvariant()}-{character.Realm.ToLowerInvariant()}-{character.Name.ToLowerInvariant()}"`
- `MeClient.SelectCharacterAsync` PUT path — server stores whatever it receives
- [`CharacterPortraitService.TryNormalise`](api/Services/CharacterPortraitService.cs) — normalises region/realm/name to lowercase before generating dict keys

Result: when `me.SelectedCharacterId` comes back from the server in canonical lowercase form (e.g. after the user selected via RunsPage or after the portrait service stored a lowercase id), the `CharKey(c) == selectedCharacterId` comparison on CharactersPage fails for any character whose `c.Region` or `c.Realm` arrive from the API in mixed case. The active-character badge silently disappears, and the same mismatch breaks the portrait dictionary lookup at [CharactersPage.razor:47](app/Pages/CharactersPage.razor#L47).

From the 2026-04-29 bug-hunt backlog (item #4).

## Change

- `app/Pages/CharactersPage.razor:444-451` — `CharKey` lowercases all three components. Added an explanatory comment naming the three downstream consumers that share this format.
- `tests/Lfm.App.Tests/CharactersPagesTests.cs` — new bUnit regression test `CharactersPage_Selected_Badge_Renders_When_Server_Id_Differs_In_Case` that constructs a `CharacterDto` with `Region: "EU"` / `Realm: "Silvermoon"` (mixed case from Battle.net) and a `MeResponse.SelectedCharacterId` of `"eu-silvermoon-arthas"` (lowercase canonical from server), asserting the active-badge outline + the localized "active" label render.

## Env / schema changes
None.

## Test plan
- [x] `dotnet build lfm.sln -c Release` — clean
- [x] `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release` — 183/183 passed (was 182; +1 new)
- [x] `dotnet format lfm.sln --verify-no-changes` — clean
- [x] Pin-the-bug check: temporarily reverted the production fix; the new test failed (`Find("[data-char-id='eu-silvermoon-arthas']")` returned nothing — the rendered card had `data-char-id="EU-Silvermoon-arthas"`) → restoring the fix turns it green
- [x] All existing CharactersPage tests pass (the existing fixture uses already-lowercase region/realm, so the change is invisible to those tests)
- [x] Commit SSH-signed
- [ ] CI green