### PR TITLE
Add software design stop hook

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -17,6 +17,11 @@
             "type": "command",
             "command": "bash \"$(git rev-parse --show-toplevel)/scripts/claude/stop-responsive-audit.sh\"",
             "statusMessage": "Checking app/UI changes for responsive audit prompt"
+          },
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/scripts/claude/stop-software-design-audit.sh\"",
+            "statusMessage": "Checking source/project/script changes for software design audit prompt"
           }
         ]
       }

--- a/scripts/claude/stop-software-design-audit.sh
+++ b/scripts/claude/stop-software-design-audit.sh
@@ -20,7 +20,7 @@
 #         script file changed and not yet prompted this session;
 #         empty exit 0 otherwise.
 #
-# Wired up in .claude/settings.json under hooks.Stop. Codex support deferred.
+# Wired up in .claude/settings.json and .codex/hooks.json under hooks.Stop.
 
 set -euo pipefail
 

--- a/scripts/claude/test-stop-audit-hooks.sh
+++ b/scripts/claude/test-stop-audit-hooks.sh
@@ -106,6 +106,7 @@ jq -e 'select(.hook == "test-audit" and .event == "skip-stop-hook-active")' "$de
 
 jq -e '
   [.hooks.Stop[].hooks[].statusMessage] as $messages
-  | ($messages | length) == 3
+  | ($messages | length) == 4
+  and any($messages[]; . == "Checking source/project/script changes for software design audit prompt")
   and all($messages[]; type == "string" and length > 0)
 ' "$repo_root/.codex/hooks.json" >/dev/null


### PR DESCRIPTION
## Summary
- Add the software-design audit script to Codex Stop hooks.
- Update the software-design hook note to reflect Claude and Codex wiring.
- Update the stop-hook test harness to expect the fourth Codex status message.

## Test Plan
- [x] `jq -e . .codex/hooks.json`
- [x] `bash -n scripts/claude/stop-software-design-audit.sh`
- [x] `bash -n scripts/claude/test-stop-audit-hooks.sh`
- [x] `bash scripts/claude/test-stop-audit-hooks.sh`
- [x] `git -C /home/souroldgeezer/repos/lfm diff --check`