### PR TITLE
Extract RunCreateService from RunsCreateFunction

### DIFF
--- a/api/Functions/RunsCreateFunction.cs
+++ b/api/Functions/RunsCreateFunction.cs
@@ -76,14 +76,19 @@ public class RunsCreateFunction(IRunCreateService service, ILogger<RunsCreateFun
 
         var result = await service.CreateAsync(body, principal, ct);
 
-        return result switch
+        // Audit-bearing branches stay at the function (this layer owns audit shape);
+        // pure HTTP-shape branches go through the shared translator.
+        switch (result)
         {
-            RunOperationResult.NotFound nf => Problem.NotFound(req.HttpContext, nf.Code, nf.Message),
-            RunOperationResult.BadRequest br => Problem.BadRequest(req.HttpContext, br.Code, br.Message),
-            RunOperationResult.Forbidden fb => EmitFailureAndReturn(fb, principal, req),
-            RunOperationResult.Ok ok => EmitSuccessAndReturn(ok, principal),
-            _ => throw new InvalidOperationException($"Unexpected result: {result.GetType().Name}"),
-        };
+            case RunOperationResult.Ok ok:
+                AuditLog.Emit(logger, new AuditEvent("run.create", principal.BattleNetId, ok.Run.Id, "success", null));
+                return new ObjectResult(RunResponseMapper.ToDetail(ok.Run, principal.BattleNetId)) { StatusCode = 201 };
+            case RunOperationResult.Forbidden fb:
+                AuditLog.Emit(logger, new AuditEvent("run.create", principal.BattleNetId, null, "failure", fb.AuditReason));
+                return result.ToProblemResult(req.HttpContext);
+            default:
+                return result.ToProblemResult(req.HttpContext);
+        }
     }
 
     /// <summary>
@@ -97,21 +102,4 @@ public class RunsCreateFunction(IRunCreateService service, ILogger<RunsCreateFun
         FunctionContext ctx,
         CancellationToken ct)
         => Run(req, ctx, ct);
-
-    private IActionResult EmitFailureAndReturn(
-        RunOperationResult.Forbidden fb,
-        SessionPrincipal principal,
-        HttpRequest req)
-    {
-        AuditLog.Emit(logger, new AuditEvent("run.create", principal.BattleNetId, null, "failure", fb.AuditReason));
-        return Problem.Forbidden(req.HttpContext, fb.Code, fb.Message);
-    }
-
-    private IActionResult EmitSuccessAndReturn(
-        RunOperationResult.Ok ok,
-        SessionPrincipal principal)
-    {
-        AuditLog.Emit(logger, new AuditEvent("run.create", principal.BattleNetId, ok.Run.Id, "success", null));
-        return new ObjectResult(RunResponseMapper.ToDetail(ok.Run, principal.BattleNetId)) { StatusCode = 201 };
-    }
 }

--- a/api/Functions/RunsCreateFunction.cs
+++ b/api/Functions/RunsCreateFunction.cs
@@ -11,8 +11,7 @@ using Lfm.Api.Auth;
 using Lfm.Api.Helpers;
 using Lfm.Api.Mappers;
 using Lfm.Api.Middleware;
-using Lfm.Api.Repositories;
-using Lfm.Api.Services;
+using Lfm.Api.Runs;
 using Lfm.Api.Validation;
 using Lfm.Contracts.Runs;
 
@@ -21,28 +20,22 @@ namespace Lfm.Api.Functions;
 /// <summary>
 /// Serves POST /api/runs.
 ///
-/// Creates a new run document. For GUILD visibility runs, the caller must have
-/// the <c>canCreateGuildRuns</c> rank permission in their guild (defaults to
-/// rank 0 only unless overridden by guild settings).
+/// HTTP adapter for <see cref="IRunCreateService"/>. The handler deserializes
+/// the request body, runs DTO validation, calls the service, and translates
+/// the resulting <see cref="RunOperationResult"/> to a 201 Created response
+/// or the appropriate <c>problem+json</c> error. Audit emission for the
+/// success and forbidden paths stays at this layer because both events tie
+/// to the HTTP-shaped boundary (status code, idempotency, traceparent).
 ///
-/// Server-side fields assigned here:
-///   - id            — new GUID
-///   - creatorBattleNetId — from the session principal
-///   - creatorGuildId / creatorGuild — from the session principal
-///   - status        — always "open" (for future use; not yet stored)
-///   - createdAt     — UTC now
-///   - ttl           — seconds until startTime + 7 days (minimum 1 day)
-///   - runCharacters — always empty on creation
+/// Run-create policy itself (raider lookup, guild guard, document
+/// construction) lives in <see cref="RunCreateService"/>.
 ///
 /// Mirrors <c>handler</c> in <c>functions/src/functions/runs-create.ts</c>.
 /// </summary>
