### PR TITLE
Extract RunSignupService from RunsSignupFunction

### DIFF
--- a/api/Functions/RunsSignupFunction.cs
+++ b/api/Functions/RunsSignupFunction.cs
@@ -11,38 +11,29 @@ using Lfm.Api.Auth;
 using Lfm.Api.Helpers;
 using Lfm.Api.Mappers;
 using Lfm.Api.Middleware;
-using Lfm.Api.Repositories;
 using Lfm.Api.Runs;
-using Lfm.Api.Services;
 using Lfm.Api.Validation;
 using Lfm.Contracts.Runs;
-using Lfm.Contracts.WoW;
 
 namespace Lfm.Api.Functions;
 
 /// <summary>
 /// Serves POST /api/runs/{id}/signup.
 ///
-/// Lets an authenticated user sign up (or update their signup) for a run with a
-/// specific character. The signup is stored as a <see cref="RunCharacterEntry"/>
-/// embedded in the run document's <c>runCharacters</c> array.
+/// HTTP adapter for <see cref="IRunSignupService"/>. The handler deserializes
+/// the request body, runs DTO validation, calls the service, and translates
+/// the resulting <see cref="RunOperationResult"/> to a 200 OK response or the
+/// appropriate <c>problem+json</c> error. Audit emission for the success and
+/// forbidden paths stays at this layer because both events tie to the
+/// HTTP-shaped boundary (status code, idempotency, traceparent).
 ///
-/// Logic:
-///   1. Load the run — 404 if not found.
-///   2. For GUILD runs: check visibility access and <c>canSignupGuildRuns</c> rank permission.
-///   3. Validate the request body (characterId, desiredAttendance, specId).
-///   4. Verify the caller owns the character (must be in their raider doc's characters list).
-///   5. Upsert the <see cref="RunCharacterEntry"/> — one signup per battleNetId per run.
-///   6. Persist the run document.
-///   7. Return the sanitized run.
+/// Run-signup policy itself (raider lookup, character ownership, run load,
+/// editability + GUILD-permission gates, rejection-list IN→OUT flip,
+/// concurrency retry loop) lives in <see cref="RunSignupService"/>.
 ///
 /// Mirrors <c>handler</c> in <c>functions/src/functions/runs-signup.ts</c>.
 /// </summary>
