### PR TITLE
Harden shared agent stop hooks

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -5,15 +5,18 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$(git rev-parse --show-toplevel)/scripts/claude/stop-test-audit.sh\""
+            "command": "bash \"$(git rev-parse --show-toplevel)/scripts/claude/stop-test-audit.sh\"",
+            "statusMessage": "Checking changed unit tests for audit prompt"
           },
           {
             "type": "command",
-            "command": "bash \"$(git rev-parse --show-toplevel)/scripts/claude/stop-devsecops-audit.sh\""
+            "command": "bash \"$(git rev-parse --show-toplevel)/scripts/claude/stop-devsecops-audit.sh\"",
+            "statusMessage": "Checking security-sensitive changes for audit prompt"
           },
           {
             "type": "command",
-            "command": "bash \"$(git rev-parse --show-toplevel)/scripts/claude/stop-responsive-audit.sh\""
+            "command": "bash \"$(git rev-parse --show-toplevel)/scripts/claude/stop-responsive-audit.sh\"",
+            "statusMessage": "Checking app/UI changes for responsive audit prompt"
           }
         ]
       }

--- a/scripts/claude/stop-devsecops-audit.sh
+++ b/scripts/claude/stop-devsecops-audit.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # SPDX-FileCopyrightText: 2026 LFM contributors
 
-# Claude Code Stop hook — nudge the devsecops-audit skill.
+# Claude/Codex Stop hook — nudge the devsecops-audit skill.
 #
 # When Claude is about to finish a turn, check whether any security-relevant
 # files in the repo have changed relative to main. If so, and the audit has
@@ -17,14 +17,17 @@
 # Output: {decision: "block", reason: ...} on stdout if any devsecops-relevant
 #         file changed and not yet prompted this session; empty exit 0 otherwise.
 #
-# Wired up in .claude/settings.json under hooks.Stop.
+# Wired up in .claude/settings.json and .codex/hooks.json under hooks.Stop.
 
 set -euo pipefail
+
+hook_name="devsecops-audit"
 
 # ---- parse stdin ------------------------------------------------------------
 input=$(cat)
 session_id=$(jq -r '.session_id // empty' <<<"$input")
 cwd=$(jq -r '.cwd // empty' <<<"$input")
+stop_hook_active=$(jq -r '.stop_hook_active // false' <<<"$input")
 
 # ---- locate repo root -------------------------------------------------------
 # Use lfm.sln as the identity marker rather than basename, so the hook still
@@ -35,12 +38,43 @@ repo_root=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || true)
 [[ -f "$repo_root/lfm.sln" ]] || exit 0
 
 # ---- loop protection: per-session marker ------------------------------------
-marker_dir="$repo_root/.cache/claude-hooks"
+marker_dir="$repo_root/.cache/agent-hooks"
 marker="$marker_dir/devsecops-audit-prompted-${session_id:-unknown}"
-[[ -f "$marker" ]] && exit 0
+
+debug_log() {
+  [[ "${AGENT_HOOK_DEBUG:-}" == "1" ||
+     "${CODEX_HOOK_DEBUG:-}" == "1" ||
+     "${CLAUDE_HOOK_DEBUG:-}" == "1" ]] || return 0
+
+  mkdir -p "$marker_dir" || return 0
+  {
+    jq -cn \
+      --arg hook "$hook_name" \
+      --arg event "$1" \
+      --arg session_id "${session_id:-unknown}" \
+      --arg cwd "$cwd" \
+      --arg repo_root "$repo_root" \
+      --arg changed "${changed:-}" \
+      '{ts: now | todateiso8601, hook: $hook, event: $event, session_id: $session_id, cwd: $cwd, repo_root: $repo_root, changed: $changed}' \
+      >>"$marker_dir/debug.jsonl"
+  } 2>/dev/null || true
+}
+
+if [[ "$stop_hook_active" == "true" ]]; then
+  debug_log "skip-stop-hook-active"
+  exit 0
+fi
+
+if [[ -f "$marker" ]]; then
+  debug_log "skip-marker-exists"
+  exit 0
+fi
 
 # ---- require main to exist --------------------------------------------------
