### PR TITLE
Add software-design Stop hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -64,6 +64,10 @@
           {
             "type": "command",
             "command": "bash ./scripts/claude/stop-responsive-audit.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash ./scripts/claude/stop-software-design-audit.sh"
           }
         ]
       }

--- a/scripts/claude/stop-software-design-audit.sh
+++ b/scripts/claude/stop-software-design-audit.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 LFM contributors
+
+# Claude Stop hook — nudge the software-design review skill.
+#
+# When Claude is about to finish a turn, check whether any source code,
+# project, or shell-script files have changed relative to main. If so, and
+# the audit has not yet been prompted in this session, block the stop with
+# a directive to invoke the souroldgeezer-design:software-design skill in
+# review mode (quick) on the changed files.
+#
+# Sibling of stop-test-audit.sh, stop-devsecops-audit.sh, and
+# stop-responsive-audit.sh. Uses the same session-marker loop-protection
+# pattern — fires at most once per session.
+#
+# Input: Stop hook JSON on stdin (session_id, cwd, transcript_path, ...).
+# Output: {decision: "block", reason: ...} on stdout if any source / project /
+#         script file changed and not yet prompted this session;
+#         empty exit 0 otherwise.
+#
+# Wired up in .claude/settings.json under hooks.Stop. Codex support deferred.
+
+set -euo pipefail
+
+hook_name="software-design-audit"
+
+# ---- parse stdin ------------------------------------------------------------
+input=$(cat)
+session_id=$(jq -r '.session_id // empty' <<<"$input")
+cwd=$(jq -r '.cwd // empty' <<<"$input")
+stop_hook_active=$(jq -r '.stop_hook_active // false' <<<"$input")
+
+# ---- locate repo root -------------------------------------------------------
+# Use lfm.sln as the identity marker rather than basename, so the hook still
+# fires inside worktrees under .worktrees/<slug>/ (CLAUDE.md mandates them).
+[[ -z "$cwd" ]] && cwd="$PWD"
+repo_root=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || true)
+[[ -z "$repo_root" ]] && exit 0
+[[ -f "$repo_root/lfm.sln" ]] || exit 0
+
+# ---- loop protection: per-session marker ------------------------------------
+marker_dir="$repo_root/.cache/agent-hooks"
+marker="$marker_dir/software-design-audit-prompted-${session_id:-unknown}"
+
+debug_log() {
+  [[ "${AGENT_HOOK_DEBUG:-}" == "1" ||
+     "${CODEX_HOOK_DEBUG:-}" == "1" ||
+     "${CLAUDE_HOOK_DEBUG:-}" == "1" ]] || return 0
+
+  mkdir -p "$marker_dir" || return 0
+  {
+    jq -cn \
+      --arg hook "$hook_name" \
+      --arg event "$1" \
+      --arg session_id "${session_id:-unknown}" \
+      --arg cwd "$cwd" \
+      --arg repo_root "$repo_root" \
+      --arg changed "${changed:-}" \
+      '{ts: now | todateiso8601, hook: $hook, event: $event, session_id: $session_id, cwd: $cwd, repo_root: $repo_root, changed: $changed}' \
+      >>"$marker_dir/debug.jsonl"
+  } 2>/dev/null || true
+}
+
+if [[ "$stop_hook_active" == "true" ]]; then
+  debug_log "skip-stop-hook-active"
+  exit 0
+fi
+
+if [[ -f "$marker" ]]; then
+  debug_log "skip-marker-exists"
+  exit 0
+fi
+
+# ---- require main to exist --------------------------------------------------
+if ! git -C "$repo_root" rev-parse --verify --quiet main >/dev/null; then
+  debug_log "skip-no-main"
+  exit 0
+fi
+
+# ---- detect changed source / project / script files -------------------------
+# Diff working tree + committed changes on branch against main, restricted to
+# files in scope of the software-design skill:
+#
+#   .NET source     — .cs files (production code; tests/ excluded — those are
+#                     covered by test-quality-audit)
+#   .NET projects   — *.csproj, *.sln, *.slnx, Directory.Build.{props,targets},
+#                     global.json (boundary / dependency-direction signals)
+#   shell scripts   — *.sh, *.bash, *.zsh (shell-script extension scope)
+#
+# Razor markup is intentionally not in scope here: visual / a11y / i18n
+# concerns belong to responsive-audit. Razor code-behind (.razor.cs) is also
+# excluded to keep the two hooks disjoint on the UI tree.
+changed=$(git -C "$repo_root" diff --name-only main 2>/dev/null \
+  | grep -vE '^tests/' \
+  | grep -vE '\.razor\.cs$' \
+  | grep -E '\.cs$|\.csproj$|\.sln[x]?$|(^|/)Directory\.Build\.(props|targets)$|(^|/)global\.json$|\.(sh|bash|zsh)$' \
+  || true)
+
+if [[ -z "$changed" ]]; then
+  debug_log "skip-no-changes"
+  exit 0
+fi
+
+# ---- emit block -------------------------------------------------------------
+mkdir -p "$marker_dir"
+touch "$marker"
+debug_log "emit-block"
+
+jq -n --arg files "$changed" '{
+  decision: "block",
+  reason: (
+    "Source / project / shell-script files changed in this task:\n\n" + $files + "\n\n" +
+    "Before finishing, invoke the `souroldgeezer-design:software-design` skill in review mode (quick) on these files. " +
+    "Read the skill reference at `souroldgeezer-design/docs/software-reference/software-design.md`, apply the rubric, " +
+    "load matching extensions (dotnet, shell-script) based on the changed paths, and present per-finding output using " +
+    "the rubric fields (bucket, layer, severity, evidence, action, ref). Cite smells by code — SD-*, dotnet.SD-*, " +
+    "shell.SD-* — and only emit findings that are actionable. " +
+    "This hook fires once per session — you will not be prompted again after this run."
+  )
+}'

