### PR TITLE
Fix run bug hunt findings

### DIFF
--- a/api/Functions/RunsCreateFunction.cs
+++ b/api/Functions/RunsCreateFunction.cs
@@ -52,13 +52,21 @@ public class RunsCreateFunction(IRunsRepository repo, IRaidersRepository raiders
     {
         var principal = ctx.GetPrincipal(); // non-null: [RequireAuth] + AuthPolicyMiddleware guarantee
 
-        var body = await JsonSerializer.DeserializeAsync<CreateRunRequest>(
-            req.Body,
-            JsonOptions,
-            cancellationToken: ct);
+        CreateRunRequest? body;
+        try
+        {
+            body = await JsonSerializer.DeserializeAsync<CreateRunRequest>(
+                req.Body,
+                JsonOptions,
+                cancellationToken: ct);
 
-        if (body is null)
+            if (body is null)
+                return Problem.BadRequest(req.HttpContext, "invalid-body", "Request body is invalid or missing.");
+        }
+        catch (JsonException)
+        {
             return Problem.BadRequest(req.HttpContext, "invalid-body", "Request body is invalid or missing.");
+        }
 
         var validator = new CreateRunRequestValidator();
         var validationResult = await validator.ValidateAsync(body, ct);

--- a/api/Functions/RunsUpdateFunction.cs
+++ b/api/Functions/RunsUpdateFunction.cs
@@ -108,15 +108,20 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
             }
         }
 
-        // 3. Parse and validate request body.
+        // 3. Parse and validate request body. Keep the raw JsonElement long
+        // enough to distinguish omitted fields from explicit nulls.
         UpdateRunRequest? body;
+        JsonDocument bodyDoc;
         try
         {
-            body = await JsonSerializer.DeserializeAsync<UpdateRunRequest>(
+            bodyDoc = await JsonDocument.ParseAsync(
                 req.Body,
-                JsonOptions,
                 cancellationToken: ct);
 
+            if (bodyDoc.RootElement.ValueKind != JsonValueKind.Object)
+                return Problem.BadRequest(req.HttpContext, "invalid-body", "Request body is invalid or missing.");
+
+            body = bodyDoc.RootElement.Deserialize<UpdateRunRequest>(JsonOptions);
             if (body is null)
                 return Problem.BadRequest(req.HttpContext, "invalid-body", "Request body is invalid or missing.");
         }
@@ -128,6 +133,7 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
             return Problem.BadRequest(req.HttpContext, "invalid-body", "Request body is invalid or missing.");
         }
 
+        using var parsedBody = bodyDoc;
         var validator = new UpdateRunRequestValidator();
         var validationResult = await validator.ValidateAsync(body, ct);
         if (!validationResult.IsValid)
@@ -139,6 +145,16 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
                 "Request body failed validation.",
                 new Dictionary<string, object?> { ["errors"] = errors });
         }
+
+        var root = parsedBody.RootElement;
+        var hasStartTime = HasJsonProperty(root, "startTime");
+        var hasSignupCloseTime = HasJsonProperty(root, "signupCloseTime");
+        var hasDescription = HasJsonProperty(root, "description");
+        var hasVisibility = HasJsonProperty(root, "visibility");
+        var hasInstanceId = HasJsonProperty(root, "instanceId");
+        var hasDifficulty = HasJsonProperty(root, "difficulty");
+        var hasSize = HasJsonProperty(root, "size");
+        var hasKeystoneLevel = HasJsonProperty(root, "keystoneLevel");
 
         // 4. Editability check — mirrors isEditingClosed in run-editability.ts.
         //    Returns 409 Conflict (the resource state conflicts with the request).
@@ -161,7 +177,7 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
                     req.HttpContext,
                     "start-time-locked",
                     "Cannot change start time after signups.");