-git -C "$repo_root" rev-parse --verify --quiet main >/dev/null || exit 0
+if ! git -C "$repo_root" rev-parse --verify --quiet main >/dev/null; then
+  debug_log "skip-no-main"
+  exit 0
+fi
 
 # ---- detect changed devsecops-relevant files --------------------------------
 # Diff working tree + committed changes on branch against main, restricted to
@@ -74,11 +108,15 @@ extra=$(git -C "$repo_root" diff --name-only main 2>/dev/null \
 
 changed=$(printf '%s\n%s\n' "$changed" "$extra" | sed '/^$/d' | sort -u)
 
-[[ -z "$changed" ]] && exit 0
+if [[ -z "$changed" ]]; then
+  debug_log "skip-no-changes"
+  exit 0
+fi
 
 # ---- emit block -------------------------------------------------------------
 mkdir -p "$marker_dir"
 touch "$marker"
+debug_log "emit-block"
 
 jq -n --arg files "$changed" '{
   decision: "block",

--- a/scripts/claude/stop-responsive-audit.sh
+++ b/scripts/claude/stop-responsive-audit.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # SPDX-FileCopyrightText: 2026 LFM contributors
 
-# Claude Code Stop hook — nudge the responsive-design review skill.
+# Claude/Codex Stop hook — nudge the responsive-design review skill.
 #
 # When Claude is about to finish a turn, check whether any files under app/
 # have changed relative to main. If so, and the audit has not yet been
@@ -19,14 +19,17 @@
 # Output: {decision: "block", reason: ...} on stdout if any app/ file
 #         changed and not yet prompted this session; empty exit 0 otherwise.
 #
-# Wired up in .claude/settings.json under hooks.Stop.
+# Wired up in .claude/settings.json and .codex/hooks.json under hooks.Stop.
 
 set -euo pipefail
+
+hook_name="responsive-audit"
 
 # ---- parse stdin ------------------------------------------------------------
 input=$(cat)
 session_id=$(jq -r '.session_id // empty' <<<"$input")
 cwd=$(jq -r '.cwd // empty' <<<"$input")
+stop_hook_active=$(jq -r '.stop_hook_active // false' <<<"$input")
 
 # ---- locate repo root -------------------------------------------------------
 # Use lfm.sln as the identity marker rather than basename, so the hook still
@@ -37,12 +40,43 @@ repo_root=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || true)
 [[ -f "$repo_root/lfm.sln" ]] || exit 0
 
 # ---- loop protection: per-session marker ------------------------------------
-marker_dir="$repo_root/.cache/claude-hooks"
+marker_dir="$repo_root/.cache/agent-hooks"
 marker="$marker_dir/responsive-audit-prompted-${session_id:-unknown}"
-[[ -f "$marker" ]] && exit 0
+
+debug_log() {
+  [[ "${AGENT_HOOK_DEBUG:-}" == "1" ||
+     "${CODEX_HOOK_DEBUG:-}" == "1" ||
+     "${CLAUDE_HOOK_DEBUG:-}" == "1" ]] || return 0
+
+  mkdir -p "$marker_dir" || return 0
+  {
+    jq -cn \
+      --arg hook "$hook_name" \
+      --arg event "$1" \
+      --arg session_id "${session_id:-unknown}" \
+      --arg cwd "$cwd" \
+      --arg repo_root "$repo_root" \
+      --arg changed "${changed:-}" \
+      '{ts: now | todateiso8601, hook: $hook, event: $event, session_id: $session_id, cwd: $cwd, repo_root: $repo_root, changed: $changed}' \
+      >>"$marker_dir/debug.jsonl"
+  } 2>/dev/null || true
+}
+
+if [[ "$stop_hook_active" == "true" ]]; then
+  debug_log "skip-stop-hook-active"
+  exit 0
+fi
+
+if [[ -f "$marker" ]]; then
+  debug_log "skip-marker-exists"
+  exit 0
+fi
 
 # ---- require main to exist --------------------------------------------------
