### PR TITLE
Add cross-user delete denial to BrowserSecuritySpec

### DIFF
--- a/tests/Lfm.E2E/Specs/BrowserSecuritySpec.cs
+++ b/tests/Lfm.E2E/Specs/BrowserSecuritySpec.cs
@@ -4,6 +4,7 @@
 using Lfm.E2E.Fixtures;
 using Lfm.E2E.Helpers;
 using Lfm.E2E.Infrastructure;
+using Lfm.E2E.Seeds;
 using Microsoft.Playwright;
 using Xunit;
 using Xunit.Abstractions;
@@ -266,6 +267,62 @@ public class BrowserSecuritySpec(BrowserSecurityFixture fixture, ITestOutputHelp
         finally
         {
             await authContext.CloseAsync();
+        }
+    }
+
+    [Fact]
+    public async Task CrossUser_DeleteAnotherUsersRun_BlockedBy403()
+    {
+        // Auth-matrix gap (E-HC-S3 cross-user cell): a valid session for user
+        // B must not be able to mutate user A's resource. Sub-lane S verifies
+        // (a) the cookie issued for SecondaryBattleNetId is correctly attached
+        // to a cross-origin fetch from the SPA, (b) the API authenticates the
+        // request (so the response is 403, not 401), and (c) the browser
+        // receives the 403 intact (no CORS layer collapses it to a network
+        // error). Server-side rejection is unit-tested by RunAccessPolicyTests
+        // and integration-tested by RunsDeleteFunctionTests; this proves the
+        // browser path top-to-bottom.
+        //
+        // Setup details (see DefaultSeed.cs):
+        //   - runs/e2e-run-001 is owned by PrimaryBattleNetId ("test-bnet-id").
+        //   - SecondaryBattleNetId ("test-bnet-id-2") is in the same Test
+        //     Guild but at rank 1, whose rankPermissions.canDeleteGuildRuns
+        //     is false. The 403 therefore fires from the guild-rank-denied
+        //     path in RunsDeleteFunction (line 75) — a cross-user denial
+        //     even though both users share a guild.
+        var userBContext = await AuthHelper.AuthenticatedContextAsync(
+            fixture.Stack.Browser,
+            fixture.Stack.ApiBaseUrl,
+            fixture.Stack.AppBaseUrl,
+            battleNetId: DefaultSeed.SecondaryBattleNetId);
+        try
+        {
+            var userBPage = await userBContext.NewPageAsync();
+
+            // Land on the SPA origin so the auth cookie is in scope for the
+            // cross-origin fetch (and the CORS request originates from the
+            // configured allowed origin, not data:null as in the negative
+            // CrossOriginFetch_FromUnregisteredOrigin_BlockedByCors test).
+            await userBPage.GotoAsync($"{fixture.Stack.AppBaseUrl}/runs",
+                new() { WaitUntil = WaitUntilState.NetworkIdle });
+
+            var encodedRunId = Uri.EscapeDataString(DefaultSeed.TestRunId);
+            var status = await userBPage.EvaluateAsync<int>(
+                $$"""
+                async () => {
+                    const res = await fetch('{{fixture.Stack.ApiBaseUrl}}/api/v1/runs/{{encodedRunId}}', {
+                        method: 'DELETE',
+                        credentials: 'include',
+                    });
+                    return res.status;
+                }
+                """);
+
+            Assert.Equal(403, status);
+        }
+        finally
+        {
+            await userBContext.CloseAsync();
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #51 — fills the cross-user cell of the auth-matrix in E2E sub-lane S.

The 2026-04-20 test-quality-audit flagged that `BrowserSecuritySpec` covered four browser-enforcement contracts (HttpOnly cookie, CORS, X-Frame-Options, CSP) plus token-tampered and token-expired, but the cross-user-access cell of the rubric's `E-HC-S3` matrix was uncovered.

This PR adds one Playwright test that drives the **valid session, wrong user, denied-mutation** scenario through a real browser:

1. Authenticates as `DefaultSeed.SecondaryBattleNetId` (Kaldris, rank 1 in the seeded Test Guild — `rankPermissions[rank=1].canDeleteGuildRuns = false`).
2. Lands on the SPA origin so the cookie is in scope and the CORS preflight uses the registered origin.
3. Issues a `fetch DELETE /api/v1/runs/e2e-run-001` (the seeded run owned by `PrimaryBattleNetId`) with `credentials: 'include'`.
4. Asserts the browser receives `status === 403`.

The 403 fires from the guild-rank-denied path in [`api/Functions/RunsDeleteFunction.cs:75`](api/Functions/RunsDeleteFunction.cs#L75) (not the not-creator path) — both users share guild 12345, but Kaldris's rank lacks `canDeleteGuildRuns`. That's a real cross-user denial, distinct from a simple "not creator" rejection, and exactly the kind of nuanced authorization that integration-layer unit tests of `RunAccessPolicy` and `GuildPermissions` cover individually but no E2E spec previously proved end-to-end.

## Other matrix cells (already covered, not touching)

| Cell | Where covered |
|------|---------------|
| anonymous → protected route | `AccessControlSpec.ProtectedRoute_Unauthenticated_RedirectsToLogin` |
| token-expired | `BrowserSecuritySpec.ExpiredSessionCookie_AccessingProtectedRoute_RedirectsToLogin` |
| token-tampered | `BrowserSecuritySpec.TamperedSessionCookie_AccessingProtectedRoute_RedirectsToLogin` |
| sufficient-scope (happy path) | every authenticated `*Spec` test |

## Change

- `tests/Lfm.E2E/Specs/BrowserSecuritySpec.cs` — added 1 test (`CrossUser_DeleteAnotherUsersRun_BlockedBy403`), 57 lines including comment block citing the seed-data state, the 403 path being exercised, and which integration-layer tests already pin the server-side rejection.
- Added `using Lfm.E2E.Seeds;` to reference `DefaultSeed.SecondaryBattleNetId` / `DefaultSeed.TestRunId`.

## Env / schema changes
None.

## Test plan

- [x] `dotnet build tests/Lfm.E2E/Lfm.E2E.csproj -c Release` — clean
- [x] `dotnet test … --filter "FullyQualifiedName~BrowserSecuritySpec"` — **7/7 passed** (6 existing + 1 new) in ~8s with Testcontainers reuse
- [x] `dotnet format lfm.sln --verify-no-changes` — clean
- [x] Commit SSH-signed
- [ ] CI green (verify, Gitleaks, reuse-lint)

## Notes for reviewer

- The test deliberately uses the existing seed (Secondary user already in same guild, rank 1 with no delete perm) rather than introducing a third seeded user — keeps the seed surface stable.
- Side benefit: the test also exercises the CORS-with-credentials happy path from the SPA origin, complementing the existing `CrossOriginFetch_FromUnregisteredOrigin_BlockedByCors` negative case.
- Issue body in #51 was truncated in the API listing earlier (CSP `<script>` quoted content trips a sanitizer); the four-contract list above mirrors what the body shows verbatim before the truncation.