### PR TITLE
Extract RunFormState shared form model

### DIFF
--- a/app/Lfm.App.Core/Runs/RunFormState.cs
+++ b/app/Lfm.App.Core/Runs/RunFormState.cs
@@ -19,7 +19,7 @@ public sealed class RunFormState
     public IReadOnlyList<ExpansionDto> Expansions { get; private set; } = Array.Empty<ExpansionDto>();
 
     public int ExpansionId { get; set; }
-    public ActivityKind Activity { get; private set; } = ActivityKind.Dungeon;
+    public ActivityKind Activity { get; set; } = ActivityKind.Dungeon;
     public int InstanceId { get; set; }
     public string Difficulty { get; private set; } = "MYTHIC_KEYSTONE";
     public int Size { get; private set; } = 5;

--- a/app/Lfm.App.Core/Runs/RunFormState.cs
+++ b/app/Lfm.App.Core/Runs/RunFormState.cs
@@ -19,7 +19,7 @@ public sealed class RunFormState
     public IReadOnlyList<ExpansionDto> Expansions { get; private set; } = Array.Empty<ExpansionDto>();
 
     public int ExpansionId { get; set; }
-    public ActivityKind Activity { get; set; } = ActivityKind.Dungeon;
+    public ActivityKind Activity { get; private set; } = ActivityKind.Dungeon;
     public int InstanceId { get; set; }
     public string Difficulty { get; private set; } = "MYTHIC_KEYSTONE";
     public int Size { get; private set; } = 5;
@@ -125,6 +125,40 @@ public sealed class RunFormState
         Difficulty = difficulty;
         Size = size;
         KeystoneLevel = keystoneLevel;
+    }
+
+    /// <summary>
+    /// Sets all form state atomically for the populate-from-stored-run path.
+    /// Unlike <see cref="OnActivityChanged"/>, this does NOT cascade clears —
+    /// callers supply every field's intended value.
+    /// </summary>
+    public void Populate(
+        ActivityKind activity,
+        int expansionId,
+        int instanceId,
+        string difficulty,
+        int size,
+        int? keystoneLevel,
+        bool anyDungeon,
+        DateTime? startTimeLocal,
+        DateTime? signupCloseLocal,
+        bool showSignupClose,
+        string visibility,
+        string description)
+    {
+        Activity = activity;
+        ExpansionId = expansionId;
+        InstanceId = instanceId;
+        Difficulty = difficulty;
+        Size = size;
+        KeystoneLevel = keystoneLevel;
+        AnyDungeon = anyDungeon;
+        StartTimeLocal = startTimeLocal;
+        SignupCloseLocal = signupCloseLocal;
+        ShowSignupClose = showSignupClose;
+        Visibility = visibility;
+        Description = description;
+        RefreshDifficultyOptions();
     }
 
     public static int ResolveCurrentSeasonId(IReadOnlyList<ExpansionDto> expansions)

--- a/app/Lfm.App.Core/Runs/RunFormState.cs
+++ b/app/Lfm.App.Core/Runs/RunFormState.cs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Contracts.Expansions;
+
+namespace Lfm.App.Runs;
+
+/// <summary>
+/// Run-form state and behavior shared by the Create and Edit run pages.
+/// Owns the field cluster, derived properties, option-rebuild helpers, and the
+/// canonical "current season" resolution. Pages drive lifecycle (load, populate,
+/// submit/save/delete) and read state via the public properties.
+/// </summary>
+public sealed class RunFormState
+{
+    public const string CurrentSeasonExpansion = "Current Season";
+
+    public IReadOnlyList<InstanceOption> AllInstances { get; private set; } = Array.Empty<InstanceOption>();
+    public IReadOnlyList<ExpansionDto> Expansions { get; private set; } = Array.Empty<ExpansionDto>();
+
+    public int ExpansionId { get; set; }
+    public ActivityKind Activity { get; private set; } = ActivityKind.Dungeon;
+    public int InstanceId { get; set; }
+    public string Difficulty { get; private set; } = "MYTHIC_KEYSTONE";
+    public int Size { get; private set; } = 5;
+    public int? KeystoneLevel { get; set; }
+    public bool AnyDungeon { get; set; } = true;
+    public DateTime? StartTimeLocal { get; set; }
+    public DateTime? SignupCloseLocal { get; set; }
+    public bool ShowSignupClose { get; set; }
+    public string Visibility { get; set; } = "PUBLIC";
+    public string Description { get; set; } = string.Empty;
+
+    public bool CanCreateGuildRuns { get; set; }
+    public bool CanShowGuildOption { get; set; }
+
+    public IReadOnlyList<DifficultyOption> DifficultyOptions { get; private set; } = Array.Empty<DifficultyOption>();
+
+    public IEnumerable<InstanceOption> FilteredInstances =>
+        AllInstances.Where(o =>
+            (o.ExpansionId is null || o.ExpansionId == ExpansionId) &&
+            o.Activity == Activity);
+
+    public bool ShowInstanceDropdown =>
+        !(Activity == ActivityKind.Dungeon && Difficulty == "MYTHIC_KEYSTONE" && AnyDungeon);
+
+    public bool ShowDifficultyToggle => InstanceId != 0 || !ShowInstanceDropdown;
+
+    public bool CanSubmit
+    {
+        get
+        {
+            if (StartTimeLocal is null) return false;
+            var isMythicPlus = Activity == ActivityKind.Dungeon && Difficulty == "MYTHIC_KEYSTONE";
+            if (isMythicPlus && AnyDungeon)
+                return KeystoneLevel is >= 2 and <= 30;
+            if (InstanceId == 0) return false;
+            return !isMythicPlus || KeystoneLevel is null || KeystoneLevel is >= 2 and <= 30;
+        }
+    }
+
+    public void LoadOptions(IReadOnlyList<InstanceOption> instances, IReadOnlyList<ExpansionDto> expansions)
+    {
+        AllInstances = instances;
+        Expansions = expansions;
+        ExpansionId = ResolveCurrentSeasonId(expansions);
+        RefreshDifficultyOptions();
+    }
+
+    public void OnActivityChanged(ActivityKind value)
+    {
+        Activity = value;
+        InstanceId = 0;
+        AnyDungeon = value == ActivityKind.Dungeon;
+        Difficulty = value == ActivityKind.Dungeon ? "MYTHIC_KEYSTONE" : "";
+        Size = value == ActivityKind.Dungeon ? 5 : 0;
+        KeystoneLevel = null;
+        RefreshDifficultyOptions();
+    }
+
+    public void OnDungeonScopeChanged(bool anyDungeon)
+    {
+        AnyDungeon = anyDungeon;
+        if (anyDungeon) InstanceId = 0;
+        RefreshDifficultyOptions();
+    }
+
+    public void OnInstanceChanged(int id)
+    {
+        InstanceId = id;
+        RefreshDifficultyOptions();
+        if (DifficultyOptions.Count > 0 && DifficultyOptions.All(o => o.DifficultyId != Difficulty))
+        {
+            var topMode = FilteredInstances
+                .FirstOrDefault(o => o.InstanceId == id)?
+                .Difficulties.LastOrDefault();
+            if (topMode is not null)
+            {
+                Difficulty = topMode.DifficultyId;
+                Size = topMode.Size;
+            }
+        }
+    }
+
+    public void OnDifficultyChanged(string value)
+    {
+        Difficulty = value;
+        var match = FilteredInstances
+            .FirstOrDefault(o => o.InstanceId == InstanceId)?
+            .Difficulties.FirstOrDefault(d => d.DifficultyId == value);
+        Size = match?.Size ?? 0;
+        if (value != "MYTHIC_KEYSTONE") KeystoneLevel = null;
+    }
+
+    public void RefreshDifficultyOptions()
+    {
+        var match = FilteredInstances.FirstOrDefault(o => o.InstanceId == InstanceId);
+        DifficultyOptions = match is null
+            ? Array.Empty<DifficultyOption>()
+            : match.Difficulties.ToList();
+    }
+
+    public void SetMode(string difficulty, int size, int? keystoneLevel)
+    {
+        Difficulty = difficulty;
+        Size = size;
+        KeystoneLevel = keystoneLevel;
+    }
+
+    public static int ResolveCurrentSeasonId(IReadOnlyList<ExpansionDto> expansions)
+    {
+        var current = expansions.FirstOrDefault(e => e.Name == CurrentSeasonExpansion);
+        if (current is not null) return current.Id;
+        return expansions.Count == 0 ? 0 : expansions.MaxBy(e => e.Id)!.Id;
+    }
+}