-git -C "$repo_root" rev-parse --verify --quiet main >/dev/null || exit 0
+if ! git -C "$repo_root" rev-parse --verify --quiet main >/dev/null; then
+  debug_log "skip-no-main"
+  exit 0
+fi
 
 # ---- detect changed app/ files ----------------------------------------------
 # Diff working tree + committed changes on branch against main, restricted to
@@ -53,11 +87,15 @@ git -C "$repo_root" rev-parse --verify --quiet main >/dev/null || exit 0
 # is safe.
 changed=$(git -C "$repo_root" diff --name-only main -- 'app/' 2>/dev/null || true)
 
-[[ -z "$changed" ]] && exit 0
+if [[ -z "$changed" ]]; then
+  debug_log "skip-no-changes"
+  exit 0
+fi
 
 # ---- emit block -------------------------------------------------------------
 mkdir -p "$marker_dir"
 touch "$marker"
+debug_log "emit-block"
 
 jq -n --arg files "$changed" '{
   decision: "block",

--- a/scripts/claude/stop-test-audit.sh
+++ b/scripts/claude/stop-test-audit.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # SPDX-FileCopyrightText: 2026 LFM contributors
 
-# Claude Code Stop hook — nudge the test-quality-audit skill.
+# Claude/Codex Stop hook — nudge the test-quality-audit skill.
 #
 # When Claude is about to finish a turn, check whether any unit test files in
 # the repo have changed relative to main. If so, and the audit has not yet
@@ -14,14 +14,17 @@
 # Output: {decision: "block", reason: ...} on stdout if tests changed and
 #         not yet prompted this session; empty exit 0 otherwise.
 #
-# Wired up in .claude/settings.json under hooks.Stop.
+# Wired up in .claude/settings.json and .codex/hooks.json under hooks.Stop.
 
 set -euo pipefail
+
+hook_name="test-audit"
 
 # ---- parse stdin ------------------------------------------------------------
 input=$(cat)
 session_id=$(jq -r '.session_id // empty' <<<"$input")
 cwd=$(jq -r '.cwd // empty' <<<"$input")
+stop_hook_active=$(jq -r '.stop_hook_active // false' <<<"$input")
 
 # ---- locate repo root -------------------------------------------------------
 # Use lfm.sln as the identity marker rather than basename, so the hook still
@@ -32,12 +35,43 @@ repo_root=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || true)
 [[ -f "$repo_root/lfm.sln" ]] || exit 0
 
 # ---- loop protection: per-session marker ------------------------------------
-marker_dir="$repo_root/.cache/claude-hooks"
+marker_dir="$repo_root/.cache/agent-hooks"
 marker="$marker_dir/test-audit-prompted-${session_id:-unknown}"
-[[ -f "$marker" ]] && exit 0
+
+debug_log() {
+  [[ "${AGENT_HOOK_DEBUG:-}" == "1" ||
+     "${CODEX_HOOK_DEBUG:-}" == "1" ||
+     "${CLAUDE_HOOK_DEBUG:-}" == "1" ]] || return 0
+
+  mkdir -p "$marker_dir" || return 0
+  {
+    jq -cn \
+      --arg hook "$hook_name" \
+      --arg event "$1" \
+      --arg session_id "${session_id:-unknown}" \
+      --arg cwd "$cwd" \
+      --arg repo_root "$repo_root" \
+      --arg changed "${changed:-}" \
+      '{ts: now | todateiso8601, hook: $hook, event: $event, session_id: $session_id, cwd: $cwd, repo_root: $repo_root, changed: $changed}' \
+      >>"$marker_dir/debug.jsonl"
+  } 2>/dev/null || true
+}
+
+if [[ "$stop_hook_active" == "true" ]]; then
+  debug_log "skip-stop-hook-active"
+  exit 0
+fi
+
+if [[ -f "$marker" ]]; then
+  debug_log "skip-marker-exists"
+  exit 0
+fi
 
 # ---- require main to exist --------------------------------------------------
