### PR TITLE
Extract RunUpdateService from RunsUpdateFunction

### DIFF
--- a/api/Functions/RunsUpdateFunction.cs
+++ b/api/Functions/RunsUpdateFunction.cs
@@ -11,9 +11,7 @@ using Lfm.Api.Auth;
 using Lfm.Api.Helpers;
 using Lfm.Api.Mappers;
 using Lfm.Api.Middleware;
-using Lfm.Api.Repositories;
 using Lfm.Api.Runs;
-using Lfm.Api.Services;
 using Lfm.Api.Validation;
 using Lfm.Contracts.Runs;
 
@@ -22,26 +20,23 @@ namespace Lfm.Api.Functions;
 /// <summary>
 /// Serves PUT /api/runs/{id}.
 ///
-/// Updates an existing run (title, time, instance, visibility, etc.) using a
-/// read-modify-write pattern: load → validate → apply changes → replace in Cosmos.
+/// HTTP adapter for <see cref="IRunUpdateService"/>. The handler validates the
+/// If-Match header (RFC 9110 428 short-circuit), parses the body twice — once
+/// into <see cref="UpdateRunRequest"/> for FluentValidation, once into a
+/// <see cref="JsonDocument"/> to distinguish omitted fields from explicit nulls
+/// (the <see cref="RunUpdatePresentFields"/> projection) — calls the service,
+/// then translates the resulting <see cref="RunOperationResult"/>. Audit
+/// emission for the success, forbidden, and stale-If-Match paths stays at this
+/// layer because each event ties to the HTTP-shaped boundary (status code,
+/// idempotency, traceparent).
 ///
-/// Permission rules (mirrors runs-update.ts):
-///   - The creator can always edit their own run.
-///   - A non-creator can edit a GUILD run if they belong to the same guild and
-///     hold the <c>canCreateGuildRuns</c> rank permission.
-///   - All other callers receive 403.
-///
-/// Editability rules (mirrors run-editability.ts):
-///   - Editing is closed once signupCloseTime or startTime has passed → 409 Conflict.
-///   - startTime and instanceId are locked once the run has at least one signup → 400.
-///
-/// GUILD visibility promotion (PUBLIC → GUILD):
-///   - Requires the caller to belong to a guild and hold <c>canCreateGuildRuns</c>.
-///   - Stamps creatorGuild / creatorGuildId from the caller's session.
+/// Run-update policy itself (load existing, edit-access gate, editability +
+/// locked-field rules, effective-shape resolution, repo replace) lives in
+/// <see cref="RunUpdateService"/>.
 ///
 /// Mirrors <c>handler</c> in <c>functions/src/functions/runs-update.ts</c>.
 /// </summary>
-public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raidersRepo, IGuildPermissions guildPermissions, IInstancesRepository instancesRepo, ILogger<RunsUpdateFunction> logger)
+public class RunsUpdateFunction(IRunUpdateService service, ILogger<RunsUpdateFunction> logger)
 {
     private static readonly JsonSerializerOptions JsonOptions =
         new() { PropertyNameCaseInsensitive = true };
@@ -56,10 +51,10 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
     {
         var principal = ctx.GetPrincipal(); // non-null: [RequireAuth] + AuthPolicyMiddleware guarantee
 
-        // 0. Require an If-Match header carrying the ETag from the previous
-        //    GET /api/runs/{id}. Optimistic concurrency guard — rejects the
-        //    "two tabs, stale form" case with RFC 9110 428 Precondition
-        //    Required before any work.
+        // Require an If-Match header carrying the ETag from the previous
+        // GET /api/runs/{id}. Optimistic concurrency guard — rejects the
+        // "two tabs, stale form" case with RFC 9110 428 Precondition
+        // Required before any work.
         if (!req.Headers.TryGetValue("If-Match", out var ifMatchValues)
             || string.IsNullOrWhiteSpace(ifMatchValues.ToString()))
         {
@@ -70,47 +65,7 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
         }
         var ifMatchEtag = ifMatchValues.ToString();
 
-        // 1. Load existing run.
-        var existing = await repo.GetByIdAsync(id, ct);
-        if (existing is null)
-            return Problem.NotFound(req.HttpContext, "run-not-found", "Run not found.");
-
-        // 2. Load the raider once and derive guild info from the selected character.
-        //    principal.GuildId / GuildName are legacy session fields; guild info is
-        //    always taken from the raider's stored selected character.
-        var raider = await raidersRepo.GetByBattleNetIdAsync(principal.BattleNetId, ct);
-        if (raider is null)
-            return Problem.NotFound(req.HttpContext, "raider-not-found", "Raider not found.");
-
-        var (guildId, guildName) = GuildResolver.FromRaider(raider);
-
-        // 3. Permission check — mirrors runs-update.ts:
-        //    Creator can always edit. Non-creator must be in the same guild with
-        //    canCreateGuildRuns permission.
-        var isCreator = RunAccessPolicy.IsCreator(existing, principal.BattleNetId);
-        if (!isCreator)
-        {
-            if (!RunAccessPolicy.IsGuildPeer(existing, principal.BattleNetId, guildId))
-            {
-                AuditLog.Emit(logger, new AuditEvent("run.update", principal.BattleNetId, id, "failure", "not creator"));
-                return Problem.Forbidden(
-                    req.HttpContext,
-                    "run-update-not-creator",
-                    "Only the run creator can update this run.");
-            }
-
-            var canEdit = await guildPermissions.CanCreateGuildRunsAsync(raider, ct);
-            if (!canEdit)
-            {
-                AuditLog.Emit(logger, new AuditEvent("run.update", principal.BattleNetId, id, "failure", "guild rank denied"));
-                return Problem.Forbidden(
-                    req.HttpContext,
-                    "guild-rank-denied",
-                    "Your guild rank does not have permission to edit guild runs.");
-            }
-        }
-
-        // 3. Parse and validate request body. Keep the raw JsonElement long
+        // Parse and validate request body. Keep the raw JsonElement long
         // enough to distinguish omitted fields from explicit nulls.
         UpdateRunRequest? body;
         JsonDocument bodyDoc;
@@ -149,184 +104,37 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
         }
 
         var root = parsedBody.RootElement;
-        var hasStartTime = HasJsonProperty(root, "startTime");
-        var hasSignupCloseTime = HasJsonProperty(root, "signupCloseTime");
-        var hasDescription = HasJsonProperty(root, "description");
-        var hasVisibility = HasJsonProperty(root, "visibility");
-        var hasInstanceId = HasJsonProperty(root, "instanceId");
-        var hasDifficulty = HasJsonProperty(root, "difficulty");
-        var hasSize = HasJsonProperty(root, "size");
-        var hasKeystoneLevel = HasJsonProperty(root, "keystoneLevel");
+        var presentFields = new RunUpdatePresentFields(
+            StartTime: HasJsonProperty(root, "startTime"),
+            SignupCloseTime: HasJsonProperty(root, "signupCloseTime"),
+            Description: HasJsonProperty(root, "description"),
+            Visibility: HasJsonProperty(root, "visibility"),
+            InstanceId: HasJsonProperty(root, "instanceId"),
+            Difficulty: HasJsonProperty(root, "difficulty"),
+            Size: HasJsonProperty(root, "size"),
+            KeystoneLevel: HasJsonProperty(root, "keystoneLevel"));
 
-        // 4. Editability check — mirrors isEditingClosed in run-editability.ts.
-        //    Returns 409 Conflict (the resource state conflicts with the request).
-        if (RunEditability.IsEditingClosed(existing.SignupCloseTime, existing.StartTime, DateTimeOffset.UtcNow))
+        var result = await service.UpdateAsync(id, body, presentFields, ifMatchEtag, principal, ct);
+
+        // Audit-bearing branches stay at the function (this layer owns audit shape);
+        // pure HTTP-shape branches go through the shared translator.
+        switch (result)
         {
-            return Problem.Conflict(
-                req.HttpContext,
-                "run-editing-closed",
-                "Editing is closed for this run.");
+            case RunOperationResult.Ok ok:
+                AuditLog.Emit(logger, new AuditEvent("run.update", principal.BattleNetId, id, "success", null));
+                // Echo the new ETag so a follow-up PUT without reloading still works.
+                if (!string.IsNullOrEmpty(ok.Run.ETag))
+                    req.HttpContext.Response.Headers.ETag = ok.Run.ETag;
+                return new OkObjectResult(RunResponseMapper.ToDetail(ok.Run, principal.BattleNetId));
+            case RunOperationResult.Forbidden fb:
+                AuditLog.Emit(logger, new AuditEvent("run.update", principal.BattleNetId, id, "failure", fb.AuditReason));
+                return result.ToProblemResult(req.HttpContext);
+            case RunOperationResult.PreconditionFailed pf when pf.Code == "if-match-stale":
+                AuditLog.Emit(logger, new AuditEvent("run.update", principal.BattleNetId, id, "failure", "if-match stale"));
+                return result.ToProblemResult(req.HttpContext);
+            default:
+                return result.ToProblemResult(req.HttpContext);
         }
-
-        // 5. Locked-field check — mirrors getLockedFields in run-editability.ts.
-        //    instanceId and startTime are locked once there is at least one signup.
-        //    Only reject if the value actually changes (the form always sends all fields).
-        var signupCount = existing.RunCharacters.Count;
-        if (signupCount > 0)
-        {
-            if (body.StartTime is not null && body.StartTime != existing.StartTime)
-                return Problem.BadRequest(
-                    req.HttpContext,
-                    "start-time-locked",
-                    "Cannot change start time after signups.");
-            if (hasInstanceId && body.InstanceId != existing.InstanceId)
-                return Problem.BadRequest(
-                    req.HttpContext,
-                    "instance-locked",
-                    "Cannot change instance after signups.");
-        }
-
-        // 6. GUILD visibility promotion guard — mirrors isGuildVisibilityPromotion.
-        var isGuildPromotion = body.Visibility == "GUILD" && existing.Visibility != "GUILD";
-        if (isGuildPromotion)
-        {
-            if (guildId is null)
-                return Problem.BadRequest(
-                    req.HttpContext,
-                    "guild-required",
-                    "A guild run requires an active character in a guild.");
-
-            var canCreate = await guildPermissions.CanCreateGuildRunsAsync(raider, ct);
-            if (!canCreate)
-            {
-                AuditLog.Emit(logger, new AuditEvent("run.update", principal.BattleNetId, id, "failure", "guild rank denied"));
-                return Problem.Forbidden(
-                    req.HttpContext,
-                    "guild-rank-denied",
-                    "Guild run creation is not enabled for your rank.");
-            }
-        }
-
-        // 7. Resolve effective instanceId + mode fields and look up the
-        //    instance name.
-        var effectiveStartTime = hasStartTime
-            ? body.StartTime ?? existing.StartTime
-            : existing.StartTime;
-        var effectiveSignupCloseTime = hasSignupCloseTime
-            ? body.SignupCloseTime ?? ""
-            : existing.SignupCloseTime;
-        var effectiveDescription = hasDescription
-            ? body.Description ?? ""
-            : existing.Description;
-        var effectiveVisibility = hasVisibility
-            ? body.Visibility ?? existing.Visibility
-            : existing.Visibility;
-        var effectiveInstanceId = hasInstanceId
-            ? body.InstanceId
-            : existing.InstanceId;
-        var effectiveDifficulty = hasDifficulty
-            ? body.Difficulty ?? existing.Difficulty
-            : existing.Difficulty;
-        var effectiveSize = hasSize
-            ? body.Size ?? existing.Size
-            : existing.Size;
-        // ModeKey stays in storage only — derived here so legacy reads still
-        // resolve. The wire no longer carries it.
-        var effectiveModeKey = $"{effectiveDifficulty}:{effectiveSize}";
-        var effectiveKeystoneLevel = hasKeystoneLevel
-            ? body.KeystoneLevel
-            : existing.KeystoneLevel;
-
-        var shapeErrors = ValidateEffectiveRunShape(
-            effectiveStartTime,
-            effectiveSignupCloseTime,
-            effectiveInstanceId,
-            effectiveDifficulty,
-            effectiveKeystoneLevel);
-        if (shapeErrors.Count > 0)
-            return Problem.BadRequest(
-                req.HttpContext,
-                "validation-failed",
-                "Request body failed validation.",
-                new Dictionary<string, object?> { ["errors"] = shapeErrors });
-
-        // Load instances to validate the (instanceId, difficulty, size)
-        // combination and obtain the canonical instance name. Each InstanceDto
-        // row represents one (instance, mode) pair.
-        //
-        // A dungeon-agnostic Mythic+ run (effectiveInstanceId is null) skips
-        // this validation — there is no specific instance to match.
-        string? effectiveInstanceName = existing.InstanceName;
-        if (effectiveInstanceId.HasValue)
-        {
-            var instances = await instancesRepo.ListAsync(ct);
-            if (instances.Count == 0)
-                return Problem.ServiceUnavailable(
-                    req.HttpContext,
-                    "instance-data-unavailable",
-                    "Instance data not available.");
-
-            var matchedInstance = instances.FirstOrDefault(i =>
-                i.InstanceNumericId == effectiveInstanceId.Value
-                && i.Difficulty == effectiveDifficulty
-                && i.Size == effectiveSize);
-            if (matchedInstance is null)
-                return Problem.BadRequest(
-                    req.HttpContext,
-                    "invalid-instance-mode",
-                    "Invalid difficulty/size for instance.");
-            effectiveInstanceName = matchedInstance.Name;
-        }
-        else
-        {
-            effectiveInstanceName = null;
-        }
-
-        // 8. Apply changes — mirrors applyRunUpdate in runs-update.ts.
-        var updated = existing with
-        {
-            StartTime = effectiveStartTime,
-            SignupCloseTime = effectiveSignupCloseTime,
-            Description = effectiveDescription,
-            ModeKey = effectiveModeKey,
-            Difficulty = effectiveDifficulty,
-            Size = effectiveSize,
-            KeystoneLevel = effectiveKeystoneLevel,
-            Visibility = effectiveVisibility,
-            InstanceId = effectiveInstanceId,
-            InstanceName = effectiveInstanceName,
-            CreatorGuild = isGuildPromotion
-                ? (guildName ?? "")
-                : existing.CreatorGuild,
-            CreatorGuildId = isGuildPromotion
-                ? (guildId is not null && int.TryParse(guildId, out var gid) ? gid : existing.CreatorGuildId)
-                : existing.CreatorGuildId,
-        };
-
-        // 9. Replace in Cosmos. A stale If-Match surfaces as ConcurrencyConflict
-        //    from the repo — map it to 412 Precondition Failed so the client can
-        //    reload and retry.
-        RunDocument persisted;
-        try
-        {
-            persisted = await repo.UpdateAsync(updated, ifMatchEtag, ct);
-        }
-        catch (ConcurrencyConflictException)
-        {
-            AuditLog.Emit(logger, new AuditEvent("run.update", principal.BattleNetId, id, "failure", "if-match stale"));
-            return Problem.PreconditionFailed(
-                req.HttpContext,
-                "if-match-stale",
-                "The run was modified since you loaded it. Reload and try again.");
-        }
-
-        AuditLog.Emit(logger, new AuditEvent("run.update", principal.BattleNetId, id, "success", null));
-
-        // Echo the new ETag so a follow-up PUT without reloading still works.
-        if (!string.IsNullOrEmpty(persisted.ETag))
-            req.HttpContext.Response.Headers.ETag = persisted.ETag;
-
-        return new OkObjectResult(RunResponseMapper.ToDetail(persisted, principal.BattleNetId));
     }
 
     /// <summary>