--- a/app/Pages/CreateRunPage.razor
+++ b/app/Pages/CreateRunPage.razor
@@ -39,20 +39,20 @@
                     <span id="createRun-activity-label" class="field__label">@Loc["createRun.activity"]</span>
                     <ToggleGroup TValue="ActivityKind"
                                  Options="_activityOptions"
-                                 Value="_activity"
+                                 Value="_form.Activity"
                                  ValueChanged="OnActivityChanged"
                                  AriaLabelledBy="createRun-activity-label"
                                  Disabled="@_submitting" />
                 </div>
 
                 @* ── Dungeon sub-toggle (M+ only) ───────────────────────── *@
-                @if (_activity == ActivityKind.Dungeon && _difficulty == "MYTHIC_KEYSTONE")
+                @if (_form.Activity == ActivityKind.Dungeon && _form.Difficulty == "MYTHIC_KEYSTONE")
                 {
                     <div>
                         <span id="createRun-dungeonScope-label" class="field__label">@Loc["createRun.dungeonScope"]</span>
                         <ToggleGroup TValue="bool"
                                      Options="_dungeonScopeOptions"
-                                     Value="_anyDungeon"
+                                     Value="_form.AnyDungeon"
                                      ValueChanged="OnDungeonScopeChanged"
                                      AriaLabelledBy="createRun-dungeonScope-label"
                                      Disabled="@_submitting" />
@@ -60,16 +60,16 @@
                 }
 
                 @* ── Instance dropdown (hidden when M+ + any-dungeon) ───── *@
-                @if (ShowInstanceDropdown)
+                @if (_form.ShowInstanceDropdown)
                 {
                     <FluentSelect Id="instance-select"
                                   Label="@Loc["createRun.instance"]"
                                   TOption="string"
-                                  Value="@_instanceId.ToString()"
+                                  Value="@_form.InstanceId.ToString()"
                                   ValueChanged="@OnInstanceChanged"
                                   Disabled="@_submitting">
                         <FluentOption Value="0">@Loc["createRun.selectInstance"]</FluentOption>
-                        @foreach (var opt in FilteredInstances)
+                        @foreach (var opt in _form.FilteredInstances)
                         {
                             <FluentOption Value="@opt.InstanceId.ToString()">@opt.Name</FluentOption>
                         }
@@ -77,13 +77,13 @@
                 }
 
                 @* ── Difficulty toggle (only when a specific instance is selected) ── *@
-                @if (ShowDifficultyToggle && _difficultyOptions.Count > 1)
+                @if (_form.ShowDifficultyToggle && _difficultyOptions.Count > 1)
                 {
                     <div>
                         <span id="createRun-difficulty-label" class="field__label">@Loc["createRun.difficulty"]</span>
                         <ToggleGroup TValue="string"
                                      Options="_difficultyOptions"
-                                     Value="_difficulty"
+                                     Value="_form.Difficulty"
                                      ValueChanged="OnDifficultyChanged"
                                      AriaLabelledBy="createRun-difficulty-label"
                                      Disabled="@_submitting" />
@@ -91,7 +91,7 @@
                 }
 
                 @* ── Key level + WNL chip (M+ only) ─────────────────────── *@
-                @if (_difficulty == "MYTHIC_KEYSTONE")
+                @if (_form.Difficulty == "MYTHIC_KEYSTONE")
                 {
                     <div>
                         <label for="keylevel-input" class="field__label">@Loc["createRun.keyLevel"]</label>
@@ -103,7 +103,7 @@
                                    max="30"
                                    inputmode="numeric"
                                    placeholder="@Loc["createRun.keyLevel.placeholder"]"
-                                   @bind="_keystoneLevel"
+                                   @bind="_form.KeystoneLevel"
                                    @bind:event="oninput"
                                    disabled="@_submitting"
                                    style="inline-size:7rem" />
@@ -114,14 +114,14 @@
                                aria-label duplicating the description would hide "WNL (+10)" from
                                the accessible name and fail the label-in-name check. *@
                             <FluentButton Appearance="Appearance.Outline"
-                                          OnClick="@(() => _keystoneLevel = 10)"
+                                          OnClick="@(() => _form.KeystoneLevel = 10)"
                                           Disabled="@_submitting"
                                           Title="@Loc["createRun.keyLevel.wnlDescription"]">
                                 @Loc["createRun.keyLevel.wnl"]
                             </FluentButton>
                         </FluentStack>
                         <small class="field__hint">
-                            @(_anyDungeon ? Loc["createRun.keyLevel.hintAny"] : Loc["createRun.keyLevel.hintSpecific"])
+                            @(_form.AnyDungeon ? Loc["createRun.keyLevel.hintAny"] : Loc["createRun.keyLevel.hintSpecific"])
                         </small>
                     </div>
                 }
@@ -132,44 +132,44 @@
                     <input type="datetime-local"
                            id="starttime-input"
                            class="field__input"
-                           @bind="_startTimeLocal"
+                           @bind="_form.StartTimeLocal"
                            disabled="@_submitting"
                            required />
                 </label>
 
                 @* ── Signups close (collapsible) ────────────────────────── *@
-                @if (_showSignupClose)
+                @if (_form.ShowSignupClose)
                 {
                     <label class="field">
                         <span class="field__label">@Loc["createRun.signupCloseTime"]</span>
                         <input type="datetime-local"
                                id="signupclose-input"
                                class="field__input"
-                               @bind="_signupCloseLocal"
+                               @bind="_form.SignupCloseLocal"
                                disabled="@_submitting" />
                     </label>
                 }
                 else
                 {
                     <FluentButton Appearance="Appearance.Stealth"
-                                  OnClick="@(() => _showSignupClose = true)"
+                                  OnClick="@(() => _form.ShowSignupClose = true)"
                                   Disabled="@_submitting">
                         @Loc["createRun.addSignupDeadline"]
                     </FluentButton>
                 }
 
                 @* ── Visibility ─────────────────────────────────────────── *@