-public class RunsSignupFunction(
-    IRunsRepository runsRepo,
-    IRaidersRepository raidersRepo,
-    IGuildPermissions guildPermissions,
-    ILogger<RunsSignupFunction> logger)
+public class RunsSignupFunction(IRunSignupService service, ILogger<RunsSignupFunction> logger)
 {
     private static readonly JsonSerializerOptions JsonOptions =
         new() { PropertyNameCaseInsensitive = true };
@@ -57,7 +48,7 @@ public class RunsSignupFunction(
     {
         var principal = ctx.GetPrincipal(); // non-null: [RequireAuth] + AuthPolicyMiddleware guarantee
 
-        // 1. Parse and validate request body (request-scoped, not retry-scoped).
+        // Parse and validate request body (request-scoped, not retry-scoped).
         SignupRequest? body;
         try
         {
@@ -89,155 +80,21 @@ public class RunsSignupFunction(
                 new Dictionary<string, object?> { ["errors"] = errors });
         }
 
-        // 2. Load raider document and verify character ownership.
-        //    Mirrors: const storedCharacter = raider.characters.find(c => c.id === body.characterId)
-        var raider = await raidersRepo.GetByBattleNetIdAsync(principal.BattleNetId, ct);
-        if (raider is null)
-            return Problem.NotFound(req.HttpContext, "raider-not-found", "Raider not found.");
+        var result = await service.SignupAsync(id, body, principal, ct);
 
-        // Derive the caller's guild from the raider's selected character for the
-        // GUILD visibility check below. principal.GuildId is a legacy session field
-        // and is no longer populated.
-        var (callerGuildId, _) = GuildResolver.FromRaider(raider);
-
-        var storedCharacter = raider.Characters?.FirstOrDefault(c => c.Id == body.CharacterId);
-        if (storedCharacter is null)
-            return Problem.BadRequest(
-                req.HttpContext,
-                "character-not-on-profile",
-                "Character not found on your profile.");
-
-        // 3. Resolve spec info — mirrors the specId block in runs-signup.ts.
-        int? specId = body.SpecId;
-        string? specName = null;
-        string? role = null;
-
-        if (specId is not null)
+        // Audit-bearing branches stay at the function (this layer owns audit shape);
+        // pure HTTP-shape branches go through the shared translator.
+        switch (result)
         {
-            var specEntry = storedCharacter.SpecializationsSummary?.Specializations
-                ?.FirstOrDefault(s => s.Specialization.Id == specId.Value);
-            if (specEntry is null)
-                return Problem.BadRequest(
-                    req.HttpContext,
-                    "invalid-spec-id",
-                    "Invalid specId: not found on character.");
-
-            specName = specEntry.Specialization.Name;
-        }
-
-        // 4. Read-modify-write loop with optimistic concurrency.
-        //    On ConcurrencyConflictException the loop re-reads the run and retries.
-        const int maxAttempts = 3;
-        for (var attempt = 0; attempt < maxAttempts; attempt++)
-        {
-            // 4a. Load existing run.
-            var run = await runsRepo.GetByIdAsync(id, ct);
-            if (run is null)
-                return Problem.NotFound(req.HttpContext, "run-not-found", "Run not found.");
-
-            // 4b. Signup close time check — reject if signups are closed.
-            if (RunEditability.IsEditingClosed(run.SignupCloseTime, run.StartTime, DateTimeOffset.UtcNow))
-            {
-                return Problem.Conflict(
-                    req.HttpContext,
-                    "signups-closed",
-                    "Signups are closed for this run.");
-            }
-
-            // 4c. Visibility check for GUILD runs — mirrors runs-signup.ts.
-            if (run.Visibility == "GUILD")
-            {
-                if (!RunAccessPolicy.CanView(run, principal.BattleNetId, callerGuildId))
-                    return Problem.NotFound(req.HttpContext, "run-not-found", "Run not found.");
-
-                var canSignup = await guildPermissions.CanSignupGuildRunsAsync(raider, ct);
-                if (!canSignup)
-                {
-                    AuditLog.Emit(logger, new AuditEvent("signup.create", principal.BattleNetId, id, "failure", "guild rank denied"));
-                    return Problem.Forbidden(
-                        req.HttpContext,
-                        "guild-rank-denied",
-                        "Guild signup is not enabled for your rank.");
-                }
-            }
-
-            // 4d. Upsert the RunCharacterEntry — one per battleNetId per run.
-            var existingIndex = -1;
-            for (var i = 0; i < run.RunCharacters.Count; i++)
-            {
-                if (run.RunCharacters[i].RaiderBattleNetId == principal.BattleNetId)
-                {
-                    existingIndex = i;
-                    break;
-                }
-            }
-
-            var entryId = existingIndex >= 0
-                ? run.RunCharacters[existingIndex].Id
-                : Guid.NewGuid().ToString();
-
-            // ReviewedAttendance defaults to "IN" for a brand-new signup. For an
-            // edit (existing entry present), the prior value is preserved so the
-            // run owner's review decision survives a self-edit. For a re-signup
-            // *after* a previous rejection (entry was removed by cancel, but the
-            // raider sits in the run's rejection list), the default flips to
-            // "OUT" — closes the cancel-then-resignup bypass documented in
-            // docs/threat-models/run-signup-peer-permission.md.
-            var rejected = run.RejectedRaiderBattleNetIds ?? [];
-            var reviewedAttendance = existingIndex >= 0
-                ? run.RunCharacters[existingIndex].ReviewedAttendance
-                : rejected.Contains(principal.BattleNetId, StringComparer.Ordinal)
-                    ? "OUT"
-                    : "IN";
-
-            var entry = new RunCharacterEntry(
-                Id: entryId,
-                CharacterId: storedCharacter.Id,
-                CharacterName: storedCharacter.Name,
-                CharacterRealm: storedCharacter.Realm,
-                CharacterLevel: storedCharacter.Level ?? 0,
-                CharacterClassId: storedCharacter.ClassId ?? 0,
-                CharacterClassName: storedCharacter.ClassName
-                    ?? (storedCharacter.ClassId is int cid ? WowClasses.GetName(cid) : ""),
-                CharacterRaceId: 0,
-                CharacterRaceName: "",
-                RaiderBattleNetId: principal.BattleNetId,
-                DesiredAttendance: body.DesiredAttendance!,
-                ReviewedAttendance: reviewedAttendance,
-                SpecId: specId,
-                SpecName: specName,
-                Role: role);
-
-            var updatedCharacters = run.RunCharacters.ToList();
-            if (existingIndex >= 0)
-                updatedCharacters[existingIndex] = entry;
-            else
-                updatedCharacters.Add(entry);
-
-            // 4e. Persist the updated run document with ETag check.
-            var updated = run with { RunCharacters = updatedCharacters };
-            try
-            {
-                // Pass null so the repository falls back to run.ETag — this is an
-                // internal retry loop, not a client-driven If-Match flow.
-                var persisted = await runsRepo.UpdateAsync(updated, ifMatchEtag: null, ct);
-
+            case RunOperationResult.Ok ok:
                 AuditLog.Emit(logger, new AuditEvent("signup.create", principal.BattleNetId, id, "success", null));
-
-                return new OkObjectResult(RunResponseMapper.ToDetail(persisted, principal.BattleNetId));
-            }
-            catch (ConcurrencyConflictException)
-            {
-                logger.LogWarning("Concurrency conflict on signup for run {RunId}, attempt {Attempt}", id, attempt + 1);
-                // Loop will re-read the document and retry.
-            }
+                return new OkObjectResult(RunResponseMapper.ToDetail(ok.Run, principal.BattleNetId));
+            case RunOperationResult.Forbidden fb:
+                AuditLog.Emit(logger, new AuditEvent("signup.create", principal.BattleNetId, id, "failure", fb.AuditReason));
+                return result.ToProblemResult(req.HttpContext);
+            default:
+                return result.ToProblemResult(req.HttpContext);
         }
-
-        // All retry attempts exhausted.
-        return Problem.Conflict(
-            req.HttpContext,
-            "concurrent-modification",
-            "Concurrent modification, please retry.");
     }
 
     /// <summary>
@@ -252,5 +109,4 @@ public class RunsSignupFunction(
         FunctionContext ctx,
         CancellationToken ct)
         => Run(req, id, ctx, ct);
-
 }

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -179,6 +179,7 @@ builder.Services.AddSingleton<Lfm.Api.Services.IIdempotencyStore, Lfm.Api.Servic
 builder.Services.AddScoped<Lfm.Api.Services.IGuildPermissions, Lfm.Api.Services.GuildPermissions>();
 builder.Services.AddScoped<Lfm.Api.Runs.IRunCreateService, Lfm.Api.Runs.RunCreateService>();
 builder.Services.AddScoped<Lfm.Api.Runs.IRunUpdateService, Lfm.Api.Runs.RunUpdateService>();
+builder.Services.AddScoped<Lfm.Api.Runs.IRunSignupService, Lfm.Api.Runs.RunSignupService>();
 
 // Audit-log actor hasher. If a salt is configured we HMAC-hash every
 // AuditActorId before it reaches Application Insights; otherwise (local

--- a/api/Runs/IRunSignupService.cs
+++ b/api/Runs/IRunSignupService.cs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Auth;
+using Lfm.Contracts.Runs;
+
+namespace Lfm.Api.Runs;
+
+/// <summary>
+/// Run-signup policy lifted out of <c>RunsSignupFunction</c>. The Function
+/// adapter handles HTTP body deserialization, request validation, and the
+/// translation of this service's <see cref="RunOperationResult"/> into
+/// <c>problem+json</c> responses or 200 OK. Audit emission for the success
+/// and forbidden paths stays at the Function — same pattern as
+/// <see cref="IRunCreateService"/> and <see cref="IRunUpdateService"/>.
+/// </summary>
+public interface IRunSignupService
+{
+    Task<RunOperationResult> SignupAsync(
+        string runId,
+        SignupRequest body,
+        SessionPrincipal principal,
+        CancellationToken ct);
+}

--- a/api/Runs/RunSignupService.cs
+++ b/api/Runs/RunSignupService.cs
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Auth;
+using Lfm.Api.Repositories;
+using Lfm.Api.Services;
+using Lfm.Contracts.Runs;
+using Lfm.Contracts.WoW;
+using Microsoft.Extensions.Logging;
+
+namespace Lfm.Api.Runs;
+
+/// <summary>
+/// Implements the run-signup policy: load the raider, verify character
+/// ownership, and run a read-modify-write loop with optimistic concurrency
+/// that loads the run, gates GUILD-visibility runs on view + canSignupGuildRuns
+/// rank permission, upserts the <see cref="RunCharacterEntry"/> (handling the
+/// rejection-list IN→OUT default flip), and persists the document.
+///
+/// Returns a <see cref="RunOperationResult"/> that the Function adapter
+/// translates to HTTP. Audit emission for the success and forbidden paths
+/// stays at the Function — same pattern as <see cref="RunCreateService"/>
+/// and <see cref="RunUpdateService"/>.
+///
+/// Mirrors <c>handler</c> in <c>functions/src/functions/runs-signup.ts</c>.
+/// </summary>
+public sealed class RunSignupService(
+    IRunsRepository runsRepo,
+    IRaidersRepository raidersRepo,
+    IGuildPermissions guildPermissions,
+    ILogger<RunSignupService> logger) : IRunSignupService
+{
+    private const int MaxAttempts = 3;
+
+    public async Task<RunOperationResult> SignupAsync(
+        string runId,
+        SignupRequest body,
+        SessionPrincipal principal,
+        CancellationToken ct)
+    {
+        // 1. Load raider document and verify character ownership.
+        //    Mirrors: const storedCharacter = raider.characters.find(c => c.id === body.characterId)
+        var raider = await raidersRepo.GetByBattleNetIdAsync(principal.BattleNetId, ct);
+        if (raider is null)
+            return new RunOperationResult.NotFound("raider-not-found", "Raider not found.");
+
+        // Derive the caller's guild from the raider's selected character for the
+        // GUILD visibility check below. principal.GuildId is a legacy session field
+        // and is no longer populated.
+        var (callerGuildId, _) = GuildResolver.FromRaider(raider);
+
+        var storedCharacter = raider.Characters?.FirstOrDefault(c => c.Id == body.CharacterId);
+        if (storedCharacter is null)
+            return new RunOperationResult.BadRequest(
+                "character-not-on-profile",
+                "Character not found on your profile.");
+
+        // 2. Resolve spec info — mirrors the specId block in runs-signup.ts.
+        int? specId = body.SpecId;
+        string? specName = null;
+        string? role = null;
+
+        if (specId is not null)
+        {
+            var specEntry = storedCharacter.SpecializationsSummary?.Specializations
+                ?.FirstOrDefault(s => s.Specialization.Id == specId.Value);
+            if (specEntry is null)
+                return new RunOperationResult.BadRequest(
+                    "invalid-spec-id",
+                    "Invalid specId: not found on character.");
+
+            specName = specEntry.Specialization.Name;
+        }
+
+        // 3. Read-modify-write loop with optimistic concurrency.
+        //    On ConcurrencyConflictException the loop re-reads the run and retries.
+        for (var attempt = 0; attempt < MaxAttempts; attempt++)
+        {
+            // 3a. Load existing run.
+            var run = await runsRepo.GetByIdAsync(runId, ct);
+            if (run is null)
+                return new RunOperationResult.NotFound("run-not-found", "Run not found.");
+
+            // 3b. Signup close time check — reject if signups are closed.
+            if (RunEditability.IsEditingClosed(run.SignupCloseTime, run.StartTime, DateTimeOffset.UtcNow))
+            {
+                return new RunOperationResult.ConflictResult(
+                    "signups-closed",
+                    "Signups are closed for this run.");
+            }
+
+            // 3c. Visibility check for GUILD runs — mirrors runs-signup.ts.
+            if (run.Visibility == "GUILD")
+            {
+                if (!RunAccessPolicy.CanView(run, principal.BattleNetId, callerGuildId))
+                    return new RunOperationResult.NotFound("run-not-found", "Run not found.");
+
+                var canSignup = await guildPermissions.CanSignupGuildRunsAsync(raider, ct);
+                if (!canSignup)
+                {
+                    return new RunOperationResult.Forbidden(
+                        "guild-rank-denied",
+                        "Guild signup is not enabled for your rank.",
+                        AuditReason: "guild rank denied");
+                }
+            }
+
+            // 3d. Upsert the RunCharacterEntry — one per battleNetId per run.
+            var existingIndex = -1;
+            for (var i = 0; i < run.RunCharacters.Count; i++)
+            {
+                if (run.RunCharacters[i].RaiderBattleNetId == principal.BattleNetId)
+                {
+                    existingIndex = i;
+                    break;
+                }
+            }
+
+            var entryId = existingIndex >= 0
+                ? run.RunCharacters[existingIndex].Id
+                : Guid.NewGuid().ToString();
+
+            // ReviewedAttendance defaults to "IN" for a brand-new signup. For an
+            // edit (existing entry present), the prior value is preserved so the
+            // run owner's review decision survives a self-edit. For a re-signup
+            // *after* a previous rejection (entry was removed by cancel, but the
+            // raider sits in the run's rejection list), the default flips to
+            // "OUT" — closes the cancel-then-resignup bypass documented in
+            // docs/threat-models/run-signup-peer-permission.md.
+            var rejected = run.RejectedRaiderBattleNetIds ?? [];
+            var reviewedAttendance = existingIndex >= 0
+                ? run.RunCharacters[existingIndex].ReviewedAttendance
+                : rejected.Contains(principal.BattleNetId, StringComparer.Ordinal)
+                    ? "OUT"
+                    : "IN";
+
+            var entry = new RunCharacterEntry(
+                Id: entryId,
+                CharacterId: storedCharacter.Id,
+                CharacterName: storedCharacter.Name,
+                CharacterRealm: storedCharacter.Realm,
+                CharacterLevel: storedCharacter.Level ?? 0,
+                CharacterClassId: storedCharacter.ClassId ?? 0,
+                CharacterClassName: storedCharacter.ClassName
+                    ?? (storedCharacter.ClassId is int cid ? WowClasses.GetName(cid) : ""),
+                CharacterRaceId: 0,
+                CharacterRaceName: "",
+                RaiderBattleNetId: principal.BattleNetId,
+                DesiredAttendance: body.DesiredAttendance!,
+                ReviewedAttendance: reviewedAttendance,
+                SpecId: specId,
+                SpecName: specName,
+                Role: role);
+
+            var updatedCharacters = run.RunCharacters.ToList();
+            if (existingIndex >= 0)
+                updatedCharacters[existingIndex] = entry;
+            else
+                updatedCharacters.Add(entry);
+
+            // 3e. Persist the updated run document with ETag check.
+            var updated = run with { RunCharacters = updatedCharacters };
+            try
+            {
+                // Pass null so the repository falls back to run.ETag — this is an
+                // internal retry loop, not a client-driven If-Match flow.
+                var persisted = await runsRepo.UpdateAsync(updated, ifMatchEtag: null, ct);
+                return new RunOperationResult.Ok(persisted);
+            }
+            catch (ConcurrencyConflictException)
+            {
+                logger.LogWarning(
+                    "Concurrency conflict on signup for run {RunId}, attempt {Attempt}",
+                    runId,
+                    attempt + 1);
+                // Loop will re-read the document and retry.
+            }
+        }
+
+        // All retry attempts exhausted.
+        return new RunOperationResult.ConflictResult(
+            "concurrent-modification",
+            "Concurrent modification, please retry.");
+    }
+}

--- a/tests/Lfm.Api.Tests/Runs/RunSignupServiceTests.cs
+++ b/tests/Lfm.Api.Tests/Runs/RunSignupServiceTests.cs
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Auth;
+using Lfm.Api.Repositories;
+using Lfm.Api.Runs;
+using Lfm.Api.Services;
+using Lfm.Contracts.Runs;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Lfm.Api.Tests.Runs;
+
+/// <summary>
+/// Unit tests for <see cref="RunSignupService"/>. Each test exercises one
+/// branch of the policy lifted out of <c>RunsSignupFunction.Run</c>; the
+/// function-level tests in <see cref="RunsSignupFunctionTests"/> stay as
+/// the HTTP-shaped integration coverage on top of this service.
+/// </summary>
+public class RunSignupServiceTests
+{
+    // Anchored to UtcNow so the fixtures never become time bombs against a
+    // future-dated assertion.
+    private static string FutureStartTime() =>
+        DateTimeOffset.UtcNow.AddHours(24).ToString("o");
+    private static string FutureSignupCloseTime() =>
+        DateTimeOffset.UtcNow.AddHours(22).ToString("o");
+
+    private static SessionPrincipal MakePrincipal(string battleNetId = "bnet-user") =>
+        new SessionPrincipal(
+            BattleNetId: battleNetId,
+            BattleTag: "User#1234",
+            GuildId: null,
+            GuildName: null,
+            IssuedAt: DateTimeOffset.UtcNow,
+            ExpiresAt: DateTimeOffset.UtcNow.AddHours(1));
+
+    private static RaiderDocument MakeRaider(
+        string battleNetId = "bnet-user",
+        string characterId = "char-1",
+        int? guildId = null) =>
+        new RaiderDocument(
+            Id: battleNetId,
+            BattleNetId: battleNetId,
+            SelectedCharacterId: characterId,
+            Locale: null,
+            Characters: [
+                new StoredSelectedCharacter(
+                    Id: characterId,
+                    Region: "eu",
+                    Realm: "silvermoon",
+                    Name: "Testchar",
+                    GuildId: guildId,
+                    GuildName: guildId is not null ? "Test Guild" : null)
+            ]);
+
+    private static RunDocument MakeOpenRun(
+        string id = "run-1",
+        string visibility = "PUBLIC",
+        int? creatorGuildId = null,
+        IReadOnlyList<RunCharacterEntry>? runCharacters = null,
+        IReadOnlyList<string>? rejected = null) =>
+        new RunDocument(
+            Id: id,
+            StartTime: FutureStartTime(),
+            SignupCloseTime: FutureSignupCloseTime(),
+            Description: "Test run",
+            ModeKey: "NORMAL:10",
+            Visibility: visibility,
+            CreatorGuild: "Test Guild",
+            CreatorGuildId: creatorGuildId,
+            InstanceId: 631,
+            InstanceName: "Icecrown Citadel",
+            CreatorBattleNetId: "bnet-creator",
+            CreatedAt: DateTimeOffset.UtcNow.AddDays(-14).ToString("o"),
+            Ttl: 86400,
+            RunCharacters: runCharacters ?? [],
+            Difficulty: "NORMAL",
+            Size: 10,
+            RejectedRaiderBattleNetIds: rejected);
+
+    private static SignupRequest MakeBody(
+        string characterId = "char-1",
+        string desiredAttendance = "IN",
+        int? specId = null) =>
+        new SignupRequest(
+            CharacterId: characterId,
+            DesiredAttendance: desiredAttendance,
+            SpecId: specId);
+
+    private static (
+        Mock<IRunsRepository> runsRepo,
+        Mock<IRaidersRepository> raidersRepo,
+        Mock<IGuildPermissions> guildPermissions,
+        Mock<ILogger<RunSignupService>> logger,
+        RunSignupService sut) MakeSut()
+    {
+        var runsRepo = new Mock<IRunsRepository>();
+        var raidersRepo = new Mock<IRaidersRepository>();
+        var guildPermissions = new Mock<IGuildPermissions>();
+        var logger = new Mock<ILogger<RunSignupService>>();
+        var sut = new RunSignupService(
+            runsRepo.Object,
+            raidersRepo.Object,
+            guildPermissions.Object,
+            logger.Object);
+        return (runsRepo, raidersRepo, guildPermissions, logger, sut);
+    }
+
+    [Fact]
+    public async Task SignupAsync_RaiderMissing_ReturnsNotFound()
+    {
+        var (_, raidersRepo, _, _, sut) = MakeSut();
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-user", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RaiderDocument?)null);
+
+        var result = await sut.SignupAsync(
+            "run-1",
+            MakeBody(),
+            MakePrincipal("bnet-user"),
+            CancellationToken.None);
+
+        var notFound = Assert.IsType<RunOperationResult.NotFound>(result);
+        Assert.Equal("raider-not-found", notFound.Code);
+    }
+
+    [Fact]
+    public async Task SignupAsync_CharacterNotOnProfile_ReturnsBadRequest()
+    {
+        var (_, raidersRepo, _, _, sut) = MakeSut();
+        // Raider has only "char-1"; body asks for "char-missing".
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-user", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRaider("bnet-user", characterId: "char-1"));
+
+        var result = await sut.SignupAsync(
+            "run-1",
+            MakeBody(characterId: "char-missing"),
+            MakePrincipal("bnet-user"),
+            CancellationToken.None);
+
+        var badRequest = Assert.IsType<RunOperationResult.BadRequest>(result);
+        Assert.Equal("character-not-on-profile", badRequest.Code);
+    }
+
+    [Fact]
+    public async Task SignupAsync_RunNotFound_ReturnsNotFound()
+    {
+        var (runsRepo, raidersRepo, _, _, sut) = MakeSut();
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-user", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRaider("bnet-user", characterId: "char-1"));
+        runsRepo.Setup(r => r.GetByIdAsync("missing-run", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RunDocument?)null);
+
+        var result = await sut.SignupAsync(
+            "missing-run",
+            MakeBody(),
+            MakePrincipal("bnet-user"),
+            CancellationToken.None);
+
+        var notFound = Assert.IsType<RunOperationResult.NotFound>(result);
+        Assert.Equal("run-not-found", notFound.Code);
+    }
+
+    [Fact]
+    public async Task SignupAsync_SignupsClosed_ReturnsConflict()
+    {
+        var (runsRepo, raidersRepo, _, _, sut) = MakeSut();
+        // Run whose start time and signup close time are both in the past.
+        var closed = MakeOpenRun() with
+        {
+            StartTime = DateTimeOffset.UtcNow.AddHours(-1).ToString("o"),
+            SignupCloseTime = DateTimeOffset.UtcNow.AddHours(-2).ToString("o"),
+        };
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-user", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRaider("bnet-user", characterId: "char-1"));
+        runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(closed);
+
+        var result = await sut.SignupAsync(
+            "run-1",
+            MakeBody(),
+            MakePrincipal("bnet-user"),
+            CancellationToken.None);
+
+        var conflict = Assert.IsType<RunOperationResult.ConflictResult>(result);
+        Assert.Equal("signups-closed", conflict.Code);
+    }
+
+    [Fact]
+    public async Task SignupAsync_HappyPath_PublicRun_ReturnsOkWithEntry()
+    {
+        var (runsRepo, raidersRepo, _, _, sut) = MakeSut();
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-user", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRaider("bnet-user", characterId: "char-1"));
+        runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeOpenRun());
+        runsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RunDocument doc, string? _, CancellationToken _) => doc);
+
+        var result = await sut.SignupAsync(
+            "run-1",
+            MakeBody(characterId: "char-1", desiredAttendance: "IN"),
+            MakePrincipal("bnet-user"),
+            CancellationToken.None);
+
+        var ok = Assert.IsType<RunOperationResult.Ok>(result);
+        var entry = Assert.Single(ok.Run.RunCharacters);
+        Assert.Equal("bnet-user", entry.RaiderBattleNetId);
+        Assert.Equal("char-1", entry.CharacterId);
+        Assert.Equal("IN", entry.DesiredAttendance);
+        Assert.Equal("IN", entry.ReviewedAttendance);
+        runsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SignupAsync_RetryExhaustion_ReturnsConflict()
+    {
+        var (runsRepo, raidersRepo, _, _, sut) = MakeSut();
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-user", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRaider("bnet-user", characterId: "char-1"));
+        runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeOpenRun());
+        runsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ConcurrencyConflictException());
+
+        var result = await sut.SignupAsync(
+            "run-1",
+            MakeBody(),
+            MakePrincipal("bnet-user"),
+            CancellationToken.None);
+
+        var conflict = Assert.IsType<RunOperationResult.ConflictResult>(result);
+        Assert.Equal("concurrent-modification", conflict.Code);
+        runsRepo.Verify(
+            r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(3));
+    }
+}