-public class RunsCreateFunction(IRunsRepository repo, IRaidersRepository raidersRepo, IGuildPermissions guildPermissions, ILogger<RunsCreateFunction> logger)
+public class RunsCreateFunction(IRunCreateService service, ILogger<RunsCreateFunction> logger)
 {
     private static readonly JsonSerializerOptions JsonOptions =
         new() { PropertyNameCaseInsensitive = true };
-
-    private const long RunTtlAfterStartMs = 7L * 24 * 3600 * 1000;
-    private const int MinTtlSeconds = 86400; // 1 day minimum
 
     [Function("runs-create")]
     [RequireAuth]
@@ -81,46 +74,16 @@ public class RunsCreateFunction(IRunsRepository repo, IRaidersRepository raiders
                 new Dictionary<string, object?> { ["errors"] = errors });
         }
 
-        // Load the raider once and derive guild info from the selected character.
-        // principal.GuildId / GuildName are legacy session fields that are no
-        // longer populated in production.
-        var raider = await raidersRepo.GetByBattleNetIdAsync(principal.BattleNetId, ct);
-        if (raider is null)
-            return Problem.NotFound(req.HttpContext, "raider-not-found", "Raider not found.");
+        var result = await service.CreateAsync(body, principal, ct);
 
-        var (guildId, guildName) = GuildResolver.FromRaider(raider);
-
-        // GUILD run guard: mirroring the checks in runs-create.ts.
-        //   1. GUILD run requires the caller to belong to a guild.
-        //   2. GUILD run requires the canCreateGuildRuns rank permission.
-        if (body.Visibility == "GUILD")
+        return result switch
         {
-            if (guildId is null)
-                return Problem.BadRequest(
-                    req.HttpContext,
-                    "guild-required",
-                    "A guild run requires an active character in a guild.");
-
-            var canCreate = await guildPermissions.CanCreateGuildRunsAsync(raider, ct);
-            if (!canCreate)
-            {
-                AuditLog.Emit(logger, new AuditEvent("run.create", principal.BattleNetId, null, "failure", "guild rank denied"));
-                return Problem.Forbidden(
-                    req.HttpContext,
-                    "guild-rank-denied",
-                    "Guild run creation is not enabled for your rank.");
-            }
-        }
-
-        var runId = Guid.NewGuid().ToString();
-        var createdAt = DateTimeOffset.UtcNow.ToString("o");
-
-        var run = BuildRunDocument(body, principal, guildId, guildName, runId, createdAt);
-        var created = await repo.CreateAsync(run, ct);
-
-        AuditLog.Emit(logger, new AuditEvent("run.create", principal.BattleNetId, runId, "success", null));
-
-        return new ObjectResult(RunResponseMapper.ToDetail(created, principal.BattleNetId)) { StatusCode = 201 };
+            RunOperationResult.NotFound nf => Problem.NotFound(req.HttpContext, nf.Code, nf.Message),
+            RunOperationResult.BadRequest br => Problem.BadRequest(req.HttpContext, br.Code, br.Message),
+            RunOperationResult.Forbidden fb => EmitFailureAndReturn(fb, principal, req),
+            RunOperationResult.Ok ok => EmitSuccessAndReturn(ok, principal),
+            _ => throw new InvalidOperationException($"Unexpected result: {result.GetType().Name}"),
+        };
     }
 
     /// <summary>
@@ -135,60 +98,20 @@ public class RunsCreateFunction(IRunsRepository repo, IRaidersRepository raiders
         CancellationToken ct)
         => Run(req, ctx, ct);
 
-    // ------------------------------------------------------------------
-    // Document builder — mirrors buildRunDocument in runs-create.ts
-    // ------------------------------------------------------------------
-
-    internal static RunDocument BuildRunDocument(
-        CreateRunRequest body,
+    private IActionResult EmitFailureAndReturn(
+        RunOperationResult.Forbidden fb,
         SessionPrincipal principal,
-        string? guildId,
-        string? guildName,
-        string id,
-        string createdAt)
+        HttpRequest req)
     {
-        var startTimeMs = DateTimeOffset.TryParse(body.StartTime, out var st)
-            ? st.ToUnixTimeMilliseconds()
-            : DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-
-        var createdAtMs = DateTimeOffset.TryParse(createdAt, out var ca)
-            ? ca.ToUnixTimeMilliseconds()
-            : DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-
-        var expiryMs = startTimeMs + RunTtlAfterStartMs;
-        var ttl = (int)Math.Max(MinTtlSeconds, (expiryMs - createdAtMs) / 1000);
-
-        int? creatorGuildId = guildId is not null
-            && int.TryParse(guildId, out var gid)
-            ? gid
-            : null;
-
-        // The validator guarantees Difficulty + Size are populated; ModeKey
-        // is computed from them so the persisted RunDocument still satisfies
-        // any legacy reader on the read side (storage-only compatibility —
-        // the wire no longer carries ModeKey).
-        var difficulty = body.Difficulty!;
-        var size = body.Size!.Value;
-        var modeKey = $"{difficulty}:{size}";
-
-        return new RunDocument(
-            Id: id,
-            StartTime: body.StartTime!,
-            SignupCloseTime: body.SignupCloseTime ?? "",
-            Description: body.Description ?? "",
-            ModeKey: modeKey,
-            Visibility: body.Visibility!,
-            CreatorGuild: guildName ?? "",
-            CreatorGuildId: creatorGuildId,
-            InstanceId: body.InstanceId,
-            InstanceName: body.InstanceName,
-            CreatorBattleNetId: principal.BattleNetId,
-            CreatedAt: createdAt,
-            Ttl: ttl,
-            RunCharacters: [],
-            Difficulty: difficulty,
-            Size: size,
-            KeystoneLevel: body.KeystoneLevel);
+        AuditLog.Emit(logger, new AuditEvent("run.create", principal.BattleNetId, null, "failure", fb.AuditReason));
+        return Problem.Forbidden(req.HttpContext, fb.Code, fb.Message);
     }
 
