### PR TITLE
Narrow runs container indexing to queried paths

### DIFF
--- a/infra/modules/cosmos.bicep
+++ b/infra/modules/cosmos.bicep
@@ -90,10 +90,28 @@ resource runsContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/conta
       indexingPolicy: {
         automatic: true
         indexingMode: 'consistent'
+        // Only paths actually used by RunsRepository queries are indexed —
+        // every other path (description, encounters[], etc.) is excluded so
+        // writes don't pay RU cost for indexing data that's never queried.
+        // Sources:
+        //   - WHERE c.visibility / c.creatorBattleNetId / c.creatorGuildId
+        //   - ORDER BY c.startTime
+        //   - ARRAY_CONTAINS(c.runCharacters, { raiderBattleNetId })
+        includedPaths: [
+          { path: '/visibility/?' }
+          { path: '/creatorBattleNetId/?' }
+          { path: '/creatorGuildId/?' }
+          { path: '/startTime/?' }
+          { path: '/runCharacters/[]/raiderBattleNetId/?' }
+        ]
+        excludedPaths: [{ path: '/*' }]
+        // Serves: WHERE visibility='GUILD' AND creatorGuildId=@id ORDER BY startTime
+        // Note: the original composite indexed /creatorGuild (string), but the
+        // query filters on /creatorGuildId (int). Corrected to match the query.
         compositeIndexes: [
           [
             { path: '/visibility', order: 'ascending' }
-            { path: '/creatorGuild', order: 'ascending' }
+            { path: '/creatorGuildId', order: 'ascending' }
             { path: '/startTime', order: 'ascending' }
           ]
         ]


### PR DESCRIPTION
## Summary

The `runs` Cosmos container had no `includedPaths` / `excludedPaths` declared — only a `compositeIndexes` block. Cosmos defaults to indexing **every** scalar property when no paths are specified, so writes were paying RU cost to index data that's never queried (description text, encounters arrays, attendance state machine fields, etc.). CLAUDE.md WAF Cost guidance: *"Minimal Cosmos indexing — only queried paths; exclude `/*` on point-read containers."*

Audited every query against the `runs` container — sole consumer is [`api/Repositories/RunsRepository.cs`](api/Repositories/RunsRepository.cs):

| Line | Field | Operator |
|------|-------|----------|
| 30, 32, 53 | `c.visibility` | `=` |
| 31, 54, 159 | `c.creatorBattleNetId` | `=` |
| 32 | `c.creatorGuildId` | `=` |
| 33, 55 | `c.startTime` | `ORDER BY` |
| 160 | `c.runCharacters[].raiderBattleNetId` | `ARRAY_CONTAINS` |
| (point reads) | `c.id` | partition-key read |

Changed [`infra/modules/cosmos.bicep:90-101`](infra/modules/cosmos.bicep#L90-L101) — added `includedPaths` for the five paths above plus `excludedPaths: [{ path: '/*' }]`, mirroring the `guilds` and `idempotency` containers.

**Bonus fix in the same diff**: the existing composite index targeted `/visibility, /creatorGuild, /startTime`, but the corresponding query at `RunsRepository.cs:32-33` filters on `c.creatorGuildId` (the `int?` field), not `c.creatorGuild` (the `string` field). The composite was dormant. Corrected to `/creatorGuildId`. From the bug-hunt backlog (item #6).

## Env / schema changes

- Cosmos indexing-policy update on the `runs` container — triggers a one-time online re-index of existing `runs` documents on next infra deploy. Free-tier RU consumption is small at the project's data volume; no read/write outage.
- No code change. Existing queries continue to work; the cost characteristic improves on writes.

## Test plan
- [x] `dotnet build lfm.sln -c Release` — clean
- [x] `dotnet format lfm.sln --verify-no-changes` — clean
- [x] Audit verified: every WHERE/ORDER BY/ARRAY_CONTAINS field on the runs container is in `includedPaths`
- [x] Commit SSH-signed
- [ ] CI green (PSRule, gitleaks, reuse-lint, verify)
- [ ] Optional post-merge sanity: `RunsListFunctionTests` E2E run produces no Cosmos query plan with `BadRequest` or `OptimisticConcurrencyControl` errors

## Notes for reviewer

- The composite-index field-name change (`/creatorGuild` → `/creatorGuildId`) is a behavior fix, not just a cosmetic rename: the prior composite index was indexing a never-queried path while the actual query had to fall back to per-field indexes.
- Re-indexing is online; the function app and reads are not blocked.
- Risk if the audit missed a query: a subsequent SQL on a non-indexed field would either (a) return a `BadRequest` if `EnableCrossPartitionScan = false`, or (b) silently fall back to a full scan with high RU cost. The audit covered every `FROM c` in `RunsRepository.cs` (4 queries, all listed above) — this is the only consumer.