--- a/tests/Lfm.Api.Tests/Runs/RunSignupServiceTests.cs
+++ b/tests/Lfm.Api.Tests/Runs/RunSignupServiceTests.cs
@@ -39,7 +39,8 @@ public class RunSignupServiceTests
     private static RaiderDocument MakeRaider(
         string battleNetId = "bnet-user",
         string characterId = "char-1",
-        int? guildId = null) =>
+        int? guildId = null,
+        StoredSpecializationsSummary? specializationsSummary = null) =>
         new RaiderDocument(
             Id: battleNetId,
             BattleNetId: battleNetId,
@@ -52,7 +53,8 @@ public class RunSignupServiceTests
                     Realm: "silvermoon",
                     Name: "Testchar",
                     GuildId: guildId,
-                    GuildName: guildId is not null ? "Test Guild" : null)
+                    GuildName: guildId is not null ? "Test Guild" : null,
+                    SpecializationsSummary: specializationsSummary)
             ]);
 
     private static RunDocument MakeOpenRun(
@@ -235,5 +237,251 @@ public class RunSignupServiceTests
         runsRepo.Verify(
             r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Exactly(3));
+    }
+
+    // ------------------------------------------------------------------
+    // GUILD visibility — non-member must see NotFound (don't leak existence).
+    // ------------------------------------------------------------------
+    [Fact]
+    public async Task SignupAsync_GuildVisibility_NonMember_ReturnsNotFound_DoesNotLeakExistence()
+    {
+        var (runsRepo, raidersRepo, _, _, sut) = MakeSut();
+        // Caller's selected character is in guild 999; run is owned by guild 123.
+        // RunAccessPolicy.CanView returns false, so the policy lifts the run as
+        // "not found" rather than "forbidden" so existence cannot be probed.
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-user", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRaider("bnet-user", characterId: "char-1", guildId: 999));
+        runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeOpenRun(visibility: "GUILD", creatorGuildId: 123));
+
+        var result = await sut.SignupAsync(
+            "run-1",
+            MakeBody(),
+            MakePrincipal("bnet-user"),
+            CancellationToken.None);
+
+        var notFound = Assert.IsType<RunOperationResult.NotFound>(result);
+        Assert.Equal("run-not-found", notFound.Code);
+        // No write should happen on the not-found branch.
+        runsRepo.Verify(
+            r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ------------------------------------------------------------------
+    // GUILD visibility — same-guild member without rank permission gets
+    // Forbidden + the audit-reason literal the function relies on.
+    // ------------------------------------------------------------------
+    [Fact]
+    public async Task SignupAsync_GuildVisibility_MemberWithoutPermission_ReturnsForbiddenWithAuditReason()
+    {
+        var (runsRepo, raidersRepo, guildPermissions, _, sut) = MakeSut();
+        // Same guild as the run (CanView true), but rank lacks canSignupGuildRuns.
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-user", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRaider("bnet-user", characterId: "char-1", guildId: 123));
+        runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeOpenRun(visibility: "GUILD", creatorGuildId: 123));
+        guildPermissions
+            .Setup(g => g.CanSignupGuildRunsAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await sut.SignupAsync(
+            "run-1",
+            MakeBody(),
+            MakePrincipal("bnet-user"),
+            CancellationToken.None);
+
+        var forbidden = Assert.IsType<RunOperationResult.Forbidden>(result);
+        Assert.Equal("guild-rank-denied", forbidden.Code);
+        Assert.Equal("guild rank denied", forbidden.AuditReason);
+        runsRepo.Verify(
+            r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ------------------------------------------------------------------
+    // GUILD visibility — happy path: same guild + rank permission allows
+    // the signup to land.
+    // ------------------------------------------------------------------
+    [Fact]
+    public async Task SignupAsync_GuildVisibility_MemberWithPermission_ReturnsOk()
+    {
+        var (runsRepo, raidersRepo, guildPermissions, _, sut) = MakeSut();
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-user", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRaider("bnet-user", characterId: "char-1", guildId: 123));
+        runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeOpenRun(visibility: "GUILD", creatorGuildId: 123));
+        guildPermissions
+            .Setup(g => g.CanSignupGuildRunsAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        runsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RunDocument doc, string? _, CancellationToken _) => doc);
+
+        var result = await sut.SignupAsync(
+            "run-1",
+            MakeBody(characterId: "char-1", desiredAttendance: "IN"),
+            MakePrincipal("bnet-user"),
+            CancellationToken.None);
+
+        var ok = Assert.IsType<RunOperationResult.Ok>(result);
+        var entry = Assert.Single(ok.Run.RunCharacters);
+        Assert.Equal("bnet-user", entry.RaiderBattleNetId);
+        Assert.Equal("char-1", entry.CharacterId);
+        Assert.Equal("IN", entry.DesiredAttendance);
+        Assert.Equal("IN", entry.ReviewedAttendance);
+    }
+
+    // ------------------------------------------------------------------
+    // Rejection list — a NEW signup (no prior entry) by a raider whose
+    // BattleNetId sits in RejectedRaiderBattleNetIds defaults to OUT, the
+    // structural defence against the cancel-then-resignup bypass.
+    // ------------------------------------------------------------------
+    [Fact]
+    public async Task SignupAsync_RaiderInRejectionList_NewSignup_DefaultsToOut()
+    {
+        var (runsRepo, raidersRepo, _, _, sut) = MakeSut();
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-user", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRaider("bnet-user", characterId: "char-1"));
+        runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeOpenRun(rejected: ["bnet-user"]));
+        runsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RunDocument doc, string? _, CancellationToken _) => doc);
+
+        var result = await sut.SignupAsync(
+            "run-1",
+            MakeBody(characterId: "char-1", desiredAttendance: "IN"),
+            MakePrincipal("bnet-user"),
+            CancellationToken.None);
+
+        var ok = Assert.IsType<RunOperationResult.Ok>(result);
+        var entry = Assert.Single(ok.Run.RunCharacters);
+        Assert.Equal("bnet-user", entry.RaiderBattleNetId);
+        Assert.Equal("IN", entry.DesiredAttendance);
+        // The rejection-list flip turns the *new* signup's review status to OUT.
+        Assert.Equal("OUT", entry.ReviewedAttendance);
+    }
+
+    // ------------------------------------------------------------------
+    // Rejection list — an EDIT to an existing entry preserves the prior
+    // ReviewedAttendance. The flip-to-OUT only applies to brand-new signups.
+    // ------------------------------------------------------------------
+    [Fact]
+    public async Task SignupAsync_RaiderInRejectionList_EditExistingEntry_PreservesPriorReviewedAttendance()
+    {
+        var (runsRepo, raidersRepo, _, _, sut) = MakeSut();
+        var existingEntry = new RunCharacterEntry(
+            Id: "entry-1",
+            CharacterId: "char-1",
+            CharacterName: "Testchar",
+            CharacterRealm: "silvermoon",
+            CharacterLevel: 80,
+            CharacterClassId: 1,
+            CharacterClassName: "Warrior",
+            CharacterRaceId: 0,
+            CharacterRaceName: "",
+            RaiderBattleNetId: "bnet-user",
+            DesiredAttendance: "IN",
+            ReviewedAttendance: "BENCH",
+            SpecId: null,
+            SpecName: null,
+            Role: null);
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-user", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRaider("bnet-user", characterId: "char-1"));
+        runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeOpenRun(
+                runCharacters: [existingEntry],
+                rejected: ["bnet-user"]));
+        runsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RunDocument doc, string? _, CancellationToken _) => doc);
+
+        var result = await sut.SignupAsync(
+            "run-1",
+            MakeBody(characterId: "char-1", desiredAttendance: "IN"),
+            MakePrincipal("bnet-user"),
+            CancellationToken.None);
+
+        var ok = Assert.IsType<RunOperationResult.Ok>(result);
+        var entry = Assert.Single(ok.Run.RunCharacters);
+        // Same entry id (upsert, not insert).
+        Assert.Equal("entry-1", entry.Id);
+        // Edits preserve the run owner's prior review decision; the OUT flip
+        // only applies to brand-new signups for raiders in the rejection list.
+        Assert.Equal("BENCH", entry.ReviewedAttendance);
+    }
+
+    // ------------------------------------------------------------------
+    // Concurrency — a single ConcurrencyConflictException retries; on the
+    // second attempt the write succeeds and the run is re-read each time.
+    // ------------------------------------------------------------------
+    [Fact]
+    public async Task SignupAsync_RetryConcurrencyConflict_ThenSucceeds_ReturnsOk()
+    {
+        var (runsRepo, raidersRepo, _, _, sut) = MakeSut();
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-user", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRaider("bnet-user", characterId: "char-1"));
+        runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeOpenRun());
+
+        // First UpdateAsync call throws, second succeeds.
+        var updateCall = 0;
+        runsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns<RunDocument, string?, CancellationToken>((doc, _, _) =>
+            {
+                updateCall++;
+                if (updateCall == 1)
+                    throw new ConcurrencyConflictException();
+                return Task.FromResult(doc);
+            });
+
+        var result = await sut.SignupAsync(
+            "run-1",
+            MakeBody(),
+            MakePrincipal("bnet-user"),
+            CancellationToken.None);
+
+        Assert.IsType<RunOperationResult.Ok>(result);
+        // Two attempts → two writes attempted, two re-reads.
+        runsRepo.Verify(
+            r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+        runsRepo.Verify(
+            r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    // ------------------------------------------------------------------
+    // Spec validation — body's SpecId must exist on the character's
+    // SpecializationsSummary; otherwise BadRequest("invalid-spec-id").
+    // ------------------------------------------------------------------
+    [Fact]
+    public async Task SignupAsync_InvalidSpecId_ReturnsBadRequest()
+    {
+        var (runsRepo, raidersRepo, _, _, sut) = MakeSut();
+        // Character knows spec 71 only; body asks for spec 999.
+        var specs = new StoredSpecializationsSummary(
+            ActiveSpecialization: null,
+            Specializations: [
+                new StoredSpecializationsEntry(
+                    new StoredCharacterSpecialization(Id: 71, Name: "Arms")),
+            ]);
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-user", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRaider(
+                "bnet-user",
+                characterId: "char-1",
+                specializationsSummary: specs));
+        runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeOpenRun());
+
+        var result = await sut.SignupAsync(
+            "run-1",
+            MakeBody(characterId: "char-1", specId: 999),
+            MakePrincipal("bnet-user"),
+            CancellationToken.None);
+
+        var badRequest = Assert.IsType<RunOperationResult.BadRequest>(result);
+        Assert.Equal("invalid-spec-id", badRequest.Code);
+        runsRepo.Verify(
+            r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 }

