### PR TITLE
Fix guild member permissions in GuildDto

### DIFF
--- a/api/Functions/GuildAdminFunction.cs
+++ b/api/Functions/GuildAdminFunction.cs
@@ -40,15 +40,7 @@ public class GuildAdminFunction(IGuildRepository guildRepo, ISiteAdminService si
         if (guildDoc is null)
             return Problem.NotFound(req.HttpContext, "guild-not-found", "Guild not found.");
 
-        // Site admin viewing any guild — show admin/editor view but not personal
-        // member permissions. Mirrors the TypeScript site-admin override path.
-        var sitePermissions = new GuildEffectivePermissions(
-            IsAdmin: true,
-            CanCreateGuildRuns: false,
-            CanSignupGuildRuns: false,
-            CanDeleteGuildRuns: false);
-
-        return new OkObjectResult(GuildMapper.MapToDto(guildDoc, sitePermissions));
+        return new OkObjectResult(GuildMapper.MapToDto(guildDoc, GuildEffectivePermissions.SiteAdminView));
     }
 
     /// <summary>

--- a/api/Functions/GuildAdminFunction.cs
+++ b/api/Functions/GuildAdminFunction.cs
@@ -40,7 +40,15 @@ public class GuildAdminFunction(IGuildRepository guildRepo, ISiteAdminService si
         if (guildDoc is null)
             return Problem.NotFound(req.HttpContext, "guild-not-found", "Guild not found.");
 
-        return new OkObjectResult(GuildMapper.MapToDto(guildDoc));
+        // Site admin viewing any guild — show admin/editor view but not personal
+        // member permissions. Mirrors the TypeScript site-admin override path.
+        var sitePermissions = new GuildEffectivePermissions(
+            IsAdmin: true,
+            CanCreateGuildRuns: false,
+            CanSignupGuildRuns: false,
+            CanDeleteGuildRuns: false);
+
+        return new OkObjectResult(GuildMapper.MapToDto(guildDoc, sitePermissions));
     }
 
     /// <summary>

--- a/api/Functions/GuildFunction.cs
+++ b/api/Functions/GuildFunction.cs
@@ -68,12 +68,14 @@ public class GuildFunction(IGuildRepository guildRepo, IRaidersRepository raider
         if (guildDoc is null)
             return Problem.NotFound(req.HttpContext, "guild-not-found", "Guild not found.");
 
+        var permissions = await guildPermissions.GetEffectivePermissionsAsync(raider, cancellationToken);
+
         // Emit the Cosmos _etag so the SPA can echo it as If-Match on PATCH /guild
         // for optimistic concurrency.
         if (!string.IsNullOrEmpty(guildDoc.ETag))
             req.HttpContext.Response.Headers.ETag = guildDoc.ETag;
 
-        return new OkObjectResult(GuildMapper.MapToDto(guildDoc));
+        return new OkObjectResult(GuildMapper.MapToDto(guildDoc, permissions));
     }
 
     /// <summary>
@@ -195,7 +197,8 @@ public class GuildFunction(IGuildRepository guildRepo, IRaidersRepository raider
         if (!string.IsNullOrEmpty(persisted.ETag))
             req.HttpContext.Response.Headers.ETag = persisted.ETag;
 
-        return new OkObjectResult(GuildMapper.MapToDto(persisted));
+        var permissions = await guildPermissions.GetEffectivePermissionsAsync(raider, cancellationToken);
+        return new OkObjectResult(GuildMapper.MapToDto(persisted, permissions));
     }
 
     /// <summary>

--- a/api/Functions/GuildMapper.cs
+++ b/api/Functions/GuildMapper.cs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
 using Lfm.Api.Repositories;
+using Lfm.Api.Services;
 using Lfm.Contracts.Guild;
 
 namespace Lfm.Api.Functions;
@@ -28,7 +29,7 @@ internal static class GuildMapper
                 CanSignupGuildRuns: false,
                 CanDeleteGuildRuns: false));
 