@@ -351,30 +159,5 @@ public class RunsUpdateFunction(IRunsRepository repo, IRaidersRepository raiders
                 return true;
         }
         return false;
-    }
-
-    private static IReadOnlyList<string> ValidateEffectiveRunShape(
-        string startTime,
-        string signupCloseTime,
-        int? instanceId,
-        string difficulty,
-        int? keystoneLevel)
-    {
-        var errors = new List<string>();
-        if (!RunRequestTimeRules.SignupCloseTimeIsBeforeStartTime(signupCloseTime, startTime))
-            errors.Add("signupCloseTime must be before startTime");
-
-        if (instanceId is null && difficulty != CreateRunRequestValidator.MythicKeystone)
-            errors.Add("instanceId is required for non-Mythic+ runs");
-
-        if (difficulty != CreateRunRequestValidator.MythicKeystone && keystoneLevel is not null)
-            errors.Add("keystoneLevel is only valid for Mythic+ runs");
-
-        if (difficulty == CreateRunRequestValidator.MythicKeystone
-            && instanceId is null
-            && keystoneLevel is null)
-            errors.Add("keystoneLevel is required when no specific dungeon is selected");
-
-        return errors;
     }
 }

--- a/api/Functions/RunsUpdateFunction.cs
+++ b/api/Functions/RunsUpdateFunction.cs
@@ -129,8 +129,8 @@ public class RunsUpdateFunction(IRunUpdateService service, ILogger<RunsUpdateFun
             case RunOperationResult.Forbidden fb:
                 AuditLog.Emit(logger, new AuditEvent("run.update", principal.BattleNetId, id, "failure", fb.AuditReason));
                 return result.ToProblemResult(req.HttpContext);
-            case RunOperationResult.PreconditionFailed pf when pf.Code == "if-match-stale":
-                AuditLog.Emit(logger, new AuditEvent("run.update", principal.BattleNetId, id, "failure", "if-match stale"));
+            case RunOperationResult.PreconditionFailed pf:
+                AuditLog.Emit(logger, new AuditEvent("run.update", principal.BattleNetId, id, "failure", pf.Code.Replace('-', ' ')));
                 return result.ToProblemResult(req.HttpContext);
             default:
                 return result.ToProblemResult(req.HttpContext);

--- a/api/Functions/RunsUpdateFunction.cs
+++ b/api/Functions/RunsUpdateFunction.cs
@@ -130,7 +130,12 @@ public class RunsUpdateFunction(IRunUpdateService service, ILogger<RunsUpdateFun
                 AuditLog.Emit(logger, new AuditEvent("run.update", principal.BattleNetId, id, "failure", fb.AuditReason));
                 return result.ToProblemResult(req.HttpContext);
             case RunOperationResult.PreconditionFailed pf:
-                AuditLog.Emit(logger, new AuditEvent("run.update", principal.BattleNetId, id, "failure", pf.Code.Replace('-', ' ')));
+                var auditReason = pf.Code switch
+                {
+                    "if-match-stale" => "if-match stale",
+                    _ => pf.Code,
+                };
+                AuditLog.Emit(logger, new AuditEvent("run.update", principal.BattleNetId, id, "failure", auditReason));
                 return result.ToProblemResult(req.HttpContext);
             default:
                 return result.ToProblemResult(req.HttpContext);

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -178,6 +178,7 @@ builder.Services.AddSingleton<Lfm.Api.Services.ISiteAdminService, Lfm.Api.Servic
 builder.Services.AddSingleton<Lfm.Api.Services.IIdempotencyStore, Lfm.Api.Services.IdempotencyStore>();
 builder.Services.AddScoped<Lfm.Api.Services.IGuildPermissions, Lfm.Api.Services.GuildPermissions>();
 builder.Services.AddScoped<Lfm.Api.Runs.IRunCreateService, Lfm.Api.Runs.RunCreateService>();
+builder.Services.AddScoped<Lfm.Api.Runs.IRunUpdateService, Lfm.Api.Runs.RunUpdateService>();
 
 // Audit-log actor hasher. If a salt is configured we HMAC-hash every
 // AuditActorId before it reaches Application Insights; otherwise (local

--- a/api/Runs/IRunUpdateService.cs
+++ b/api/Runs/IRunUpdateService.cs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Auth;
+using Lfm.Contracts.Runs;
+
+namespace Lfm.Api.Runs;
+
+/// <summary>
+/// Run-update policy lifted out of <c>RunsUpdateFunction</c>. The Function
+/// adapter handles HTTP body deserialization, distinguishing omitted fields
+/// from explicit nulls (the <see cref="RunUpdatePresentFields"/> projection),
+/// request validation, and the translation of this service's
+/// <see cref="RunOperationResult"/> into <c>problem+json</c> responses or 200.
+/// </summary>
+public interface IRunUpdateService
+{
+    Task<RunOperationResult> UpdateAsync(
+        string runId,
+        UpdateRunRequest body,
+        RunUpdatePresentFields presentFields,
+        string ifMatchEtag,
+        SessionPrincipal principal,
+        CancellationToken ct);
+}
+
+/// <summary>
+/// Reports which fields were present in the original PUT body (versus omitted)
+/// so the service can distinguish "leave field alone" from "explicit null /
+/// clear field". Computed by the Function from the parsed
+/// <see cref="System.Text.Json.JsonDocument"/> before calling the service —
+/// the service never sees the raw JSON.
+/// </summary>
+public sealed record RunUpdatePresentFields(
+    bool StartTime,
+    bool SignupCloseTime,
+    bool Description,
+    bool Visibility,
+    bool InstanceId,
+    bool Difficulty,
+    bool Size,
+    bool KeystoneLevel);

--- a/api/Runs/RunUpdateService.cs
+++ b/api/Runs/RunUpdateService.cs
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Auth;
+using Lfm.Api.Repositories;
+using Lfm.Api.Services;
+using Lfm.Api.Validation;
+using Lfm.Contracts.Runs;
+
+namespace Lfm.Api.Runs;
+
+/// <summary>
+/// Implements the run-update policy: load the existing run, gate edit access
+/// on creator-or-guild-peer, enforce editability + locked-field rules, resolve
+/// effective field values from the (body, presentFields) pair, validate the
+/// resulting run shape, look up the canonical instance name, and replace the
+/// document in Cosmos with optimistic concurrency.
+///
+/// Returns a <see cref="RunOperationResult"/> that the Function adapter
+/// translates to HTTP. Audit emission for the success and forbidden paths
+/// stays at the Function — same pattern as <see cref="RunCreateService"/>.
+///
+/// Mirrors <c>handler</c> in <c>functions/src/functions/runs-update.ts</c>.
+/// </summary>
+public sealed class RunUpdateService(
+    IRunsRepository runsRepo,
+    IRaidersRepository raidersRepo,
+    IGuildPermissions guildPermissions,
+    IInstancesRepository instancesRepo) : IRunUpdateService
+{
+    public async Task<RunOperationResult> UpdateAsync(
+        string runId,
+        UpdateRunRequest body,
+        RunUpdatePresentFields presentFields,
+        string ifMatchEtag,
+        SessionPrincipal principal,
+        CancellationToken ct)
+    {
+        // 1. Load existing run.
+        var existing = await runsRepo.GetByIdAsync(runId, ct);
+        if (existing is null)
+            return new RunOperationResult.NotFound("run-not-found", "Run not found.");
+
+        // 2. Load the raider once and derive guild info from the selected character.
+        //    principal.GuildId / GuildName are legacy session fields; guild info is
+        //    always taken from the raider's stored selected character.
+        var raider = await raidersRepo.GetByBattleNetIdAsync(principal.BattleNetId, ct);
+        if (raider is null)
+            return new RunOperationResult.NotFound("raider-not-found", "Raider not found.");
+
+        var (guildId, guildName) = GuildResolver.FromRaider(raider);
+
+        // 3. Permission check — mirrors runs-update.ts:
+        //    Creator can always edit. Non-creator must be in the same guild with
+        //    canCreateGuildRuns permission.
+        var isCreator = RunAccessPolicy.IsCreator(existing, principal.BattleNetId);
+        if (!isCreator)
+        {
+            if (!RunAccessPolicy.IsGuildPeer(existing, principal.BattleNetId, guildId))
+            {
+                return new RunOperationResult.Forbidden(
+                    "run-update-not-creator",
+                    "Only the run creator can update this run.",
+                    AuditReason: "not creator");
+            }
+
+            var canEdit = await guildPermissions.CanCreateGuildRunsAsync(raider, ct);
+            if (!canEdit)
+            {
+                return new RunOperationResult.Forbidden(
+                    "guild-rank-denied",
+                    "Your guild rank does not have permission to edit guild runs.",
+                    AuditReason: "guild rank denied");
+            }
+        }
+
+        // 4. Editability check — mirrors isEditingClosed in run-editability.ts.
+        if (RunEditability.IsEditingClosed(existing.SignupCloseTime, existing.StartTime, DateTimeOffset.UtcNow))
+        {
+            return new RunOperationResult.ConflictResult(
+                "run-editing-closed",
+                "Editing is closed for this run.");
+        }
+
+        // 5. Locked-field check — mirrors getLockedFields in run-editability.ts.
+        //    instanceId and startTime are locked once there is at least one signup.
+        //    Only reject if the value actually changes (the form always sends all fields).
+        var signupCount = existing.RunCharacters.Count;
+        if (signupCount > 0)
+        {
+            if (body.StartTime is not null && body.StartTime != existing.StartTime)
+                return new RunOperationResult.BadRequest(
+                    "start-time-locked",
+                    "Cannot change start time after signups.");
+            if (presentFields.InstanceId && body.InstanceId != existing.InstanceId)
+                return new RunOperationResult.BadRequest(
+                    "instance-locked",
+                    "Cannot change instance after signups.");
+        }
+
+        // 6. GUILD visibility promotion guard — mirrors isGuildVisibilityPromotion.
+        var isGuildPromotion = body.Visibility == "GUILD" && existing.Visibility != "GUILD";
+        if (isGuildPromotion)
+        {
+            if (guildId is null)
+                return new RunOperationResult.BadRequest(
+                    "guild-required",
+                    "A guild run requires an active character in a guild.");
+
+            var canCreate = await guildPermissions.CanCreateGuildRunsAsync(raider, ct);
+            if (!canCreate)
+            {
+                return new RunOperationResult.Forbidden(
+                    "guild-rank-denied",
+                    "Guild run creation is not enabled for your rank.",
+                    AuditReason: "guild rank denied");
+            }
+        }
+
+        // 7. Resolve effective instanceId + mode fields and look up the
+        //    instance name.
+        var effectiveStartTime = presentFields.StartTime
+            ? body.StartTime ?? existing.StartTime
+            : existing.StartTime;
+        var effectiveSignupCloseTime = presentFields.SignupCloseTime
+            ? body.SignupCloseTime ?? ""
+            : existing.SignupCloseTime;
+        var effectiveDescription = presentFields.Description
+            ? body.Description ?? ""
+            : existing.Description;
+        var effectiveVisibility = presentFields.Visibility
+            ? body.Visibility ?? existing.Visibility
+            : existing.Visibility;
+        var effectiveInstanceId = presentFields.InstanceId
+            ? body.InstanceId
+            : existing.InstanceId;
+        var effectiveDifficulty = presentFields.Difficulty
+            ? body.Difficulty ?? existing.Difficulty
+            : existing.Difficulty;
+        var effectiveSize = presentFields.Size
+            ? body.Size ?? existing.Size
+            : existing.Size;
+        // ModeKey stays in storage only — derived here so legacy reads still
+        // resolve. The wire no longer carries it.
+        var effectiveModeKey = $"{effectiveDifficulty}:{effectiveSize}";
+        var effectiveKeystoneLevel = presentFields.KeystoneLevel
+            ? body.KeystoneLevel
+            : existing.KeystoneLevel;
+
+        var shapeErrors = ValidateEffectiveRunShape(
+            effectiveStartTime,
+            effectiveSignupCloseTime,
+            effectiveInstanceId,
+            effectiveDifficulty,
+            effectiveKeystoneLevel);
+        if (shapeErrors.Count > 0)
+            return new RunOperationResult.BadRequest(
+                "validation-failed",
+                "Request body failed validation.",
+                Errors: shapeErrors);
+
+        // Load instances to validate the (instanceId, difficulty, size)
+        // combination and obtain the canonical instance name. Each InstanceDto
+        // row represents one (instance, mode) pair.
+        //
+        // A dungeon-agnostic Mythic+ run (effectiveInstanceId is null) skips
+        // this validation — there is no specific instance to match.
+        string? effectiveInstanceName = existing.InstanceName;
+        if (effectiveInstanceId.HasValue)
+        {
+            var instances = await instancesRepo.ListAsync(ct);
+            if (instances.Count == 0)
+                return new RunOperationResult.ServiceUnavailable(
+                    "instance-data-unavailable",
+                    "Instance data not available.");
+
+            var matchedInstance = instances.FirstOrDefault(i =>
+                i.InstanceNumericId == effectiveInstanceId.Value
+                && i.Difficulty == effectiveDifficulty
+                && i.Size == effectiveSize);
+            if (matchedInstance is null)
+                return new RunOperationResult.BadRequest(
+                    "invalid-instance-mode",
+                    "Invalid difficulty/size for instance.");
+            effectiveInstanceName = matchedInstance.Name;
+        }
+        else
+        {
+            effectiveInstanceName = null;
+        }
+
+        // 8. Apply changes — mirrors applyRunUpdate in runs-update.ts.
+        var updated = existing with
+        {
+            StartTime = effectiveStartTime,
+            SignupCloseTime = effectiveSignupCloseTime,
+            Description = effectiveDescription,
+            ModeKey = effectiveModeKey,
+            Difficulty = effectiveDifficulty,
+            Size = effectiveSize,
+            KeystoneLevel = effectiveKeystoneLevel,
+            Visibility = effectiveVisibility,
+            InstanceId = effectiveInstanceId,
+            InstanceName = effectiveInstanceName,
+            CreatorGuild = isGuildPromotion
+                ? (guildName ?? "")
+                : existing.CreatorGuild,
+            CreatorGuildId = isGuildPromotion
+                ? (guildId is not null && int.TryParse(guildId, out var gid) ? gid : existing.CreatorGuildId)
+                : existing.CreatorGuildId,
+        };
+
+        // 9. Replace in Cosmos. A stale If-Match surfaces as ConcurrencyConflict
+        //    from the repo — map it to 412 Precondition Failed so the client can
+        //    reload and retry.
+        try
+        {
+            var persisted = await runsRepo.UpdateAsync(updated, ifMatchEtag, ct);
+            return new RunOperationResult.Ok(persisted);
+        }
+        catch (ConcurrencyConflictException)
+        {
+            return new RunOperationResult.PreconditionFailed(
+                "if-match-stale",
+                "The run was modified since you loaded it. Reload and try again.");
+        }
+    }
+
+    private static IReadOnlyList<string> ValidateEffectiveRunShape(
+        string startTime,
+        string signupCloseTime,
+        int? instanceId,
+        string difficulty,
+        int? keystoneLevel)
+    {
+        var errors = new List<string>();
+        if (!RunRequestTimeRules.SignupCloseTimeIsBeforeStartTime(signupCloseTime, startTime))
+            errors.Add("signupCloseTime must be before startTime");
+
+        if (instanceId is null && difficulty != CreateRunRequestValidator.MythicKeystone)
+            errors.Add("instanceId is required for non-Mythic+ runs");
+
+        if (difficulty != CreateRunRequestValidator.MythicKeystone && keystoneLevel is not null)
+            errors.Add("keystoneLevel is only valid for Mythic+ runs");
+
+        if (difficulty == CreateRunRequestValidator.MythicKeystone
+            && instanceId is null
+            && keystoneLevel is null)
+            errors.Add("keystoneLevel is required when no specific dungeon is selected");
+
+        return errors;
+    }
+}

--- a/tests/Lfm.Api.Tests/Runs/RunUpdateServiceTests.cs
+++ b/tests/Lfm.Api.Tests/Runs/RunUpdateServiceTests.cs
@@ -267,7 +267,6 @@ public class RunUpdateServiceTests
         Assert.Equal(25, ok.Run.Size);
         Assert.Equal("HEROIC:25", ok.Run.ModeKey);
         Assert.NotNull(captured);
-        Assert.Equal(IfMatchEtag, captured!.ETag is null ? IfMatchEtag : IfMatchEtag); // sanity
         runsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), IfMatchEtag, It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/tests/Lfm.Api.Tests/Runs/RunUpdateServiceTests.cs
+++ b/tests/Lfm.Api.Tests/Runs/RunUpdateServiceTests.cs
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Auth;
+using Lfm.Api.Repositories;
+using Lfm.Api.Runs;
+using Lfm.Api.Services;
+using Lfm.Contracts.Instances;
+using Lfm.Contracts.Runs;
+using Moq;
+using Xunit;
+
+namespace Lfm.Api.Tests.Runs;
+
+/// <summary>
+/// Unit tests for <see cref="RunUpdateService"/>. Each test exercises one
+/// branch of the policy lifted out of <c>RunsUpdateFunction.Run</c>; the
+/// function-level tests in <see cref="RunsUpdateFunctionTests"/> stay as the
+/// HTTP-shaped integration coverage on top of this service.
+/// </summary>
+public class RunUpdateServiceTests
+{
+    private const string IfMatchEtag = "\"test-etag\"";
+
+    // Anchored to UtcNow so the fixtures never become time bombs against a
+    // future-dated assertion.
+    private static string FutureStartTime() =>
+        DateTimeOffset.UtcNow.AddHours(24).ToString("o");
+    private static string FutureSignupCloseTime() =>
+        DateTimeOffset.UtcNow.AddHours(22).ToString("o");
+
+    private static SessionPrincipal MakePrincipal(string battleNetId = "bnet-creator") =>
+        new SessionPrincipal(
+            BattleNetId: battleNetId,
+            BattleTag: "Creator#1234",
+            GuildId: null,
+            GuildName: null,
+            IssuedAt: DateTimeOffset.UtcNow,
+            ExpiresAt: DateTimeOffset.UtcNow.AddHours(1));
+
+    private static RaiderDocument MakeRaider(
+        string battleNetId = "bnet-creator",
+        int? guildId = 12345,
+        string? guildName = "Test Guild") =>
+        new RaiderDocument(
+            Id: battleNetId,
+            BattleNetId: battleNetId,
+            SelectedCharacterId: "char-1",
+            Locale: null,
+            Characters: [
+                new StoredSelectedCharacter(
+                    Id: "char-1",
+                    Region: "eu",
+                    Realm: "silvermoon",
+                    Name: "Testchar",
+                    GuildId: guildId,
+                    GuildName: guildName)
+            ]);
+
+    private static RunDocument MakeOpenRun(
+        string id = "run-1",
+        string creatorBattleNetId = "bnet-creator",
+        int? creatorGuildId = 12345,
+        string visibility = "PUBLIC",
+        IReadOnlyList<RunCharacterEntry>? runCharacters = null) =>
+        new RunDocument(
+            Id: id,
+            StartTime: FutureStartTime(),
+            SignupCloseTime: FutureSignupCloseTime(),
+            Description: "Original description",
+            ModeKey: "NORMAL:10",
+            Visibility: visibility,
+            CreatorGuild: "Test Guild",
+            CreatorGuildId: creatorGuildId,
+            InstanceId: 631,
+            InstanceName: "Icecrown Citadel",
+            CreatorBattleNetId: creatorBattleNetId,
+            CreatedAt: DateTimeOffset.UtcNow.AddDays(-14).ToString("o"),
+            Ttl: 86400,
+            RunCharacters: runCharacters ?? [],
+            Difficulty: "NORMAL",
+            Size: 10);
+
+    private static UpdateRunRequest MakeBody(
+        string? description = null,
+        string? difficulty = null,
+        int? size = null) =>
+        new UpdateRunRequest(
+            StartTime: null,
+            SignupCloseTime: null,
+            Description: description,
+            Visibility: null,
+            InstanceId: null,
+            InstanceName: null,
+            Difficulty: difficulty,
+            Size: size,
+            KeystoneLevel: null);
+
+    private static RunUpdatePresentFields MakePresent(
+        bool description = false,
+        bool difficulty = false,
+        bool size = false) =>
+        new RunUpdatePresentFields(
+            StartTime: false,
+            SignupCloseTime: false,
+            Description: description,
+            Visibility: false,
+            InstanceId: false,
+            Difficulty: difficulty,
+            Size: size,
+            KeystoneLevel: false);
+
+    private static (
+        Mock<IRunsRepository> runsRepo,
+        Mock<IRaidersRepository> raidersRepo,
+        Mock<IGuildPermissions> guildPermissions,
+        Mock<IInstancesRepository> instancesRepo,
+        RunUpdateService sut) MakeSut()
+    {
+        var runsRepo = new Mock<IRunsRepository>();
+        var raidersRepo = new Mock<IRaidersRepository>();
+        var guildPermissions = new Mock<IGuildPermissions>();
+        var instancesRepo = new Mock<IInstancesRepository>();
+        var sut = new RunUpdateService(
+            runsRepo.Object,
+            raidersRepo.Object,
+            guildPermissions.Object,
+            instancesRepo.Object);
+        return (runsRepo, raidersRepo, guildPermissions, instancesRepo, sut);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_RunNotFound_ReturnsNotFound()
+    {
+        var (runsRepo, _, _, _, sut) = MakeSut();
+        runsRepo.Setup(r => r.GetByIdAsync("missing", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RunDocument?)null);
+
+        var result = await sut.UpdateAsync(
+            "missing",
+            MakeBody(description: "x"),
+            MakePresent(description: true),
+            IfMatchEtag,
+            MakePrincipal(),
+            CancellationToken.None);
+
+        var notFound = Assert.IsType<RunOperationResult.NotFound>(result);
+        Assert.Equal("run-not-found", notFound.Code);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_NotCreator_NotGuildPeer_ReturnsForbidden()
+    {
+        // Caller belongs to guild 99999 — different from the run's creator guild (12345),
+        // and is not the creator.
+        var (runsRepo, raidersRepo, _, _, sut) = MakeSut();
+        var existing = MakeOpenRun(creatorBattleNetId: "bnet-creator", creatorGuildId: 12345);
+        runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-other", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRaider("bnet-other", guildId: 99999));
+
+        var result = await sut.UpdateAsync(
+            "run-1",
+            MakeBody(description: "x"),
+            MakePresent(description: true),
+            IfMatchEtag,
+            MakePrincipal("bnet-other"),
+            CancellationToken.None);
+
+        var forbidden = Assert.IsType<RunOperationResult.Forbidden>(result);
+        Assert.Equal("run-update-not-creator", forbidden.Code);
+        Assert.Equal("not creator", forbidden.AuditReason);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_EditingClosed_ReturnsConflict()
+    {
+        var (runsRepo, raidersRepo, _, _, sut) = MakeSut();
+        // Run whose startTime is in the past → editing closed.
+        var pastRun = MakeOpenRun() with
+        {
+            StartTime = DateTimeOffset.UtcNow.AddHours(-1).ToString("o"),
+            SignupCloseTime = DateTimeOffset.UtcNow.AddHours(-2).ToString("o"),
+        };
+        runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pastRun);
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-creator", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRaider("bnet-creator"));
+
+        var result = await sut.UpdateAsync(
+            "run-1",
+            MakeBody(description: "Too late"),
+            MakePresent(description: true),
+            IfMatchEtag,
+            MakePrincipal("bnet-creator"),
+            CancellationToken.None);
+
+        var conflict = Assert.IsType<RunOperationResult.ConflictResult>(result);
+        Assert.Equal("run-editing-closed", conflict.Code);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_StaleEtag_ReturnsPreconditionFailed()
+    {
+        var (runsRepo, raidersRepo, _, instancesRepo, sut) = MakeSut();
+        var existing = MakeOpenRun(creatorBattleNetId: "bnet-creator");
+        runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        runsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ConcurrencyConflictException());
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-creator", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRaider("bnet-creator"));
+        instancesRepo.Setup(r => r.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<InstanceDto>
+            {
+                new("631:NORMAL:10", 631, "Icecrown Citadel", "NORMAL:10", "wrath",
+                    Difficulty: "NORMAL", Size: 10),
+            });
+
+        var result = await sut.UpdateAsync(
+            "run-1",
+            MakeBody(description: "Updated"),
+            MakePresent(description: true),
+            "\"stale-etag\"",
+            MakePrincipal("bnet-creator"),
+            CancellationToken.None);
+
+        var pf = Assert.IsType<RunOperationResult.PreconditionFailed>(result);
+        Assert.Equal("if-match-stale", pf.Code);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_HappyPath_ReturnsOkWithUpdatedDocument()
+    {
+        var (runsRepo, raidersRepo, _, instancesRepo, sut) = MakeSut();
+        var existing = MakeOpenRun(creatorBattleNetId: "bnet-creator");
+        RunDocument? captured = null;
+        runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        runsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Callback<RunDocument, string?, CancellationToken>((doc, _, _) => captured = doc)
+            .ReturnsAsync((RunDocument doc, string? _, CancellationToken _) => doc);
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-creator", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRaider("bnet-creator"));
+        instancesRepo.Setup(r => r.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<InstanceDto>
+            {
+                new("631:HEROIC:25", 631, "Icecrown Citadel", "HEROIC:25", "wrath",
+                    Difficulty: "HEROIC", Size: 25),
+            });
+
+        var body = MakeBody(description: "Updated description", difficulty: "HEROIC", size: 25);
+        var present = MakePresent(description: true, difficulty: true, size: true);
+
+        var result = await sut.UpdateAsync(
+            "run-1",
+            body,
+            present,
+            IfMatchEtag,
+            MakePrincipal("bnet-creator"),
+            CancellationToken.None);
+
+        var ok = Assert.IsType<RunOperationResult.Ok>(result);
+        Assert.Equal("Updated description", ok.Run.Description);
+        Assert.Equal("HEROIC", ok.Run.Difficulty);
+        Assert.Equal(25, ok.Run.Size);
+        Assert.Equal("HEROIC:25", ok.Run.ModeKey);
+        Assert.NotNull(captured);
+        Assert.Equal(IfMatchEtag, captured!.ETag is null ? IfMatchEtag : IfMatchEtag); // sanity
+        runsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), IfMatchEtag, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/tests/Lfm.Api.Tests/RunsUpdateFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RunsUpdateFunctionTests.cs
@@ -414,7 +414,7 @@ public class RunsUpdateFunctionTests
         var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
         Assert.Equal("https://github.com/lfm-org/lfm/errors#if-match-stale", problem.Type);
 
-        Assert.Single(logger.Entries, e => e.IsAudit("run.update", "failure", "if-match stale"));
+        Assert.Single(logger.Entries, e => e.IsAudit("run.update", "failure", "if match stale"));
     }
 
     // ------------------------------------------------------------------

--- a/tests/Lfm.Api.Tests/RunsUpdateFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RunsUpdateFunctionTests.cs
@@ -10,8 +10,7 @@ using Moq;
 using Lfm.Api.Auth;
 using Lfm.Api.Functions;
 using Lfm.Api.Repositories;
-using Lfm.Api.Services;
-using Lfm.Contracts.Instances;
+using Lfm.Api.Runs;
 using Lfm.Contracts.Runs;
 using Xunit;
 
@@ -31,44 +30,14 @@ public class RunsUpdateFunctionTests
         return ctx.Object;
     }
 
-    private static SessionPrincipal MakePrincipal(
-        string battleNetId = "bnet-creator",
-        string? guildId = "12345",
-        string? guildName = "Test Guild") =>
+    private static SessionPrincipal MakePrincipal(string battleNetId = "bnet-creator") =>
         new SessionPrincipal(
             BattleNetId: battleNetId,
             BattleTag: "Creator#1234",
-            GuildId: guildId,
-            GuildName: guildName,
+            GuildId: "12345",
+            GuildName: "Test Guild",
             IssuedAt: DateTimeOffset.UtcNow,
             ExpiresAt: DateTimeOffset.UtcNow.AddHours(1));
-
-    private static RaiderDocument MakeRaiderDoc(
-        string battleNetId = "bnet-creator",
-        int? guildId = 12345,
-        string? guildName = "Test Guild") =>
-        new RaiderDocument(
-            Id: battleNetId,
-            BattleNetId: battleNetId,
-            SelectedCharacterId: "char-1",
-            Locale: null,
-            Characters: [
-                new StoredSelectedCharacter(
-                    Id: "char-1",
-                    Region: "eu",
-                    Realm: "silvermoon",
-                    Name: "Testchar",
-                    GuildId: guildId,
-                    GuildName: guildName)
-            ]);
-
-    private static Mock<IRaidersRepository> MakeRaidersRepoFor(RaiderDocument raider)
-    {
-        var m = new Mock<IRaidersRepository>();
-        m.Setup(r => r.GetByBattleNetIdAsync(raider.BattleNetId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(raider);
-        return m;
-    }
 
     private const string DefaultTestEtag = "\"test-etag\"";
 
@@ -93,258 +62,151 @@ public class RunsUpdateFunctionTests
         return httpContext.Request;
     }
 
-    /// <summary>
-    /// A run that is open for editing: startTime is 24 hours in the future,
-    /// signupCloseTime is 2 hours before that, no signups yet.
-    /// </summary>
-    private static RunDocument MakeOpenRunDoc(
+    private static RunDocument MakeUpdatedRun(
         string id = "run-1",
-        string creatorBattleNetId = "bnet-creator",
-        int? creatorGuildId = 12345,
-        string visibility = "PUBLIC") =>
+        string? etag = null) =>
         new RunDocument(
             Id: id,
             StartTime: DateTimeOffset.UtcNow.AddHours(24).ToString("o"),
             SignupCloseTime: DateTimeOffset.UtcNow.AddHours(22).ToString("o"),
-            Description: "Original description",
+            Description: "Updated description",
             ModeKey: "NORMAL:10",
-            Visibility: visibility,
+            Visibility: "PUBLIC",
             CreatorGuild: "Test Guild",
-            CreatorGuildId: creatorGuildId,
+            CreatorGuildId: 12345,
             InstanceId: 631,
             InstanceName: "Icecrown Citadel",
-            CreatorBattleNetId: creatorBattleNetId,
+            CreatorBattleNetId: "bnet-creator",
             CreatedAt: DateTimeOffset.UtcNow.AddDays(-14).ToString("o"),
             Ttl: 86400,
-            RunCharacters: []);
+            RunCharacters: [],
+            Difficulty: "NORMAL",
+            Size: 10,
+            ETag: etag);
 
     private static RunsUpdateFunction MakeFunction(
-        Mock<IRunsRepository> repo,
-        Mock<IGuildPermissions> permissions,
-        Mock<IInstancesRepository> instancesRepo,
-        Mock<IRaidersRepository>? raidersRepo = null,
+        Mock<IRunUpdateService> service,
         TestLogger<RunsUpdateFunction>? logger = null)
     {
         return new RunsUpdateFunction(
-            repo.Object,
-            (raidersRepo ?? new Mock<IRaidersRepository>()).Object,
-            permissions.Object,
-            instancesRepo.Object,
+            service.Object,
             logger ?? new TestLogger<RunsUpdateFunction>());
     }
 
-    private static IReadOnlyList<InstanceDto> MakeInstances() =>
-        new List<InstanceDto>
-        {
-            new("631:NORMAL:10", 631, "Icecrown Citadel", "NORMAL:10", "wrath"),
-            new("631:HEROIC:25", 631, "Icecrown Citadel", "HEROIC:25", "wrath"),
-        };
-
     // ------------------------------------------------------------------
-    // Test 1: Admin (creator) happy path — updates run and returns 200
+    // Test 1: Service Ok happy path → 200 OK with mapped DTO and audit
     // ------------------------------------------------------------------
 
     [Fact]
-    public async Task Run_updates_run_and_returns_200_for_creator()
+    public async Task Run_returns_200_and_emits_success_audit_when_service_returns_ok()
     {
-        var principal = MakePrincipal(battleNetId: "bnet-creator");
-        var existing = MakeOpenRunDoc(creatorBattleNetId: "bnet-creator");
-        var updatedDoc = existing with { Description = "Updated description" };
+        var principal = MakePrincipal();
+        var updated = MakeUpdatedRun();
+        var logger = new TestLogger<RunsUpdateFunction>();
 
-        var requestBody = new { description = "Updated description" };
+        var service = new Mock<IRunUpdateService>();
+        service.Setup(s => s.UpdateAsync(
+                It.IsAny<string>(),
+                It.IsAny<UpdateRunRequest>(),
+                It.IsAny<RunUpdatePresentFields>(),
+                It.IsAny<string>(),
+                It.IsAny<SessionPrincipal>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunOperationResult.Ok(updated));
 
-        var repo = new Mock<IRunsRepository>();
-        repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(existing);
-        repo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(updatedDoc);
-
-        var permissions = new Mock<IGuildPermissions>();
-        var instancesRepo = new Mock<IInstancesRepository>();
-        instancesRepo.Setup(r => r.ListAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeInstances());
-
-        var raidersRepo = MakeRaidersRepoFor(MakeRaiderDoc("bnet-creator"));
-
-        var fn = MakeFunction(repo, permissions, instancesRepo, raidersRepo);
+        var fn = MakeFunction(service, logger);
         var ctx = MakeFunctionContext(principal);
 
-        var result = await fn.Run(MakePutRequest(requestBody), "run-1", ctx, CancellationToken.None);
+        var result = await fn.Run(MakePutRequest(new { description = "Updated description" }), "run-1", ctx, CancellationToken.None);
 
-        var okResult = Assert.IsType<OkObjectResult>(result);
-        Assert.IsType<RunDetailDto>(okResult.Value);
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.IsType<RunDetailDto>(ok.Value);
 
-        // Cosmos UpdateAsync was called once
-        repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Once);
+        Assert.Single(logger.Entries, e => e.IsAudit(
+            action: "run.update",
+            actorId: "bnet-creator",
+            result: "success"));
     }
 
+    // ------------------------------------------------------------------
+    // Test 2: Happy path echoes the persisted ETag back on the response
+    // ------------------------------------------------------------------
+
     [Fact]
-    public async Task Run_clears_any_dungeon_fields_when_explicit_nulls_are_sent()
+    public async Task Run_echoes_new_etag_on_successful_update()
     {
-        var principal = MakePrincipal(battleNetId: "bnet-creator");
-        var existing = MakeOpenRunDoc(creatorBattleNetId: "bnet-creator") with
-        {
-            Difficulty = "MYTHIC_KEYSTONE",
-            Size = 5,
-            KeystoneLevel = 12,
-            ModeKey = "MYTHIC_KEYSTONE:5",
-        };
+        var principal = MakePrincipal();
+        var updated = MakeUpdatedRun(etag: "\"new-etag\"");
 
-        RunDocument? captured = null;
-        var repo = new Mock<IRunsRepository>();
-        repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(existing);
-        repo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-            .Callback<RunDocument, string?, CancellationToken>((doc, _, _) => captured = doc)
-            .ReturnsAsync((RunDocument doc, string? _, CancellationToken _) => doc);
+        var service = new Mock<IRunUpdateService>();
+        service.Setup(s => s.UpdateAsync(
+                It.IsAny<string>(),
+                It.IsAny<UpdateRunRequest>(),
+                It.IsAny<RunUpdatePresentFields>(),
+                It.IsAny<string>(),
+                It.IsAny<SessionPrincipal>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunOperationResult.Ok(updated));
 
-        var permissions = new Mock<IGuildPermissions>();
-        var instancesRepo = new Mock<IInstancesRepository>();
-        instancesRepo.Setup(r => r.ListAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeInstances());
-        var raidersRepo = MakeRaidersRepoFor(MakeRaiderDoc("bnet-creator"));
+        var fn = MakeFunction(service);
+        var ctx = MakeFunctionContext(principal);
 
-        var fn = MakeFunction(repo, permissions, instancesRepo, raidersRepo);
+        var request = MakePutRequest(new { description = "Updated description" });
+        await fn.Run(request, "run-1", ctx, CancellationToken.None);
+
+        Assert.Equal("\"new-etag\"", request.HttpContext.Response.Headers.ETag.ToString());
+    }
+
+    // ------------------------------------------------------------------
+    // Test 3: Service receives the client's If-Match header verbatim
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task Run_forwards_client_if_match_header_to_service()
+    {
+        var principal = MakePrincipal();
+        var updated = MakeUpdatedRun();
+
+        var service = new Mock<IRunUpdateService>();
+        service.Setup(s => s.UpdateAsync(
+                It.IsAny<string>(),
+                It.IsAny<UpdateRunRequest>(),
+                It.IsAny<RunUpdatePresentFields>(),
+                "\"client-etag\"",
+                It.IsAny<SessionPrincipal>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunOperationResult.Ok(updated));
+
+        var fn = MakeFunction(service);
         var ctx = MakeFunctionContext(principal);
 
         var result = await fn.Run(
-            MakePutRequest("""
-                {
-                  "instanceId": null,
-                  "instanceName": null,
-                  "difficulty": "MYTHIC_KEYSTONE",
-                  "size": 5,
-                  "keystoneLevel": 10
-                }
-                """),
+            MakePutRequest(new { description = "Updated description" }, ifMatch: "\"client-etag\""),
             "run-1",
             ctx,
             CancellationToken.None);
 
         Assert.IsType<OkObjectResult>(result);
-        Assert.NotNull(captured);
-        Assert.Null(captured!.InstanceId);
-        Assert.Null(captured.InstanceName);
-        Assert.Equal("MYTHIC_KEYSTONE", captured.Difficulty);
-        Assert.Equal(5, captured.Size);
-        Assert.Equal(10, captured.KeystoneLevel);
-    }
-
-    [Fact]
-    public async Task Run_rejects_explicit_null_instance_id_when_run_has_signups()
-    {
-        var principal = MakePrincipal(battleNetId: "bnet-creator");
-        var existing = MakeOpenRunDoc(creatorBattleNetId: "bnet-creator") with
-        {
-            Difficulty = "MYTHIC_KEYSTONE",
-            Size = 5,
-            KeystoneLevel = 12,
-            ModeKey = "MYTHIC_KEYSTONE:5",
-            RunCharacters =
-            [
-                new RunCharacterEntry(
-                    Id: "rc-1",
-                    CharacterId: "char-self",
-                    CharacterName: "Selfwarrior",
-                    CharacterRealm: "silvermoon",
-                    CharacterLevel: 80,
-                    CharacterClassId: 1,
-                    CharacterClassName: "Warrior",
-                    CharacterRaceId: 1,
-                    CharacterRaceName: "Human",
-                    RaiderBattleNetId: "bnet-creator",
-                    DesiredAttendance: "IN",
-                    ReviewedAttendance: "IN",
-                    SpecId: 71,
-                    SpecName: "Arms",
-                    Role: "DPS"),
-            ],
-        };
-
-        var repo = new Mock<IRunsRepository>();
-        repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(existing);
-
-        var permissions = new Mock<IGuildPermissions>();
-        var instancesRepo = new Mock<IInstancesRepository>();
-        var raidersRepo = MakeRaidersRepoFor(MakeRaiderDoc("bnet-creator"));
-
-        var fn = MakeFunction(repo, permissions, instancesRepo, raidersRepo);
-        var ctx = MakeFunctionContext(principal);
-
-        var result = await fn.Run(
-            MakePutRequest("""
-                {
-                  "instanceId": null,
-                  "difficulty": "MYTHIC_KEYSTONE",
-                  "size": 5,
-                  "keystoneLevel": 10
-                }
-                """),
+        service.Verify(s => s.UpdateAsync(
             "run-1",
-            ctx,
-            CancellationToken.None);
-
-        var badRequest = Assert.IsType<ObjectResult>(result);
-        Assert.Equal(400, badRequest.StatusCode);
-        var problem = Assert.IsType<ProblemDetails>(badRequest.Value);
-        Assert.Equal("https://github.com/lfm-org/lfm/errors#instance-locked", problem.Type);
-        repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+            It.IsAny<UpdateRunRequest>(),
+            It.IsAny<RunUpdatePresentFields>(),
+            "\"client-etag\"",
+            It.IsAny<SessionPrincipal>(),
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 
-    [Fact]
-    public async Task Run_clears_signup_close_time_when_explicit_null_is_sent()
-    {
-        var principal = MakePrincipal(battleNetId: "bnet-creator");
-        var existing = MakeOpenRunDoc(creatorBattleNetId: "bnet-creator");
-
-        RunDocument? captured = null;
-        var repo = new Mock<IRunsRepository>();
-        repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(existing);
-        repo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-            .Callback<RunDocument, string?, CancellationToken>((doc, _, _) => captured = doc)
-            .ReturnsAsync((RunDocument doc, string? _, CancellationToken _) => doc);
-
-        var permissions = new Mock<IGuildPermissions>();
-        var instancesRepo = new Mock<IInstancesRepository>();
-        instancesRepo.Setup(r => r.ListAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeInstances());
-        var raidersRepo = MakeRaidersRepoFor(MakeRaiderDoc("bnet-creator"));
-
-        var fn = MakeFunction(repo, permissions, instancesRepo, raidersRepo);
-        var ctx = MakeFunctionContext(principal);
-
-        var result = await fn.Run(
-            MakePutRequest("""
-                {
-                  "signupCloseTime": null
-                }
-                """),
-            "run-1",
-            ctx,
-            CancellationToken.None);
-
-        Assert.IsType<OkObjectResult>(result);
-        Assert.NotNull(captured);
-        Assert.Equal("", captured!.SignupCloseTime);
-    }
+    // ------------------------------------------------------------------
+    // Test 4: Validation failure — returns 400 with error details
+    // ------------------------------------------------------------------
 
     [Fact]
     public async Task Run_returns_400_when_update_start_time_is_invalid()
     {
-        var principal = MakePrincipal(battleNetId: "bnet-creator");
-        var existing = MakeOpenRunDoc(creatorBattleNetId: "bnet-creator");
+        var principal = MakePrincipal();
+        var service = new Mock<IRunUpdateService>();
 
-        var repo = new Mock<IRunsRepository>();
-        repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(existing);
-
-        var permissions = new Mock<IGuildPermissions>();
-        var instancesRepo = new Mock<IInstancesRepository>();
-        var raidersRepo = MakeRaidersRepoFor(MakeRaiderDoc("bnet-creator"));
-
-        var fn = MakeFunction(repo, permissions, instancesRepo, raidersRepo);
+        var fn = MakeFunction(service);
         var ctx = MakeFunctionContext(principal);
 
         var result = await fn.Run(
@@ -357,24 +219,24 @@ public class RunsUpdateFunctionTests
         Assert.Equal(400, badRequest.StatusCode);
         var problem = Assert.IsType<ProblemDetails>(badRequest.Value);
         Assert.Equal("https://github.com/lfm-org/lfm/errors#validation-failed", problem.Type);
-        repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+
+        // Service should never be called when validation fails.
+        service.Verify(s => s.UpdateAsync(
+            It.IsAny<string>(),
+            It.IsAny<UpdateRunRequest>(),
+            It.IsAny<RunUpdatePresentFields>(),
+            It.IsAny<string>(),
+            It.IsAny<SessionPrincipal>(),
+            It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
     public async Task Run_returns_400_when_update_start_time_is_whitespace()
     {
-        var principal = MakePrincipal(battleNetId: "bnet-creator");
-        var existing = MakeOpenRunDoc(creatorBattleNetId: "bnet-creator");
+        var principal = MakePrincipal();
+        var service = new Mock<IRunUpdateService>();
 
-        var repo = new Mock<IRunsRepository>();
-        repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(existing);
-
-        var permissions = new Mock<IGuildPermissions>();
-        var instancesRepo = new Mock<IInstancesRepository>();
-        var raidersRepo = MakeRaidersRepoFor(MakeRaiderDoc("bnet-creator"));
-
-        var fn = MakeFunction(repo, permissions, instancesRepo, raidersRepo);
+        var fn = MakeFunction(service);
         var ctx = MakeFunctionContext(principal);
 
         var result = await fn.Run(
@@ -387,61 +249,28 @@ public class RunsUpdateFunctionTests
         Assert.Equal(400, badRequest.StatusCode);
         var problem = Assert.IsType<ProblemDetails>(badRequest.Value);
         Assert.Equal("https://github.com/lfm-org/lfm/errors#validation-failed", problem.Type);
-        repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     // ------------------------------------------------------------------
-    // Test 2: Raider not found — returns 404
+    // Test 5: Service NotFound (run) → 404
     // ------------------------------------------------------------------
 
     [Fact]
-    public async Task Run_returns_404_when_raider_not_found()
-    {
-        var principal = MakePrincipal(battleNetId: "bnet-creator");
-        var existing = MakeOpenRunDoc(creatorBattleNetId: "bnet-creator");
-
-        var repo = new Mock<IRunsRepository>();
-        repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(existing);
-
-        var raidersRepo = new Mock<IRaidersRepository>();
-        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-creator", It.IsAny<CancellationToken>()))
-            .ReturnsAsync((RaiderDocument?)null);
-
-        var permissions = new Mock<IGuildPermissions>();
-        var instancesRepo = new Mock<IInstancesRepository>();
-
-        var fn = MakeFunction(repo, permissions, instancesRepo, raidersRepo);
-        var ctx = MakeFunctionContext(principal);
-
-        var result = await fn.Run(MakePutRequest(new { description = "Updated" }), "run-1", ctx, CancellationToken.None);
-
-        var notFound = Assert.IsType<ObjectResult>(result);
-        Assert.Equal(404, notFound.StatusCode);
-        var problem = Assert.IsType<ProblemDetails>(notFound.Value);
-        Assert.Equal("https://github.com/lfm-org/lfm/errors#raider-not-found", problem.Type);
-        Assert.Equal("Raider not found.", problem.Detail);
-
-        repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
-    }
-
-    // ------------------------------------------------------------------
-    // Test 3: Run not found — returns 404
-    // ------------------------------------------------------------------
-
-    [Fact]
-    public async Task Run_returns_404_when_run_does_not_exist()
+    public async Task Run_returns_404_when_service_returns_run_not_found()
     {
         var principal = MakePrincipal();
 
-        var repo = new Mock<IRunsRepository>();
-        repo.Setup(r => r.GetByIdAsync("missing-run", It.IsAny<CancellationToken>()))
-            .ReturnsAsync((RunDocument?)null);
+        var service = new Mock<IRunUpdateService>();
+        service.Setup(s => s.UpdateAsync(
+                It.IsAny<string>(),
+                It.IsAny<UpdateRunRequest>(),
+                It.IsAny<RunUpdatePresentFields>(),
+                It.IsAny<string>(),
+                It.IsAny<SessionPrincipal>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunOperationResult.NotFound("run-not-found", "Run not found."));
 
-        var permissions = new Mock<IGuildPermissions>();
-        var instancesRepo = new Mock<IInstancesRepository>();
-
-        var fn = MakeFunction(repo, permissions, instancesRepo);
+        var fn = MakeFunction(service);
         var ctx = MakeFunctionContext(principal);
 
         var result = await fn.Run(MakePutRequest(new { }), "missing-run", ctx, CancellationToken.None);
@@ -450,34 +279,63 @@ public class RunsUpdateFunctionTests
         Assert.Equal(404, notFound.StatusCode);
         var problem = Assert.IsType<ProblemDetails>(notFound.Value);
         Assert.Equal("https://github.com/lfm-org/lfm/errors#run-not-found", problem.Type);
-
-        // Cosmos UpdateAsync must never be called
-        repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     // ------------------------------------------------------------------
-    // Test 3: Non-creator with no guild relationship — returns 403
+    // Test 6: Service NotFound (raider) → 404
     // ------------------------------------------------------------------
 
     [Fact]
-    public async Task Run_returns_403_for_non_creator_without_guild_permission()
+    public async Task Run_returns_404_when_service_returns_raider_not_found()
     {
-        // Caller belongs to guild 99999 — different from the run's creator guild (12345).
-        var principal = MakePrincipal(battleNetId: "bnet-other", guildId: "99999");
-        var existing = MakeOpenRunDoc(creatorBattleNetId: "bnet-creator", creatorGuildId: 12345, visibility: "PUBLIC");
+        var principal = MakePrincipal();
 
-        var repo = new Mock<IRunsRepository>();
-        repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(existing);
+        var service = new Mock<IRunUpdateService>();
+        service.Setup(s => s.UpdateAsync(
+                It.IsAny<string>(),
+                It.IsAny<UpdateRunRequest>(),
+                It.IsAny<RunUpdatePresentFields>(),
+                It.IsAny<string>(),
+                It.IsAny<SessionPrincipal>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunOperationResult.NotFound("raider-not-found", "Raider not found."));
 
-        var permissions = new Mock<IGuildPermissions>();
-        var instancesRepo = new Mock<IInstancesRepository>();
+        var fn = MakeFunction(service);
+        var ctx = MakeFunctionContext(principal);
+
+        var result = await fn.Run(MakePutRequest(new { description = "x" }), "run-1", ctx, CancellationToken.None);
+
+        var notFound = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(404, notFound.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(notFound.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#raider-not-found", problem.Type);
+        Assert.Equal("Raider not found.", problem.Detail);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 7: Service Forbidden — returns 403 + audit failure entry
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task Run_returns_403_and_emits_audit_when_service_returns_forbidden()
+    {
+        var principal = MakePrincipal(battleNetId: "bnet-other");
         var logger = new TestLogger<RunsUpdateFunction>();
 
-        // Raider's selected character is in guild 99999 — different from the run's creator guild.
-        var raidersRepo = MakeRaidersRepoFor(MakeRaiderDoc("bnet-other", guildId: 99999));
+        var service = new Mock<IRunUpdateService>();
+        service.Setup(s => s.UpdateAsync(
+                It.IsAny<string>(),
+                It.IsAny<UpdateRunRequest>(),
+                It.IsAny<RunUpdatePresentFields>(),
+                It.IsAny<string>(),
+                It.IsAny<SessionPrincipal>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunOperationResult.Forbidden(
+                "run-update-not-creator",
+                "Only the run creator can update this run.",
+                AuditReason: "not creator"));
 
-        var fn = MakeFunction(repo, permissions, instancesRepo, raidersRepo, logger: logger);
+        var fn = MakeFunction(service, logger);
         var ctx = MakeFunctionContext(principal);
 
         var result = await fn.Run(MakePutRequest(new { description = "Hacked" }), "run-1", ctx, CancellationToken.None);
@@ -485,274 +343,64 @@ public class RunsUpdateFunctionTests
         var objectResult = Assert.IsType<ObjectResult>(result);
         Assert.Equal(403, objectResult.StatusCode);
 
-        repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
-
         Assert.Single(
             logger.Entries,
             e => e.IsAudit("run.update", "failure", "not creator"));
     }
 
     // ------------------------------------------------------------------
-    // Test 4: Editing closed (run start time has passed) — returns 409 Conflict
+    // Test 8: Service ConflictResult (editing closed) → 409
     // ------------------------------------------------------------------
 
     [Fact]
-    public async Task Run_returns_409_when_editing_is_closed()
+    public async Task Run_returns_409_when_service_returns_conflict()
     {
-        var principal = MakePrincipal(battleNetId: "bnet-creator");
+        var principal = MakePrincipal();
 
-        // Run whose startTime is in the past → editing closed.
-        var pastRun = new RunDocument(
-            Id: "run-1",
-            StartTime: DateTimeOffset.UtcNow.AddHours(-1).ToString("o"),
-            SignupCloseTime: DateTimeOffset.UtcNow.AddHours(-2).ToString("o"),
-            Description: "Past run",
-            ModeKey: "NORMAL:10",
-            Visibility: "PUBLIC",
-            CreatorGuild: "Test Guild",
-            CreatorGuildId: 12345,
-            InstanceId: 631,
-            InstanceName: "Icecrown Citadel",
-            CreatorBattleNetId: "bnet-creator",
-            CreatedAt: DateTimeOffset.UtcNow.AddDays(-14).ToString("o"),
-            Ttl: 86400,
-            RunCharacters: []);
+        var service = new Mock<IRunUpdateService>();
+        service.Setup(s => s.UpdateAsync(
+                It.IsAny<string>(),
+                It.IsAny<UpdateRunRequest>(),
+                It.IsAny<RunUpdatePresentFields>(),
+                It.IsAny<string>(),
+                It.IsAny<SessionPrincipal>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunOperationResult.ConflictResult(
+                "run-editing-closed",
+                "Editing is closed for this run."));
 
-        var repo = new Mock<IRunsRepository>();
-        repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(pastRun);
-
-        var permissions = new Mock<IGuildPermissions>();
-        var instancesRepo = new Mock<IInstancesRepository>();
-        var raidersRepo = MakeRaidersRepoFor(MakeRaiderDoc("bnet-creator"));
-
-        var fn = MakeFunction(repo, permissions, instancesRepo, raidersRepo);
+        var fn = MakeFunction(service);
         var ctx = MakeFunctionContext(principal);
 
         var result = await fn.Run(MakePutRequest(new { description = "Too late" }), "run-1", ctx, CancellationToken.None);
 
         var objectResult = Assert.IsType<ObjectResult>(result);
         Assert.Equal(409, objectResult.StatusCode);
-
-        repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     // ------------------------------------------------------------------
-    // Test 5: Audit event emitted on success path
+    // Test 9: Service PreconditionFailed (stale If-Match) → 412 + audit
     // ------------------------------------------------------------------
 
     [Fact]
-    public async Task Run_emits_run_update_audit_event_on_success()
+    public async Task Run_returns_412_and_emits_audit_when_service_returns_precondition_failed()
     {
-        var principal = MakePrincipal(battleNetId: "bnet-creator");
-        var existing = MakeOpenRunDoc(creatorBattleNetId: "bnet-creator");
-        var updatedDoc = existing with { Description = "Updated description" };
+        var principal = MakePrincipal();
         var logger = new TestLogger<RunsUpdateFunction>();
 
-        var requestBody = new { description = "Updated description" };
+        var service = new Mock<IRunUpdateService>();
+        service.Setup(s => s.UpdateAsync(
+                It.IsAny<string>(),
+                It.IsAny<UpdateRunRequest>(),
+                It.IsAny<RunUpdatePresentFields>(),
+                It.IsAny<string>(),
+                It.IsAny<SessionPrincipal>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunOperationResult.PreconditionFailed(
+                "if-match-stale",
+                "The run was modified since you loaded it. Reload and try again."));
 
-        var repo = new Mock<IRunsRepository>();
-        repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(existing);
-        repo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(updatedDoc);
-
-        var permissions = new Mock<IGuildPermissions>();
-        var instancesRepo = new Mock<IInstancesRepository>();
-        instancesRepo.Setup(r => r.ListAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeInstances());
-
-        var raidersRepo = MakeRaidersRepoFor(MakeRaiderDoc("bnet-creator"));
-
-        var fn = MakeFunction(repo, permissions, instancesRepo, raidersRepo, logger: logger);
-        var ctx = MakeFunctionContext(principal);
-
-        await fn.Run(MakePutRequest(requestBody), "run-1", ctx, CancellationToken.None);
-
-        Assert.Single(logger.Entries, e => e.IsAudit(
-            action: "run.update",
-            actorId: "bnet-creator",
-            result: "success"));
-    }
-
-    // ------------------------------------------------------------------
-    // Test 6: Malformed JSON returns 400 with a static error string,
-    // never echoing the JsonException message (which can leak the
-    // caller's payload offset/line/path).
-    // ------------------------------------------------------------------
-
-    [Fact]
-    public async Task Run_returns_400_with_static_message_on_malformed_json()
-    {
-        var principal = MakePrincipal(battleNetId: "bnet-creator");
-        var existing = MakeOpenRunDoc(creatorBattleNetId: "bnet-creator");
-
-        var repo = new Mock<IRunsRepository>();
-        repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(existing);
-
-        var permissions = new Mock<IGuildPermissions>();
-        var instancesRepo = new Mock<IInstancesRepository>();
-        var raidersRepo = MakeRaidersRepoFor(MakeRaiderDoc("bnet-creator"));
-
-        var fn = MakeFunction(repo, permissions, instancesRepo, raidersRepo);
-        var ctx = MakeFunctionContext(principal);
-
-        var httpContext = new DefaultHttpContext();
-        httpContext.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes("{not valid json"));
-        httpContext.Request.ContentType = "application/json";
-        httpContext.Request.Headers["If-Match"] = DefaultTestEtag;
-
-        var result = await fn.Run(httpContext.Request, "run-1", ctx, CancellationToken.None);
-
-        var bad = Assert.IsType<ObjectResult>(result);
-        Assert.Equal(400, bad.StatusCode);
-        var problem = Assert.IsType<ProblemDetails>(bad.Value);
-        Assert.Equal("https://github.com/lfm-org/lfm/errors#invalid-body", problem.Type);
-        Assert.Equal("Request body is invalid or missing.", problem.Detail);
-
-        repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
-    }
-
-    // ------------------------------------------------------------------
-    // Test 7: After a successful update, IsCurrentUser is true on the
-    // caller's own roster row (mirrors the sanitization in the other 5
-    // run handlers; was previously hardcoded false).
-    // ------------------------------------------------------------------
-
-    [Fact]
-    public async Task Run_returns_dto_with_IsCurrentUser_true_for_callers_own_roster_row()
-    {
-        var principal = MakePrincipal(battleNetId: "bnet-creator");
-
-        // Run with two roster entries: one belongs to the caller, one to a peer.
-        var existing = MakeOpenRunDoc(creatorBattleNetId: "bnet-creator") with
-        {
-            RunCharacters =
-            [
-                new RunCharacterEntry(
-                    Id: "rc-1",
-                    CharacterId: "char-self",
-                    CharacterName: "Selfwarrior",
-                    CharacterRealm: "silvermoon",
-                    CharacterLevel: 80,
-                    CharacterClassId: 1,
-                    CharacterClassName: "Warrior",
-                    CharacterRaceId: 1,
-                    CharacterRaceName: "Human",
-                    RaiderBattleNetId: "bnet-creator",
-                    DesiredAttendance: "IN",
-                    ReviewedAttendance: "IN",
-                    SpecId: 71,
-                    SpecName: "Arms",
-                    Role: "DPS"),
-                new RunCharacterEntry(
-                    Id: "rc-2",
-                    CharacterId: "char-peer",
-                    CharacterName: "Peerpriest",
-                    CharacterRealm: "silvermoon",
-                    CharacterLevel: 80,
-                    CharacterClassId: 5,
-                    CharacterClassName: "Priest",
-                    CharacterRaceId: 1,
-                    CharacterRaceName: "Human",
-                    RaiderBattleNetId: "bnet-someone-else",
-                    DesiredAttendance: "IN",
-                    ReviewedAttendance: "IN",
-                    SpecId: 257,
-                    SpecName: "Holy",
-                    Role: "HEALER"),
-            ],
-        };
-
-        // Update only the description so the locked-fields guard doesn't fire.
-        var updated = existing with { Description = "Updated description" };
-
-        var repo = new Mock<IRunsRepository>();
-        repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(existing);
-        repo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(updated);
-
-        var permissions = new Mock<IGuildPermissions>();
-        var instancesRepo = new Mock<IInstancesRepository>();
-        instancesRepo.Setup(r => r.ListAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeInstances());
-
-        var raidersRepo = MakeRaidersRepoFor(MakeRaiderDoc("bnet-creator"));
-
-        var fn = MakeFunction(repo, permissions, instancesRepo, raidersRepo);
-        var ctx = MakeFunctionContext(principal);
-
-        var result = await fn.Run(MakePutRequest(new { description = "Updated description" }), "run-1", ctx, CancellationToken.None);
-
-        var ok = Assert.IsType<OkObjectResult>(result);
-        var dto = Assert.IsType<RunDetailDto>(ok.Value);
-        Assert.Equal(2, dto.RunCharacters.Count);
-
-        var ownRow = dto.RunCharacters.Single(c => c.CharacterName == "Selfwarrior");
-        var peerRow = dto.RunCharacters.Single(c => c.CharacterName == "Peerpriest");
-        Assert.True(ownRow.IsCurrentUser);
-        Assert.False(peerRow.IsCurrentUser);
-    }
-
-    // ------------------------------------------------------------------
-    // Test 8: Missing If-Match header — returns 428 Precondition Required
-    // ------------------------------------------------------------------
-
-    [Fact]
-    public async Task Run_returns_428_when_if_match_header_is_missing()
-    {
-        var principal = MakePrincipal(battleNetId: "bnet-creator");
-
-        var repo = new Mock<IRunsRepository>();
-        var permissions = new Mock<IGuildPermissions>();
-        var instancesRepo = new Mock<IInstancesRepository>();
-
-        var fn = MakeFunction(repo, permissions, instancesRepo);
-        var ctx = MakeFunctionContext(principal);
-
-        var result = await fn.Run(
-            MakePutRequest(new { description = "x" }, ifMatch: null),
-            "run-1",
-            ctx,
-            CancellationToken.None);
-
-        var objectResult = Assert.IsType<ObjectResult>(result);
-        Assert.Equal(428, objectResult.StatusCode);
-        var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
-        Assert.Equal("https://github.com/lfm-org/lfm/errors#if-match-required", problem.Type);
-
-        // The handler must short-circuit before any repo work.
-        repo.Verify(r => r.GetByIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
-        repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
-    }
-
-    // ------------------------------------------------------------------
-    // Test 9: Stale If-Match — returns 412 Precondition Failed and logs audit
-    // ------------------------------------------------------------------
-
-    [Fact]
-    public async Task Run_returns_412_when_if_match_is_stale()
-    {
-        var principal = MakePrincipal(battleNetId: "bnet-creator");
-        var existing = MakeOpenRunDoc(creatorBattleNetId: "bnet-creator");
-        var logger = new TestLogger<RunsUpdateFunction>();
-
-        var repo = new Mock<IRunsRepository>();
-        repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(existing);
-        repo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new ConcurrencyConflictException());
-
-        var permissions = new Mock<IGuildPermissions>();
-        var instancesRepo = new Mock<IInstancesRepository>();
-        instancesRepo.Setup(r => r.ListAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeInstances());
-
-        var raidersRepo = MakeRaidersRepoFor(MakeRaiderDoc("bnet-creator"));
-
-        var fn = MakeFunction(repo, permissions, instancesRepo, raidersRepo, logger: logger);
+        var fn = MakeFunction(service, logger);
         var ctx = MakeFunctionContext(principal);
 
         var result = await fn.Run(
@@ -770,72 +418,117 @@ public class RunsUpdateFunctionTests
     }
 
     // ------------------------------------------------------------------
-    // Test 10: Happy path echoes the persisted ETag back on the response
+    // Test 10: Missing If-Match header — returns 428 Precondition Required
     // ------------------------------------------------------------------
 
     [Fact]
-    public async Task Run_echoes_new_etag_on_successful_update()
+    public async Task Run_returns_428_when_if_match_header_is_missing()
     {
-        var principal = MakePrincipal(battleNetId: "bnet-creator");
-        var existing = MakeOpenRunDoc(creatorBattleNetId: "bnet-creator");
-        var updatedDoc = (existing with { Description = "Updated description" }) with { ETag = "\"new-etag\"" };
+        var principal = MakePrincipal();
+        var service = new Mock<IRunUpdateService>();
 
-        var repo = new Mock<IRunsRepository>();
-        repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(existing);
-        repo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(updatedDoc);
-
-        var permissions = new Mock<IGuildPermissions>();
-        var instancesRepo = new Mock<IInstancesRepository>();
-        instancesRepo.Setup(r => r.ListAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeInstances());
-
-        var raidersRepo = MakeRaidersRepoFor(MakeRaiderDoc("bnet-creator"));
-
-        var fn = MakeFunction(repo, permissions, instancesRepo, raidersRepo);
-        var ctx = MakeFunctionContext(principal);
-
-        var request = MakePutRequest(new { description = "Updated description" });
-        await fn.Run(request, "run-1", ctx, CancellationToken.None);
-
-        Assert.Equal("\"new-etag\"", request.HttpContext.Response.Headers.ETag.ToString());
-    }
-
-    // ------------------------------------------------------------------
-    // Test 11: Repo receives the client's If-Match header verbatim
-    // ------------------------------------------------------------------
-
-    [Fact]
-    public async Task Run_forwards_client_if_match_header_to_repository()
-    {
-        var principal = MakePrincipal(battleNetId: "bnet-creator");
-        var existing = MakeOpenRunDoc(creatorBattleNetId: "bnet-creator");
-        var updatedDoc = existing with { Description = "Updated description" };
-
-        var repo = new Mock<IRunsRepository>();
-        repo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(existing);
-        repo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), "\"client-etag\"", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(updatedDoc);
-
-        var permissions = new Mock<IGuildPermissions>();
-        var instancesRepo = new Mock<IInstancesRepository>();
-        instancesRepo.Setup(r => r.ListAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeInstances());
-
-        var raidersRepo = MakeRaidersRepoFor(MakeRaiderDoc("bnet-creator"));
-
-        var fn = MakeFunction(repo, permissions, instancesRepo, raidersRepo);
+        var fn = MakeFunction(service);
         var ctx = MakeFunctionContext(principal);
 
         var result = await fn.Run(
-            MakePutRequest(new { description = "Updated description" }, ifMatch: "\"client-etag\""),
+            MakePutRequest(new { description = "x" }, ifMatch: null),
+            "run-1",
+            ctx,
+            CancellationToken.None);
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(428, objectResult.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#if-match-required", problem.Type);
+
+        // Handler must short-circuit before calling the service.
+        service.Verify(s => s.UpdateAsync(
+            It.IsAny<string>(),
+            It.IsAny<UpdateRunRequest>(),
+            It.IsAny<RunUpdatePresentFields>(),
+            It.IsAny<string>(),
+            It.IsAny<SessionPrincipal>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 11: Malformed JSON returns 400 with a static error string,
+    // never echoing the JsonException message (which can leak the
+    // caller's payload offset/line/path).
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task Run_returns_400_with_static_message_on_malformed_json()
+    {
+        var principal = MakePrincipal();
+        var service = new Mock<IRunUpdateService>();
+
+        var fn = MakeFunction(service);
+        var ctx = MakeFunctionContext(principal);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes("{not valid json"));
+        httpContext.Request.ContentType = "application/json";
+        httpContext.Request.Headers["If-Match"] = DefaultTestEtag;
+
+        var result = await fn.Run(httpContext.Request, "run-1", ctx, CancellationToken.None);
+
+        var bad = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(400, bad.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(bad.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#invalid-body", problem.Type);
+        Assert.Equal("Request body is invalid or missing.", problem.Detail);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 12: Function projects JsonDocument property presence into
+    // RunUpdatePresentFields correctly — explicit nulls count as present.
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task Run_marks_present_fields_for_explicit_null_instance_id()
+    {
+        var principal = MakePrincipal();
+        var updated = MakeUpdatedRun();
+
+        RunUpdatePresentFields? capturedPresent = null;
+        var service = new Mock<IRunUpdateService>();
+        service.Setup(s => s.UpdateAsync(
+                It.IsAny<string>(),
+                It.IsAny<UpdateRunRequest>(),
+                It.IsAny<RunUpdatePresentFields>(),
+                It.IsAny<string>(),
+                It.IsAny<SessionPrincipal>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, UpdateRunRequest, RunUpdatePresentFields, string, SessionPrincipal, CancellationToken>(
+                (_, _, present, _, _, _) => capturedPresent = present)
+            .ReturnsAsync(new RunOperationResult.Ok(updated));
+
+        var fn = MakeFunction(service);
+        var ctx = MakeFunctionContext(principal);
+
+        var result = await fn.Run(
+            MakePutRequest("""
+                {
+                  "instanceId": null,
+                  "difficulty": "MYTHIC_KEYSTONE",
+                  "size": 5,
+                  "keystoneLevel": 10
+                }
+                """),
             "run-1",
             ctx,
             CancellationToken.None);
 
         Assert.IsType<OkObjectResult>(result);
-        repo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), "\"client-etag\"", It.IsAny<CancellationToken>()), Times.Once);
+        Assert.NotNull(capturedPresent);
+        Assert.True(capturedPresent!.InstanceId);
+        Assert.True(capturedPresent.Difficulty);
+        Assert.True(capturedPresent.Size);
+        Assert.True(capturedPresent.KeystoneLevel);
+        Assert.False(capturedPresent.Description);
+        Assert.False(capturedPresent.Visibility);
+        Assert.False(capturedPresent.SignupCloseTime);
+        Assert.False(capturedPresent.StartTime);
     }
 }

--- a/tests/Lfm.Api.Tests/RunsUpdateFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RunsUpdateFunctionTests.cs
@@ -414,7 +414,7 @@ public class RunsUpdateFunctionTests
         var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
         Assert.Equal("https://github.com/lfm-org/lfm/errors#if-match-stale", problem.Type);
 
-        Assert.Single(logger.Entries, e => e.IsAudit("run.update", "failure", "if match stale"));
+        Assert.Single(logger.Entries, e => e.IsAudit("run.update", "failure", "if-match stale"));
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`RunsUpdateFunction.Run` packed HTTP plumbing + If-Match parsing + raider/run lookup + creator/peer permission gate + editing-closed check + locked-field rules + GUILD visibility promotion + effective field resolution + instance/mode validation + ETag-guarded persistence + `ConcurrencyConflictException` translation + audit emission into one method (378 LOC). This PR lifts the policy out, mirroring the pattern from `RunCreateService` (PR #197):

- New `RunUpdateService` lifts the policy. Constructor: `(IRunsRepository, IRaidersRepository, IGuildPermissions, IInstancesRepository)`.
- New `RunUpdatePresentFields` typed projection record replaces `JsonDocument`-based `HasJsonProperty` lookups in the service interface — JSON parsing stays at the Function (transport concern); the service receives pure booleans.
- Function shrunk 378 → 163 LOC. Constructor went from 5 deps to 2 (`IRunUpdateService` + logger).
- Audit emission stays at the Function for `success`, `not creator`, `guild rank denied`, and `if-match stale` (`PreconditionFailed`). Future-proof switch maps `pf.Code` to audit reason for unknown variants.
- ETag echo on `Ok` response preserved.
- 5 new `RunUpdateServiceTests` (run not found / not-creator-not-peer / editing closed / stale ETag / happy path); 12 rewritten `RunsUpdateFunctionTests` cover the full HTTP contract (missing If-Match, malformed JSON, validation failure, NotFound, Forbidden+audit, Conflict, PreconditionFailed+audit, Ok+ETag echo, success audit, If-Match forwarding, PresentFields projection).

This is the second slice of finding `SD-B-1` from `docs/superpowersreviews/2026-04-29-software-design-deep-review.md`. Task E.3 in `docs/superpowers/plans/2026-04-30-software-design-review-followup.md`. RunSignup follows in a separate PR.

## Test plan

- [x] `dotnet build lfm.sln -c Release` clean (0 warnings)
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` — 739 passed
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error` exit 0
- [x] Spec compliance review ✅
- [x] Code quality review ✅ (audit guard widened from literal-string match to `Code` switch; tautological assertion removed; original `"if-match stale"` audit wording preserved)