### PR TITLE
Parameterize storage account name in role-cleanup step

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -61,11 +61,12 @@ jobs:
           fi
 
       - name: Clean up stale role assignments from previous managed identity
+        env:
+          APP: ${{ vars.FUNCTION_APP_NAME }}
+          RG: ${{ vars.AZURE_RESOURCE_GROUP }}
+          KV: ${{ vars.KEY_VAULT_NAME }}
+          STORAGE: ${{ vars.STORAGE_ACCOUNT_NAME }}
         run: |
-          APP="${{ vars.FUNCTION_APP_NAME }}"
-          RG="${{ vars.AZURE_RESOURCE_GROUP }}"
-          KV="${{ vars.KEY_VAULT_NAME }}"
-
           CURRENT_PRINCIPAL=$(az functionapp identity show \
             --name "$APP" --resource-group "$RG" \
             --query "principalId" -o tsv 2>/dev/null || echo "")
@@ -81,7 +82,7 @@ jobs:
           # Resources where Bicep creates role assignments, with their ARM
           # resource types (needed for lock management). App Insights has no lock.
           declare -A LOCKED_SCOPES=(
-            ["/subscriptions/$SUB_ID/resourceGroups/$RG/providers/Microsoft.Storage/storageAccounts/lfmstore"]="Microsoft.Storage/storageAccounts lfmstore"
+            ["/subscriptions/$SUB_ID/resourceGroups/$RG/providers/Microsoft.Storage/storageAccounts/$STORAGE"]="Microsoft.Storage/storageAccounts $STORAGE"
             ["/subscriptions/$SUB_ID/resourceGroups/$RG/providers/Microsoft.KeyVault/vaults/$KV"]="Microsoft.KeyVault/vaults $KV"
           )
           UNLOCKED_SCOPES=(


### PR DESCRIPTION
## Summary

`.github/workflows/deploy-infra.yml:84` had a hardcoded `lfmstore` literal in the `LOCKED_SCOPES` map of the "Clean up stale role assignments" step:

```bash
declare -A LOCKED_SCOPES=(
  ["/subscriptions/$SUB_ID/resourceGroups/$RG/providers/Microsoft.Storage/storageAccounts/lfmstore"]="Microsoft.Storage/storageAccounts lfmstore"
  ...
)
```

The CLAUDE.md "Workflow parameterization" table requires every project-specific name to come from a repo variable. Two consequences of leaving this hardcoded:

1. The cleanup loop silently no-ops on any deployment whose storage account is named anything other than `lfmstore` — stale RBAC role assignments accumulate and block subsequent Bicep `roleAssignments` redeploys.
2. The repo can't be forked into a new tenant without editing the workflow.

From the bug-hunt backlog (item #7).

## Change

[`.github/workflows/deploy-infra.yml:63-86`](.github/workflows/deploy-infra.yml#L63-L86):

- Hoisted the four `${{ vars.* }}` references at the top of the `run:` block (`APP`, `RG`, `KV`, plus the new `STORAGE`) into a step-level `env:` mapping. This is GitHub's [recommended pattern](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/) — interpolating into env first prevents shell-injection edge cases and is idiomatic for variables consumed by an entire script.
- Replaced both `lfmstore` literals with `$STORAGE` (now backed by `${{ vars.STORAGE_ACCOUNT_NAME }}`).

Diff: 1 file, +6/−5 lines.

## Env / schema changes

- Reads existing repo variable `vars.STORAGE_ACCOUNT_NAME` (already used elsewhere in this workflow at lines 160, 180 for Bicep parameter passing). No new GitHub variable needed.

## Test plan

- [x] `yq eval '.' .github/workflows/deploy-infra.yml > /dev/null` — YAML still valid
- [x] `grep -rn 'lfmstore' .github/workflows/` — zero matches after the change
- [x] Audit confirms `$APP`, `$RG`, `$KV`, `$STORAGE` are referenced consistently inside the script (no unscoped reassignments that would mask the env values)
- [x] Commit SSH-signed
- [ ] CI green
- [ ] Optional smoke: trigger a deploy after merge; cleanup loop should report on the actual storage account name from `vars.STORAGE_ACCOUNT_NAME`, not the hardcoded literal

## Notes for reviewer

- This is workflow-only — no Bicep/runtime/cost impact. The role-cleanup step still does exactly the same thing; it just uses the right resource path on every tenant.
- The `env:`-block hoist for `APP`/`RG`/`KV` is a concurrent style improvement: it removes 3 inline `${{ vars.* }}` interpolations from the heredoc body, which the GitHub Actions security guide flags as a workflow-injection footgun for event-payload variables. `vars.*` is admin-controlled (not user input) so this isn't a live vulnerability, but the env-mapping pattern is uniformly safer.