-    internal static GuildDto MapToDto(GuildDocument doc)
+    internal static GuildDto MapToDto(GuildDocument doc, GuildEffectivePermissions permissions)
     {
         var profile = doc.BlizzardProfileRaw;
 
@@ -59,17 +60,30 @@ internal static class GuildMapper
             Timezone: doc.Setup?.Timezone ?? "Europe/Helsinki",
             Locale: doc.Setup?.Locale ?? "fi");
 
-        var editor = new GuildEditorDto(CanEdit: false);
+        var editor = new GuildEditorDto(CanEdit: permissions.IsAdmin);
 
         var memberPermissions = new GuildMemberPermissionsDto(
-            CanCreateGuildRuns: false,
-            CanSignupGuildRuns: false,
-            CanDeleteGuildRuns: false);
+            CanCreateGuildRuns: permissions.CanCreateGuildRuns,
+            CanSignupGuildRuns: permissions.CanSignupGuildRuns,
+            CanDeleteGuildRuns: permissions.CanDeleteGuildRuns);
+
+        GuildSettingsDto? settings = null;
+        if (permissions.IsAdmin)
+        {
+            var rankPerms = (doc.RankPermissions ?? Array.Empty<GuildRankPermission>())
+                .Select(rp => new GuildRankPermissionDto(
+                    Rank: rp.Rank,
+                    CanCreateGuildRuns: rp.CanCreateGuildRuns,
+                    CanSignupGuildRuns: rp.CanSignupGuildRuns,
+                    CanDeleteGuildRuns: rp.CanDeleteGuildRuns))
+                .ToList();
+            settings = new GuildSettingsDto(RankPermissions: rankPerms);
+        }
 
         return new GuildDto(
             Guild: guildInfo,
             Setup: setup,
-            Settings: null,
+            Settings: settings,
             Editor: editor,
             MemberPermissions: memberPermissions);
     }

--- a/api/Services/GuildPermissions.cs
+++ b/api/Services/GuildPermissions.cs
@@ -188,4 +188,50 @@ public sealed class GuildPermissions(IGuildRepository guildRepo) : IGuildPermiss
         // No stored permission entry → fall back to default (only rank 0 can delete).
         return bestRank.Value == 0;
     }
+
+    public async Task<GuildEffectivePermissions> GetEffectivePermissionsAsync(
+        RaiderDocument raider, CancellationToken ct)
+    {
+        var (guildId, _) = GuildResolver.FromRaider(raider);
+        if (guildId is null) return GuildEffectivePermissions.None;
+
+        var guild = await guildRepo.GetAsync(guildId, ct);
+        if (guild?.BlizzardRosterRaw?.Members is null) return GuildEffectivePermissions.None;
+
+        var rankByKey = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var member in guild.BlizzardRosterRaw.Members)
+            rankByKey[$"{member.Character.Realm.Slug}:{member.Character.Name}"] = member.Rank;
+
+        int? bestRank = null;
+        if (raider.Characters is not null)
+        {
+            foreach (var character in raider.Characters)
+            {
+                var key = $"{character.Realm}:{character.Name}";
+                if (rankByKey.TryGetValue(key, out var rank))
+                {
+                    if (bestRank is null || rank < bestRank) bestRank = rank;
+                }
+            }
+        }
+
+        var isAdmin = bestRank == 0;
+
+        // Roster-freshness check matches CanCreate/Signup/DeleteGuildRunsAsync —
+        // 1-hour TTL after BlizzardRosterFetchedAt.
+        var rosterFresh =
+            guild.BlizzardRosterFetchedAt is not null
+            && DateTimeOffset.TryParse(guild.BlizzardRosterFetchedAt, out var fetchedAt)
+            && DateTimeOffset.UtcNow - fetchedAt < TimeSpan.FromHours(1);
+
+        if (!rosterFresh || bestRank is null)
+            return new GuildEffectivePermissions(isAdmin, false, false, false);
+
+        var perm = guild.RankPermissions?.FirstOrDefault(rp => rp.Rank == bestRank.Value);
+        var canCreate = perm is not null ? perm.CanCreateGuildRuns : bestRank.Value == 0;
+        var canSignup = perm is not null ? perm.CanSignupGuildRuns : true;
+        var canDelete = perm is not null ? perm.CanDeleteGuildRuns : bestRank.Value == 0;
+
+        return new GuildEffectivePermissions(isAdmin, canCreate, canSignup, canDelete);
+    }
 }