--- a/tests/Lfm.Api.Tests/RunsSignupFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RunsSignupFunctionTests.cs
@@ -10,7 +10,7 @@ using Moq;
 using Lfm.Api.Auth;
 using Lfm.Api.Functions;
 using Lfm.Api.Repositories;
-using Lfm.Api.Services;
+using Lfm.Api.Runs;
 using Lfm.Contracts.Runs;
 using Xunit;
 
@@ -30,15 +30,12 @@ public class RunsSignupFunctionTests
         return ctx.Object;
     }
 
-    private static SessionPrincipal MakePrincipal(
-        string battleNetId = "bnet-user",
-        string? guildId = null,
-        string? guildName = null) =>
+    private static SessionPrincipal MakePrincipal(string battleNetId = "bnet-user") =>
         new SessionPrincipal(
             BattleNetId: battleNetId,
             BattleTag: "User#1234",
-            GuildId: guildId,
-            GuildName: guildName,
+            GuildId: null,
+            GuildName: null,
             IssuedAt: DateTimeOffset.UtcNow,
             ExpiresAt: DateTimeOffset.UtcNow.AddHours(1));
 
@@ -51,23 +48,25 @@ public class RunsSignupFunctionTests
         return httpContext.Request;
     }
 
+    private static HttpRequest MakePostRequest(string rawJson)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(rawJson));
+        httpContext.Request.ContentType = "application/json";
+        return httpContext.Request;
+    }
+
     private static RunsSignupFunction MakeFunction(
-        Mock<IRunsRepository> runsRepo,
-        Mock<IRaidersRepository> raidersRepo,
-        Mock<IGuildPermissions> permissions,
+        Mock<IRunSignupService> service,
         TestLogger<RunsSignupFunction>? logger = null)
     {
         return new RunsSignupFunction(
-            runsRepo.Object,
-            raidersRepo.Object,
-            permissions.Object,
+            service.Object,
             logger ?? new TestLogger<RunsSignupFunction>());
     }
 
     private static RunDocument MakeRunDoc(
         string id = "run-1",
-        string visibility = "PUBLIC",
-        int? creatorGuildId = null,
         IReadOnlyList<RunCharacterEntry>? runCharacters = null) =>
         new RunDocument(
             Id: id,
@@ -75,61 +74,17 @@ public class RunsSignupFunctionTests
             SignupCloseTime: DateTimeOffset.UtcNow.AddHours(22).ToString("o"),
             Description: "Test run",
             ModeKey: "NORMAL:10",
-            Visibility: visibility,
+            Visibility: "PUBLIC",
             CreatorGuild: "Test Guild",
-            CreatorGuildId: creatorGuildId,
+            CreatorGuildId: null,
             InstanceId: 631,
             InstanceName: "Icecrown Citadel",
             CreatorBattleNetId: "bnet-creator",
             CreatedAt: DateTimeOffset.UtcNow.AddDays(-14).ToString("o"),
             Ttl: 86400,
-            RunCharacters: runCharacters ?? []);
-
-    private static RaiderDocument MakeRaiderDoc(
-        string battleNetId = "bnet-user",
-        string characterId = "char-1",
-        int? guildId = null) =>
-        new RaiderDocument(
-            Id: battleNetId,
-            BattleNetId: battleNetId,
-            SelectedCharacterId: characterId,
-            Locale: null,
-            Characters: [
-                new StoredSelectedCharacter(
-                    Id: characterId,
-                    Region: "eu",
-                    Realm: "silvermoon",
-                    Name: "Testchar",
-                    GuildId: guildId,
-                    GuildName: guildId is not null ? "Test Guild" : null)
-            ]);
-
-    /// <summary>
-    /// Pre-wired mocks for a successful signup call. Each test can mutate the
-    /// fields before invoking the function to introduce a single axis of variance.
-    /// </summary>
-    private sealed class HappyPathFixture
-    {
-        public required Mock<IRunsRepository> RunsRepo { get; init; }
-        public required Mock<IRaidersRepository> RaidersRepo { get; init; }
-        public required Mock<IGuildPermissions> Permissions { get; init; }
-        public required TestLogger<RunsSignupFunction> Logger { get; init; }
-        public required SessionPrincipal Principal { get; init; }
-        public required FunctionContext Context { get; init; }
-        public required object RequestBody { get; init; }
-    }
-
-    private static HappyPathFixture MakeHappyPath()
-    {
-        var principal = MakePrincipal(battleNetId: "bnet-user");
-        var run = MakeRunDoc();
-        var raider = MakeRaiderDoc(battleNetId: "bnet-user", characterId: "char-1");
-
-        var updatedRun = run with
-        {
-            RunCharacters = [
+            RunCharacters: runCharacters ?? [
                 new RunCharacterEntry(
-                    Id: "new-entry-id",
+                    Id: "entry-1",
                     CharacterId: "char-1",
                     CharacterName: "Testchar",
                     CharacterRealm: "silvermoon",
@@ -144,252 +99,199 @@ public class RunsSignupFunctionTests
                     SpecId: null,
                     SpecName: null,
                     Role: null)
-            ]
-        };
+            ]);
 
