### PR TITLE
Move translation mappers to api/Mappers

### DIFF
--- a/api/Functions/GuildAdminFunction.cs
+++ b/api/Functions/GuildAdminFunction.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Lfm.Api.Auth;
 using Lfm.Api.Helpers;
+using Lfm.Api.Mappers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;

--- a/api/Functions/GuildFunction.cs
+++ b/api/Functions/GuildFunction.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using Lfm.Api.Audit;
 using Lfm.Api.Auth;
 using Lfm.Api.Helpers;
+using Lfm.Api.Mappers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;

--- a/api/Functions/RunsCancelSignupFunction.cs
+++ b/api/Functions/RunsCancelSignupFunction.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using Lfm.Api.Audit;
 using Lfm.Api.Auth;
 using Lfm.Api.Helpers;
+using Lfm.Api.Mappers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;

--- a/api/Functions/RunsCreateFunction.cs
+++ b/api/Functions/RunsCreateFunction.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using Lfm.Api.Audit;
 using Lfm.Api.Auth;
 using Lfm.Api.Helpers;
+using Lfm.Api.Mappers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;

--- a/api/Functions/RunsDetailFunction.cs
+++ b/api/Functions/RunsDetailFunction.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Lfm.Api.Auth;
 using Lfm.Api.Helpers;
+using Lfm.Api.Mappers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;

--- a/api/Functions/RunsListFunction.cs
+++ b/api/Functions/RunsListFunction.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Lfm.Api.Auth;
 using Lfm.Api.Helpers;
+using Lfm.Api.Mappers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;

--- a/api/Functions/RunsSignupFunction.cs
+++ b/api/Functions/RunsSignupFunction.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using Lfm.Api.Audit;
 using Lfm.Api.Auth;
 using Lfm.Api.Helpers;
+using Lfm.Api.Mappers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;

--- a/api/Functions/RunsUpdateFunction.cs
+++ b/api/Functions/RunsUpdateFunction.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using Lfm.Api.Audit;
 using Lfm.Api.Auth;
 using Lfm.Api.Helpers;
+using Lfm.Api.Mappers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;

--- a/api/Mappers/GuildMapper.cs
+++ b/api/Mappers/GuildMapper.cs
@@ -5,7 +5,7 @@ using Lfm.Api.Repositories;
 using Lfm.Api.Services;
 using Lfm.Contracts.Guild;
 
-namespace Lfm.Api.Functions;
+namespace Lfm.Api.Mappers;
 
 /// <summary>
 /// Shared mapping from <see cref="GuildDocument"/> to <see cref="GuildDto"/>.

--- a/api/Mappers/RunResponseMapper.cs
+++ b/api/Mappers/RunResponseMapper.cs
@@ -5,7 +5,7 @@ using Lfm.Api.Helpers;
 using Lfm.Api.Repositories;
 using Lfm.Contracts.Runs;
 
-namespace Lfm.Api.Functions;
+namespace Lfm.Api.Mappers;
 
 internal static class RunResponseMapper
 {

--- a/tests/Lfm.Api.Tests/GuildMapperTests.cs
+++ b/tests/Lfm.Api.Tests/GuildMapperTests.cs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
-using Lfm.Api.Functions;
+using Lfm.Api.Mappers;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;
 using Xunit;

--- a/tests/Lfm.Api.Tests/RunResponseMapperTests.cs
+++ b/tests/Lfm.Api.Tests/RunResponseMapperTests.cs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
-using Lfm.Api.Functions;
+using Lfm.Api.Mappers;
 using Lfm.Api.Repositories;
 using Xunit;
 


### PR DESCRIPTION
## Summary

Pure mechanical refactor: `api/Functions/RunResponseMapper.cs` and `api/Functions/GuildMapper.cs` are projection helpers, not Functions. Move them to `api/Mappers/` (namespace `Lfm.Api.Mappers`) so the `Functions/` folder only holds HTTP-trigger entry points.

- 2 files moved (git rename similarity 98–99%, no body changes)
- 8 production consumers + 2 test files gain `using Lfm.Api.Mappers;`
- 12 files changed, +12 / -4

Identified during the software design deep review (`docs/superpowersreviews/2026-04-29-software-design-deep-review.md`, finding `dotnet.SD-B-1`). Tracked as Task B in `docs/superpowers/plans/2026-04-30-software-design-review-followup.md`.

## Test plan

- [x] `dotnet build lfm.sln -c Release` clean (0 warnings)
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` — 733 passed
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error` exit 0
- [x] Spec compliance review ✅
- [x] Code quality review ✅