+    private IActionResult EmitSuccessAndReturn(
+        RunOperationResult.Ok ok,
+        SessionPrincipal principal)
+    {
+        AuditLog.Emit(logger, new AuditEvent("run.create", principal.BattleNetId, ok.Run.Id, "success", null));
+        return new ObjectResult(RunResponseMapper.ToDetail(ok.Run, principal.BattleNetId)) { StatusCode = 201 };
+    }
 }

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -177,6 +177,7 @@ builder.Services.AddSingleton<Lfm.Api.Services.ISecretResolver, Lfm.Api.Services
 builder.Services.AddSingleton<Lfm.Api.Services.ISiteAdminService, Lfm.Api.Services.SiteAdminService>();
 builder.Services.AddSingleton<Lfm.Api.Services.IIdempotencyStore, Lfm.Api.Services.IdempotencyStore>();
 builder.Services.AddScoped<Lfm.Api.Services.IGuildPermissions, Lfm.Api.Services.GuildPermissions>();
+builder.Services.AddScoped<Lfm.Api.Runs.IRunCreateService, Lfm.Api.Runs.RunCreateService>();
 
 // Audit-log actor hasher. If a salt is configured we HMAC-hash every
 // AuditActorId before it reaches Application Insights; otherwise (local

--- a/api/Runs/IRunCreateService.cs
+++ b/api/Runs/IRunCreateService.cs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Auth;
+using Lfm.Contracts.Runs;
+
+namespace Lfm.Api.Runs;
+
+/// <summary>
+/// Run-create policy lifted out of <c>RunsCreateFunction</c>. The Function
+/// adapter handles HTTP body deserialization, request validation, and the
+/// translation of this service's <see cref="RunOperationResult"/> into
+/// <c>problem+json</c> responses or 201 Created.
+/// </summary>
+public interface IRunCreateService
+{
+    Task<RunOperationResult> CreateAsync(
+        CreateRunRequest body,
+        SessionPrincipal principal,
+        CancellationToken ct);
+}

--- a/api/Runs/RunCreateService.cs
+++ b/api/Runs/RunCreateService.cs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Auth;
+using Lfm.Api.Repositories;
+using Lfm.Api.Services;
+using Lfm.Contracts.Runs;
+
+namespace Lfm.Api.Runs;
+
+/// <summary>
+/// Implements the run-create policy: load the raider, derive guild context,
+/// gate GUILD-visibility runs on the <c>canCreateGuildRuns</c> rank
+/// permission, build the Cosmos document with server-assigned fields, and
+/// persist it. Returns a <see cref="RunOperationResult"/> that the Function
+/// adapter translates to HTTP.
+///
+/// Mirrors <c>handler</c> in <c>functions/src/functions/runs-create.ts</c>.
+/// </summary>
+public sealed class RunCreateService(
+    IRunsRepository runsRepo,
+    IRaidersRepository raidersRepo,
+    IGuildPermissions guildPermissions) : IRunCreateService
+{
+    private const long RunTtlAfterStartMs = 7L * 24 * 3600 * 1000;
+    private const int MinTtlSeconds = 86400; // 1 day minimum
+
+    public async Task<RunOperationResult> CreateAsync(
+        CreateRunRequest body,
+        SessionPrincipal principal,
+        CancellationToken ct)
+    {
+        // Load the raider once and derive guild info from the selected character.
+        // principal.GuildId / GuildName are legacy session fields that are no
+        // longer populated in production.
+        var raider = await raidersRepo.GetByBattleNetIdAsync(principal.BattleNetId, ct);
+        if (raider is null)
+            return new RunOperationResult.NotFound("raider-not-found", "Raider not found.");
+
+        var (guildId, guildName) = GuildResolver.FromRaider(raider);
+
+        // GUILD run guard: mirroring the checks in runs-create.ts.
+        //   1. GUILD run requires the caller to belong to a guild.
+        //   2. GUILD run requires the canCreateGuildRuns rank permission.
+        if (body.Visibility == "GUILD")
+        {
+            if (guildId is null)
+                return new RunOperationResult.BadRequest(
+                    "guild-required",
+                    "A guild run requires an active character in a guild.");
+
+            var canCreate = await guildPermissions.CanCreateGuildRunsAsync(raider, ct);
+            if (!canCreate)
+                return new RunOperationResult.Forbidden(
+                    "guild-rank-denied",
+                    "Guild run creation is not enabled for your rank.",
+                    AuditReason: "guild rank denied");
+        }
+
+        var runId = Guid.NewGuid().ToString();
+        var createdAt = DateTimeOffset.UtcNow.ToString("o");
+
+        var run = BuildRunDocument(body, principal, guildId, guildName, runId, createdAt);
+        var created = await runsRepo.CreateAsync(run, ct);
+
+        return new RunOperationResult.Ok(created);
+    }
+
+    // ------------------------------------------------------------------
+    // Document builder — mirrors buildRunDocument in runs-create.ts
+    // ------------------------------------------------------------------
+
+    internal static RunDocument BuildRunDocument(
+        CreateRunRequest body,
+        SessionPrincipal principal,
+        string? guildId,
+        string? guildName,
+        string id,
+        string createdAt)
+    {
+        var startTimeMs = DateTimeOffset.TryParse(body.StartTime, out var st)
+            ? st.ToUnixTimeMilliseconds()
+            : DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+        var createdAtMs = DateTimeOffset.TryParse(createdAt, out var ca)
+            ? ca.ToUnixTimeMilliseconds()
+            : DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+        var expiryMs = startTimeMs + RunTtlAfterStartMs;
+        var ttl = (int)Math.Max(MinTtlSeconds, (expiryMs - createdAtMs) / 1000);
+
+        int? creatorGuildId = guildId is not null
+            && int.TryParse(guildId, out var gid)
+            ? gid
+            : null;
+
+        // The validator guarantees Difficulty + Size are populated; ModeKey
+        // is computed from them so the persisted RunDocument still satisfies
+        // any legacy reader on the read side (storage-only compatibility —
+        // the wire no longer carries ModeKey).
+        var difficulty = body.Difficulty!;
+        var size = body.Size!.Value;
+        var modeKey = $"{difficulty}:{size}";
+
+        return new RunDocument(
+            Id: id,
+            StartTime: body.StartTime!,
+            SignupCloseTime: body.SignupCloseTime ?? "",
+            Description: body.Description ?? "",
+            ModeKey: modeKey,
+            Visibility: body.Visibility!,
+            CreatorGuild: guildName ?? "",
+            CreatorGuildId: creatorGuildId,
+            InstanceId: body.InstanceId,
+            InstanceName: body.InstanceName,
+            CreatorBattleNetId: principal.BattleNetId,
+            CreatedAt: createdAt,
+            Ttl: ttl,
+            RunCharacters: [],
+            Difficulty: difficulty,
+            Size: size,
+            KeystoneLevel: body.KeystoneLevel);
+    }
+}