-                @if (_canShowGuildOption)
+                @if (_form.CanShowGuildOption)
                 {
                     <div>
                         <span id="createRun-visibility-label" class="field__label">@Loc["createRun.visibility"]</span>
                         <ToggleGroup TValue="string"
                                      Options="_visibilityOptions"
-                                     Value="_visibility"
-                                     ValueChanged="@(v => _visibility = v)"
+                                     Value="_form.Visibility"
+                                     ValueChanged="@(v => _form.Visibility = v)"
                                      AriaLabelledBy="createRun-visibility-label"
                                      Disabled="@_submitting" />
-                        @if (!_canCreateGuildRuns)
+                        @if (!_form.CanCreateGuildRuns)
                         {
                             <small class="field__hint">@Loc["createRun.visibility.guildDisabledReason"]</small>
                         }
@@ -187,13 +187,13 @@
                 <div>
                     <FluentTextArea Id="description-input"
                                     Label="@Loc["createRun.description"]"
-                                    Value="@_description"
-                                    ValueChanged="@(v => _description = v ?? string.Empty)"
+                                    Value="@_form.Description"
+                                    ValueChanged="@(v => _form.Description = v ?? string.Empty)"
                                     Disabled="@_submitting"
                                     Rows="5"
                                     Resize="TextAreaResize.Vertical"
                                     @attributes="DescriptionAttrs" />
-                    <small class="field__hint">@(Loc["createRun.description.charCount", _description.Length])</small>
+                    <small class="field__hint">@(Loc["createRun.description.charCount", _form.Description.Length])</small>
                 </div>
 
                 @* ── Error surfacing ────────────────────────────────────── *@
@@ -211,7 +211,7 @@
                 <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="8" Wrap="true">
                     <FluentButton Appearance="Appearance.Accent"
                                   OnClick="@HandleSubmit"
-                                  Disabled="@(!CanSubmit || _submitting)">
+                                  Disabled="@(!_form.CanSubmit || _submitting)">
                         @(_submitting ? Loc["createRun.creating"] : Loc["createRun.submit"])
                     </FluentButton>
                     <FluentButton Appearance="Appearance.Outline"
@@ -226,30 +226,9 @@
 </FluentStack>
 
 @code {
-    // The instance list is scoped to Blizzard's "Current Season" journal
-    // expansion tier. The create-run form does not let the user pick an
-    // expansion — M+, raids, and non-M+ dungeons are all pulled from the
-    // currently-active rotation.
-    private const string CurrentSeasonExpansion = "Current Season";
-
-    // ── Loaded data ────────────────────────────────────────────────────────
-    private IReadOnlyList<ExpansionDto> _expansions = [];
-    private IReadOnlyList<InstanceOption> _allInstances = [];
-    private GuildDto? _guild;
-
     // ── Form state ─────────────────────────────────────────────────────────
-    private int _expansionId;
-    private ActivityKind _activity = ActivityKind.Dungeon;
-    private int _instanceId;                // 0 = unselected
-    private string _difficulty = "MYTHIC_KEYSTONE";
-    private int _size = 5;
-    private int? _keystoneLevel;
-    private bool _anyDungeon = true;        // M+ "Any dungeon" sub-toggle
-    private DateTime? _startTimeLocal;
-    private DateTime? _signupCloseLocal;
-    private bool _showSignupClose;
-    private string _visibility = "PUBLIC";
-    private string _description = string.Empty;
+    private readonly RunFormState _form = new();
+    private GuildDto? _guild;
 
     // ── Page state ─────────────────────────────────────────────────────────
     private bool _loading = true;
@@ -262,33 +241,6 @@
     private IReadOnlyList<(bool, string)> _dungeonScopeOptions = [];
     private IReadOnlyList<(string, string)> _difficultyOptions = [];
     private IReadOnlyList<(string, string)> _visibilityOptions = [];
-
-    // ── Derived ────────────────────────────────────────────────────────────
-    private bool _canCreateGuildRuns;
-    private bool _canShowGuildOption => _guild?.Guild is not null;
-
-    private IEnumerable<InstanceOption> FilteredInstances =>
-        _allInstances.Where(o =>
-            (o.ExpansionId is null || o.ExpansionId == _expansionId) &&
-            o.Activity == _activity);
-
-    private bool ShowInstanceDropdown =>
-        !(_activity == ActivityKind.Dungeon && _difficulty == "MYTHIC_KEYSTONE" && _anyDungeon);
-
-    private bool ShowDifficultyToggle => _instanceId != 0 || !ShowInstanceDropdown;
-
-    private bool CanSubmit
-    {
-        get
-        {
-            if (_startTimeLocal is null) return false;
-            var isMythicPlus = _activity == ActivityKind.Dungeon && _difficulty == "MYTHIC_KEYSTONE";
-            if (isMythicPlus && _anyDungeon)
-                return _keystoneLevel is >= 2 and <= 30;
-            if (_instanceId == 0) return false;
-            return !isMythicPlus || _keystoneLevel is null || _keystoneLevel is >= 2 and <= 30;
-        }
-    }
 
     private static readonly Dictionary<string, object> DescriptionAttrs = new()
     {
@@ -306,22 +258,21 @@
             var guildTask = GuildClient.GetAsync(CancellationToken.None);
             await Task.WhenAll(expansionsTask, instancesTask);
 
-            _expansions = await expansionsTask;
-            _allInstances = InstanceOptions.Build(await instancesTask);
+            _form.LoadOptions(InstanceOptions.Build(await instancesTask), await expansionsTask);
 
             // A guild fetch failure must not block the form — fall back to
             // PUBLIC-only visibility rather than an unusable screen.
             try { _guild = await guildTask; }
             catch { _guild = null; }
 
-            _expansionId = ResolveCurrentSeasonId(_expansions);
+            _form.CanShowGuildOption = _guild?.Guild is not null;
 
             RebuildStaticOptions();
             RefreshDifficultyOptions();
             ApplyVisibilityDefault();
 
             // Start-time defaults to next Thursday at 20:00 local wall-clock.
-            _startTimeLocal = RunTimeDefaults.NextThursday20(DateTime.Now);
+            _form.StartTimeLocal = RunTimeDefaults.NextThursday20(DateTime.Now);
         }
         catch (Exception ex)
         {
@@ -336,49 +287,26 @@
     // ── Event handlers ─────────────────────────────────────────────────────
     private void OnActivityChanged(ActivityKind value)
     {
-        _activity = value;
-        _instanceId = 0;
-        _anyDungeon = value == ActivityKind.Dungeon;
-        _difficulty = value == ActivityKind.Dungeon ? "MYTHIC_KEYSTONE" : "";
-        _size = value == ActivityKind.Dungeon ? 5 : 0;
-        _keystoneLevel = null;
+        _form.OnActivityChanged(value);
         RefreshDifficultyOptions();
     }
 
     private void OnDungeonScopeChanged(bool anyDungeon)
     {
-        _anyDungeon = anyDungeon;
-        if (anyDungeon) _instanceId = 0;
+        _form.OnDungeonScopeChanged(anyDungeon);
         RefreshDifficultyOptions();
     }
 
     private void OnInstanceChanged(string value)
     {
         if (!int.TryParse(value, out var id)) return;
-        _instanceId = id;
+        _form.OnInstanceChanged(id);
         RefreshDifficultyOptions();
-        // Default to the highest-available difficulty of this instance.
-        if (_difficultyOptions.Count > 0 && !_difficultyOptions.Any(o => o.Item1 == _difficulty))
-        {
-            var topMode = FilteredInstances
-                .FirstOrDefault(o => o.InstanceId == id)?
-                .Difficulties.LastOrDefault();
-            if (topMode is not null)
-            {
-                _difficulty = topMode.DifficultyId;
-                _size = topMode.Size;
-            }
-        }
     }
 
     private void OnDifficultyChanged(string value)
     {
-        _difficulty = value;
-        var match = FilteredInstances
-            .FirstOrDefault(o => o.InstanceId == _instanceId)?
-            .Difficulties.FirstOrDefault(d => d.DifficultyId == value);
-        _size = match?.Size ?? 0;
-        if (value != "MYTHIC_KEYSTONE") _keystoneLevel = null;
+        _form.OnDifficultyChanged(value);
     }
 
     // ── Option builders ────────────────────────────────────────────────────
@@ -403,31 +331,19 @@
 
     private void RefreshDifficultyOptions()
     {
-        var match = FilteredInstances.FirstOrDefault(o => o.InstanceId == _instanceId);
-        _difficultyOptions = match is null
-            ? []
-            : match.Difficulties
-                .Select(d => (d.DifficultyId, d.DisplayName))
-                .ToList();
+        _form.RefreshDifficultyOptions();
+        _difficultyOptions = _form.DifficultyOptions
+            .Select(d => (d.DifficultyId, d.DisplayName))
+            .ToList();
     }
 
     private void ApplyVisibilityDefault()
     {
-        _canCreateGuildRuns = _guild?.MemberPermissions?.CanCreateGuildRuns ?? false;
-        if (_canShowGuildOption && _canCreateGuildRuns)
-            _visibility = "GUILD";
+        _form.CanCreateGuildRuns = _guild?.MemberPermissions?.CanCreateGuildRuns ?? false;
+        if (_form.CanShowGuildOption && _form.CanCreateGuildRuns)
+            _form.Visibility = "GUILD";
         else
-            _visibility = "PUBLIC";
-    }
-
-    // Match the Blizzard "Current Season" tier by its canonical English name.
-    // Falls back to the highest-id expansion so the form still works on a
-    // stale manifest that predates the current rotation being ingested.
-    private static int ResolveCurrentSeasonId(IReadOnlyList<ExpansionDto> expansions)
-    {
-        var current = expansions.FirstOrDefault(e => e.Name == CurrentSeasonExpansion);
-        if (current is not null) return current.Id;
-        return expansions.Count == 0 ? 0 : expansions.MaxBy(e => e.Id)!.Id;
+            _form.Visibility = "PUBLIC";
     }
 
     // The native <input type="datetime-local"> binds wall-clock time with no
@@ -442,23 +358,23 @@
     {
         _submitting = true;
         _inlineError = null;
-        var isMythicPlus = _activity == ActivityKind.Dungeon && _difficulty == "MYTHIC_KEYSTONE";
-        var instanceOption = isMythicPlus && _anyDungeon
+        var isMythicPlus = _form.Activity == ActivityKind.Dungeon && _form.Difficulty == "MYTHIC_KEYSTONE";
+        var instanceOption = isMythicPlus && _form.AnyDungeon
             ? null
-            : FilteredInstances.FirstOrDefault(o => o.InstanceId == _instanceId);
+            : _form.FilteredInstances.FirstOrDefault(o => o.InstanceId == _form.InstanceId);
 
         try
         {
             var request = new CreateRunRequest(
-                StartTime: ToIsoOrNull(_startTimeLocal) ?? string.Empty,
-                SignupCloseTime: ToIsoOrNull(_signupCloseLocal),
-                Description: string.IsNullOrWhiteSpace(_description) ? null : _description,
-                Visibility: _visibility,
+                StartTime: ToIsoOrNull(_form.StartTimeLocal) ?? string.Empty,
+                SignupCloseTime: ToIsoOrNull(_form.SignupCloseLocal),
+                Description: string.IsNullOrWhiteSpace(_form.Description) ? null : _form.Description,
+                Visibility: _form.Visibility,
                 InstanceId: instanceOption?.InstanceId,
                 InstanceName: instanceOption?.Name,
-                Difficulty: _difficulty,
-                Size: _size,
-                KeystoneLevel: isMythicPlus ? _keystoneLevel : null);
+                Difficulty: _form.Difficulty,
+                Size: _form.Size,
+                KeystoneLevel: isMythicPlus ? _form.KeystoneLevel : null);
 
             var created = await RunsClient.CreateAsync(request, CancellationToken.None);
             if (created is null)

--- a/app/Pages/CreateRunPage.razor
+++ b/app/Pages/CreateRunPage.razor
@@ -40,7 +40,7 @@
                     <ToggleGroup TValue="ActivityKind"
                                  Options="_activityOptions"
                                  Value="_form.Activity"
-                                 ValueChanged="OnActivityChanged"
+                                 ValueChanged="HandleActivityChanged"
                                  AriaLabelledBy="createRun-activity-label"
                                  Disabled="@_submitting" />
                 </div>
@@ -53,7 +53,7 @@
                         <ToggleGroup TValue="bool"
                                      Options="_dungeonScopeOptions"
                                      Value="_form.AnyDungeon"
-                                     ValueChanged="OnDungeonScopeChanged"
+                                     ValueChanged="HandleDungeonScopeChanged"
                                      AriaLabelledBy="createRun-dungeonScope-label"
                                      Disabled="@_submitting" />
                     </div>
@@ -66,7 +66,7 @@
                                   Label="@Loc["createRun.instance"]"
                                   TOption="string"
                                   Value="@_form.InstanceId.ToString()"
-                                  ValueChanged="@OnInstanceChanged"
+                                  ValueChanged="@HandleInstanceChanged"
                                   Disabled="@_submitting">
                         <FluentOption Value="0">@Loc["createRun.selectInstance"]</FluentOption>
                         @foreach (var opt in _form.FilteredInstances)
@@ -84,7 +84,7 @@
                         <ToggleGroup TValue="string"
                                      Options="_difficultyOptions"
                                      Value="_form.Difficulty"
-                                     ValueChanged="OnDifficultyChanged"
+                                     ValueChanged="HandleDifficultyChanged"
                                      AriaLabelledBy="createRun-difficulty-label"
                                      Disabled="@_submitting" />
                     </div>
@@ -268,7 +268,7 @@
             _form.CanShowGuildOption = _guild?.Guild is not null;
 
             RebuildStaticOptions();
-            RefreshDifficultyOptions();
+            SyncDifficultyOptionTuples();
             ApplyVisibilityDefault();
 
             // Start-time defaults to next Thursday at 20:00 local wall-clock.
@@ -285,26 +285,26 @@
     }
 
     // ── Event handlers ─────────────────────────────────────────────────────
-    private void OnActivityChanged(ActivityKind value)
+    private void HandleActivityChanged(ActivityKind value)
     {
         _form.OnActivityChanged(value);
-        RefreshDifficultyOptions();
+        SyncDifficultyOptionTuples();
     }
 
-    private void OnDungeonScopeChanged(bool anyDungeon)
+    private void HandleDungeonScopeChanged(bool anyDungeon)
     {
         _form.OnDungeonScopeChanged(anyDungeon);
-        RefreshDifficultyOptions();
+        SyncDifficultyOptionTuples();
     }
 
-    private void OnInstanceChanged(string value)
+    private void HandleInstanceChanged(string value)
     {
         if (!int.TryParse(value, out var id)) return;
         _form.OnInstanceChanged(id);
-        RefreshDifficultyOptions();
+        SyncDifficultyOptionTuples();
     }
 
-    private void OnDifficultyChanged(string value)
+    private void HandleDifficultyChanged(string value)
     {
         _form.OnDifficultyChanged(value);
     }
@@ -329,7 +329,7 @@
         };
     }
 
-    private void RefreshDifficultyOptions()
+    private void SyncDifficultyOptionTuples()
     {
         _form.RefreshDifficultyOptions();
         _difficultyOptions = _form.DifficultyOptions

--- a/app/Pages/EditRunPage.razor
+++ b/app/Pages/EditRunPage.razor
@@ -47,7 +47,7 @@
                         <ToggleGroup TValue="ActivityKind"
                                      Options="_activityOptions"
                                      Value="_form.Activity"
-                                     ValueChanged="OnActivityChanged"
+                                     ValueChanged="HandleActivityChanged"
                                      AriaLabelledBy="editRun-activity-label"
                                      Disabled="@(_saving || _hasSignups)" />
                     </div>
@@ -59,7 +59,7 @@
                             <ToggleGroup TValue="bool"
                                          Options="_dungeonScopeOptions"
                                          Value="_form.AnyDungeon"
-                                         ValueChanged="OnDungeonScopeChanged"
+                                         ValueChanged="HandleDungeonScopeChanged"
                                          AriaLabelledBy="editRun-dungeonScope-label"
                                          Disabled="@(_saving || _hasSignups)" />
                         </div>
@@ -71,7 +71,7 @@
                                       Label="@Loc["createRun.instance"]"
                                       TOption="string"
                                       Value="@_form.InstanceId.ToString()"
-                                      ValueChanged="@OnInstanceChanged"
+                                      ValueChanged="@HandleInstanceChanged"
                                       Disabled="@(_saving || _hasSignups)">
                             <FluentOption Value="0">@Loc["createRun.selectInstance"]</FluentOption>
                             @foreach (var opt in _form.FilteredInstances)
@@ -88,7 +88,7 @@
                             <ToggleGroup TValue="string"
                                          Options="_difficultyOptions"
                                          Value="_form.Difficulty"
-                                         ValueChanged="OnDifficultyChanged"
+                                         ValueChanged="HandleDifficultyChanged"
                                          AriaLabelledBy="editRun-difficulty-label"
                                          Disabled="@(_saving || _hasSignups)" />
                         </div>
@@ -381,30 +381,30 @@
             visibility: string.IsNullOrEmpty(run.Visibility) ? "PUBLIC" : run.Visibility,
             description: run.Description ?? string.Empty);
 
-        RefreshDifficultyOptions();
+        SyncDifficultyOptionTuples();
         _form.CanCreateGuildRuns = _guild?.MemberPermissions?.CanCreateGuildRuns ?? false;
     }
 