-git -C "$repo_root" rev-parse --verify --quiet main >/dev/null || exit 0
+if ! git -C "$repo_root" rev-parse --verify --quiet main >/dev/null; then
+  debug_log "skip-no-main"
+  exit 0
+fi
 
 # ---- detect changed unit test files -----------------------------------------
 # Diff working tree + committed changes on branch against main, restricted to
@@ -46,11 +80,15 @@ changed=$(git -C "$repo_root" diff --name-only main -- \
   'tests/Lfm.Api.Tests' 'tests/Lfm.App.Tests' 'tests/Lfm.App.Core.Tests' 2>/dev/null \
   | grep -E 'Tests?\.cs$' || true)
 
-[[ -z "$changed" ]] && exit 0
+if [[ -z "$changed" ]]; then
+  debug_log "skip-no-changes"
+  exit 0
+fi
 
 # ---- emit block -------------------------------------------------------------
 mkdir -p "$marker_dir"
 touch "$marker"
+debug_log "emit-block"
 
 jq -n --arg files "$changed" '{
   decision: "block",

--- a/scripts/claude/test-stop-audit-hooks.sh
+++ b/scripts/claude/test-stop-audit-hooks.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 LFM contributors
+
+set -euo pipefail
+
+repo_root=$(git -C "$(dirname "$0")" rev-parse --show-toplevel)
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+make_fixture() {
+  local fixture=$1
+  mkdir -p "$fixture/scripts/claude" \
+    "$fixture/tests/Lfm.Api.Tests" \
+    "$fixture/api/Functions" \
+    "$fixture/app/Pages"
+
+  cp "$repo_root"/scripts/claude/stop-*-audit.sh "$fixture/scripts/claude/"
+  touch "$fixture/lfm.sln" \
+    "$fixture/tests/Lfm.Api.Tests/SampleTests.cs" \
+    "$fixture/api/Functions/SampleFunction.cs" \
+    "$fixture/app/Pages/SamplePage.razor"
+
+  git -C "$fixture" init -q -b main
+  git -C "$fixture" config user.email "hook-test@example.invalid"
+  git -C "$fixture" config user.name "Hook Test"
+  git -C "$fixture" add .
+  git -C "$fixture" commit -q -m "baseline"
+  git -C "$fixture" switch -q -c agents/hook-test
+
+  printf '// changed\n' >>"$fixture/tests/Lfm.Api.Tests/SampleTests.cs"
+  printf '// changed\n' >>"$fixture/api/Functions/SampleFunction.cs"
+  printf '@* changed *@\n' >>"$fixture/app/Pages/SamplePage.razor"
+}
+
+hook_input() {
+  local cwd=$1
+  local session_id=$2
+  local active=$3
+  jq -n \
+    --arg cwd "$cwd" \
+    --arg session_id "$session_id" \
+    --argjson stop_hook_active "$active" \
+    '{
+      session_id: $session_id,
+      cwd: $cwd,
+      hook_event_name: "Stop",
+      stop_hook_active: $stop_hook_active,
+      last_assistant_message: "base"
+    }'
+}
+
+assert_block() {
+  local output=$1
+  local needle=$2
+  [[ "$(jq -r '.decision' <<<"$output")" == "block" ]]
+  jq -e --arg needle "$needle" '.reason | contains($needle)' <<<"$output" >/dev/null
+}
+
+fixture="$tmp/repo"
+make_fixture "$fixture"
+
+test_output=$(hook_input "$fixture" "test-agent-hooks" false |
+  AGENT_HOOK_DEBUG=1 bash "$fixture/scripts/claude/stop-test-audit.sh")
+devsecops_output=$(hook_input "$fixture" "devsecops-agent-hooks" false |
+  AGENT_HOOK_DEBUG=1 bash "$fixture/scripts/claude/stop-devsecops-audit.sh")
+responsive_output=$(hook_input "$fixture" "responsive-agent-hooks" false |
+  AGENT_HOOK_DEBUG=1 bash "$fixture/scripts/claude/stop-responsive-audit.sh")
+
+assert_block "$test_output" "Unit test files changed"
+assert_block "$devsecops_output" "Security-relevant files changed"
+assert_block "$responsive_output" "UI / app files changed"
+
+blocked_debug_fixture="$tmp/blocked-debug-repo"
+make_fixture "$blocked_debug_fixture"
+mkdir -p "$blocked_debug_fixture/.cache/agent-hooks/debug.jsonl"
+
+blocked_debug_stderr="$tmp/blocked-debug.stderr"
+blocked_debug_output=$(hook_input "$blocked_debug_fixture" "blocked-debug" false |
+  AGENT_HOOK_DEBUG=1 bash "$blocked_debug_fixture/scripts/claude/stop-test-audit.sh" 2>"$blocked_debug_stderr")
+assert_block "$blocked_debug_output" "Unit test files changed"
+[[ ! -s "$blocked_debug_stderr" ]]
+
+[[ -f "$fixture/.cache/agent-hooks/test-audit-prompted-test-agent-hooks" ]]
+[[ -f "$fixture/.cache/agent-hooks/devsecops-audit-prompted-devsecops-agent-hooks" ]]
+[[ -f "$fixture/.cache/agent-hooks/responsive-audit-prompted-responsive-agent-hooks" ]]
+[[ ! -d "$fixture/.cache/claude-hooks" ]]
+
+debug_log="$fixture/.cache/agent-hooks/debug.jsonl"
+[[ -f "$debug_log" ]]
+jq -e 'select(.hook == "test-audit" and .event == "emit-block")' "$debug_log" >/dev/null
+jq -e 'select(.hook == "devsecops-audit" and .event == "emit-block")' "$debug_log" >/dev/null
+jq -e 'select(.hook == "responsive-audit" and .event == "emit-block")' "$debug_log" >/dev/null
+
+stop_active_output=$(hook_input "$fixture" "new-session" true |
+  AGENT_HOOK_DEBUG=1 bash "$fixture/scripts/claude/stop-test-audit.sh")
+[[ -z "$stop_active_output" ]]
+[[ ! -f "$fixture/.cache/agent-hooks/test-audit-prompted-new-session" ]]
+jq -e 'select(.hook == "test-audit" and .event == "skip-stop-hook-active")' "$debug_log" >/dev/null
+
+jq -e '
+  [.hooks.Stop[].hooks[].statusMessage] as $messages
+  | ($messages | length) == 3
+  and all($messages[]; type == "string" and length > 0)
+' "$repo_root/.codex/hooks.json" >/dev/null


### PR DESCRIPTION
## Summary
- Move Claude/Codex Stop hook markers to the shared `.cache/agent-hooks` namespace.
- Add Codex-visible hook status messages, `stop_hook_active` loop protection, and gated debug logging.
- Cover the shared hook behavior with a shell regression test, including debug-log failure isolation.

## Test Plan
- [x] `bash scripts/claude/test-stop-audit-hooks.sh`
- [x] `bash -n scripts/claude/stop-test-audit.sh scripts/claude/stop-devsecops-audit.sh scripts/claude/stop-responsive-audit.sh scripts/claude/test-stop-audit-hooks.sh`
- [x] `shellcheck scripts/claude/stop-test-audit.sh scripts/claude/stop-devsecops-audit.sh scripts/claude/stop-responsive-audit.sh scripts/claude/test-stop-audit-hooks.sh`
- [x] `jq -e . .codex/hooks.json >/dev/null`
- [x] `git diff --check`
- [x] `dotnet build lfm.sln -c Release --no-restore`