--- a/api/Runs/RunOperationResult.cs
+++ b/api/Runs/RunOperationResult.cs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Repositories;
+
+namespace Lfm.Api.Runs;
+
+/// <summary>
+/// Discriminated result returned by the run-* services
+/// (<c>IRunCreateService</c>, <c>IRunUpdateService</c>, <c>IRunSignupService</c>).
+/// Functions translate each variant to the appropriate <c>problem+json</c>
+/// response or 200/201.
+/// </summary>
+public abstract record RunOperationResult
+{
+    public sealed record Ok(RunDocument Run) : RunOperationResult;
+    public sealed record NotFound(string Code, string Message) : RunOperationResult;
+    public sealed record BadRequest(string Code, string Message, IReadOnlyList<string>? Errors = null) : RunOperationResult;
+    public sealed record Forbidden(string Code, string Message, string AuditReason) : RunOperationResult;
+    public sealed record ConflictResult(string Code, string Message) : RunOperationResult;
+    public sealed record PreconditionFailed(string Code, string Message) : RunOperationResult;
+    public sealed record ServiceUnavailable(string Code, string Message) : RunOperationResult;
+}

--- a/api/Runs/RunOperationResult.cs
+++ b/api/Runs/RunOperationResult.cs
@@ -17,6 +17,8 @@ public abstract record RunOperationResult
     public sealed record NotFound(string Code, string Message) : RunOperationResult;
     public sealed record BadRequest(string Code, string Message, IReadOnlyList<string>? Errors = null) : RunOperationResult;
     public sealed record Forbidden(string Code, string Message, string AuditReason) : RunOperationResult;
+    // Suffixed "Result" to avoid shadowing Microsoft.AspNetCore.Mvc.ConflictResult
+    // at Function call sites that use both namespaces.
     public sealed record ConflictResult(string Code, string Message) : RunOperationResult;
     public sealed record PreconditionFailed(string Code, string Message) : RunOperationResult;
     public sealed record ServiceUnavailable(string Code, string Message) : RunOperationResult;