--- a/api/Services/GuildPermissions.cs
+++ b/api/Services/GuildPermissions.cs
@@ -228,9 +228,9 @@ public sealed class GuildPermissions(IGuildRepository guildRepo) : IGuildPermiss
             return new GuildEffectivePermissions(isAdmin, false, false, false);
 
         var perm = guild.RankPermissions?.FirstOrDefault(rp => rp.Rank == bestRank.Value);
-        var canCreate = perm is not null ? perm.CanCreateGuildRuns : bestRank.Value == 0;
-        var canSignup = perm is not null ? perm.CanSignupGuildRuns : true;
-        var canDelete = perm is not null ? perm.CanDeleteGuildRuns : bestRank.Value == 0;
+        var canCreate = perm?.CanCreateGuildRuns ?? bestRank.Value == 0;
+        var canSignup = perm?.CanSignupGuildRuns ?? true;
+        var canDelete = perm?.CanDeleteGuildRuns ?? bestRank.Value == 0;
 
         return new GuildEffectivePermissions(isAdmin, canCreate, canSignup, canDelete);
     }

--- a/api/Services/IGuildPermissions.cs
+++ b/api/Services/IGuildPermissions.cs
@@ -58,4 +58,26 @@ public interface IGuildPermissions
     /// <c>GuildResolver.FromRaider</c>.
     /// </summary>
     Task<bool> CanDeleteGuildRunsAsync(RaiderDocument raider, CancellationToken ct);
+
+    /// <summary>
+    /// Computes <see cref="IsAdminAsync"/>, <see cref="CanCreateGuildRunsAsync"/>,
+    /// <see cref="CanSignupGuildRunsAsync"/>, and <see cref="CanDeleteGuildRunsAsync"/>
+    /// in a single guild-document load. Use from the guild GET path so a single
+    /// response does not trigger four guild reads.
+    /// </summary>
+    Task<GuildEffectivePermissions> GetEffectivePermissionsAsync(RaiderDocument raider, CancellationToken ct);
+}
+
+/// <summary>
+/// Combined effective permissions returned by
+/// <see cref="IGuildPermissions.GetEffectivePermissionsAsync"/>. Mirrors the
+/// shape consumed by the SPA's <c>GuildMemberPermissionsDto</c> + editor flag.
+/// </summary>
+public sealed record GuildEffectivePermissions(
+    bool IsAdmin,
+    bool CanCreateGuildRuns,
+    bool CanSignupGuildRuns,
+    bool CanDeleteGuildRuns)
+{
+    public static readonly GuildEffectivePermissions None = new(false, false, false, false);
 }

--- a/api/Services/IGuildPermissions.cs
+++ b/api/Services/IGuildPermissions.cs
@@ -80,4 +80,11 @@ public sealed record GuildEffectivePermissions(
     bool CanDeleteGuildRuns)
 {
     public static readonly GuildEffectivePermissions None = new(false, false, false, false);
+
+    /// <summary>
+    /// Site admin viewing a guild they do not belong to: editor view is enabled
+    /// (so admin tooling and Settings render), but personal member permissions
+    /// stay false because the admin is not a guild member.
+    /// </summary>
+    public static readonly GuildEffectivePermissions SiteAdminView = new(IsAdmin: true, false, false, false);
 }

--- a/tests/Lfm.Api.Tests/GuildAdminFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/GuildAdminFunctionTests.cs
@@ -43,6 +43,7 @@ public class GuildAdminFunctionTests
             GuildId: 99,
             RealmSlug: "test-realm",
             Slogan: "Admin view",