-    private void OnActivityChanged(ActivityKind value)
+    private void HandleActivityChanged(ActivityKind value)
     {
         _form.OnActivityChanged(value);
-        RefreshDifficultyOptions();
+        SyncDifficultyOptionTuples();
     }
 
-    private void OnDungeonScopeChanged(bool anyDungeon)
+    private void HandleDungeonScopeChanged(bool anyDungeon)
     {
         _form.OnDungeonScopeChanged(anyDungeon);
-        RefreshDifficultyOptions();
+        SyncDifficultyOptionTuples();
     }
 
-    private void OnInstanceChanged(string value)
+    private void HandleInstanceChanged(string value)
     {
         if (!int.TryParse(value, out var id)) return;
         _form.OnInstanceChanged(id);
-        RefreshDifficultyOptions();
+        SyncDifficultyOptionTuples();
     }
 
-    private void OnDifficultyChanged(string value)
+    private void HandleDifficultyChanged(string value)
     {
         _form.OnDifficultyChanged(value);
     }
@@ -428,7 +428,7 @@
         };
     }
 
-    private void RefreshDifficultyOptions()
+    private void SyncDifficultyOptionTuples()
     {
         _form.RefreshDifficultyOptions();
         _difficultyOptions = _form.DifficultyOptions

--- a/app/Pages/EditRunPage.razor
+++ b/app/Pages/EditRunPage.razor
@@ -46,55 +46,55 @@
                         <span id="editRun-activity-label" class="field__label">@Loc["createRun.activity"]</span>
                         <ToggleGroup TValue="ActivityKind"
                                      Options="_activityOptions"
-                                     Value="_activity"
+                                     Value="_form.Activity"
                                      ValueChanged="OnActivityChanged"
                                      AriaLabelledBy="editRun-activity-label"
                                      Disabled="@(_saving || _hasSignups)" />
                     </div>
 
-                    @if (_activity == ActivityKind.Dungeon && _difficulty == "MYTHIC_KEYSTONE")
+                    @if (_form.Activity == ActivityKind.Dungeon && _form.Difficulty == "MYTHIC_KEYSTONE")
                     {
                         <div>
                             <span id="editRun-dungeonScope-label" class="field__label">@Loc["createRun.dungeonScope"]</span>
                             <ToggleGroup TValue="bool"
                                          Options="_dungeonScopeOptions"
-                                         Value="_anyDungeon"
+                                         Value="_form.AnyDungeon"
                                          ValueChanged="OnDungeonScopeChanged"
                                          AriaLabelledBy="editRun-dungeonScope-label"
                                          Disabled="@(_saving || _hasSignups)" />
                         </div>
                     }
 
-                    @if (ShowInstanceDropdown)
+                    @if (_form.ShowInstanceDropdown)
                     {
                         <FluentSelect Id="instance-select"
                                       Label="@Loc["createRun.instance"]"
                                       TOption="string"
-                                      Value="@_instanceId.ToString()"
+                                      Value="@_form.InstanceId.ToString()"
                                       ValueChanged="@OnInstanceChanged"
                                       Disabled="@(_saving || _hasSignups)">
                             <FluentOption Value="0">@Loc["createRun.selectInstance"]</FluentOption>
-                            @foreach (var opt in FilteredInstances)
+                            @foreach (var opt in _form.FilteredInstances)
                             {
                                 <FluentOption Value="@opt.InstanceId.ToString()">@opt.Name</FluentOption>
                             }
                         </FluentSelect>
                     }
 
-                    @if (ShowDifficultyToggle && _difficultyOptions.Count > 1)
+                    @if (_form.ShowDifficultyToggle && _difficultyOptions.Count > 1)
                     {
                         <div>
                             <span id="editRun-difficulty-label" class="field__label">@Loc["createRun.difficulty"]</span>
                             <ToggleGroup TValue="string"
                                          Options="_difficultyOptions"
-                                         Value="_difficulty"
+                                         Value="_form.Difficulty"
                                          ValueChanged="OnDifficultyChanged"
                                          AriaLabelledBy="editRun-difficulty-label"
                                          Disabled="@(_saving || _hasSignups)" />
                         </div>
                     }
 
-                    @if (_difficulty == "MYTHIC_KEYSTONE")
+                    @if (_form.Difficulty == "MYTHIC_KEYSTONE")
                     {
                         <div>
                             <label for="keylevel-input" class="field__label">@Loc["createRun.keyLevel"]</label>
@@ -106,12 +106,12 @@
                                        max="30"
                                        inputmode="numeric"
                                        placeholder="@Loc["createRun.keyLevel.placeholder"]"
-                                       @bind="_keystoneLevel"
+                                       @bind="_form.KeystoneLevel"
                                        @bind:event="oninput"
                                        disabled="@_saving"
                                        style="inline-size:7rem" />
                                 <FluentButton Appearance="Appearance.Outline"
-                                              OnClick="@(() => _keystoneLevel = 10)"
+                                              OnClick="@(() => _form.KeystoneLevel = 10)"
                                               Disabled="@_saving"
                                               Title="@Loc["createRun.keyLevel.wnlDescription"]"
                                               aria-label="@Loc["createRun.keyLevel.wnlDescription"]">
@@ -119,7 +119,7 @@
                                 </FluentButton>
                             </FluentStack>
                             <small class="field__hint">
-                                @(_anyDungeon ? Loc["createRun.keyLevel.hintAny"] : Loc["createRun.keyLevel.hintSpecific"])
+                                @(_form.AnyDungeon ? Loc["createRun.keyLevel.hintAny"] : Loc["createRun.keyLevel.hintSpecific"])
                             </small>
                         </div>
                     }
@@ -129,42 +129,42 @@
                         <input type="datetime-local"
                                id="starttime-input"
                                class="field__input"
-                               @bind="_startTimeLocal"
+                               @bind="_form.StartTimeLocal"
                                disabled="@(_saving || _hasSignups)"
                                required />
                     </label>
 
-                    @if (_showSignupClose)
+                    @if (_form.ShowSignupClose)
                     {
                         <label class="field">
                             <span class="field__label">@Loc["createRun.signupCloseTime"]</span>
                             <input type="datetime-local"
                                    id="signupclose-input"
                                    class="field__input"
-                                   @bind="_signupCloseLocal"
+                                   @bind="_form.SignupCloseLocal"
                                    disabled="@_saving" />
                         </label>
                     }
                     else
                     {
                         <FluentButton Appearance="Appearance.Stealth"
-                                      OnClick="@(() => _showSignupClose = true)"
+                                      OnClick="@(() => _form.ShowSignupClose = true)"
                                       Disabled="@_saving">
                             @Loc["createRun.addSignupDeadline"]
                         </FluentButton>
                     }
 
-                    @if (_canShowGuildOption)
+                    @if (_form.CanShowGuildOption)
                     {
                         <div>
                             <span id="editRun-visibility-label" class="field__label">@Loc["createRun.visibility"]</span>
                             <ToggleGroup TValue="string"
                                          Options="_visibilityOptions"
-                                         Value="_visibility"
-                                         ValueChanged="@(v => _visibility = v)"
+                                         Value="_form.Visibility"
+                                         ValueChanged="@(v => _form.Visibility = v)"
                                          AriaLabelledBy="editRun-visibility-label"
                                          Disabled="@_saving" />
-                            @if (!_canCreateGuildRuns)
+                            @if (!_form.CanCreateGuildRuns)
                             {
                                 <small class="field__hint">@Loc["createRun.visibility.guildDisabledReason"]</small>
                             }
@@ -174,13 +174,13 @@
                     <div>
                         <FluentTextArea Id="description-input"
                                         Label="@Loc["createRun.description"]"
-                                        Value="@_description"
-                                        ValueChanged="@(v => _description = v ?? string.Empty)"
+                                        Value="@_form.Description"
+                                        ValueChanged="@(v => _form.Description = v ?? string.Empty)"
                                         Disabled="@_saving"
                                         Rows="5"
                                         Resize="TextAreaResize.Vertical"
                                         @attributes="DescriptionAttrs" />
-                        <small class="field__hint">@(Loc["createRun.description.charCount", _description.Length])</small>
+                        <small class="field__hint">@(Loc["createRun.description.charCount", _form.Description.Length])</small>
                     </div>
 
                     @if (_inlineError is not null)
@@ -262,33 +262,12 @@
 </FluentStack>
 
 @code {
-    // The instance list is scoped to Blizzard's "Current Season" journal
-    // expansion tier. The edit-run form does not let the user pick an
-    // expansion — M+, raids, and non-M+ dungeons are all pulled from the
-    // currently-active rotation.
-    private const string CurrentSeasonExpansion = "Current Season";
-
     [Parameter] public string? RunId { get; set; }
 
     // ── Loading ────────────────────────────────────────────────────────────
     private LoadingState<RunDetailDto> _state = new LoadingState<RunDetailDto>.Idle();
-    private IReadOnlyList<ExpansionDto> _expansions = [];
-    private IReadOnlyList<InstanceOption> _allInstances = [];
+    private readonly RunFormState _form = new();
     private GuildDto? _guild;
-
-    // ── Form state ─────────────────────────────────────────────────────────
-    private int _expansionId;
-    private ActivityKind _activity = ActivityKind.Raid;
-    private int _instanceId;
-    private string _difficulty = "";
-    private int _size;
-    private int? _keystoneLevel;
-    private bool _anyDungeon;
-    private DateTime? _startTimeLocal;
-    private DateTime? _signupCloseLocal;
-    private bool _showSignupClose;
-    private string _visibility = "PUBLIC";
-    private string _description = string.Empty;
 
     // ── Page state ─────────────────────────────────────────────────────────
     private bool _saving;
@@ -301,20 +280,6 @@
     private RunError? _inlineError;
     private ElementReference _deleteDialogRef;
     private IJSObjectReference? _dialogModule;
-
-    // ── Derived ────────────────────────────────────────────────────────────
-    private bool _canCreateGuildRuns;
-    private bool _canShowGuildOption => _guild?.Guild is not null;
-
-    private IEnumerable<InstanceOption> FilteredInstances =>
-        _allInstances.Where(o =>
-            (o.ExpansionId is null || o.ExpansionId == _expansionId) &&
-            o.Activity == _activity);
-
-    private bool ShowInstanceDropdown =>
-        !(_activity == ActivityKind.Dungeon && _difficulty == "MYTHIC_KEYSTONE" && _anyDungeon);
-
-    private bool ShowDifficultyToggle => _instanceId != 0 || !ShowInstanceDropdown;
 
     private IReadOnlyList<(ActivityKind, string)> _activityOptions = [];
     private IReadOnlyList<(bool, string)> _dungeonScopeOptions = [];
@@ -334,16 +299,6 @@
 
     private static string? ToIsoOrNull(DateTime? dt) =>
         dt is null ? null : dt.Value.ToUniversalTime().ToString("o");
-
-    // Match the Blizzard "Current Season" tier by its canonical English name.
-    // Falls back to the highest-id expansion so the form still works on a
-    // stale manifest that predates the current rotation being ingested.
-    private static int ResolveCurrentSeasonId(IReadOnlyList<ExpansionDto> expansions)
-    {
-        var current = expansions.FirstOrDefault(e => e.Name == CurrentSeasonExpansion);
-        if (current is not null) return current.Id;
-        return expansions.Count == 0 ? 0 : expansions.MaxBy(e => e.Id)!.Id;
-    }
 
     // ── Lifecycle ──────────────────────────────────────────────────────────
     protected override async Task OnInitializedAsync()
@@ -373,9 +328,10 @@
             var run = runEnvelope.Run;
             _runEtag = runEnvelope.ETag;
 
-            _allInstances = InstanceOptions.Build(await instancesTask);
-            _expansions = await expansionsTask;
+            _form.LoadOptions(InstanceOptions.Build(await instancesTask), await expansionsTask);
             try { _guild = await guildTask; } catch { _guild = null; }
+
+            _form.CanShowGuildOption = _guild?.Guild is not null;
 
             _hasSignups = run.RunCharacters.Count > 0;
             RebuildStaticOptions();
@@ -395,76 +351,54 @@
         // If the run is an M+ "any dungeon" session (InstanceId null), fall back
         // to the dungeon-any branch with no specific instance selected.
         var match = run.InstanceId is int id
-            ? _allInstances.FirstOrDefault(o => o.InstanceId == id)
+            ? _form.AllInstances.FirstOrDefault(o => o.InstanceId == id)
             : null;
 
-        _activity = match?.Activity
+        _form.Activity = match?.Activity
             ?? (run.Difficulty == "MYTHIC_KEYSTONE" ? ActivityKind.Dungeon : ActivityKind.Raid);
-        _expansionId = match?.ExpansionId ?? ResolveCurrentSeasonId(_expansions);
-        _instanceId = match?.InstanceId ?? 0;
-        _difficulty = string.IsNullOrEmpty(run.Difficulty)
+        _form.ExpansionId = match?.ExpansionId ?? RunFormState.ResolveCurrentSeasonId(_form.Expansions);
+        _form.InstanceId = match?.InstanceId ?? 0;
+        var difficulty = string.IsNullOrEmpty(run.Difficulty)
             ? (match?.Difficulties.LastOrDefault()?.DifficultyId ?? "")
             : run.Difficulty;
-        _size = run.Size > 0 ? run.Size : (match?.Difficulties.FirstOrDefault(d => d.DifficultyId == _difficulty)?.Size ?? 0);
-        _keystoneLevel = run.KeystoneLevel;
-        _anyDungeon = _activity == ActivityKind.Dungeon
-                      && _difficulty == "MYTHIC_KEYSTONE"
-                      && run.InstanceId is null;
+        var size = run.Size > 0 ? run.Size : (match?.Difficulties.FirstOrDefault(d => d.DifficultyId == difficulty)?.Size ?? 0);
+        _form.SetMode(difficulty, size, run.KeystoneLevel);
+        _form.AnyDungeon = _form.Activity == ActivityKind.Dungeon
+                          && _form.Difficulty == "MYTHIC_KEYSTONE"
+                          && run.InstanceId is null;
 
-        _startTimeLocal = ParseIso(run.StartTime);
-        _signupCloseLocal = ParseIso(run.SignupCloseTime);
-        _showSignupClose = _signupCloseLocal is not null;
-        _visibility = string.IsNullOrEmpty(run.Visibility) ? "PUBLIC" : run.Visibility;
-        _description = run.Description ?? string.Empty;
+        _form.StartTimeLocal = ParseIso(run.StartTime);
+        _form.SignupCloseLocal = ParseIso(run.SignupCloseTime);
+        _form.ShowSignupClose = _form.SignupCloseLocal is not null;
+        _form.Visibility = string.IsNullOrEmpty(run.Visibility) ? "PUBLIC" : run.Visibility;
+        _form.Description = run.Description ?? string.Empty;
 
         RefreshDifficultyOptions();
-        _canCreateGuildRuns = _guild?.MemberPermissions?.CanCreateGuildRuns ?? false;
+        _form.CanCreateGuildRuns = _guild?.MemberPermissions?.CanCreateGuildRuns ?? false;
     }
 
     private void OnActivityChanged(ActivityKind value)
     {
-        _activity = value;
-        _instanceId = 0;
-        _anyDungeon = value == ActivityKind.Dungeon;
-        _difficulty = value == ActivityKind.Dungeon ? "MYTHIC_KEYSTONE" : "";
-        _size = value == ActivityKind.Dungeon ? 5 : 0;
-        _keystoneLevel = null;
+        _form.OnActivityChanged(value);
         RefreshDifficultyOptions();
     }
 
     private void OnDungeonScopeChanged(bool anyDungeon)
     {
-        _anyDungeon = anyDungeon;
-        if (anyDungeon) _instanceId = 0;
+        _form.OnDungeonScopeChanged(anyDungeon);
         RefreshDifficultyOptions();
     }
 
     private void OnInstanceChanged(string value)
     {
         if (!int.TryParse(value, out var id)) return;
-        _instanceId = id;
+        _form.OnInstanceChanged(id);
         RefreshDifficultyOptions();
-        if (_difficultyOptions.Count > 0 && !_difficultyOptions.Any(o => o.Item1 == _difficulty))
-        {
-            var topMode = FilteredInstances
-                .FirstOrDefault(o => o.InstanceId == id)?
-                .Difficulties.LastOrDefault();
-            if (topMode is not null)
-            {
-                _difficulty = topMode.DifficultyId;
-                _size = topMode.Size;
-            }
-        }
     }
 
     private void OnDifficultyChanged(string value)
     {
-        _difficulty = value;
-        var match = FilteredInstances
-            .FirstOrDefault(o => o.InstanceId == _instanceId)?
-            .Difficulties.FirstOrDefault(d => d.DifficultyId == value);
-        _size = match?.Size ?? 0;
-        if (value != "MYTHIC_KEYSTONE") _keystoneLevel = null;
+        _form.OnDifficultyChanged(value);
     }
 
     private void RebuildStaticOptions()
@@ -488,12 +422,10 @@
 
     private void RefreshDifficultyOptions()
     {
-        var match = FilteredInstances.FirstOrDefault(o => o.InstanceId == _instanceId);
-        _difficultyOptions = match is null
-            ? []
-            : match.Difficulties
-                .Select(d => (d.DifficultyId, d.DisplayName))
-                .ToList();
+        _form.RefreshDifficultyOptions();
+        _difficultyOptions = _form.DifficultyOptions
+            .Select(d => (d.DifficultyId, d.DisplayName))
+            .ToList();
     }
 
     // ── Save / delete ──────────────────────────────────────────────────────
@@ -501,23 +433,23 @@
     {
         _saving = true;
         _inlineError = null;
-        var isMythicPlus = _activity == ActivityKind.Dungeon && _difficulty == "MYTHIC_KEYSTONE";
-        var instanceOption = isMythicPlus && _anyDungeon
+        var isMythicPlus = _form.Activity == ActivityKind.Dungeon && _form.Difficulty == "MYTHIC_KEYSTONE";
+        var instanceOption = isMythicPlus && _form.AnyDungeon
             ? null
-            : FilteredInstances.FirstOrDefault(o => o.InstanceId == _instanceId);
+            : _form.FilteredInstances.FirstOrDefault(o => o.InstanceId == _form.InstanceId);
 
         try
         {
             var request = new UpdateRunRequest(
-                StartTime: ToIsoOrNull(_startTimeLocal) ?? string.Empty,
-                SignupCloseTime: ToIsoOrNull(_signupCloseLocal),
-                Description: _description,
-                Visibility: _visibility,
+                StartTime: ToIsoOrNull(_form.StartTimeLocal) ?? string.Empty,
+                SignupCloseTime: ToIsoOrNull(_form.SignupCloseLocal),
+                Description: _form.Description,
+                Visibility: _form.Visibility,
                 InstanceId: instanceOption?.InstanceId,
                 InstanceName: instanceOption?.Name,
-                Difficulty: _difficulty,
-                Size: _size,
-                KeystoneLevel: isMythicPlus ? _keystoneLevel : null);
+                Difficulty: _form.Difficulty,
+                Size: _form.Size,
+                KeystoneLevel: isMythicPlus ? _form.KeystoneLevel : null);
 
             if (string.IsNullOrEmpty(_runEtag))
             {

--- a/app/Pages/EditRunPage.razor
+++ b/app/Pages/EditRunPage.razor
@@ -354,24 +354,32 @@
             ? _form.AllInstances.FirstOrDefault(o => o.InstanceId == id)
             : null;
 
-        _form.Activity = match?.Activity
+        var activity = match?.Activity
             ?? (run.Difficulty == "MYTHIC_KEYSTONE" ? ActivityKind.Dungeon : ActivityKind.Raid);
-        _form.ExpansionId = match?.ExpansionId ?? RunFormState.ResolveCurrentSeasonId(_form.Expansions);
-        _form.InstanceId = match?.InstanceId ?? 0;
+        var expansionId = match?.ExpansionId ?? RunFormState.ResolveCurrentSeasonId(_form.Expansions);
+        var instanceId = match?.InstanceId ?? 0;
         var difficulty = string.IsNullOrEmpty(run.Difficulty)
             ? (match?.Difficulties.LastOrDefault()?.DifficultyId ?? "")
             : run.Difficulty;
         var size = run.Size > 0 ? run.Size : (match?.Difficulties.FirstOrDefault(d => d.DifficultyId == difficulty)?.Size ?? 0);
-        _form.SetMode(difficulty, size, run.KeystoneLevel);
-        _form.AnyDungeon = _form.Activity == ActivityKind.Dungeon
-                          && _form.Difficulty == "MYTHIC_KEYSTONE"
+        var anyDungeon = activity == ActivityKind.Dungeon
+                          && difficulty == "MYTHIC_KEYSTONE"
                           && run.InstanceId is null;
+        var signupCloseLocal = ParseIso(run.SignupCloseTime);
 
-        _form.StartTimeLocal = ParseIso(run.StartTime);
-        _form.SignupCloseLocal = ParseIso(run.SignupCloseTime);
-        _form.ShowSignupClose = _form.SignupCloseLocal is not null;
-        _form.Visibility = string.IsNullOrEmpty(run.Visibility) ? "PUBLIC" : run.Visibility;
-        _form.Description = run.Description ?? string.Empty;
+        _form.Populate(
+            activity: activity,
+            expansionId: expansionId,
+            instanceId: instanceId,
+            difficulty: difficulty,
+            size: size,
+            keystoneLevel: run.KeystoneLevel,
+            anyDungeon: anyDungeon,
+            startTimeLocal: ParseIso(run.StartTime),
+            signupCloseLocal: signupCloseLocal,
+            showSignupClose: signupCloseLocal is not null,
+            visibility: string.IsNullOrEmpty(run.Visibility) ? "PUBLIC" : run.Visibility,
+            description: run.Description ?? string.Empty);
 
         RefreshDifficultyOptions();
         _form.CanCreateGuildRuns = _guild?.MemberPermissions?.CanCreateGuildRuns ?? false;

--- a/tests/Lfm.App.Core.Tests/Runs/RunFormStateTests.cs
+++ b/tests/Lfm.App.Core.Tests/Runs/RunFormStateTests.cs
@@ -107,6 +107,31 @@ public class RunFormStateTests
     }
 
     [Fact]
+    public void OnInstanceChanged_PicksTopModeDifficulty_WhenCurrentUnavailable()
+    {
+        var state = new RunFormState();
+        state.LoadOptions(Instances, Expansions);
+
+        // Start on the dungeon, on Mythic Keystone difficulty.
+        state.OnActivityChanged(ActivityKind.Dungeon);
+        state.OnInstanceChanged(1023); // dungeon "Some Dungeon" — has MYTHIC_KEYSTONE + HEROIC
+
+        // Switch to a raid via Activity. After Activity → Raid, AnyDungeon is false,
+        // Difficulty is "" (empty) per OnActivityChanged, and InstanceId is 0.
+        state.OnActivityChanged(ActivityKind.Raid);
+        Assert.Equal("", state.Difficulty);
+
+        // Now select a raid instance whose difficulty options do NOT contain "" —
+        // the cascade rule should pick the top-of-list (last) DifficultyOption.
+        // Test data: "Some Raid" (id 2055) lists MYTHIC, HEROIC, NORMAL in that
+        // order, so LastOrDefault() = NORMAL with size 20.
+        state.OnInstanceChanged(2055);
+
+        Assert.Equal("NORMAL", state.Difficulty);
+        Assert.Equal(20, state.Size);
+    }
+
+    [Fact]
     public void Populate_SetsAllFields_WithoutCascading()
     {
         var state = new RunFormState();

--- a/tests/Lfm.App.Core.Tests/Runs/RunFormStateTests.cs
+++ b/tests/Lfm.App.Core.Tests/Runs/RunFormStateTests.cs
@@ -105,4 +105,36 @@ public class RunFormStateTests
     {
         Assert.Equal(14, RunFormState.ResolveCurrentSeasonId(Expansions));
     }
+
+    [Fact]
+    public void Populate_SetsAllFields_WithoutCascading()
+    {
+        var state = new RunFormState();
+        state.LoadOptions(Instances, Expansions);
+
+        state.Populate(
+            activity: ActivityKind.Raid,
+            expansionId: 14,
+            instanceId: 2055,
+            difficulty: "MYTHIC",
+            size: 20,
+            keystoneLevel: null,
+            anyDungeon: false,
+            startTimeLocal: new DateTime(2026, 5, 1, 20, 0, 0),
+            signupCloseLocal: null,
+            showSignupClose: false,
+            visibility: "PUBLIC",
+            description: "test");
+
+        Assert.Equal(ActivityKind.Raid, state.Activity);
+        Assert.Equal(2055, state.InstanceId);
+        Assert.Equal("MYTHIC", state.Difficulty);
+        Assert.Equal(20, state.Size);
+        Assert.Null(state.KeystoneLevel);
+        Assert.False(state.AnyDungeon);
+        Assert.Equal("test", state.Description);
+        // The Mythic raid difficulty options for instance 2055 must be loaded
+        // (RefreshDifficultyOptions ran).
+        Assert.Contains(state.DifficultyOptions, d => d.DifficultyId == "MYTHIC");
+    }
 }

--- a/tests/Lfm.App.Core.Tests/Runs/RunFormStateTests.cs
+++ b/tests/Lfm.App.Core.Tests/Runs/RunFormStateTests.cs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.App.Runs;
+using Lfm.Contracts.Expansions;
+using Lfm.Contracts.Instances;
+using Xunit;
+
+namespace Lfm.App.Core.Tests.Runs;
+
+public class RunFormStateTests
+{
+    private static readonly IReadOnlyList<ExpansionDto> Expansions = new[]
+    {
+        new ExpansionDto(Id: 11, Name: "The War Within"),
+        new ExpansionDto(Id: 14, Name: "Current Season"),
+    };
+
+    private static readonly IReadOnlyList<InstanceOption> Instances = new[]
+    {
+        new InstanceOption(
+            InstanceId: 1023,
+            Name: "Some Dungeon",
+            Activity: ActivityKind.Dungeon,
+            ExpansionId: 14,
+            Difficulties: new[]
+            {
+                new DifficultyOption("MYTHIC_KEYSTONE", 5, "Mythic+ (5)"),
+                new DifficultyOption("HEROIC", 5, "Heroic (5)"),
+            }),
+        new InstanceOption(
+            InstanceId: 2055,
+            Name: "Some Raid",
+            Activity: ActivityKind.Raid,
+            ExpansionId: 14,
+            Difficulties: new[]
+            {
+                new DifficultyOption("MYTHIC", 20, "Mythic (20)"),
+                new DifficultyOption("HEROIC", 20, "Heroic (20)"),
+                new DifficultyOption("NORMAL", 20, "Normal (20)"),
+            }),
+    };
+
+    [Fact]
+    public void OnActivityChanged_ToRaid_ClearsInstanceAndKeystone()
+    {
+        var state = new RunFormState();
+        state.LoadOptions(Instances, Expansions);
+        state.OnActivityChanged(ActivityKind.Dungeon);
+        state.InstanceId = 1023;
+        state.KeystoneLevel = 12;
+        state.OnActivityChanged(ActivityKind.Raid);
+
+        Assert.Equal(ActivityKind.Raid, state.Activity);
+        Assert.Equal(0, state.InstanceId);
+        Assert.Null(state.KeystoneLevel);
+        Assert.Equal("", state.Difficulty);
+    }
+
+    [Fact]
+    public void OnDifficultyChanged_NonMythicPlus_ClearsKeystone()
+    {
+        var state = new RunFormState();
+        state.LoadOptions(Instances, Expansions);
+        state.OnActivityChanged(ActivityKind.Dungeon);
+        state.InstanceId = 1023;
+        state.KeystoneLevel = 12;
+        state.OnDifficultyChanged("HEROIC");
+
+        Assert.Equal("HEROIC", state.Difficulty);
+        Assert.Null(state.KeystoneLevel);
+    }
+
+    [Fact]
+    public void CanSubmit_AnyDungeon_RequiresKeystoneInRange()
+    {
+        var state = new RunFormState();
+        state.LoadOptions(Instances, Expansions);
+        state.OnActivityChanged(ActivityKind.Dungeon);
+        state.AnyDungeon = true;
+        state.StartTimeLocal = DateTime.Now.AddDays(1);
+
+        state.KeystoneLevel = null;
+        Assert.False(state.CanSubmit);
+
+        state.KeystoneLevel = 1;
+        Assert.False(state.CanSubmit);
+
+        state.KeystoneLevel = 12;
+        Assert.True(state.CanSubmit);
+
+        state.KeystoneLevel = 31;
+        Assert.False(state.CanSubmit);
+    }
+
+    [Fact]
+    public void ResolveCurrentSeason_FallsBackToHighestId()
+    {
+        var noCanonical = new[] { new ExpansionDto(Id: 7, Name: "Cataclysm"), new ExpansionDto(Id: 11, Name: "TWW") };
+        Assert.Equal(11, RunFormState.ResolveCurrentSeasonId(noCanonical));
+    }
+
+    [Fact]
+    public void ResolveCurrentSeason_PrefersCanonicalMatch()
+    {
+        Assert.Equal(14, RunFormState.ResolveCurrentSeasonId(Expansions));
+    }
+}


### PR DESCRIPTION
## Summary

`CreateRunPage.razor` (481 LOC) and `EditRunPage.razor` (620 LOC) carried duplicated form-state field clusters, derived properties (`FilteredInstances`, `ShowInstanceDropdown`, `ShowDifficultyToggle`, `CanSubmit`), event handlers (`OnActivityChanged`, `OnDungeonScopeChanged`, `OnInstanceChanged`, `OnDifficultyChanged`), helpers (`RefreshDifficultyOptions`, `ResolveCurrentSeasonId`, `ToIsoOrNull`), and option lists. This PR extracts a single source of truth into `app/Lfm.App.Core/Runs/RunFormState.cs` and rewires both pages to delegate to a `_form` instance.

- New `RunFormState` (~170 LOC) holds the field cluster + behavior; pages keep markup, lifecycle, submit/save/delete handlers, and a thin `Sync*Tuples` adapter for FluentUI's `(string, string)` tuple shape.
- `Activity`/`Difficulty`/`Size`/`DifficultyOptions` are private-set; cascades only happen through `OnActivityChanged`/`OnDifficultyChanged`/`OnInstanceChanged`/`SetMode`/`Populate`.
- New `Populate(...)` method is the atomic populate-from-stored-run path used by `EditRunPage.PopulateForm` (no cascading; callers supply every field).
- 7 new `RunFormStateTests` cover activity reset, difficulty reset, anydungeon-keystone `CanSubmit`, current-season fallback + canonical match, atomic `Populate`, and the instance-change top-mode cascade.
- Net delta: +357 / -265 across 4 files. Both pages preserve all visual markup.

Identified during the software design deep review (`docs/superpowersreviews/2026-04-29-software-design-deep-review.md`, findings `SD-W-5` + `SD-E-1`). Tracked as Task D in `docs/superpowers/plans/2026-04-30-software-design-review-followup.md`.

## Test plan

- [x] `dotnet build lfm.sln -c Release` clean (0 warnings)
- [x] `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release` — 188 passed (was 181 + 7 new)
- [x] `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release` — 186 passed (bUnit)
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error` exit 0
- [x] Spec compliance review ✅ (after fix to revert public Activity setter)
- [x] Code quality review ✅ (after fix to disambiguate page adapter names + add cascade test)