--- a/api/Runs/RunOperationResultExtensions.cs
+++ b/api/Runs/RunOperationResultExtensions.cs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Lfm.Api.Helpers;
+
+namespace Lfm.Api.Runs;
+
+/// <summary>
+/// Translates a <see cref="RunOperationResult"/> failure variant into the
+/// matching <c>problem+json</c> <see cref="IActionResult"/>. Functions handle
+/// the success path themselves (status code 200/201 + custom DTO mapping +
+/// success audit emission), so this translator is failure-only.
+/// </summary>
+public static class RunOperationResultExtensions
+{
+    public static IActionResult ToProblemResult(this RunOperationResult result, HttpContext httpContext) =>
+        result switch
+        {
+            RunOperationResult.NotFound nf =>
+                Problem.NotFound(httpContext, nf.Code, nf.Message),
+            RunOperationResult.BadRequest br when br.Errors is not null =>
+                Problem.BadRequest(httpContext, br.Code, br.Message,
+                    new Dictionary<string, object?> { ["errors"] = br.Errors }),
+            RunOperationResult.BadRequest br =>
+                Problem.BadRequest(httpContext, br.Code, br.Message),
+            RunOperationResult.Forbidden fb =>
+                Problem.Forbidden(httpContext, fb.Code, fb.Message),
+            RunOperationResult.ConflictResult cf =>
+                Problem.Conflict(httpContext, cf.Code, cf.Message),
+            RunOperationResult.PreconditionFailed pf =>
+                Problem.PreconditionFailed(httpContext, pf.Code, pf.Message),
+            RunOperationResult.ServiceUnavailable su =>
+                Problem.ServiceUnavailable(httpContext, su.Code, su.Message),
+            RunOperationResult.Ok =>
+                throw new InvalidOperationException(
+                    "RunOperationResult.Ok is a success — translate at the call site, not via ToProblemResult."),
+            _ => throw new InvalidOperationException($"Unhandled RunOperationResult: {result.GetType().Name}"),
+        };
+}