-        var runsRepo = new Mock<IRunsRepository>();
-        runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(run);
-        runsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(updatedRun);
-
-        var raidersRepo = new Mock<IRaidersRepository>();
-        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-user", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(raider);
-
-        return new HappyPathFixture
-        {
-            RunsRepo = runsRepo,
-            RaidersRepo = raidersRepo,
-            Permissions = new Mock<IGuildPermissions>(),
-            Logger = new TestLogger<RunsSignupFunction>(),
-            Principal = principal,
-            Context = MakeFunctionContext(principal),
-            RequestBody = new
-            {
-                characterId = "char-1",
-                desiredAttendance = "IN",
-                specId = (int?)null,
-            },
-        };
-    }
+    private static object MakeBody(
+        string characterId = "char-1",
+        string desiredAttendance = "IN") =>
+        new { characterId, desiredAttendance, specId = (int?)null };
 
     // ------------------------------------------------------------------
-    // Test 1: Happy path — new signup returns 200 with sanitized run
+    // Test 1: Service Ok happy path → 200 with mapped DTO + audit
     // ------------------------------------------------------------------
 
     [Fact]
-    public async Task Run_adds_signup_and_returns_200()
+    public async Task Run_returns_200_when_service_returns_ok()
     {
-        var fx = MakeHappyPath();
+        var principal = MakePrincipal("bnet-user");
+        var persisted = MakeRunDoc();
 
-        var fn = MakeFunction(fx.RunsRepo, fx.RaidersRepo, fx.Permissions, fx.Logger);
-        var result = await fn.Run(MakePostRequest(fx.RequestBody), "run-1", fx.Context, CancellationToken.None);
+        var service = new Mock<IRunSignupService>();
+        service.Setup(s => s.SignupAsync(
+                "run-1",
+                It.IsAny<SignupRequest>(),
+                It.IsAny<SessionPrincipal>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunOperationResult.Ok(persisted));
 
-        var okResult = Assert.IsType<OkObjectResult>(result);
-        var dto = Assert.IsType<RunDetailDto>(okResult.Value);
+        var fn = MakeFunction(service);
+        var ctx = MakeFunctionContext(principal);
+
+        var result = await fn.Run(MakePostRequest(MakeBody()), "run-1", ctx, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var dto = Assert.IsType<RunDetailDto>(ok.Value);
         Assert.Single(dto.RunCharacters);
         Assert.True(dto.RunCharacters[0].IsCurrentUser);
 
-        fx.RunsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Once);
+        service.Verify(
+            s => s.SignupAsync("run-1", It.IsAny<SignupRequest>(), It.IsAny<SessionPrincipal>(), It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     // ------------------------------------------------------------------
-    // Test 2: Run not found — returns 404
-    // ------------------------------------------------------------------
-
-    [Fact]
-    public async Task Run_returns_404_when_run_does_not_exist()
-    {
-        var principal = MakePrincipal();
-        var raider = MakeRaiderDoc(battleNetId: "bnet-user", characterId: "char-1");
-
-        var runsRepo = new Mock<IRunsRepository>();
-        runsRepo.Setup(r => r.GetByIdAsync("missing-run", It.IsAny<CancellationToken>()))
-            .ReturnsAsync((RunDocument?)null);
-
-        var raidersRepo = new Mock<IRaidersRepository>();
-        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-user", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(raider);
-
-        var permissions = new Mock<IGuildPermissions>();
-
-        var fn = MakeFunction(runsRepo, raidersRepo, permissions);
-        var ctx = MakeFunctionContext(principal);
-
-        var requestBody = new { characterId = "char-1", desiredAttendance = "IN" };
-        var result = await fn.Run(MakePostRequest(requestBody), "missing-run", ctx, CancellationToken.None);
-
-        var notFound = Assert.IsType<ObjectResult>(result);
-        Assert.Equal(404, notFound.StatusCode);
-        var problem = Assert.IsType<ProblemDetails>(notFound.Value);
-        Assert.Equal("https://github.com/lfm-org/lfm/errors#run-not-found", problem.Type);
-
-        runsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
-    }
-
-    // ------------------------------------------------------------------
-    // Test 3: GUILD run — caller lacks canSignupGuildRuns — returns 403
-    // ------------------------------------------------------------------
-
-    [Fact]
-    public async Task Run_returns_403_for_guild_run_when_caller_lacks_signup_permission()
-    {
-        // Caller is in same guild but lacks canSignupGuildRuns.
-        var principal = MakePrincipal(battleNetId: "bnet-member", guildId: "12345");
-        var run = MakeRunDoc(visibility: "GUILD", creatorGuildId: 12345);
-        var raider = MakeRaiderDoc(battleNetId: "bnet-member", characterId: "char-1", guildId: 12345);
-
-        var runsRepo = new Mock<IRunsRepository>();
-        runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(run);
-
-        var raidersRepo = new Mock<IRaidersRepository>();
-        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-member", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(raider);
-
-        var permissions = new Mock<IGuildPermissions>();
-        permissions.Setup(p => p.CanSignupGuildRunsAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(false);
-
-        var logger = new TestLogger<RunsSignupFunction>();
-        var fn = MakeFunction(runsRepo, raidersRepo, permissions, logger);
-        var ctx = MakeFunctionContext(principal);
-
-        var requestBody = new { characterId = "char-1", desiredAttendance = "IN" };
-        var result = await fn.Run(MakePostRequest(requestBody), "run-1", ctx, CancellationToken.None);
-
-        var objectResult = Assert.IsType<ObjectResult>(result);
-        Assert.Equal(403, objectResult.StatusCode);
-        var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
-        Assert.Equal("https://github.com/lfm-org/lfm/errors#guild-rank-denied", problem.Type);
-
-        runsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
-
-        Assert.Single(logger.Entries, e => e.IsAudit("signup.create", "failure", "guild rank denied"));
-    }
-
-    // ------------------------------------------------------------------
-    // Test 5: Happy path — emits signup.create audit event
+    // Test 2: Audit success entry on Ok path
     // ------------------------------------------------------------------
 
     [Fact]
     public async Task Run_emits_signup_create_audit_event_on_success()
     {
-        var fx = MakeHappyPath();
+        var principal = MakePrincipal("bnet-user");
+        var persisted = MakeRunDoc();
+        var logger = new TestLogger<RunsSignupFunction>();
 
-        var fn = MakeFunction(fx.RunsRepo, fx.RaidersRepo, fx.Permissions, fx.Logger);
-        await fn.Run(MakePostRequest(fx.RequestBody), "run-1", fx.Context, CancellationToken.None);
+        var service = new Mock<IRunSignupService>();
+        service.Setup(s => s.SignupAsync(
+                It.IsAny<string>(),
+                It.IsAny<SignupRequest>(),
+                It.IsAny<SessionPrincipal>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunOperationResult.Ok(persisted));
 
-        Assert.Single(fx.Logger.Entries, e => e.IsAudit(
+        var fn = MakeFunction(service, logger);
+        var ctx = MakeFunctionContext(principal);
+
+        await fn.Run(MakePostRequest(MakeBody()), "run-1", ctx, CancellationToken.None);
+
+        Assert.Single(logger.Entries, e => e.IsAudit(
             action: "signup.create",
             actorId: "bnet-user",
             result: "success"));
     }
 
     // ------------------------------------------------------------------
-    // Test 6: Signup close time has passed — returns 409
+    // Test 3: Service NotFound → 404 problem+json
     // ------------------------------------------------------------------
 
     [Fact]
-    public async Task Run_returns_409_when_signup_close_time_has_passed()
+    public async Task Run_returns_404_when_service_returns_not_found()
     {
-        var principal = MakePrincipal(battleNetId: "bnet-user");
-        var raider = MakeRaiderDoc(battleNetId: "bnet-user", characterId: "char-1");
+        var principal = MakePrincipal("bnet-user");
 
-        // Run whose signupCloseTime is in the past.
-        var closedRun = new RunDocument(
-            Id: "run-1",
-            StartTime: DateTimeOffset.UtcNow.AddHours(2).ToString("o"),
-            SignupCloseTime: DateTimeOffset.UtcNow.AddHours(-1).ToString("o"),
-            Description: "Closed run",
-            ModeKey: "NORMAL:10",
-            Visibility: "PUBLIC",
-            CreatorGuild: "Test Guild",
-            CreatorGuildId: null,
-            InstanceId: 631,
-            InstanceName: "Icecrown Citadel",
-            CreatorBattleNetId: "bnet-creator",
-            CreatedAt: DateTimeOffset.UtcNow.AddDays(-14).ToString("o"),
-            Ttl: 86400,
-            RunCharacters: []);
+        var service = new Mock<IRunSignupService>();
+        service.Setup(s => s.SignupAsync(
+                It.IsAny<string>(),
+                It.IsAny<SignupRequest>(),
+                It.IsAny<SessionPrincipal>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunOperationResult.NotFound("run-not-found", "Run not found."));
 
-        var runsRepo = new Mock<IRunsRepository>();
-        runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(closedRun);
-
-        var raidersRepo = new Mock<IRaidersRepository>();
-        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-user", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(raider);
-
-        var permissions = new Mock<IGuildPermissions>();
-        var fn = MakeFunction(runsRepo, raidersRepo, permissions);
+        var fn = MakeFunction(service);
         var ctx = MakeFunctionContext(principal);
 
-        var requestBody = new { characterId = "char-1", desiredAttendance = "IN" };
-        var result = await fn.Run(MakePostRequest(requestBody), "run-1", ctx, CancellationToken.None);
+        var result = await fn.Run(MakePostRequest(MakeBody()), "missing-run", ctx, CancellationToken.None);
+
+        var notFound = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(404, notFound.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(notFound.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#run-not-found", problem.Type);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 4: Service Forbidden → 403 problem+json + audit failure entry
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task Run_returns_403_and_emits_audit_when_service_returns_forbidden()
+    {
+        var principal = MakePrincipal("bnet-member");
+
+        var service = new Mock<IRunSignupService>();
+        service.Setup(s => s.SignupAsync(
+                It.IsAny<string>(),
+                It.IsAny<SignupRequest>(),
+                It.IsAny<SessionPrincipal>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunOperationResult.Forbidden(
+                "guild-rank-denied",
+                "Guild signup is not enabled for your rank.",
+                AuditReason: "guild rank denied"));
+
+        var logger = new TestLogger<RunsSignupFunction>();
+        var fn = MakeFunction(service, logger);
+        var ctx = MakeFunctionContext(principal);
+
+        var result = await fn.Run(MakePostRequest(MakeBody()), "run-1", ctx, CancellationToken.None);
 
         var objectResult = Assert.IsType<ObjectResult>(result);
-        Assert.Equal(409, objectResult.StatusCode);
+        Assert.Equal(403, objectResult.StatusCode);
         var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
-        Assert.Equal("https://github.com/lfm-org/lfm/errors#signups-closed", problem.Type);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#guild-rank-denied", problem.Type);
 
-        runsRepo.Verify(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+        Assert.Single(
+            logger.Entries,
+            e => e.IsAudit("signup.create", "failure", "guild rank denied"));
     }
 
     // ------------------------------------------------------------------
-    // Test 7: Concurrency conflict retries and succeeds on second attempt
+    // Test 5: Service ConflictResult → 409 problem+json (no audit)
     // ------------------------------------------------------------------
 
     [Fact]
-    public async Task Run_retries_on_concurrency_conflict_and_succeeds()
+    public async Task Run_returns_409_when_service_returns_conflict()
     {
-        var fx = MakeHappyPath();
+        var principal = MakePrincipal("bnet-user");
 
-        // Override UpdateAsync to throw on the first call, then succeed.
-        // The behavior we care about is: after a transient conflict the caller
-        // sees a successful 200 with the persisted run state. The exact retry
-        // count is a loop-structure detail and is not pinned here.
-        var callCount = 0;
-        fx.RunsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-            .Returns<RunDocument, string?, CancellationToken>((doc, _, _) =>
-            {
-                callCount++;
-                if (callCount == 1)
-                    throw new ConcurrencyConflictException();
-                return Task.FromResult(doc);
-            });
+        var service = new Mock<IRunSignupService>();
+        service.Setup(s => s.SignupAsync(
+                It.IsAny<string>(),
+                It.IsAny<SignupRequest>(),
+                It.IsAny<SessionPrincipal>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunOperationResult.ConflictResult(
+                "concurrent-modification",
+                "Concurrent modification, please retry."));
 
-        var fn = MakeFunction(fx.RunsRepo, fx.RaidersRepo, fx.Permissions, fx.Logger);
-        var result = await fn.Run(MakePostRequest(fx.RequestBody), "run-1", fx.Context, CancellationToken.None);
+        var fn = MakeFunction(service);
+        var ctx = MakeFunctionContext(principal);
 
-        var ok = Assert.IsType<OkObjectResult>(result);
-        var detail = Assert.IsType<RunDetailDto>(ok.Value);
-        Assert.Equal("run-1", detail.Id);
-    }
+        var result = await fn.Run(MakePostRequest(MakeBody()), "run-1", ctx, CancellationToken.None);
 
-    // ------------------------------------------------------------------
-    // Test 8: Concurrency conflict exhausts all retries — returns 409
-    // ------------------------------------------------------------------
-
-    [Fact]
-    public async Task Run_returns_409_after_exhausting_concurrency_retries()
-    {
-        var fx = MakeHappyPath();
-
-        fx.RunsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new ConcurrencyConflictException());
-
-        var fn = MakeFunction(fx.RunsRepo, fx.RaidersRepo, fx.Permissions, fx.Logger);
-        var result = await fn.Run(MakePostRequest(fx.RequestBody), "run-1", fx.Context, CancellationToken.None);
-
-        // The visible 409 is sufficient evidence that the retry loop exhausted —
-        // pinning Times.Exactly(3) couples the test to the loop count, which is a
-        // structural detail that may legitimately change (e.g. policy library swap).
         var objectResult = Assert.IsType<ObjectResult>(result);
         Assert.Equal(409, objectResult.StatusCode);
         var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
         Assert.Equal("https://github.com/lfm-org/lfm/errors#concurrent-modification", problem.Type);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 6: Validation failure — service is never called
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task Run_returns_400_when_body_fails_validation()
+    {
+        var principal = MakePrincipal("bnet-user");
+
+        // Missing required fields (e.g., desiredAttendance).
+        var requestBody = new { characterId = "char-1" };
+
+        var service = new Mock<IRunSignupService>();
+
+        var fn = MakeFunction(service);
+        var ctx = MakeFunctionContext(principal);
+
+        var result = await fn.Run(MakePostRequest(requestBody), "run-1", ctx, CancellationToken.None);
+
+        var badRequest = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(400, badRequest.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(badRequest.Value);
+        Assert.Equal("https://github.com/lfm-org/lfm/errors#validation-failed", problem.Type);
+        Assert.True(problem.Extensions.ContainsKey("errors"));
+
+        // Service should never be called when validation fails.
+        service.Verify(
+            s => s.SignupAsync(It.IsAny<string>(), It.IsAny<SignupRequest>(), It.IsAny<SessionPrincipal>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     // ------------------------------------------------------------------
@@ -404,17 +306,15 @@ public class RunsSignupFunctionTests
     [Fact]
     public async Task Run_returns_generic_400_when_body_is_invalid_json()
     {
-        var principal = MakePrincipal();
-        var runsRepo = new Mock<IRunsRepository>();
-        var raidersRepo = new Mock<IRaidersRepository>();
-        var permissions = new Mock<IGuildPermissions>();
-        var fn = MakeFunction(runsRepo, raidersRepo, permissions);
+        var principal = MakePrincipal("bnet-user");
+        var service = new Mock<IRunSignupService>();
+        var fn = MakeFunction(service);
 
-        var httpContext = new DefaultHttpContext();
-        httpContext.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes("{ not valid json at all"));
-        httpContext.Request.ContentType = "application/json";
-
-        var result = await fn.Run(httpContext.Request, "run-1", MakeFunctionContext(principal), CancellationToken.None);
+        var result = await fn.Run(
+            MakePostRequest("{ not valid json at all"),
+            "run-1",
+            MakeFunctionContext(principal),
+            CancellationToken.None);
 
         var bad = Assert.IsType<ObjectResult>(result);
         Assert.Equal(400, bad.StatusCode);
@@ -428,81 +328,7 @@ public class RunsSignupFunctionTests
         Assert.DoesNotContain("position", json, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("Request body is invalid or missing.", json);
 
-        // Repos must not have been touched for a parse failure.
-        runsRepo.VerifyNoOtherCalls();
-        raidersRepo.VerifyNoOtherCalls();
-        permissions.VerifyNoOtherCalls();
-    }
-
-    // ------------------------------------------------------------------
-    // Tests N+1/N+2: rejected-raider list defends the cancel-then-resignup
-    //   bypass documented in docs/threat-models/run-signup-peer-permission.md.
-    // ------------------------------------------------------------------
-
-    [Fact]
-    public async Task Run_defaults_reviewedAttendance_to_OUT_when_raider_in_rejection_list()
-    {
-        // The run owner has previously rejected this raider. The raider had
-        // cancelled the prior signup (so existingIndex < 0 here), but the
-        // RejectedRaiderBattleNetIds list still names them — re-signup must
-        // *not* silently flip back to "IN".
-        var principal = MakePrincipal(battleNetId: "bnet-user");
-        var run = MakeRunDoc() with { RejectedRaiderBattleNetIds = ["bnet-user"] };
-        var raider = MakeRaiderDoc(battleNetId: "bnet-user", characterId: "char-1");
-
-        var runsRepo = new Mock<IRunsRepository>();
-        runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(run);
-
-        RunDocument? captured = null;
-        runsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-            .Callback<RunDocument, string?, CancellationToken>((r, _, _) => captured = r)
-            .ReturnsAsync((RunDocument r, string? _, CancellationToken _) => r);
-
-        var raidersRepo = new Mock<IRaidersRepository>();
-        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-user", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(raider);
-
-        var fn = MakeFunction(runsRepo, raidersRepo, new Mock<IGuildPermissions>());
-        var body = new { characterId = "char-1", desiredAttendance = "IN", specId = (int?)null };
-        var result = await fn.Run(MakePostRequest(body), "run-1", MakeFunctionContext(principal), CancellationToken.None);
-
-        Assert.IsType<OkObjectResult>(result);
-        Assert.NotNull(captured);
-        var entry = Assert.Single(captured!.RunCharacters);
-        Assert.Equal("OUT", entry.ReviewedAttendance);
-    }
-
-    [Fact]
-    public async Task Run_defaults_reviewedAttendance_to_IN_when_raider_not_in_rejection_list()
-    {
-        // Negative case: a raider who has *not* been rejected gets the normal
-        // "IN" default on a fresh signup. Guards against the inverted-condition
-        // mutant where every signup would silently land as "OUT".
-        var principal = MakePrincipal(battleNetId: "bnet-user");
-        var run = MakeRunDoc() with { RejectedRaiderBattleNetIds = ["someone-else"] };
-        var raider = MakeRaiderDoc(battleNetId: "bnet-user", characterId: "char-1");
-
-        var runsRepo = new Mock<IRunsRepository>();
-        runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(run);
-
-        RunDocument? captured = null;
-        runsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-            .Callback<RunDocument, string?, CancellationToken>((r, _, _) => captured = r)
-            .ReturnsAsync((RunDocument r, string? _, CancellationToken _) => r);
-
-        var raidersRepo = new Mock<IRaidersRepository>();
-        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-user", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(raider);
-
-        var fn = MakeFunction(runsRepo, raidersRepo, new Mock<IGuildPermissions>());
-        var body = new { characterId = "char-1", desiredAttendance = "IN", specId = (int?)null };
-        var result = await fn.Run(MakePostRequest(body), "run-1", MakeFunctionContext(principal), CancellationToken.None);
-
-        Assert.IsType<OkObjectResult>(result);
-        Assert.NotNull(captured);
-        var entry = Assert.Single(captured!.RunCharacters);
-        Assert.Equal("IN", entry.ReviewedAttendance);
+        // Service must not have been touched for a parse failure.
+        service.VerifyNoOtherCalls();
     }
 }


### PR DESCRIPTION
## Summary

`RunsSignupFunction.Run` packed HTTP plumbing + raider/character/spec lookup + retry loop with optimistic-concurrency conflict translation + GUILD visibility check + rank-permission gate + RunCharacterEntry build with rejection-list IN→OUT flip into one method (256 LOC). This PR lifts the policy out, mirroring the pattern from `RunCreateService` (PR #197) and `RunUpdateService` (PR #198):

- New `RunSignupService` lifts the policy. Constructor: `(IRunsRepository, IRaidersRepository, IGuildPermissions, ILogger<RunSignupService>)`. Service owns the retry loop and the per-attempt `LogWarning`.
- Function shrunk 256 → 112 LOC. Constructor went from 4 deps to 2 (`IRunSignupService` + logger).
- Audit emission stays at the Function for `signup.create` success on Ok and failure with `AuditReason="guild rank denied"` on Forbidden.
- v1 alias preserved.
- 13 new `RunSignupServiceTests`: raider missing / character not on profile / run not found / signups closed / public happy path / retry exhaustion / GUILD non-member 404 (don't leak existence) / GUILD without rank / GUILD with rank / rejection-list new-signup OUT-default / rejection-list edit preserves prior / retry-then-succeed / invalid spec id.
- 7 rewritten `RunsSignupFunctionTests` cover the HTTP translator: Ok→200, success audit, NotFound, Forbidden+audit, ConflictResult, validation 400, malformed JSON.

This closes finding `SD-B-1` (run-signup slice) from `docs/superpowersreviews/2026-04-29-software-design-deep-review.md`. Task E.4 in `docs/superpowers/plans/2026-04-30-software-design-review-followup.md`. With this PR, all three run-mutation Functions (Create / Update / Signup) follow the same `IService` → `RunOperationResult` → `result.ToProblemResult(...)` pattern.

## Test plan

- [x] `dotnet build lfm.sln -c Release` clean (0 warnings)
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` — 749 passed
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error` exit 0
- [x] Spec compliance review ✅
- [x] Code quality review ✅ (after second commit added 7 service-level tests for lifted security-relevant semantics: rejection-list flip, GUILD-visibility 404, retry-then-succeed, edit-preserves-attendance, invalid spec id)