### PR TITLE
Move run domain helpers to api/Runs

### DIFF
--- a/api/Functions/RunsSignupFunction.cs
+++ b/api/Functions/RunsSignupFunction.cs
@@ -12,6 +12,7 @@ using Lfm.Api.Helpers;
 using Lfm.Api.Mappers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
+using Lfm.Api.Runs;
 using Lfm.Api.Services;
 using Lfm.Api.Validation;
 using Lfm.Contracts.Runs;

--- a/api/Functions/RunsUpdateFunction.cs
+++ b/api/Functions/RunsUpdateFunction.cs
@@ -12,6 +12,7 @@ using Lfm.Api.Helpers;
 using Lfm.Api.Mappers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
+using Lfm.Api.Runs;
 using Lfm.Api.Services;
 using Lfm.Api.Validation;
 using Lfm.Contracts.Runs;

--- a/api/Mappers/RunResponseMapper.cs
+++ b/api/Mappers/RunResponseMapper.cs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
-using Lfm.Api.Helpers;
 using Lfm.Api.Repositories;
+using Lfm.Api.Runs;
 using Lfm.Contracts.Runs;
 
 namespace Lfm.Api.Mappers;

--- a/api/Repositories/RunsRepository.cs
+++ b/api/Repositories/RunsRepository.cs
@@ -4,8 +4,8 @@
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Lfm.Api.Helpers;
 using Lfm.Api.Options;
+using Lfm.Api.Runs;
 
 namespace Lfm.Api.Repositories;
 

--- a/api/Runs/RunEditability.cs
+++ b/api/Runs/RunEditability.cs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
-namespace Lfm.Api.Helpers;
+namespace Lfm.Api.Runs;
 
 /// <summary>
 /// Shared editability check for runs. Mirrors isEditingClosed in run-editability.ts.

--- a/api/Runs/RunModeResolver.cs
+++ b/api/Runs/RunModeResolver.cs
@@ -4,7 +4,7 @@
 using Lfm.Api.Repositories;
 using Lfm.Contracts.Runs;
 
-namespace Lfm.Api.Helpers;
+namespace Lfm.Api.Runs;
 
 /// <summary>
 /// Resolves the canonical typed mode fields (<c>Difficulty</c>, <c>Size</c>) for

--- a/tests/Lfm.Api.Tests/Helpers/RunModeResolverTests.cs
+++ b/tests/Lfm.Api.Tests/Helpers/RunModeResolverTests.cs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
-using Lfm.Api.Helpers;
 using Lfm.Api.Repositories;
+using Lfm.Api.Runs;
 using Xunit;
 
 namespace Lfm.Api.Tests.Helpers;

--- a/tests/Lfm.Api.Tests/RunEditabilityTests.cs
+++ b/tests/Lfm.Api.Tests/RunEditabilityTests.cs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
-using Lfm.Api.Helpers;
+using Lfm.Api.Runs;
 using Xunit;
 
 namespace Lfm.Api.Tests;


### PR DESCRIPTION
## Summary

Pure mechanical refactor: `api/Helpers/` was mixing transport types (`Problem`, `InternalErrorResult`) with run-domain policy (`RunEditability`, `RunModeResolver`). Move the run-domain pair to `api/Runs/` (namespace `Lfm.Api.Runs`). `api/Helpers/` is now transport-only.

- 2 files moved (git rename similarity 96–98%, no body changes)
- 6 consumers updated (4 production, 2 test); 2 keep both `using Helpers` + `using Runs` because they consume `Problem.*`, the rest swap to `using Runs` only.
- 8 files changed, +8 / -6

Identified during the software design deep review (`docs/superpowersreviews/2026-04-29-software-design-deep-review.md`, finding `SD-C-3`). Tracked as Task C in `docs/superpowers/plans/2026-04-30-software-design-review-followup.md`.

## Test plan

- [x] `dotnet build lfm.sln -c Release` clean (0 warnings)
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` — 733 passed
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error` exit 0
- [x] Spec compliance review ✅
- [x] Code quality review ✅ (approved with one tiny follow-up to mirror test folder layout, tracked separately)