--- a/tests/Lfm.Api.Tests/Runs/RunCreateServiceTests.cs
+++ b/tests/Lfm.Api.Tests/Runs/RunCreateServiceTests.cs
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Auth;
+using Lfm.Api.Repositories;
+using Lfm.Api.Runs;
+using Lfm.Api.Services;
+using Lfm.Contracts.Runs;
+using Moq;
+using Xunit;
+
+namespace Lfm.Api.Tests.Runs;
+
+/// <summary>
+/// Unit tests for <see cref="RunCreateService"/>. Each test exercises one
+/// branch of the policy that used to live inline in <c>RunsCreateFunction.Run</c>;
+/// the function-level tests in <see cref="RunsCreateFunctionTests"/> stay as
+/// the HTTP-shaped integration coverage on top of this service.
+/// </summary>
+public class RunCreateServiceTests
+{
+    // Anchored to UtcNow so the fixtures never become time bombs against a
+    // future-dated assertion.
+    private static readonly string FutureStartTime =
+        DateTimeOffset.UtcNow.AddDays(30).ToString("o");
+    private static readonly string FutureSignupCloseTime =
+        DateTimeOffset.UtcNow.AddDays(30).AddHours(-2).ToString("o");
+
+    private static SessionPrincipal MakePrincipal(
+        string battleNetId = "bnet-admin") =>
+        new SessionPrincipal(
+            BattleNetId: battleNetId,
+            BattleTag: "Admin#1234",
+            GuildId: null,
+            GuildName: null,
+            IssuedAt: DateTimeOffset.UtcNow,
+            ExpiresAt: DateTimeOffset.UtcNow.AddHours(1));
+
+    private static RaiderDocument MakeRaiderWithGuild(
+        string battleNetId = "bnet-admin",
+        int guildId = 12345,
+        string guildName = "Test Guild") =>
+        new RaiderDocument(
+            Id: battleNetId,
+            BattleNetId: battleNetId,
+            SelectedCharacterId: "char-1",
+            Locale: null,
+            Characters: [
+                new StoredSelectedCharacter(
+                    Id: "char-1",
+                    Region: "eu",
+                    Realm: "silvermoon",
+                    Name: "Testchar",
+                    GuildId: guildId,
+                    GuildName: guildName)
+            ]);
+
+    private static RaiderDocument MakeRaiderWithoutGuild(
+        string battleNetId = "bnet-admin") =>
+        new RaiderDocument(
+            Id: battleNetId,
+            BattleNetId: battleNetId,
+            SelectedCharacterId: null,
+            Locale: null,
+            Characters: null);
+
+    private static CreateRunRequest MakeRequest(string visibility = "PUBLIC") =>
+        new CreateRunRequest(
+            StartTime: FutureStartTime,
+            SignupCloseTime: FutureSignupCloseTime,
+            Description: "Created run",
+            Visibility: visibility,
+            InstanceId: 631,
+            InstanceName: "Icecrown Citadel",
+            Difficulty: "NORMAL",
+            Size: 20);
+
+    private static (
+        Mock<IRunsRepository> runsRepo,
+        Mock<IRaidersRepository> raidersRepo,
+        Mock<IGuildPermissions> guildPermissions,
+        RunCreateService sut) MakeSut()
+    {
+        var runsRepo = new Mock<IRunsRepository>();
+        var raidersRepo = new Mock<IRaidersRepository>();
+        var guildPermissions = new Mock<IGuildPermissions>();
+        var sut = new RunCreateService(runsRepo.Object, raidersRepo.Object, guildPermissions.Object);
+        return (runsRepo, raidersRepo, guildPermissions, sut);
+    }
+
+    [Fact]
+    public async Task CreateAsync_RaiderMissing_ReturnsNotFound()
+    {
+        var (_, raidersRepo, _, sut) = MakeSut();
+        var principal = MakePrincipal("bnet-admin");
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-admin", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RaiderDocument?)null);
+
+        var result = await sut.CreateAsync(MakeRequest(), principal, CancellationToken.None);
+
+        var notFound = Assert.IsType<RunOperationResult.NotFound>(result);
+        Assert.Equal("raider-not-found", notFound.Code);
+    }
+
+    [Fact]
+    public async Task CreateAsync_GuildVisibilityWithoutGuild_ReturnsBadRequest()
+    {
+        var (_, raidersRepo, _, sut) = MakeSut();
+        var principal = MakePrincipal("bnet-admin");
+        var raider = MakeRaiderWithoutGuild("bnet-admin");
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-admin", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(raider);
+
+        var result = await sut.CreateAsync(MakeRequest("GUILD"), principal, CancellationToken.None);
+
+        var badRequest = Assert.IsType<RunOperationResult.BadRequest>(result);
+        Assert.Equal("guild-required", badRequest.Code);
+    }
+
+    [Fact]
+    public async Task CreateAsync_GuildVisibilityWithoutPermission_ReturnsForbidden()
+    {
+        var (_, raidersRepo, guildPermissions, sut) = MakeSut();
+        var principal = MakePrincipal("bnet-member");
+        var raider = MakeRaiderWithGuild("bnet-member");
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-member", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(raider);
+        guildPermissions.Setup(p => p.CanCreateGuildRunsAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await sut.CreateAsync(MakeRequest("GUILD"), principal, CancellationToken.None);
+
+        var forbidden = Assert.IsType<RunOperationResult.Forbidden>(result);
+        Assert.Equal("guild-rank-denied", forbidden.Code);
+        Assert.Equal("guild rank denied", forbidden.AuditReason);
+    }
+
+    [Fact]
+    public async Task CreateAsync_PublicRunHappyPath_ReturnsOkWithCreatedDocument()
+    {
+        var (runsRepo, raidersRepo, _, sut) = MakeSut();
+        var principal = MakePrincipal("bnet-admin");
+        // Even with a guild, a PUBLIC run should not consult guild permissions.
+        var raider = MakeRaiderWithGuild("bnet-admin");
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-admin", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(raider);
+        runsRepo.Setup(r => r.CreateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RunDocument doc, CancellationToken _) => doc);
+
+        var result = await sut.CreateAsync(MakeRequest("PUBLIC"), principal, CancellationToken.None);
+
+        var ok = Assert.IsType<RunOperationResult.Ok>(result);
+        Assert.NotNull(ok.Run.Id);
+        Assert.NotEqual(string.Empty, ok.Run.Id);
+        Assert.Equal("bnet-admin", ok.Run.CreatorBattleNetId);
+        Assert.Equal("PUBLIC", ok.Run.Visibility);
+        Assert.True(ok.Run.Ttl >= 86400);
+        Assert.Equal("NORMAL:20", ok.Run.ModeKey);
+        Assert.Empty(ok.Run.RunCharacters);
+        runsRepo.Verify(r => r.CreateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateAsync_GuildRunHappyPath_AssignsGuildId()
+    {
+        var (runsRepo, raidersRepo, guildPermissions, sut) = MakeSut();
+        var principal = MakePrincipal("bnet-admin");
+        var raider = MakeRaiderWithGuild("bnet-admin", guildId: 123, guildName: "Test Guild");
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-admin", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(raider);
+        guildPermissions.Setup(p => p.CanCreateGuildRunsAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        runsRepo.Setup(r => r.CreateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RunDocument doc, CancellationToken _) => doc);
+
+        var result = await sut.CreateAsync(MakeRequest("GUILD"), principal, CancellationToken.None);
+
+        var ok = Assert.IsType<RunOperationResult.Ok>(result);
+        Assert.Equal(123, ok.Run.CreatorGuildId);
+        Assert.Equal("Test Guild", ok.Run.CreatorGuild);
+        Assert.Equal("GUILD", ok.Run.Visibility);
+    }
+}

--- a/tests/Lfm.Api.Tests/RunsCreateFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RunsCreateFunctionTests.cs
@@ -10,7 +10,7 @@ using Moq;
 using Lfm.Api.Auth;
 using Lfm.Api.Functions;
 using Lfm.Api.Repositories;
-using Lfm.Api.Services;
+using Lfm.Api.Runs;
 using Lfm.Contracts.Runs;
 using Xunit;
 
@@ -51,22 +51,6 @@ public class RunsCreateFunctionTests
             IssuedAt: DateTimeOffset.UtcNow,
             ExpiresAt: DateTimeOffset.UtcNow.AddHours(1));
 
-    private static RaiderDocument MakeRaiderDoc(string battleNetId = "bnet-admin") =>
-        new RaiderDocument(
-            Id: battleNetId,
-            BattleNetId: battleNetId,
-            SelectedCharacterId: "char-1",
-            Locale: null,
-            Characters: [
-                new StoredSelectedCharacter(
-                    Id: "char-1",
-                    Region: "eu",
-                    Realm: "silvermoon",
-                    Name: "Testchar",
-                    GuildId: 12345,
-                    GuildName: "Test Guild")
-            ]);
-
     private static HttpRequest MakePostRequest(object body)
     {
         var json = JsonSerializer.Serialize(body);
@@ -85,15 +69,11 @@ public class RunsCreateFunctionTests
     }
 
     private static RunsCreateFunction MakeFunction(
-        Mock<IRunsRepository> repo,
-        Mock<IRaidersRepository> raidersRepo,
-        Mock<IGuildPermissions> permissions,
+        Mock<IRunCreateService> service,
         TestLogger<RunsCreateFunction>? logger = null)
     {
         return new RunsCreateFunction(
-            repo.Object,
-            raidersRepo.Object,
-            permissions.Object,
+            service.Object,
             logger ?? new TestLogger<RunsCreateFunction>());
     }
 
@@ -115,15 +95,14 @@ public class RunsCreateFunctionTests
             RunCharacters: []);
 
     // ------------------------------------------------------------------
