### PR TITLE
Scan RunDetailPage axe after focusing Edit button

### DIFF
--- a/tests/Lfm.E2E/Specs/AccessibilitySpec.cs
+++ b/tests/Lfm.E2E/Specs/AccessibilitySpec.cs
@@ -154,6 +154,17 @@ public class AccessibilitySpec(AccessibilityFixture fixture, ITestOutputHelper o
             .ToBeVisibleAsync(new() { Timeout = 15000 });
 
         await AccessibilityHelper.ScanAndAssert(page, Output, $"/runs/{DefaultSeed.TestRunId}");
+
+        // Re-scan after keyboard-focusing the Edit button — its focus
+        // indicator, accent-fill states, and any aria-describedby tooltips
+        // only surface after interaction, mirroring the LoginPage post-focus
+        // scan above (`E-HC-A2`).
+        await AccessibilityHelper.ScanAfterAsync(page, Output, $"/runs/{DefaultSeed.TestRunId} (edit focused)", async () =>
+        {
+            var runsPage = new RunsPage(page);
+            await Assertions.Expect(runsPage.EditButton).ToBeVisibleAsync(new() { Timeout = 15000 });
+            await runsPage.EditButton.FocusAsync();
+        });
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes #52 (partial — see "Notes for reviewer" below for the unactionable parts of the original issue).

The 2026-04-20 audit flagged four AccessibilitySpec page-scans as load-time-only. Two of the four are no longer load-only on `main`:

- `LoginPage_MeetsWcag22AA` — already gained `ScanAfterAsync` for sign-in-button focus at [AccessibilitySpec.cs:70](tests/Lfm.E2E/Specs/AccessibilitySpec.cs#L70).
- `PrivacyPage_MeetsWcag22AA` — issue itself marks this as defer-low-value (static content).

The remaining two listed pages have a current-shape mismatch with the suggestions:

- **`RunDetailPage_MeetsWcag22AA`** — issue suggests "re-scan after toggling the edit-mode button." There is no toggle: the Edit control is a `FluentButton` whose `OnClick` navigates to `/runs/{id}/edit` (a separate page). What *is* useful is keyboard-focusing the Edit button so the focus indicator, accent-fill state, and any `aria-describedby` tooltips on a real interactive primitive get audited (the same value the LoginPage post-focus scan delivers). **This PR adds that scan.**
- **`InstancesPage_MeetsWcag22AA`** — issue itself is conditional: "could re-scan after sorting / filtering **if/when those surfaces exist**". The current `FluentDataGrid` declares `PropertyColumn`s without `Sortable` / `Filter` props, so no post-interaction surface exists yet. Skipped intentionally; the issue's own conditional means this is "wait for the feature."

## Change

[`tests/Lfm.E2E/Specs/AccessibilitySpec.cs`](tests/Lfm.E2E/Specs/AccessibilitySpec.cs) — added 1 `ScanAfterAsync` block in `RunDetailPage_MeetsWcag22AA` that focuses the seeded run's Edit button (visible because the seeded run signup window is always open relative to test time) and re-runs axe.

Diff: 1 file, +11 lines.

## Env / schema changes
None.

## Test plan
- [x] `dotnet build tests/Lfm.E2E/Lfm.E2E.csproj -c Release` — clean
- [x] `dotnet test … --filter "FullyQualifiedName~RunDetailPage_MeetsWcag22AA"` — **1/1 passed** in 2s (Testcontainers reuse)
- [x] `dotnet format lfm.sln --verify-no-changes` — clean
- [x] Commit SSH-signed
- [ ] CI green

## Notes for reviewer

- This PR closes the *actionable* part of #52. The InstancesPage cell stays open as documented in #52 — the post-interaction scan should land alongside the future PR that adds sortable / filterable columns to InstancesPage.
- After merge, #52 can be closed with a comment pointing to this PR + a note that the InstancesPage cell is reborn as a follow-up tied to the sort/filter feature (or the issue can be repurposed to track exactly that future work).