-            if (body.InstanceId is not null && body.InstanceId != existing.InstanceId)
+            if (hasInstanceId && body.InstanceId != existing.InstanceId)
                 return Problem.BadRequest(
                     req.HttpContext,
                     "instance-locked",
@@ -191,13 +207,46 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
 
         // 7. Resolve effective instanceId + mode fields and look up the
         //    instance name.
-        var effectiveInstanceId = body.InstanceId ?? existing.InstanceId;
-        var effectiveDifficulty = body.Difficulty ?? existing.Difficulty;
-        var effectiveSize = body.Size ?? existing.Size;
+        var effectiveStartTime = hasStartTime
+            ? body.StartTime ?? existing.StartTime
+            : existing.StartTime;
+        var effectiveSignupCloseTime = hasSignupCloseTime
+            ? body.SignupCloseTime ?? ""
+            : existing.SignupCloseTime;
+        var effectiveDescription = hasDescription
+            ? body.Description ?? ""
+            : existing.Description;
+        var effectiveVisibility = hasVisibility
+            ? body.Visibility ?? existing.Visibility
+            : existing.Visibility;
+        var effectiveInstanceId = hasInstanceId
+            ? body.InstanceId
+            : existing.InstanceId;
+        var effectiveDifficulty = hasDifficulty
+            ? body.Difficulty ?? existing.Difficulty
+            : existing.Difficulty;
+        var effectiveSize = hasSize
+            ? body.Size ?? existing.Size
+            : existing.Size;
         // ModeKey stays in storage only — derived here so legacy reads still
         // resolve. The wire no longer carries it.
         var effectiveModeKey = $"{effectiveDifficulty}:{effectiveSize}";
-        var effectiveKeystoneLevel = body.KeystoneLevel ?? existing.KeystoneLevel;
+        var effectiveKeystoneLevel = hasKeystoneLevel
+            ? body.KeystoneLevel
+            : existing.KeystoneLevel;
+
+        var shapeErrors = ValidateEffectiveRunShape(
+            effectiveStartTime,
+            effectiveSignupCloseTime,
+            effectiveInstanceId,
+            effectiveDifficulty,
+            effectiveKeystoneLevel);
+        if (shapeErrors.Count > 0)
+            return Problem.BadRequest(
+                req.HttpContext,
+                "validation-failed",
+                "Request body failed validation.",
+                new Dictionary<string, object?> { ["errors"] = shapeErrors });
 
         // Load instances to validate the (instanceId, difficulty, size)
         // combination and obtain the canonical instance name. Each InstanceDto
@@ -234,14 +283,14 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
         // 8. Apply changes — mirrors applyRunUpdate in runs-update.ts.
         var updated = existing with
         {
-            StartTime = body.StartTime ?? existing.StartTime,
-            SignupCloseTime = body.SignupCloseTime ?? existing.SignupCloseTime,
-            Description = body.Description ?? existing.Description,
+            StartTime = effectiveStartTime,
+            SignupCloseTime = effectiveSignupCloseTime,
+            Description = effectiveDescription,
             ModeKey = effectiveModeKey,
             Difficulty = effectiveDifficulty,
             Size = effectiveSize,
             KeystoneLevel = effectiveKeystoneLevel,
-            Visibility = body.Visibility ?? existing.Visibility,
+            Visibility = effectiveVisibility,
             InstanceId = effectiveInstanceId,
             InstanceName = effectiveInstanceName,
             CreatorGuild = isGuildPromotion
@@ -291,4 +340,39 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
         CancellationToken ct)
         => Run(req, id, ctx, ct);
 
+    private static bool HasJsonProperty(JsonElement root, string name)
+    {
+        foreach (var property in root.EnumerateObject())
+        {
+            if (property.NameEquals(name)
+                || string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+
+    private static IReadOnlyList<string> ValidateEffectiveRunShape(
+        string startTime,
+        string signupCloseTime,
+        int? instanceId,
+        string difficulty,
+        int? keystoneLevel)
+    {
+        var errors = new List<string>();
+        if (!RunRequestTimeRules.SignupCloseTimeIsBeforeStartTime(signupCloseTime, startTime))
+            errors.Add("signupCloseTime must be before startTime");
+
+        if (instanceId is null && difficulty != CreateRunRequestValidator.MythicKeystone)
+            errors.Add("instanceId is required for non-Mythic+ runs");
+
+        if (difficulty != CreateRunRequestValidator.MythicKeystone && keystoneLevel is not null)
+            errors.Add("keystoneLevel is only valid for Mythic+ runs");
+
+        if (difficulty == CreateRunRequestValidator.MythicKeystone
+            && instanceId is null
+            && keystoneLevel is null)
+            errors.Add("keystoneLevel is required when no specific dungeon is selected");
+
+        return errors;
+    }
 }

--- a/api/Middleware/IdempotencyMiddleware.cs
+++ b/api/Middleware/IdempotencyMiddleware.cs
@@ -69,6 +69,12 @@ public sealed class IdempotencyMiddleware : IFunctionsWorkerMiddleware
             return;
         }
 
+        if (IsAccountDelete(httpContext.Request))
+        {
+            await next(context);
+            return;
+        }
+
         if (!httpContext.Request.Headers.TryGetValue(HeaderName, out var values))
         {
             await next(context);
@@ -180,5 +186,17 @@ public sealed class IdempotencyMiddleware : IFunctionsWorkerMiddleware
             problem.Extensions["traceId"] = traceId;
 
         await JsonSerializer.SerializeAsync(httpContext.Response.Body, problem);
+    }
+
+    private static bool IsAccountDelete(HttpRequest request)
+    {
+        if (!HttpMethods.IsDelete(request.Method))
+            return false;
+
+        var path = request.Path.Value;
+        return string.Equals(path, "/api/me", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(path, "/api/v1/me", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(path, "/me", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(path, "/v1/me", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/api/Validation/RequestValidators.cs
+++ b/api/Validation/RequestValidators.cs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
 using System.Text.RegularExpressions;
+using System.Globalization;
 using FluentValidation;
 using Lfm.Contracts.Guild;
 using Lfm.Contracts.Me;
@@ -28,9 +29,18 @@ public sealed class CreateRunRequestValidator : AbstractValidator<CreateRunReque
         RuleFor(x => x.StartTime)
             .NotEmpty().WithMessage("startTime is required")
             .MaximumLength(64).WithMessage("startTime must be at most 64 characters");
+        RuleFor(x => x.StartTime)
+            .Must(RunRequestTimeRules.IsValidDateTimeOrEmpty)
+            .WithMessage("startTime must be a valid date/time");
 
         RuleFor(x => x.SignupCloseTime)
             .MaximumLength(64).WithMessage("signupCloseTime must be at most 64 characters");
+        RuleFor(x => x.SignupCloseTime)
+            .Must(RunRequestTimeRules.IsValidDateTimeOrEmpty)
+            .WithMessage("signupCloseTime must be a valid date/time");
+        RuleFor(x => x)
+            .Must(x => RunRequestTimeRules.SignupCloseTimeIsBeforeStartTime(x.SignupCloseTime, x.StartTime))
+            .WithMessage("signupCloseTime must be before startTime");
 
         RuleFor(x => x.Difficulty)
             .NotEmpty().WithMessage("difficulty is required");
@@ -84,9 +94,18 @@ public sealed class UpdateRunRequestValidator : AbstractValidator<UpdateRunReque
 
         RuleFor(x => x.StartTime)
             .MaximumLength(64).WithMessage("startTime must be at most 64 characters");
+        RuleFor(x => x.StartTime)
+            .Must(RunRequestTimeRules.IsValidDateTimeOrMissing)
+            .WithMessage("startTime must be a valid date/time");
 
         RuleFor(x => x.SignupCloseTime)
             .MaximumLength(64).WithMessage("signupCloseTime must be at most 64 characters");
+        RuleFor(x => x.SignupCloseTime)
+            .Must(RunRequestTimeRules.IsValidDateTimeOrEmpty)
+            .WithMessage("signupCloseTime must be a valid date/time");
+        RuleFor(x => x)
+            .Must(x => RunRequestTimeRules.SignupCloseTimeIsBeforeStartTime(x.SignupCloseTime, x.StartTime))
+            .WithMessage("signupCloseTime must be before startTime");
 
         RuleFor(x => x.Difficulty)
             .Must(d => d is null || CreateRunRequestValidator.ValidDifficulties.Contains(d))
@@ -192,5 +211,45 @@ public sealed class UpdateGuildRequestValidator : AbstractValidator<UpdateGuildR
 
         RuleFor(x => x.Slogan)
             .MaximumLength(200).WithMessage("slogan must be at most 200 characters");
+    }
+}
+
+internal static class RunRequestTimeRules
+{
+    internal static bool IsValidDateTimeOrMissing(string? value) =>
+        value is null || IsValidRequiredDateTime(value);
+
+    internal static bool IsValidDateTimeOrEmpty(string? value) =>
+        string.IsNullOrWhiteSpace(value)
+        || IsValidRequiredDateTime(value);
+
+    private static bool IsValidRequiredDateTime(string value) =>
+        !string.IsNullOrWhiteSpace(value)
+        && DateTimeOffset.TryParse(
+            value,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.RoundtripKind,
+            out _);
+
+    internal static bool SignupCloseTimeIsBeforeStartTime(string? signupCloseTime, string? startTime)
+    {
+        if (string.IsNullOrWhiteSpace(signupCloseTime))
+            return true;
+
+        if (!DateTimeOffset.TryParse(
+                signupCloseTime,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.RoundtripKind,
+                out var closeTime))
+            return true;
+
+        if (!DateTimeOffset.TryParse(
+                startTime,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.RoundtripKind,
+                out var runStart))
+            return true;
+
+        return closeTime < runStart;
     }
 }

--- a/app/Lfm.App.Core/Services/IRunsClient.cs
+++ b/app/Lfm.App.Core/Services/IRunsClient.cs
@@ -31,7 +31,7 @@ public interface IRunsClient
     /// request with 412 Precondition Failed so the caller can prompt the
     /// user to reload instead of showing a generic "save failed" error.
     /// </summary>
-    Task<RunDetailDto?> UpdateAsync(string id, UpdateRunRequest request, string ifMatchEtag, CancellationToken ct);
+    Task<RunDetailWithEtag?> UpdateAsync(string id, UpdateRunRequest request, string ifMatchEtag, CancellationToken ct);
 
     Task<bool> DeleteAsync(string id, CancellationToken ct);
     Task<RunDetailDto?> SignupAsync(string runId, SignupRequest request, CancellationToken ct);

--- a/app/Lfm.App.Core/Services/RunsClient.cs
+++ b/app/Lfm.App.Core/Services/RunsClient.cs
@@ -49,7 +49,7 @@ public sealed class RunsClient(IHttpClientFactory factory) : IRunsClient
         return await response.Content.ReadFromJsonAsync<RunDetailDto>(ct);
     }
 
-    public async Task<RunDetailDto?> UpdateAsync(
+    public async Task<RunDetailWithEtag?> UpdateAsync(
         string id, UpdateRunRequest request, string ifMatchEtag, CancellationToken ct)
     {
         var http = factory.CreateClient("api");
@@ -72,7 +72,11 @@ public sealed class RunsClient(IHttpClientFactory factory) : IRunsClient
             throw new StaleEtagException(body);
         }
         if (!response.IsSuccessStatusCode) return null;
-        return await response.Content.ReadFromJsonAsync<RunDetailDto>(ct);
+
+        var dto = await response.Content.ReadFromJsonAsync<RunDetailDto>(ct);
+        if (dto is null) return null;
+
+        return new RunDetailWithEtag(dto, response.Headers.ETag?.Tag);
     }
 
     public async Task<bool> DeleteAsync(string id, CancellationToken ct)

--- a/app/Pages/CreateRunPage.razor
+++ b/app/Pages/CreateRunPage.razor
@@ -304,7 +304,7 @@
             var expansionsTask = ExpansionsClient.ListAsync(CancellationToken.None);
             var instancesTask = InstancesClient.ListAsync(CancellationToken.None);
             var guildTask = GuildClient.GetAsync(CancellationToken.None);
-            await Task.WhenAll(expansionsTask, instancesTask, guildTask);
+            await Task.WhenAll(expansionsTask, instancesTask);
 
             _expansions = await expansionsTask;
             _allInstances = InstanceOptions.Build(await instancesTask);

--- a/app/Pages/EditRunPage.razor
+++ b/app/Pages/EditRunPage.razor
@@ -361,7 +361,7 @@
             var instancesTask = InstancesClient.ListAsync(CancellationToken.None);
             var expansionsTask = ExpansionsClient.ListAsync(CancellationToken.None);
             var guildTask = GuildClient.GetAsync(CancellationToken.None);
-            await Task.WhenAll(runTask, instancesTask, expansionsTask, guildTask);
+            await Task.WhenAll(runTask, instancesTask, expansionsTask);
 
             var runEnvelope = await runTask;
             if (runEnvelope is null)
@@ -528,15 +528,16 @@
                 return;
             }
 
-            var updated = await RunsClient.UpdateAsync(RunId!, request, _runEtag!, CancellationToken.None);
-            if (updated is null)
+            var updatedEnvelope = await RunsClient.UpdateAsync(RunId!, request, _runEtag!, CancellationToken.None);
+            if (updatedEnvelope is null)
             {
                 _inlineError = new RunError(RunErrorKind.Unknown, [Loc["editRun.saveFailed"].Value]);
             }
             else
             {
+                _runEtag = updatedEnvelope.ETag ?? _runEtag;
                 Toast.ShowSuccess(Loc["editRun.saveSuccess"]);
-                _state = new LoadingState<RunDetailDto>.Success(updated);
+                _state = new LoadingState<RunDetailDto>.Success(updatedEnvelope.Run);
             }
         }
         catch (StaleEtagException)

--- a/tests/Lfm.Api.Tests/Middleware/IdempotencyMiddlewareTests.cs
+++ b/tests/Lfm.Api.Tests/Middleware/IdempotencyMiddlewareTests.cs
@@ -23,10 +23,12 @@ public class IdempotencyMiddlewareTests
     private static (IdempotencyMiddleware middleware, Mock<FunctionContext> context, DefaultHttpContext httpContext, Mock<IIdempotencyStore> store) Setup(
         string method = "POST",
         string? idempotencyKey = "abc-123",
-        SessionPrincipal? principal = null)
+        SessionPrincipal? principal = null,
+        string path = "/api/runs")
     {
         var httpContext = new DefaultHttpContext();
         httpContext.Request.Method = method;
+        httpContext.Request.Path = path;
         httpContext.Response.Body = new MemoryStream();
         if (idempotencyKey is not null)
             httpContext.Request.Headers["Idempotency-Key"] = idempotencyKey;
@@ -200,6 +202,29 @@ public class IdempotencyMiddlewareTests
         await middleware.Invoke(ctx.Object, next);
 
         // Non-2xx responses must not be cached — a retry should re-evaluate.
+        store.Verify(s => s.PutAsync(It.IsAny<IdempotencyEntry>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Bypasses_replay_cache_for_account_delete()
+    {
+        var (middleware, ctx, httpContext, store) = Setup(
+            method: "DELETE",
+            idempotencyKey: "delete-key",
+            principal: MakePrincipal("bnet-1"),
+            path: "/api/v1/me");
+        var nextCalled = false;
+        FunctionExecutionDelegate next = _ =>
+        {
+            nextCalled = true;
+            httpContext.Response.StatusCode = 200;
+            return Task.CompletedTask;
+        };
+
+        await middleware.Invoke(ctx.Object, next);
+
+        Assert.True(nextCalled);
+        store.Verify(s => s.TryGetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         store.Verify(s => s.PutAsync(It.IsAny<IdempotencyEntry>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 

--- a/tests/Lfm.Api.Tests/Runs/CreateRunRequestValidatorTests.cs
+++ b/tests/Lfm.Api.Tests/Runs/CreateRunRequestValidatorTests.cs
@@ -38,6 +38,34 @@ public class CreateRunRequestValidatorTests
     }
 
     [Fact]
+    public void Rejects_invalid_StartTime()
+    {
+        var req = Valid() with { StartTime = "not-a-date" };
+        var result = Sut.Validate(req);
+        Assert.Contains(result.Errors, e => e.ErrorMessage.Contains("startTime must be a valid date/time"));
+    }
+
+    [Fact]
+    public void Rejects_invalid_SignupCloseTime()
+    {
+        var req = Valid() with { SignupCloseTime = "not-a-date" };
+        var result = Sut.Validate(req);
+        Assert.Contains(result.Errors, e => e.ErrorMessage.Contains("signupCloseTime must be a valid date/time"));
+    }
+
+    [Fact]
+    public void Rejects_SignupCloseTime_after_StartTime()
+    {
+        var req = Valid() with
+        {
+            StartTime = "2026-05-01T20:00:00Z",
+            SignupCloseTime = "2026-05-01T21:00:00Z",
+        };
+        var result = Sut.Validate(req);
+        Assert.Contains(result.Errors, e => e.ErrorMessage.Contains("signupCloseTime must be before startTime"));
+    }
+
+    [Fact]
     public void Rejects_missing_Difficulty()
     {
         var req = Valid() with { Difficulty = null };

--- a/tests/Lfm.Api.Tests/RunsCreateFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RunsCreateFunctionTests.cs
@@ -76,6 +76,14 @@ public class RunsCreateFunctionTests
         return httpContext.Request;
     }
 
+    private static HttpRequest MakePostRequest(string rawJson)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(rawJson));
+        httpContext.Request.ContentType = "application/json";
+        return httpContext.Request;
+    }
+
     private static RunsCreateFunction MakeFunction(
         Mock<IRunsRepository> repo,
         Mock<IRaidersRepository> raidersRepo,
@@ -185,6 +193,28 @@ public class RunsCreateFunctionTests
         Assert.True(problem.Extensions.ContainsKey("errors"));
 
         // Cosmos should never be called
+        repo.Verify(r => r.CreateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Run_returns_400_when_body_is_malformed_json()
+    {
+        var principal = MakePrincipal();
+        var repo = new Mock<IRunsRepository>();
+        var raidersRepo = new Mock<IRaidersRepository>();
+        var permissions = new Mock<IGuildPermissions>();
+
+        var fn = MakeFunction(repo, raidersRepo, permissions);
+        var ctx = MakeFunctionContext(principal);
+
+        var result = await fn.Run(MakePostRequest("{"), ctx, CancellationToken.None);
+
+        var badRequest = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(400, badRequest.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(badRequest.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#invalid-body", problem.Type);
+        Assert.Equal("Request body is invalid or missing.", problem.Detail);
+
         repo.Verify(r => r.CreateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 

--- a/tests/Lfm.Api.Tests/RunsUpdateFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RunsUpdateFunctionTests.cs
@@ -83,6 +83,16 @@ public class RunsUpdateFunctionTests
         return httpContext.Request;
     }
 
+    private static HttpRequest MakePutRequest(string rawJson, string? ifMatch = DefaultTestEtag)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(rawJson));
+        httpContext.Request.ContentType = "application/json";
+        if (ifMatch is not null)
+            httpContext.Request.Headers["If-Match"] = ifMatch;
+        return httpContext.Request;
+    }
+
     /// <summary>
     /// A run that is open for editing: startTime is 24 hours in the future,
     /// signupCloseTime is 2 hours before that, no signups yet.
@@ -166,6 +176,218 @@ public class RunsUpdateFunctionTests
 
         // Cosmos UpdateAsync was called once
         repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Run_clears_any_dungeon_fields_when_explicit_nulls_are_sent()
+    {
+        var principal = MakePrincipal(battleNetId: "bnet-creator");
+        var existing = MakeOpenRunDoc(creatorBattleNetId: "bnet-creator") with
+        {
+            Difficulty = "MYTHIC_KEYSTONE",
+            Size = 5,
+            KeystoneLevel = 12,
+            ModeKey = "MYTHIC_KEYSTONE:5",
+        };
+
+        RunDocument? captured = null;
+        var repo = new Mock<IRunsRepository>();
+        repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        repo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Callback<RunDocument, string?, CancellationToken>((doc, _, _) => captured = doc)
+            .ReturnsAsync((RunDocument doc, string? _, CancellationToken _) => doc);
+
+        var permissions = new Mock<IGuildPermissions>();
+        var instancesRepo = new Mock<IInstancesRepository>();
+        instancesRepo.Setup(r => r.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeInstances());
+        var raidersRepo = MakeRaidersRepoFor(MakeRaiderDoc("bnet-creator"));
+
+        var fn = MakeFunction(repo, permissions, instancesRepo, raidersRepo);
+        var ctx = MakeFunctionContext(principal);
+
+        var result = await fn.Run(
+            MakePutRequest("""
+                {
+                  "instanceId": null,
+                  "instanceName": null,
+                  "difficulty": "MYTHIC_KEYSTONE",
+                  "size": 5,
+                  "keystoneLevel": 10
+                }
+                """),
+            "run-1",
+            ctx,
+            CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.NotNull(captured);
+        Assert.Null(captured!.InstanceId);
+        Assert.Null(captured.InstanceName);
+        Assert.Equal("MYTHIC_KEYSTONE", captured.Difficulty);
+        Assert.Equal(5, captured.Size);
+        Assert.Equal(10, captured.KeystoneLevel);
+    }
+
+    [Fact]
+    public async Task Run_rejects_explicit_null_instance_id_when_run_has_signups()
+    {
+        var principal = MakePrincipal(battleNetId: "bnet-creator");
+        var existing = MakeOpenRunDoc(creatorBattleNetId: "bnet-creator") with
+        {
+            Difficulty = "MYTHIC_KEYSTONE",
+            Size = 5,
+            KeystoneLevel = 12,
+            ModeKey = "MYTHIC_KEYSTONE:5",
+            RunCharacters =
+            [
+                new RunCharacterEntry(
+                    Id: "rc-1",
+                    CharacterId: "char-self",
+                    CharacterName: "Selfwarrior",
+                    CharacterRealm: "silvermoon",
+                    CharacterLevel: 80,
+                    CharacterClassId: 1,
+                    CharacterClassName: "Warrior",
+                    CharacterRaceId: 1,
+                    CharacterRaceName: "Human",
+                    RaiderBattleNetId: "bnet-creator",
+                    DesiredAttendance: "IN",
+                    ReviewedAttendance: "IN",
+                    SpecId: 71,
+                    SpecName: "Arms",
+                    Role: "DPS"),
+            ],
+        };
+
+        var repo = new Mock<IRunsRepository>();
+        repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+
+        var permissions = new Mock<IGuildPermissions>();
+        var instancesRepo = new Mock<IInstancesRepository>();
+        var raidersRepo = MakeRaidersRepoFor(MakeRaiderDoc("bnet-creator"));
+
+        var fn = MakeFunction(repo, permissions, instancesRepo, raidersRepo);
+        var ctx = MakeFunctionContext(principal);
+
+        var result = await fn.Run(
+            MakePutRequest("""
+                {
+                  "instanceId": null,
+                  "difficulty": "MYTHIC_KEYSTONE",
+                  "size": 5,
+                  "keystoneLevel": 10
+                }
+                """),
+            "run-1",
+            ctx,
+            CancellationToken.None);
+
+        var badRequest = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(400, badRequest.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(badRequest.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#instance-locked", problem.Type);
+        repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Run_clears_signup_close_time_when_explicit_null_is_sent()
+    {
+        var principal = MakePrincipal(battleNetId: "bnet-creator");
+        var existing = MakeOpenRunDoc(creatorBattleNetId: "bnet-creator");
+
+        RunDocument? captured = null;
+        var repo = new Mock<IRunsRepository>();
+        repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        repo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Callback<RunDocument, string?, CancellationToken>((doc, _, _) => captured = doc)
+            .ReturnsAsync((RunDocument doc, string? _, CancellationToken _) => doc);
+
+        var permissions = new Mock<IGuildPermissions>();
+        var instancesRepo = new Mock<IInstancesRepository>();
+        instancesRepo.Setup(r => r.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeInstances());
+        var raidersRepo = MakeRaidersRepoFor(MakeRaiderDoc("bnet-creator"));
+
+        var fn = MakeFunction(repo, permissions, instancesRepo, raidersRepo);
+        var ctx = MakeFunctionContext(principal);
+
+        var result = await fn.Run(
+            MakePutRequest("""
+                {
+                  "signupCloseTime": null
+                }
+                """),
+            "run-1",
+            ctx,
+            CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.NotNull(captured);
+        Assert.Equal("", captured!.SignupCloseTime);
+    }
+
+    [Fact]
+    public async Task Run_returns_400_when_update_start_time_is_invalid()
+    {
+        var principal = MakePrincipal(battleNetId: "bnet-creator");
+        var existing = MakeOpenRunDoc(creatorBattleNetId: "bnet-creator");
+
+        var repo = new Mock<IRunsRepository>();
+        repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+
+        var permissions = new Mock<IGuildPermissions>();
+        var instancesRepo = new Mock<IInstancesRepository>();
+        var raidersRepo = MakeRaidersRepoFor(MakeRaiderDoc("bnet-creator"));
+
+        var fn = MakeFunction(repo, permissions, instancesRepo, raidersRepo);
+        var ctx = MakeFunctionContext(principal);
+
+        var result = await fn.Run(
+            MakePutRequest(new { startTime = "not-a-date" }),
+            "run-1",
+            ctx,
+            CancellationToken.None);
+
+        var badRequest = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(400, badRequest.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(badRequest.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#validation-failed", problem.Type);
+        repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Run_returns_400_when_update_start_time_is_whitespace()
+    {
+        var principal = MakePrincipal(battleNetId: "bnet-creator");
+        var existing = MakeOpenRunDoc(creatorBattleNetId: "bnet-creator");
+
+        var repo = new Mock<IRunsRepository>();
+        repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+
+        var permissions = new Mock<IGuildPermissions>();
+        var instancesRepo = new Mock<IInstancesRepository>();
+        var raidersRepo = MakeRaidersRepoFor(MakeRaiderDoc("bnet-creator"));
+
+        var fn = MakeFunction(repo, permissions, instancesRepo, raidersRepo);
+        var ctx = MakeFunctionContext(principal);
+
+        var result = await fn.Run(
+            MakePutRequest(new { startTime = "   " }),
+            "run-1",
+            ctx,
+            CancellationToken.None);
+
+        var badRequest = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(400, badRequest.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(badRequest.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#validation-failed", problem.Type);
+        repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     // ------------------------------------------------------------------

--- a/tests/Lfm.App.Core.Tests/Services/RunsClientTests.cs
+++ b/tests/Lfm.App.Core.Tests/Services/RunsClientTests.cs
@@ -202,7 +202,17 @@ public class RunsClientTests
     [Fact]
     public async Task UpdateAsync_puts_request_body_and_if_match_header()
     {
-        var (client, handler) = MakeClient(StubHttpMessageHandler.Json(HttpStatusCode.OK, MakeDetail("run-1")));
+        var detail = MakeDetail("run-1");
+        var handler = new StubHttpMessageHandler(_ =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = System.Net.Http.Json.JsonContent.Create(detail),
+            };
+            response.Headers.ETag = new System.Net.Http.Headers.EntityTagHeaderValue("\"etag-v2\"");
+            return response;
+        });
+        var (client, _) = MakeClient(handler);
         var request = new UpdateRunRequest(
             StartTime: FutureStartTime,
             SignupCloseTime: FutureSignupCloseTime,
@@ -216,6 +226,8 @@ public class RunsClientTests
         var result = await client.UpdateAsync("run-1", request, "\"etag-v1\"", CancellationToken.None);
 
         Assert.NotNull(result);
+        Assert.Equal("run-1", result!.Run.Id);
+        Assert.Equal("\"etag-v2\"", result.ETag);
         Assert.Equal(HttpMethod.Put, handler.LastRequest!.Method);
         Assert.Equal("/api/v1/runs/run-1", handler.LastRequest.RequestUri!.PathAndQuery);
         Assert.Equal("application/json", handler.LastRequest.Content!.Headers.ContentType!.MediaType);

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -485,7 +485,8 @@ public class RunsPagesTests : ComponentTestBase
         IReadOnlyList<InstanceDto>? instances = null,
         IReadOnlyList<ExpansionDto>? expansions = null,
         GuildDto? guild = null,
-        TaskCompletionSource<IReadOnlyList<InstanceDto>>? instancesPending = null)
+        TaskCompletionSource<IReadOnlyList<InstanceDto>>? instancesPending = null,
+        bool guildThrows = false)
     {
         var instancesClient = new Mock<IInstancesClient>();
         if (instancesPending is not null)
@@ -502,8 +503,12 @@ public class RunsPagesTests : ComponentTestBase
         Services.AddSingleton(expansionsClient.Object);
 
         var guildClient = new Mock<IGuildClient>();
-        guildClient.Setup(c => c.GetAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(guild);
+        if (guildThrows)
+            guildClient.Setup(c => c.GetAsync(It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("guild unavailable"));
+        else
+            guildClient.Setup(c => c.GetAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(guild);
         Services.AddSingleton(guildClient.Object);
 
         Services.AddSingleton(new Mock<IRunsClient>().Object);
@@ -543,6 +548,21 @@ public class RunsPagesTests : ComponentTestBase
 
         cut.WaitForAssertion(() =>
             Assert.Contains(Loc("createRun.submit"), cut.Markup));
+    }
+
+    [Fact]
+    public void CreateRunPage_Renders_Public_Form_When_Guild_Load_Fails()
+    {
+        WireCreateRunServices(
+            instances: [MakeInstanceFixture()],
+            guildThrows: true);
+
+        var cut = Render<CreateRunPage>();
+
+        cut.WaitForAssertion(() =>
+            Assert.Contains(Loc("createRun.submit"), cut.Markup));
+        Assert.DoesNotContain("Failed to load form data", cut.Markup);
+        Assert.DoesNotContain(Loc("createRun.guildOnly"), cut.Markup);
     }
 
     [Fact]
@@ -637,7 +657,8 @@ public class RunsPagesTests : ComponentTestBase
         Mock<IRunsClient>? runsClient = null,
         IReadOnlyList<InstanceDto>? instances = null,
         IReadOnlyList<ExpansionDto>? expansions = null,
-        GuildDto? guild = null)
+        GuildDto? guild = null,
+        bool guildThrows = false)
     {
         runsClient ??= new Mock<IRunsClient>();
         var instancesClient = new Mock<IInstancesClient>();
@@ -647,7 +668,11 @@ public class RunsPagesTests : ComponentTestBase
         expansionsClient.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(expansions ?? [new ExpansionDto(505, "The War Within")]);
         var guildClient = new Mock<IGuildClient>();
-        guildClient.Setup(c => c.GetAsync(It.IsAny<CancellationToken>())).ReturnsAsync(guild);
+        if (guildThrows)
+            guildClient.Setup(c => c.GetAsync(It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("guild unavailable"));
+        else
+            guildClient.Setup(c => c.GetAsync(It.IsAny<CancellationToken>())).ReturnsAsync(guild);
 
         Services.AddSingleton(instancesClient.Object);
         Services.AddSingleton(expansionsClient.Object);
@@ -681,6 +706,22 @@ public class RunsPagesTests : ComponentTestBase
 
         cut.WaitForAssertion(() =>
             Assert.Contains(Loc("editRun.saveChanges"), cut.Markup));
+    }
+
+    [Fact]
+    public void EditRunPage_Renders_Public_Form_When_Guild_Load_Fails()
+    {
+        var runsClient = new Mock<IRunsClient>();
+        runsClient.Setup(c => c.GetWithEtagAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunDetailWithEtag(MakeDetail(), "\"etag-v1\""));
+        WireEditRunServices(runsClient, instances: [MakeInstanceFixture()], guildThrows: true);
+
+        var cut = Render<EditRunPage>(p => p.Add(x => x.RunId, "run-1"));
+
+        cut.WaitForAssertion(() =>
+            Assert.Contains(Loc("editRun.saveChanges"), cut.Markup));
+        Assert.DoesNotContain("Failed to load run", cut.Markup);
+        Assert.DoesNotContain(Loc("createRun.guildOnly"), cut.Markup);
     }
 
     [Fact]
@@ -742,7 +783,7 @@ public class RunsPagesTests : ComponentTestBase
                 captured = req;
                 capturedIfMatch = ifMatch;
             })
-            .ReturnsAsync((RunDetailDto?)null);
+            .ReturnsAsync((RunDetailWithEtag?)null);
         WireEditRunServices(runsClient);
 
         var cut = Render<EditRunPage>(p => p.Add(x => x.RunId, "run-1"));
@@ -760,6 +801,40 @@ public class RunsPagesTests : ComponentTestBase
         // Save must echo the loaded ETag on If-Match so the server can reject
         // stale updates with 412 instead of silently overwriting.
         Assert.Equal("\"etag-v1\"", capturedIfMatch);
+    }
+
+    [Fact]
+    public void EditRunPage_Save_Refreshes_Etag_From_Update_Response()
+    {
+        var ifMatches = new List<string>();
+        var runsClient = new Mock<IRunsClient>();
+        runsClient.Setup(c => c.GetWithEtagAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunDetailWithEtag(MakeDetail(), "\"etag-v1\""));
+        runsClient.Setup(c => c.UpdateAsync("run-1", It.IsAny<UpdateRunRequest>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<string, UpdateRunRequest, string, CancellationToken>((_, _, ifMatch, _) => ifMatches.Add(ifMatch))
+            .ReturnsAsync(() =>
+            {
+                var etag = ifMatches.Count == 1 ? "\"etag-v2\"" : "\"etag-v3\"";
+                return new RunDetailWithEtag(MakeDetail(), etag);
+            });
+        WireEditRunServices(runsClient);
+
+        var cut = Render<EditRunPage>(p => p.Add(x => x.RunId, "run-1"));
+
+        cut.WaitForAssertion(() =>
+            Assert.Contains(Loc("editRun.saveChanges"), cut.Markup));
+
+        var saveButton = cut.FindAll("fluent-button")
+            .First(b => b.TextContent.Contains(Loc("editRun.saveChanges")));
+        saveButton.Click();
+        cut.WaitForAssertion(() => Assert.Single(ifMatches));
+
+        saveButton = cut.FindAll("fluent-button")
+            .First(b => b.TextContent.Contains(Loc("editRun.saveChanges")));
+        saveButton.Click();
+        cut.WaitForAssertion(() => Assert.Equal(2, ifMatches.Count));
+
+        Assert.Equal(["\"etag-v1\"", "\"etag-v2\""], ifMatches);
     }
 
     // RD-DIALOG-1 (#26): the delete confirmation renders as a native <dialog>


### PR DESCRIPTION
## Summary

Stale-but-reviewable branch authored as `e7c97c1` on 2026-04-29 19:56 (parent: PR #178 merge `18452e4`). Rebased onto current `main` at `d31cb2c` for review/merge. Single commit, 14 files, +599 / −33.

The branch fills several remaining-after-PR-#178 gaps in the run create/update flow:

| Area | Change |
|------|--------|
| **`api/Functions/RunsCreateFunction.cs`** | Wraps the request-body deserialization in `try/catch (JsonException)` so malformed JSON returns 400 instead of bubbling to a 500. |
| **`api/Functions/RunsUpdateFunction.cs`** | Switches from `JsonSerializer.DeserializeAsync` to `JsonDocument.ParseAsync` + `RootElement.Deserialize<T>()` so the handler can distinguish *omitted* fields from *explicit nulls*. Adds `HasJsonProperty` (case-insensitive) field-presence helper and a post-merge `ValidateEffectiveRunShape` invariant check (signup-close < start, instanceId required for non-Mythic+, keystoneLevel only on Mythic+). The `body.InstanceId is not null` check at `:177` becomes `hasInstanceId` so explicit-null clears the field while omitted leaves it untouched. |
| **`api/Validation/RequestValidators.cs`** | New shared `RunRequestTimeRules` static class — `IsValidDateTimeOrEmpty`, `IsValidDateTimeOrMissing`, `SignupCloseTimeIsBeforeStartTime`. Wires the rules into `CreateRunRequestValidator` and `UpdateRunRequestValidator` via FluentValidation `Must()`. Uses `CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind` everywhere (clears the `LC-3` defensive concern from the bug hunt). |
| **`api/Middleware/IdempotencyMiddleware.cs`** | Adds an early-exit for `DELETE /me` / `/v1/me` / `/api/me` / `/api/v1/me` — account deletion is destructive and must not replay, the second attempt should genuinely 404 (or whatever the real state produces). |
| **`app/Lfm.App.Core/Services/IRunsClient.cs` + `RunsClient.cs`** | `UpdateAsync` return type changes from `RunDetailDto?` to `RunDetailWithEtag?` (envelope of DTO + response ETag). Lets EditRunPage capture the new ETag after a successful save instead of caching the pre-save value. |
| **`app/Pages/EditRunPage.razor`** | Consumes the new envelope: `_runEtag = updatedEnvelope.ETag ?? _runEtag` after save, then unwraps the DTO into `_state`. Drops `guildTask` from the initial `Task.WhenAll` (one fewer parallel API call gating first paint; the page doesn't render guild data on the form). |
| **`app/Pages/CreateRunPage.razor`** | Same `Task.WhenAll` simplification as EditRunPage. |
| **Tests** | New: `tests/Lfm.Api.Tests/Runs/CreateRunRequestValidatorTests.cs` (validator-rule pin). Modified: `RunsCreateFunctionTests.cs` (+30, JsonException → 400), `RunsUpdateFunctionTests.cs` (+222, partial-update field-presence & shape-validation matrix), `IdempotencyMiddlewareTests.cs` (+27, account-delete bypass), `RunsClientTests.cs` (+14, RunDetailWithEtag round-trip), `RunsPagesTests.cs` (+87, EditRunPage etag-after-save behaviour). |

## Provenance / why this PR is opening late

This branch was authored on the original `.worktrees/bug-hunt` directory created at the start of the 2026-04-29 deep-dive bug-hunt session and was never pushed. It surfaced during the session-end finishing pass; rather than discarding 599 lines of useful work, it's being pushed for review now. Rebased onto current `main` cleanly (no conflicts — original parent `18452e4` was the PR #178 merge, which sits on the direct ancestor chain of `d31cb2c`).

## Env / schema changes
None.

## Test plan

- [x] `dotnet build lfm.sln -c Release` — clean, 0 warnings, 0 errors
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` — **726 passed**
- [x] `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release` — **186 passed**
- [x] `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release` — **181 passed**
- [x] `dotnet format lfm.sln --verify-no-changes` — clean
- [x] DevSecOps quick audit (Bicep + Functions changes) — no `bicep.HC-*`, `gha.HC-*`, or other Band-1 findings
- [x] Test-quality quick audit — every new test follows the specification-style pattern; no `block`/`warn` smells
- [x] Responsive-design quick audit — diff is C# / behaviour only, no markup or styling change
- [x] Commit SSH-signed
- [ ] CI green
- [ ] Reviewer sanity-check `RunsUpdateFunctionTests` to confirm assertions are on the **response** (status + body), not on the internal `JsonDocument` shape

## Notes for reviewer

- `RunsUpdateFunction.cs:136` introduces `using var parsedBody = bodyDoc;` — the `bodyDoc` is declared inside the `try` and assigned to `parsedBody` for disposal scope. Slightly unusual structure but correct: parsedBody owns disposal, bodyDoc is a non-owning reference.
- The `IsAccountDelete` path-string match in `IdempotencyMiddleware` uses literal paths rather than `RouteData`. Acceptable for now; flagged as a minor maintenance note if the path layout changes.
- All field-presence checks in `RunsUpdateFunction` use case-insensitive comparison via `HasJsonProperty`, matching `JsonOptions.PropertyNameCaseInsensitive = true` upstream.