-    // Test 1: Admin happy path — creates run and returns 201
+    // Test 1: Service Ok happy path → 201 Created with mapped DTO
     // ------------------------------------------------------------------
 
     [Fact]
-    public async Task Run_creates_run_and_returns_201_for_guild_admin()
+    public async Task Run_creates_run_and_returns_201_when_service_returns_ok()
     {
         var principal = MakePrincipal(battleNetId: "bnet-admin", guildId: "12345");
         var created = MakeRunDoc("run-new");
-        var raider = MakeRaiderDoc("bnet-admin");
 
         var requestBody = new
         {
@@ -137,19 +116,11 @@ public class RunsCreateFunctionTests
             instanceName = "Icecrown Citadel",
         };
 
-        var repo = new Mock<IRunsRepository>();
-        repo.Setup(r => r.CreateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(created);
+        var service = new Mock<IRunCreateService>();
+        service.Setup(s => s.CreateAsync(It.IsAny<CreateRunRequest>(), It.IsAny<SessionPrincipal>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunOperationResult.Ok(created));
 
-        var raidersRepo = new Mock<IRaidersRepository>();
-        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-admin", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(raider);
-
-        var permissions = new Mock<IGuildPermissions>();
-        permissions.Setup(p => p.CanCreateGuildRunsAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
-
-        var fn = MakeFunction(repo, raidersRepo, permissions);
+        var fn = MakeFunction(service);
         var ctx = MakeFunctionContext(principal);
 
         var result = await fn.Run(MakePostRequest(requestBody), ctx, CancellationToken.None);
@@ -158,8 +129,9 @@ public class RunsCreateFunctionTests
         Assert.Equal(201, objectResult.StatusCode);
         Assert.IsType<RunDetailDto>(objectResult.Value);
 
-        // Cosmos CreateAsync was called once
-        repo.Verify(r => r.CreateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Once);
+        service.Verify(
+            s => s.CreateAsync(It.IsAny<CreateRunRequest>(), It.IsAny<SessionPrincipal>(), It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     // ------------------------------------------------------------------
@@ -171,17 +143,15 @@ public class RunsCreateFunctionTests
     {
         var principal = MakePrincipal();
 
-        // Missing required fields: modeKey, visibility, instanceId
+        // Missing required fields.
         var requestBody = new
         {
             startTime = FutureStartTime,
         };
 
-        var repo = new Mock<IRunsRepository>();
-        var raidersRepo = new Mock<IRaidersRepository>();
-        var permissions = new Mock<IGuildPermissions>();
+        var service = new Mock<IRunCreateService>();
 
-        var fn = MakeFunction(repo, raidersRepo, permissions);
+        var fn = MakeFunction(service);
         var ctx = MakeFunctionContext(principal);
 
         var result = await fn.Run(MakePostRequest(requestBody), ctx, CancellationToken.None);
@@ -192,19 +162,19 @@ public class RunsCreateFunctionTests
         Assert.Equal("https://github.com/lfm-org/lfm/errors#validation-failed", problem.Type);
         Assert.True(problem.Extensions.ContainsKey("errors"));
 
-        // Cosmos should never be called
-        repo.Verify(r => r.CreateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Never);
+        // Service should never be called when validation fails.
+        service.Verify(
+            s => s.CreateAsync(It.IsAny<CreateRunRequest>(), It.IsAny<SessionPrincipal>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]
     public async Task Run_returns_400_when_body_is_malformed_json()
     {
         var principal = MakePrincipal();
-        var repo = new Mock<IRunsRepository>();
-        var raidersRepo = new Mock<IRaidersRepository>();
-        var permissions = new Mock<IGuildPermissions>();
+        var service = new Mock<IRunCreateService>();
 
-        var fn = MakeFunction(repo, raidersRepo, permissions);
+        var fn = MakeFunction(service);
         var ctx = MakeFunctionContext(principal);
 
         var result = await fn.Run(MakePostRequest("{"), ctx, CancellationToken.None);
@@ -215,18 +185,19 @@ public class RunsCreateFunctionTests
         Assert.Equal("https://github.com/lfm-org/lfm/errors#invalid-body", problem.Type);
         Assert.Equal("Request body is invalid or missing.", problem.Detail);
 
-        repo.Verify(r => r.CreateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Never);
+        service.Verify(
+            s => s.CreateAsync(It.IsAny<CreateRunRequest>(), It.IsAny<SessionPrincipal>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     // ------------------------------------------------------------------
-    // Test 3: Non-admin — returns 403 for GUILD run
+    // Test 3: Service Forbidden → 403 problem+json + audit failure entry
     // ------------------------------------------------------------------
 
     [Fact]
-    public async Task Run_returns_403_for_guild_run_when_caller_lacks_permission()
+    public async Task Run_returns_403_and_emits_audit_when_service_returns_forbidden()
     {
         var principal = MakePrincipal(battleNetId: "bnet-member", guildId: "12345");
-        var raider = MakeRaiderDoc("bnet-member");
 
         var requestBody = new
         {
@@ -237,18 +208,15 @@ public class RunsCreateFunctionTests
             instanceId = 631,
         };
 
-        var repo = new Mock<IRunsRepository>();
-
-        var raidersRepo = new Mock<IRaidersRepository>();
-        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-member", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(raider);
-
-        var permissions = new Mock<IGuildPermissions>();
-        permissions.Setup(p => p.CanCreateGuildRunsAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(false);
+        var service = new Mock<IRunCreateService>();
+        service.Setup(s => s.CreateAsync(It.IsAny<CreateRunRequest>(), It.IsAny<SessionPrincipal>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunOperationResult.Forbidden(
+                "guild-rank-denied",
+                "Guild run creation is not enabled for your rank.",
+                AuditReason: "guild rank denied"));
 
         var logger = new TestLogger<RunsCreateFunction>();
-        var fn = MakeFunction(repo, raidersRepo, permissions, logger);
+        var fn = MakeFunction(service, logger);
         var ctx = MakeFunctionContext(principal);
 
         var result = await fn.Run(MakePostRequest(requestBody), ctx, CancellationToken.None);
@@ -258,15 +226,13 @@ public class RunsCreateFunctionTests
         var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
         Assert.Equal("https://github.com/lfm-org/lfm/errors#guild-rank-denied", problem.Type);
 
-        repo.Verify(r => r.CreateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()), Times.Never);
-
         Assert.Single(
             logger.Entries,
             e => e.IsAudit("run.create", "failure", "guild rank denied"));
     }
 
     // ------------------------------------------------------------------
-    // Test 4: Audit event emitted on success path
+    // Test 4: Audit success entry on Ok path
     // ------------------------------------------------------------------
 
     [Fact]
@@ -274,7 +240,6 @@ public class RunsCreateFunctionTests
     {
         var principal = MakePrincipal(battleNetId: "bnet-admin", guildId: "12345");
         var created = MakeRunDoc("run-new");
-        var raider = MakeRaiderDoc("bnet-admin");
         var logger = new TestLogger<RunsCreateFunction>();
 
         var requestBody = new
@@ -289,19 +254,11 @@ public class RunsCreateFunctionTests
             instanceName = "Icecrown Citadel",
         };
 
-        var repo = new Mock<IRunsRepository>();
-        repo.Setup(r => r.CreateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(created);
+        var service = new Mock<IRunCreateService>();
+        service.Setup(s => s.CreateAsync(It.IsAny<CreateRunRequest>(), It.IsAny<SessionPrincipal>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunOperationResult.Ok(created));
 
-        var raidersRepo = new Mock<IRaidersRepository>();
-        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-admin", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(raider);
-
-        var permissions = new Mock<IGuildPermissions>();
-        permissions.Setup(p => p.CanCreateGuildRunsAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
-
-        var fn = MakeFunction(repo, raidersRepo, permissions, logger);
+        var fn = MakeFunction(service, logger);
         var ctx = MakeFunctionContext(principal);
 
         await fn.Run(MakePostRequest(requestBody), ctx, CancellationToken.None);


### PR DESCRIPTION
## Summary

`RunsCreateFunction.Run` packed HTTP plumbing + raider lookup + GUILD permission check + run-document construction + persistence + audit emission into one method. This PR lifts the policy out:

- New `RunOperationResult` discriminated record (`Ok` + 6 failure variants) — the contract between run-mutation services and Function adapters.
- New `RunOperationResultExtensions.ToProblemResult(...)` shared translator that maps every failure variant to the matching `Problem.*` IActionResult. Reusable from RunsUpdateFunction / RunsSignupFunction in follow-up PRs.
- New `RunCreateService` lifts the run-create policy. Function shrinks to: deserialize → validate → call service → switch over result + audit + translate. Constructor went from 4 deps (3 repos + permissions + logger) to 2 (`IRunCreateService` + logger).
- Audit emission stays at the Function (HTTP-shaped boundary owns audit shape).
- `RunsCreateFunction.cs`: 193 → ~110 LOC.
- 5 new `RunCreateServiceTests` (raider missing / GUILD without guild / GUILD without permission / PUBLIC happy path / GUILD happy path); 4 pre-existing `RunsCreateFunctionTests` updated to mock the new service.

This is the first slice of finding `SD-B-1` from `docs/superpowersreviews/2026-04-29-software-design-deep-review.md`. RunUpdate and RunSignup follow in separate PRs (each branch keeps the per-CLAUDE.md ≤900 LOC budget). Tracked as Task E in `docs/superpowers/plans/2026-04-30-software-design-review-followup.md`.

## Test plan

- [x] `dotnet build lfm.sln -c Release` clean (0 warnings)
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` — 738 passed (was 733 + 5 new)
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error` exit 0
- [x] Spec compliance review ✅
- [x] Code quality review ✅ (translator extracted, BadRequest.Errors honored, ConflictResult naming commented — pre-E.3 action items closed)