+            RankPermissions: new[] { new GuildRankPermission(0, true, true, true) },
             Setup: new GuildSetup(
                 InitializedAt: "2025-01-01T00:00:00Z",
                 Timezone: "Europe/Helsinki",
@@ -137,6 +138,11 @@ public class GuildAdminFunctionTests
         var dto = Assert.IsType<GuildDto>(ok.Value);
         Assert.Equal("fi", dto.Setup.Locale);
         Assert.Equal("Europe/Helsinki", dto.Setup.Timezone);
+        Assert.True(dto.Editor.CanEdit);
+        Assert.NotNull(dto.Settings);
+        Assert.False(dto.MemberPermissions.CanCreateGuildRuns);
+        Assert.False(dto.MemberPermissions.CanSignupGuildRuns);
+        Assert.False(dto.MemberPermissions.CanDeleteGuildRuns);
     }
 
     // ---------------------------------------------------------------------------

--- a/tests/Lfm.Api.Tests/GuildFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/GuildFunctionTests.cs
@@ -83,10 +83,21 @@ public class GuildFunctionTests
         Mock<IGuildPermissions>? permissions = null,
         TestLogger<GuildFunction>? logger = null)
     {
+        // Ensure a freshly-created permissions mock returns a non-null record
+        // for GetEffectivePermissionsAsync so MapToDto does not NRE. Caller-
+        // supplied mocks are expected to set this up themselves when needed.
+        if (permissions is null)
+        {
+            permissions = new Mock<IGuildPermissions>();
+            permissions
+                .Setup(p => p.GetEffectivePermissionsAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(GuildEffectivePermissions.None);
+        }
+
         return new GuildFunction(
             (guildRepo ?? new Mock<IGuildRepository>()).Object,
             (raidersRepo ?? new Mock<IRaidersRepository>()).Object,
-            (permissions ?? new Mock<IGuildPermissions>()).Object,
+            permissions.Object,
             logger ?? new TestLogger<GuildFunction>());
     }
 
@@ -110,6 +121,9 @@ public class GuildFunctionTests
             .ReturnsAsync(raiderDoc);
 
         var permissions = new Mock<IGuildPermissions>();
+        permissions
+            .Setup(p => p.GetEffectivePermissionsAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(GuildEffectivePermissions.None);
 
         var logger = new TestLogger<GuildFunction>();
         var fn = MakeFunction(guildRepo, raidersRepo, permissions, logger);
@@ -122,6 +136,52 @@ public class GuildFunctionTests
         Assert.Equal("fi", dto.Setup.Locale);
         Assert.Equal("Europe/Helsinki", dto.Setup.Timezone);
         Assert.True(dto.Setup.IsInitialized);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 1b: GET surfaces effective permissions in response DTO
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task GuildGet_RankZeroRaider_ReturnsAdminEditorAndSettings()
+    {
+        var principal = MakePrincipal();
+        var guildDoc = MakeGuildDoc() with
+        {
+            RankPermissions =
+            [
+                new GuildRankPermission(Rank: 0, CanCreateGuildRuns: true, CanSignupGuildRuns: true, CanDeleteGuildRuns: true),
+            ],
+        };
+        var raiderDoc = MakeRaiderDoc();
+
+        var guildRepo = new Mock<IGuildRepository>();
+        guildRepo.Setup(r => r.GetAsync("12345", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(guildDoc);
+
+        var raidersRepo = new Mock<IRaidersRepository>();
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(raiderDoc);
+
+        var permissions = new Mock<IGuildPermissions>();
+        permissions
+            .Setup(p => p.GetEffectivePermissionsAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GuildEffectivePermissions(
+                IsAdmin: true,
+                CanCreateGuildRuns: true,
+                CanSignupGuildRuns: true,
+                CanDeleteGuildRuns: true));
+
+        var fn = MakeFunction(guildRepo, raidersRepo, permissions);
+        var ctx = MakeFunctionContext(principal);
+
+        var result = await fn.GuildGet(MakeGetRequest(), ctx, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var dto = Assert.IsType<GuildDto>(ok.Value);
+        Assert.True(dto.Editor.CanEdit);
+        Assert.True(dto.MemberPermissions.CanCreateGuildRuns);
+        Assert.NotNull(dto.Settings);
     }
 
     // ------------------------------------------------------------------
@@ -212,6 +272,8 @@ public class GuildFunctionTests
         var permissions = new Mock<IGuildPermissions>();
         permissions.Setup(p => p.IsAdminAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
+        permissions.Setup(p => p.GetEffectivePermissionsAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(GuildEffectivePermissions.None);
 
         var logger = new TestLogger<GuildFunction>();
         var fn = MakeFunction(guildRepo, raidersRepo, permissions, logger);
@@ -300,6 +362,8 @@ public class GuildFunctionTests
         var permissions = new Mock<IGuildPermissions>();
         permissions.Setup(p => p.IsAdminAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
+        permissions.Setup(p => p.GetEffectivePermissionsAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(GuildEffectivePermissions.None);
 
         var fn = MakeFunction(guildRepo, raidersRepo, permissions, logger);
         var ctx = MakeFunctionContext(principal);
@@ -353,6 +417,8 @@ public class GuildFunctionTests
         var permissions = new Mock<IGuildPermissions>();
         permissions.Setup(p => p.IsAdminAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
+        permissions.Setup(p => p.GetEffectivePermissionsAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(GuildEffectivePermissions.None);
 
         var fn = MakeFunction(guildRepo, raidersRepo, permissions);
         var ctx = MakeFunctionContext(principal);
@@ -418,6 +484,8 @@ public class GuildFunctionTests
         var permissions = new Mock<IGuildPermissions>();
         permissions.Setup(p => p.IsAdminAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
+        permissions.Setup(p => p.GetEffectivePermissionsAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(GuildEffectivePermissions.None);
 
         var fn = MakeFunction(guildRepo, raidersRepo, permissions);
         var ctx = MakeFunctionContext(principal);
@@ -451,6 +519,8 @@ public class GuildFunctionTests
         var permissions = new Mock<IGuildPermissions>();
         permissions.Setup(p => p.IsAdminAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
+        permissions.Setup(p => p.GetEffectivePermissionsAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(GuildEffectivePermissions.None);
 
         var fn = MakeFunction(guildRepo, raidersRepo, permissions, logger);
         var ctx = MakeFunctionContext(principal);
@@ -485,6 +555,8 @@ public class GuildFunctionTests
         var permissions = new Mock<IGuildPermissions>();
         permissions.Setup(p => p.IsAdminAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
+        permissions.Setup(p => p.GetEffectivePermissionsAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(GuildEffectivePermissions.None);
 
         var fn = MakeFunction(guildRepo, raidersRepo, permissions);
         var ctx = MakeFunctionContext(principal);

--- a/tests/Lfm.Api.Tests/GuildMapperTests.cs
+++ b/tests/Lfm.Api.Tests/GuildMapperTests.cs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Functions;
+using Lfm.Api.Repositories;
+using Lfm.Api.Services;
+using Xunit;
+
+namespace Lfm.Api.Tests;
+
+public class GuildMapperTests
+{
+    private static GuildDocument SampleDoc() => new(
+        Id: "123",
+        GuildId: 123,
+        RealmSlug: "ravencrest",
+        Slogan: "for the alliance",
+        BlizzardRosterFetchedAt: DateTimeOffset.UtcNow.ToString("o"),
+        BlizzardProfileRaw: new BlizzardGuildProfileRaw(
+            Name: "Test Guild",
+            Realm: new BlizzardGuildProfileRealm(Slug: "ravencrest", Name: "Ravencrest"),
+            Faction: new BlizzardGuildProfileFaction(Name: "Alliance"),
+            MemberCount: 50),
+        RankPermissions: new[]
+        {
+            new GuildRankPermission(Rank: 0, CanCreateGuildRuns: true, CanSignupGuildRuns: true, CanDeleteGuildRuns: true),
+            new GuildRankPermission(Rank: 5, CanCreateGuildRuns: false, CanSignupGuildRuns: true, CanDeleteGuildRuns: false),
+        });
+
+    [Fact]
+    public void MapToDto_RankZero_PopulatesPermissionsAndSettings()
+    {
+        var perms = new GuildEffectivePermissions(
+            IsAdmin: true,
+            CanCreateGuildRuns: true,
+            CanSignupGuildRuns: true,
+            CanDeleteGuildRuns: true);
+
+        var dto = GuildMapper.MapToDto(SampleDoc(), perms);
+
+        Assert.NotNull(dto.Guild);
+        Assert.True(dto.Editor.CanEdit);
+        Assert.True(dto.MemberPermissions.CanCreateGuildRuns);
+        Assert.True(dto.MemberPermissions.CanSignupGuildRuns);
+        Assert.True(dto.MemberPermissions.CanDeleteGuildRuns);
+        Assert.NotNull(dto.Settings);
+        Assert.Equal(2, dto.Settings.RankPermissions.Count);
+    }
+
+    [Fact]
+    public void MapToDto_NonAdmin_OmitsSettings_PopulatesMemberPermissions()
+    {
+        var perms = new GuildEffectivePermissions(
+            IsAdmin: false,
+            CanCreateGuildRuns: false,
+            CanSignupGuildRuns: true,
+            CanDeleteGuildRuns: false);
+
+        var dto = GuildMapper.MapToDto(SampleDoc(), perms);
+
+        Assert.False(dto.Editor.CanEdit);
+        Assert.Null(dto.Settings);
+        Assert.False(dto.MemberPermissions.CanCreateGuildRuns);
+        Assert.True(dto.MemberPermissions.CanSignupGuildRuns);
+        Assert.False(dto.MemberPermissions.CanDeleteGuildRuns);
+    }
+
+    [Fact]
+    public void NoGuildDto_AllFalse()
+    {
+        var dto = GuildMapper.NoGuildDto();
+        Assert.Null(dto.Guild);
+        Assert.False(dto.Editor.CanEdit);
+        Assert.False(dto.MemberPermissions.CanCreateGuildRuns);
+        Assert.False(dto.MemberPermissions.CanSignupGuildRuns);
+        Assert.False(dto.MemberPermissions.CanDeleteGuildRuns);
+        Assert.Null(dto.Settings);
+    }
+}

--- a/tests/Lfm.Api.Tests/GuildPermissionsTests.cs
+++ b/tests/Lfm.Api.Tests/GuildPermissionsTests.cs
@@ -407,4 +407,114 @@ public class GuildPermissionsTests
 
         Assert.False(result);
     }
+
+    // ─── GetEffectivePermissionsAsync ───────────────────────────────────────
+
+    [Fact]
+    public async Task GetEffectivePermissions_RankZero_AllTrue()
+    {
+        var guildRepo = new Mock<IGuildRepository>();
+        guildRepo.Setup(r => r.GetAsync("123", It.IsAny<CancellationToken>())).ReturnsAsync(
+            new GuildDocument(
+                Id: "123",
+                GuildId: 123,
+                RealmSlug: "ravencrest",
+                BlizzardRosterFetchedAt: DateTimeOffset.UtcNow.ToString("o"),
+                BlizzardRosterRaw: new BlizzardGuildRosterRaw(Members: new[]
+                {
+                    new BlizzardGuildRosterMember(
+                        Character: new BlizzardGuildRosterMemberCharacter(
+                            Name: "Alice",
+                            Realm: new BlizzardGuildRosterRealm(Slug: "ravencrest")),
+                        Rank: 0),
+                }),
+                RankPermissions: null));
+
+        var raider = new RaiderDocument(
+            Id: "abc",
+            BattleNetId: "abc",
+            SelectedCharacterId: "us-ravencrest-alice",
+            Locale: null,
+            Characters: new[]
+            {
+                new StoredSelectedCharacter(
+                    Id: "us-ravencrest-alice",
+                    Region: "us",
+                    Realm: "ravencrest",
+                    Name: "Alice",
+                    GuildId: 123,
+                    GuildName: "Test Guild"),
+            });
+
+        var sut = new GuildPermissions(guildRepo.Object);
+        var perms = await sut.GetEffectivePermissionsAsync(raider, CancellationToken.None);
+
+        Assert.True(perms.IsAdmin);
+        Assert.True(perms.CanCreateGuildRuns);
+        Assert.True(perms.CanSignupGuildRuns);
+        Assert.True(perms.CanDeleteGuildRuns);
+    }
+
+    [Fact]
+    public async Task GetEffectivePermissions_NoGuild_AllFalse()
+    {
+        var guildRepo = new Mock<IGuildRepository>();
+        var raider = new RaiderDocument(Id: "abc", BattleNetId: "abc", SelectedCharacterId: null, Locale: null);
+
+        var sut = new GuildPermissions(guildRepo.Object);
+        var perms = await sut.GetEffectivePermissionsAsync(raider, CancellationToken.None);
+
+        Assert.False(perms.IsAdmin);
+        Assert.False(perms.CanCreateGuildRuns);
+        Assert.False(perms.CanSignupGuildRuns);
+        Assert.False(perms.CanDeleteGuildRuns);
+        guildRepo.Verify(r => r.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetEffectivePermissions_StaleRoster_AdminTrue_RunPermsFalse()
+    {
+        var guildRepo = new Mock<IGuildRepository>();
+        guildRepo.Setup(r => r.GetAsync("123", It.IsAny<CancellationToken>())).ReturnsAsync(
+            new GuildDocument(
+                Id: "123",
+                GuildId: 123,
+                RealmSlug: "ravencrest",
+                // 2 hours old — past the 1-hour TTL.
+                BlizzardRosterFetchedAt: DateTimeOffset.UtcNow.AddHours(-2).ToString("o"),
+                BlizzardRosterRaw: new BlizzardGuildRosterRaw(Members: new[]
+                {
+                    new BlizzardGuildRosterMember(
+                        Character: new BlizzardGuildRosterMemberCharacter(
+                            Name: "Alice",
+                            Realm: new BlizzardGuildRosterRealm(Slug: "ravencrest")),
+                        Rank: 0),
+                }),
+                RankPermissions: null));
+
+        var raider = new RaiderDocument(
+            Id: "abc",
+            BattleNetId: "abc",
+            SelectedCharacterId: "us-ravencrest-alice",
+            Locale: null,
+            Characters: new[]
+            {
+                new StoredSelectedCharacter(
+                    Id: "us-ravencrest-alice",
+                    Region: "us",
+                    Realm: "ravencrest",
+                    Name: "Alice",
+                    GuildId: 123,
+                    GuildName: "Test Guild"),
+            });
+
+        var sut = new GuildPermissions(guildRepo.Object);
+        var perms = await sut.GetEffectivePermissionsAsync(raider, CancellationToken.None);
+
+        // IsAdmin does not require fresh roster; CanX permissions do.
+        Assert.True(perms.IsAdmin);
+        Assert.False(perms.CanCreateGuildRuns);
+        Assert.False(perms.CanSignupGuildRuns);
+        Assert.False(perms.CanDeleteGuildRuns);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a TS→.NET port regression where `GuildMapper.MapToDto` hardcoded `Editor.CanEdit = false`, `MemberPermissions = all-false`, and `Settings = null`. The TypeScript implementation populated all three from the caller's effective rank permissions; the SPA reads `_guild?.MemberPermissions?.CanCreateGuildRuns` to default the visibility selector in `CreateRunPage` and to gate `GuildSettingsEditor`. The regression silently degraded UX for guild members and admins.

- New `IGuildPermissions.GetEffectivePermissionsAsync` returns admin / create / signup / delete in one Cosmos guild-document load (down from four single-purpose calls).
- `GuildMapper.MapToDto` now takes a `GuildEffectivePermissions` parameter and populates `Editor.CanEdit`, `MemberPermissions`, and `Settings` (admin-only) from it.
- `GuildAdminFunction.Run` uses a new `GuildEffectivePermissions.SiteAdminView` factory so site admins see editor view + Settings without inheriting member permissions of guilds they don't belong to.
- 7 new tests close the coverage gap that let the original regression slip in.

Identified during the software design deep review (`docs/superpowersreviews/2026-04-29-software-design-deep-review.md`, finding `SD-B-5`). Tracked as Task A in `docs/superpowers/plans/2026-04-30-software-design-review-followup.md`.

## Test plan

- [x] `dotnet build lfm.sln -c Release` clean (0 warnings)
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` — 733 passed
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error` exit 0
- [x] Spec compliance review ✅
- [x] Code quality review ✅