--- a/scripts/claude/test-stop-audit-hooks.sh
+++ b/scripts/claude/test-stop-audit-hooks.sh
@@ -67,10 +67,13 @@ devsecops_output=$(hook_input "$fixture" "devsecops-agent-hooks" false |
   AGENT_HOOK_DEBUG=1 bash "$fixture/scripts/claude/stop-devsecops-audit.sh")
 responsive_output=$(hook_input "$fixture" "responsive-agent-hooks" false |
   AGENT_HOOK_DEBUG=1 bash "$fixture/scripts/claude/stop-responsive-audit.sh")
+software_design_output=$(hook_input "$fixture" "software-design-agent-hooks" false |
+  AGENT_HOOK_DEBUG=1 bash "$fixture/scripts/claude/stop-software-design-audit.sh")
 
 assert_block "$test_output" "Unit test files changed"
 assert_block "$devsecops_output" "Security-relevant files changed"
 assert_block "$responsive_output" "UI / app files changed"
+assert_block "$software_design_output" "Source / project / shell-script files changed"
 
 blocked_debug_fixture="$tmp/blocked-debug-repo"
 make_fixture "$blocked_debug_fixture"
@@ -85,6 +88,7 @@ assert_block "$blocked_debug_output" "Unit test files changed"
 [[ -f "$fixture/.cache/agent-hooks/test-audit-prompted-test-agent-hooks" ]]
 [[ -f "$fixture/.cache/agent-hooks/devsecops-audit-prompted-devsecops-agent-hooks" ]]
 [[ -f "$fixture/.cache/agent-hooks/responsive-audit-prompted-responsive-agent-hooks" ]]
+[[ -f "$fixture/.cache/agent-hooks/software-design-audit-prompted-software-design-agent-hooks" ]]
 [[ ! -d "$fixture/.cache/claude-hooks" ]]
 
 debug_log="$fixture/.cache/agent-hooks/debug.jsonl"
@@ -92,6 +96,7 @@ debug_log="$fixture/.cache/agent-hooks/debug.jsonl"
 jq -e 'select(.hook == "test-audit" and .event == "emit-block")' "$debug_log" >/dev/null
 jq -e 'select(.hook == "devsecops-audit" and .event == "emit-block")' "$debug_log" >/dev/null
 jq -e 'select(.hook == "responsive-audit" and .event == "emit-block")' "$debug_log" >/dev/null
+jq -e 'select(.hook == "software-design-audit" and .event == "emit-block")' "$debug_log" >/dev/null
 
 stop_active_output=$(hook_input "$fixture" "new-session" true |
   AGENT_HOOK_DEBUG=1 bash "$fixture/scripts/claude/stop-test-audit.sh")


### PR DESCRIPTION
## Summary

- New `scripts/claude/stop-software-design-audit.sh` Stop hook that nudges the `souroldgeezer-design:software-design` skill in review mode (quick) when source / project / shell-script files have changed vs `main`.
- Wired into `.claude/settings.json` as the 4th sibling of `stop-test-audit`, `stop-devsecops-audit`, and `stop-responsive-audit`. Same once-per-session marker pattern under `.cache/agent-hooks/`.
- Trigger scope: any `.cs`, `.csproj`, `.sln`/`.slnx`, `Directory.Build.{props,targets}`, `global.json`, or `.sh`/`.bash`/`.zsh` change. Excludes `tests/` (covered by `test-quality-audit`) and `*.razor.cs` (kept disjoint from `responsive-audit` on the UI tree).
- `scripts/claude/test-stop-audit-hooks.sh` extended with invocation, block-message assertion, marker-file check, and debug-log emit-block check for the new hook.
- Codex support deferred — `.codex/hooks.json` unchanged.

No env or schema changes. No UI changes.

## Test Plan

- [x] `bash scripts/claude/test-stop-audit-hooks.sh` exits 0 (all 4 hooks emit block, markers written, debug-log entries present, stop-hook-active short-circuit still works)
- [x] `dotnet build lfm.sln -c Release` succeeds (0 warnings, 0 errors)
- [x] `.claude/settings.json` parses as JSON; `hooks.Stop[0].hooks` has 4 commands
- [x] New script staged with mode 100755 (`git ls-files --stage` confirms)
- [ ] Sanity-check in a live session: change a `.cs` file under `api/` or `app/`, end the turn, observe the hook fires once
