### PR TITLE
Split Blizzard wire shapes from persistence shapes

### DIFF
--- a/api/Functions/BattleNetCharactersFunction.cs
+++ b/api/Functions/BattleNetCharactersFunction.cs
@@ -93,7 +93,7 @@ public class BattleNetCharactersFunction(
     /// <c>functions/src/lib/blizzard-adapters.ts</c>.
     /// </summary>
     internal static List<CharacterDto> MapToCharacterDtos(
-        BlizzardAccountProfileSummary summary,
+        StoredBlizzardAccountProfile summary,
         string region,
         IReadOnlyList<StoredSelectedCharacter>? storedCharacters,
         IReadOnlyDictionary<string, string>? portraitCache)

--- a/api/Functions/BattleNetCharactersRefreshFunction.cs
+++ b/api/Functions/BattleNetCharactersRefreshFunction.cs
@@ -7,6 +7,8 @@ using Lfm.Api.Middleware;
 using Lfm.Api.Options;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;
+using Lfm.Api.Services.Blizzard;
+using Lfm.Api.Services.Blizzard.Models;
 using Lfm.Contracts.Characters;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -74,7 +76,7 @@ public class BattleNetCharactersRefreshFunction(
                 "missing-access-token",
                 "Session does not contain an access token. Please log out and log in again.");
 
-        BlizzardAccountProfileSummary freshSummary;
+        AccountProfileSummaryResponse freshSummary;
         try
         {
             freshSummary = await profileClient.GetAccountProfileSummaryAsync(accessToken, cancellationToken);
@@ -88,10 +90,11 @@ public class BattleNetCharactersRefreshFunction(
                 "Failed to fetch characters from Blizzard.");
         }
 
+        var freshSummaryStored = BlizzardModelTranslator.ToStored(freshSummary);
         var now = DateTimeOffset.UtcNow.ToString("O");
         var updated = raider with
         {
-            AccountProfileSummary = freshSummary,
+            AccountProfileSummary = freshSummaryStored,
             AccountProfileFetchedAt = now,
             AccountProfileRefreshedAt = now,
             Ttl = 180 * 86400,
@@ -100,7 +103,7 @@ public class BattleNetCharactersRefreshFunction(
 
         var region = _blizzardOpts.Region.ToLowerInvariant();
         var characters = BattleNetCharactersFunction.MapToCharacterDtos(
-            freshSummary, region, raider.Characters, raider.PortraitCache);
+            freshSummaryStored, region, raider.Characters, raider.PortraitCache);
 
         return new OkObjectResult(characters);
     }

--- a/api/Functions/RaiderCharacterAddFunction.cs
+++ b/api/Functions/RaiderCharacterAddFunction.cs
@@ -7,6 +7,8 @@ using Lfm.Api.Helpers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;
+using Lfm.Api.Services.Blizzard;
+using Lfm.Api.Services.Blizzard.Models;
 using Lfm.Api.Validation;
 using Lfm.Contracts.Characters;
 using Lfm.Contracts.Raiders;
@@ -125,9 +127,9 @@ public class RaiderCharacterAddFunction(
                     "missing-access-token",
                     "Session does not contain an access token. Please log out and log in again.");
 
-            BlizzardCharacterProfileResponse? profile = null;
-            BlizzardCharacterSpecializationsResponse? specs = null;
-            BlizzardCharacterMediaSummary? media = null;
+            CharacterProfileResponse? profile = null;
+            CharacterSpecializationsResponse? specs = null;
+            CharacterMediaSummaryResponse? media = null;
             try
             {
                 if (plan.FetchProfile)
@@ -203,9 +205,9 @@ public class RaiderCharacterAddFunction(
     internal static StoredSelectedCharacter Merge(
         StoredSelectedCharacter? existing,
         string id, string region, string realm, string nameDisplay,
-        BlizzardCharacterProfileResponse? profile,
-        BlizzardCharacterSpecializationsResponse? specs,
-        BlizzardCharacterMediaSummary? media,
+        CharacterProfileResponse? profile,
+        CharacterSpecializationsResponse? specs,
+        CharacterMediaSummaryResponse? media,
         string now,
         EnrichmentPlan plan)
     {
@@ -215,7 +217,7 @@ public class RaiderCharacterAddFunction(
         var guildId = profile?.Guild?.Id ?? existing?.GuildId;
         var guildName = profile?.Guild?.Name ?? existing?.GuildName;
         var specs2 = specs is not null ? MapSpecializationsSummary(specs) : existing?.SpecializationsSummary;
-        var media2 = media ?? existing?.MediaSummary;
+        var media2 = media is not null ? BlizzardModelTranslator.ToStored(media) : existing?.MediaSummary;
         var portrait = media is not null ? PickPortraitUrl(media) : existing?.PortraitUrl;
 
         return new StoredSelectedCharacter(
@@ -244,7 +246,7 @@ public class RaiderCharacterAddFunction(
     internal static bool IsCharacterOwnedByAccount(
         string characterId,
         string region,
-        BlizzardAccountProfileSummary? accountProfileSummary)
+        StoredBlizzardAccountProfile? accountProfileSummary)
     {
         if (accountProfileSummary is null) return true;
 
@@ -266,7 +268,7 @@ public class RaiderCharacterAddFunction(
     /// first asset if no key named "avatar" is present.  Returns null when the
     /// media summary is null or has no assets.
     /// </summary>
-    internal static string? PickPortraitUrl(BlizzardCharacterMediaSummary? media)
+    internal static string? PickPortraitUrl(CharacterMediaSummaryResponse? media)
     {
         if (media?.Assets is null || media.Assets.Count == 0) return null;
         var avatar = media.Assets.FirstOrDefault(a =>
@@ -279,7 +281,7 @@ public class RaiderCharacterAddFunction(
     /// shape the rest of the application uses.
     /// </summary>
     internal static StoredSpecializationsSummary MapSpecializationsSummary(
-        BlizzardCharacterSpecializationsResponse specs)
+        CharacterSpecializationsResponse specs)
     {
         var active = specs.ActiveSpecialization is null
             ? null

--- a/api/Functions/RaiderCharacterEnrichFunction.cs
+++ b/api/Functions/RaiderCharacterEnrichFunction.cs
@@ -6,6 +6,7 @@ using Lfm.Api.Helpers;
 using Lfm.Api.Middleware;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;
+using Lfm.Api.Services.Blizzard.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
@@ -76,9 +77,9 @@ public sealed class RaiderCharacterEnrichFunction(
                     "missing-access-token",
                     "Session does not contain an access token. Please log out and log in again.");
 
-            BlizzardCharacterProfileResponse? profile = null;
-            BlizzardCharacterSpecializationsResponse? specs = null;
-            BlizzardCharacterMediaSummary? media = null;
+            CharacterProfileResponse? profile = null;
+            CharacterSpecializationsResponse? specs = null;
+            CharacterMediaSummaryResponse? media = null;
             try
             {
                 if (plan.FetchProfile)

--- a/api/Repositories/IGuildRepository.cs
+++ b/api/Repositories/IGuildRepository.cs
@@ -44,55 +44,63 @@ public sealed record GuildDocument(
     GuildSetup? Setup = null,
     string? LastOverrideBy = null,
     string? LastOverrideAt = null,
-    // blizzardRosterRaw: embedded JSON object — modelled as opaque string to
-    // avoid pulling in the full Blizzard roster type in this iteration.
-    // The service layer deserialises it when needed.
-    BlizzardGuildRosterRaw? BlizzardRosterRaw = null,
-    BlizzardGuildProfileRaw? BlizzardProfileRaw = null,
+    // blizzardRosterRaw / blizzardProfileRaw: cached Blizzard responses,
+    // translated from Blizzard wire shapes via BlizzardModelTranslator.
+    StoredGuildRoster? BlizzardRosterRaw = null,
+    StoredGuildProfile? BlizzardProfileRaw = null,
     // Cosmos _etag — populated by the repository on read, used by PATCH /guild
     // to honor client-supplied If-Match headers for optimistic concurrency.
     [property: System.Text.Json.Serialization.JsonPropertyName("_etag")] string? ETag = null);
 
+// ---------------------------------------------------------------------------
+// Stored Blizzard guild roster — embedded inside the guild Cosmos document.
+// Cosmos keys are derived from .NET property names via CamelCase contract
+// resolver. Renaming any property here changes the JSON key written to Cosmos
+// and breaks reading existing documents.
+//
+// Resolves SD-S-5 from docs/superpowersreviews/2026-04-29-software-design-deep-review.md.
+// ---------------------------------------------------------------------------
+
 /// <summary>
-/// Blizzard guild roster member character (minimal fields needed for rank matching).
+/// Stored Blizzard guild roster member character (minimal fields needed for rank matching).
 /// </summary>
-public sealed record BlizzardGuildRosterMemberCharacter(
+public sealed record StoredGuildRosterMemberCharacter(
     string Name,
-    BlizzardGuildRosterRealm Realm,
+    StoredGuildRosterRealm Realm,
     int? Id = null);
 
-/// <summary>Realm reference embedded in a Blizzard guild roster member.</summary>
-public sealed record BlizzardGuildRosterRealm(string Slug);
+/// <summary>Realm reference embedded in a stored Blizzard guild roster member.</summary>
+public sealed record StoredGuildRosterRealm(string Slug);
 
-/// <summary>Single member entry in a Blizzard guild roster response.</summary>
-public sealed record BlizzardGuildRosterMember(
-    BlizzardGuildRosterMemberCharacter Character,
+/// <summary>Single member entry in a stored Blizzard guild roster.</summary>
+public sealed record StoredGuildRosterMember(
+    StoredGuildRosterMemberCharacter Character,
     int Rank);
 
 /// <summary>
-/// Blizzard guild roster response as stored inside the guild document.
+/// Blizzard guild roster as stored inside the guild Cosmos document.
 /// Only the fields used by GuildPermissions (rank matching) are modelled here.
 /// </summary>
-public sealed record BlizzardGuildRosterRaw(
-    IReadOnlyList<BlizzardGuildRosterMember>? Members = null);
+public sealed record StoredGuildRoster(
+    IReadOnlyList<StoredGuildRosterMember>? Members = null);
 
-/// <summary>Faction reference in a Blizzard guild profile response.</summary>
-public sealed record BlizzardGuildProfileFaction(
+/// <summary>Faction reference in a stored Blizzard guild profile.</summary>
+public sealed record StoredGuildProfileFaction(
     [property: JsonConverter(typeof(LocalizedStringConverter))] string? Name = null);
 
-/// <summary>Realm reference in a Blizzard guild profile response.</summary>
-public sealed record BlizzardGuildProfileRealm(
+/// <summary>Realm reference in a stored Blizzard guild profile.</summary>
+public sealed record StoredGuildProfileRealm(
     string Slug,
     [property: JsonConverter(typeof(LocalizedStringConverter))] string? Name = null);
 
 /// <summary>
-/// Blizzard guild profile as stored inside the guild document.
+/// Blizzard guild profile as stored inside the guild Cosmos document.
 /// Only the fields used for building the GuildDto are modelled here.
 /// </summary>
-public sealed record BlizzardGuildProfileRaw(
+public sealed record StoredGuildProfile(
     [property: JsonConverter(typeof(LocalizedStringConverter))] string Name,
-    BlizzardGuildProfileRealm Realm,
-    BlizzardGuildProfileFaction? Faction = null,
+    StoredGuildProfileRealm Realm,
+    StoredGuildProfileFaction? Faction = null,
     int? MemberCount = null,
     int? AchievementPoints = null);
 

--- a/api/Repositories/IRaidersRepository.cs
+++ b/api/Repositories/IRaidersRepository.cs
@@ -7,32 +7,37 @@ using Lfm.Api.Serialization;
 namespace Lfm.Api.Repositories;
 
 // ---------------------------------------------------------------------------
-// Blizzard account profile — stored verbatim as returned by the Blizzard API.
-// Field names follow Blizzard's snake_case convention; STJ [JsonPropertyName]
-// attributes are required because the Cosmos client is configured for camelCase
-// only at the *top-level document* boundary, not for nested objects.
+// Stored Blizzard account profile — embedded inside the raider Cosmos document.
+// Cosmos keys are derived from .NET property names via CamelCase contract
+// resolver (see Program.cs CosmosClientOptions). Renaming any property here
+// changes the JSON key written to Cosmos and breaks reading existing documents.
+//
+// These types were previously dual-roled as Blizzard HTTP wire models. The
+// HTTP wire shapes now live in api/Services/Blizzard/Models/ and a translator
+// converts wire → stored at the Blizzard adapter boundary.
+// Resolves SD-S-5 from docs/superpowersreviews/2026-04-29-software-design-deep-review.md.
 // ---------------------------------------------------------------------------
 
-public sealed record BlizzardRealmRef(
-    [property: JsonPropertyName("slug")] string Slug,
-    [property: JsonPropertyName("name")] string? Name = null);
+public sealed record StoredBlizzardRealmRef(
+    string Slug,
+    string? Name = null);
 
-public sealed record BlizzardNamedRef(
-    [property: JsonPropertyName("id")] int Id,
-    [property: JsonPropertyName("name")] string? Name = null);
+public sealed record StoredBlizzardNamedRef(
+    int Id,
+    string? Name = null);
 
-public sealed record BlizzardAccountCharacter(
-    [property: JsonPropertyName("name")] string Name,
-    [property: JsonPropertyName("level")] int Level,
-    [property: JsonPropertyName("realm")] BlizzardRealmRef Realm,
-    [property: JsonPropertyName("playable_class")] BlizzardNamedRef? PlayableClass = null);
+public sealed record StoredBlizzardAccountCharacter(
+    string Name,
+    int Level,
+    StoredBlizzardRealmRef Realm,
+    StoredBlizzardNamedRef? PlayableClass = null);
 
-public sealed record BlizzardWowAccount(
-    [property: JsonPropertyName("id")] int? Id,
-    [property: JsonPropertyName("characters")] IReadOnlyList<BlizzardAccountCharacter>? Characters = null);
+public sealed record StoredBlizzardWowAccount(
+    int? Id,
+    IReadOnlyList<StoredBlizzardAccountCharacter>? Characters = null);
 
-public sealed record BlizzardAccountProfileSummary(
-    [property: JsonPropertyName("wow_accounts")] IReadOnlyList<BlizzardWowAccount>? WowAccounts = null);
+public sealed record StoredBlizzardAccountProfile(
+    IReadOnlyList<StoredBlizzardWowAccount>? WowAccounts = null);
 
 // ---------------------------------------------------------------------------
 // Stored selected character — minimal fields required for character mapping.
@@ -50,18 +55,18 @@ public sealed record StoredSpecializationsSummary(
 public sealed record StoredSpecializationsEntry(StoredCharacterSpecialization Specialization);
 
 /// <summary>
-/// A single asset entry in a Blizzard character media summary.
-/// Field names match the snake_case Blizzard API response (e.g. "avatar", "main").
+/// A single asset entry in a Blizzard character media summary, as stored in
+/// Cosmos. Field names round-trip through Newtonsoft to camelCase ("key", "value").
 /// </summary>
-public sealed record BlizzardCharacterMediaAsset(string Key, string Value);
+public sealed record StoredBlizzardCharacterMediaAsset(string Key, string Value);
 
 /// <summary>
-/// The Blizzard character media summary response.
-/// Mirrors <c>BlizzardCharacterMediaSummary</c> from
-/// <c>functions/src/types/blizzard.ts</c>.
+/// The Blizzard character media summary as stored in Cosmos (inside
+/// <see cref="StoredSelectedCharacter.MediaSummary"/>). Round-trips through
+/// Newtonsoft + camelCase contract resolver.
 /// </summary>
-public sealed record BlizzardCharacterMediaSummary(
-    IReadOnlyList<BlizzardCharacterMediaAsset>? Assets = null);
+public sealed record StoredBlizzardCharacterMedia(
+    IReadOnlyList<StoredBlizzardCharacterMediaAsset>? Assets = null);
 
 public sealed record StoredSelectedCharacter(
     string Id,
@@ -70,7 +75,7 @@ public sealed record StoredSelectedCharacter(
     string Name,
     string? PortraitUrl = null,
     StoredSpecializationsSummary? SpecializationsSummary = null,
-    BlizzardCharacterMediaSummary? MediaSummary = null,
+    StoredBlizzardCharacterMedia? MediaSummary = null,
     int? ClassId = null,
     [property: Newtonsoft.Json.JsonConverter(typeof(LocalizedStringConverter))] string? ClassName = null,
     int? Level = null,
@@ -101,7 +106,7 @@ public sealed record RaiderDocument(
     [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     int? Ttl = null,
     // accountProfileSummary: cached Blizzard profile response (populated by battlenet-characters-refresh).
-    BlizzardAccountProfileSummary? AccountProfileSummary = null,
+    StoredBlizzardAccountProfile? AccountProfileSummary = null,
     // accountProfileRefreshedAt: ISO-8601 timestamp of last cooldown reset (even on 304 / not-modified).
     string? AccountProfileRefreshedAt = null,
     // accountProfileFetchedAt: ISO-8601 timestamp of last full Blizzard fetch (only updated on 200 OK).
@@ -113,37 +118,6 @@ public sealed record RaiderDocument(
     // Cosmos _etag — populated by the repository on read, used by PATCH /me to
     // honor client-supplied If-Match headers for optimistic concurrency.
     [property: JsonPropertyName("_etag")] string? ETag = null);
-
-// ---------------------------------------------------------------------------
-// Blizzard character profile — response from /profile/wow/character/{realm}/{name}
-// ---------------------------------------------------------------------------
-
-public sealed record BlizzardCharacterGuildRef(
-    [property: JsonPropertyName("id")] int Id,
-    [property: JsonPropertyName("name")] string? Name = null);
-
-public sealed record BlizzardCharacterProfileResponse(
-    [property: JsonPropertyName("name")] string Name,
-    [property: JsonPropertyName("level")] int Level,
-    [property: JsonPropertyName("character_class")] BlizzardNamedRef? CharacterClass = null,
-    [property: JsonPropertyName("race")] BlizzardNamedRef? Race = null,
-    [property: JsonPropertyName("realm")] BlizzardRealmRef? Realm = null,
-    [property: JsonPropertyName("guild")] BlizzardCharacterGuildRef? Guild = null);
-
-// ---------------------------------------------------------------------------
-// Blizzard character specializations — response from /profile/wow/character/{realm}/{name}/specializations
-// ---------------------------------------------------------------------------
-
-public sealed record BlizzardSpecializationRef(
-    [property: JsonPropertyName("id")] int Id,
-    [property: JsonPropertyName("name")] string? Name = null);
-
-public sealed record BlizzardSpecializationEntry(
-    [property: JsonPropertyName("specialization")] BlizzardSpecializationRef Specialization);
-
-public sealed record BlizzardCharacterSpecializationsResponse(
-    [property: JsonPropertyName("active_specialization")] BlizzardSpecializationRef? ActiveSpecialization = null,
-    [property: JsonPropertyName("specializations")] IReadOnlyList<BlizzardSpecializationEntry>? Specializations = null);
 
 public interface IRaidersRepository
 {

--- a/api/Services/Blizzard/BlizzardModelTranslator.cs
+++ b/api/Services/Blizzard/BlizzardModelTranslator.cs
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Repositories;
+using Lfm.Api.Services.Blizzard.Models;
+
+namespace Lfm.Api.Services.Blizzard;
+
+/// <summary>
+/// Translates Blizzard HTTP response models (<see cref="Models"/>) into the
+/// persistence shapes (<c>Stored*</c>) we store in Cosmos. Owned by the Blizzard
+/// adapter so any future Blizzard schema change is contained at this boundary,
+/// not in repositories or Function handlers.
+///
+/// Resolves finding SD-S-5 from
+/// docs/superpowersreviews/2026-04-29-software-design-deep-review.md.
+/// </summary>
+internal static class BlizzardModelTranslator
+{
+    // ---------- Account profile ----------
+
+    public static StoredBlizzardAccountProfile ToStored(AccountProfileSummaryResponse src) =>
+        new(WowAccounts: src.WowAccounts?.Select(ToStored).ToList());
+
+    private static StoredBlizzardWowAccount ToStored(WowAccountResponse src) =>
+        new(Id: src.Id, Characters: src.Characters?.Select(ToStored).ToList());
+
+    private static StoredBlizzardAccountCharacter ToStored(AccountCharacterResponse src) =>
+        new(
+            Name: src.Name,
+            Level: src.Level,
+            Realm: ToStored(src.Realm),
+            PlayableClass: src.PlayableClass is null ? null : ToStored(src.PlayableClass));
+
+    private static StoredBlizzardRealmRef ToStored(RealmRefResponse src) =>
+        new(Slug: src.Slug, Name: src.Name);
+
+    private static StoredBlizzardNamedRef ToStored(NamedRefResponse src) =>
+        new(Id: src.Id, Name: src.Name);
+
+    // ---------- Character media ----------
+
+    public static StoredBlizzardCharacterMedia ToStored(CharacterMediaSummaryResponse src) =>
+        new(Assets: src.Assets?
+            .Select(a => new StoredBlizzardCharacterMediaAsset(a.Key, a.Value))
+            .ToList());
+
+    // ---------- Guild roster ----------
+
+    public static StoredGuildRoster ToStored(GuildRosterResponse src) =>
+        new(Members: src.Members?.Select(ToStored).ToList());
+
+    private static StoredGuildRosterMember ToStored(GuildRosterMemberResponse src) =>
+        new(Character: ToStored(src.Character), Rank: src.Rank);
+
+    private static StoredGuildRosterMemberCharacter ToStored(GuildRosterMemberCharacterResponse src) =>
+        new(Name: src.Name, Realm: ToStored(src.Realm), Id: src.Id);
+
+    private static StoredGuildRosterRealm ToStored(GuildRosterRealmResponse src) =>
+        new(Slug: src.Slug);
+
+    // ---------- Guild profile ----------
+
+    public static StoredGuildProfile ToStored(GuildProfileResponse src) => new(
+        Name: src.Name,
+        Realm: ToStored(src.Realm),
+        Faction: src.Faction is null ? null : ToStored(src.Faction),
+        MemberCount: src.MemberCount,
+        AchievementPoints: src.AchievementPoints);
+
+    private static StoredGuildProfileRealm ToStored(GuildProfileRealmResponse src) =>
+        new(Slug: src.Slug, Name: src.Name);
+
+    private static StoredGuildProfileFaction ToStored(GuildProfileFactionResponse src) =>
+        new(Name: src.Name);
+}

--- a/api/Services/Blizzard/Models/AccountProfileSummaryResponse.cs
+++ b/api/Services/Blizzard/Models/AccountProfileSummaryResponse.cs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Text.Json.Serialization;
+
+namespace Lfm.Api.Services.Blizzard.Models;
+
+/// <summary>
+/// Blizzard <c>/profile/user/wow</c> response (HTTP wire shape).
+/// STJ-only snake_case mapping from Blizzard's response payload. Never stored
+/// directly in Cosmos — translate via <see cref="BlizzardModelTranslator"/> first.
+/// </summary>
+public sealed record AccountProfileSummaryResponse(
+    [property: JsonPropertyName("wow_accounts")] IReadOnlyList<WowAccountResponse>? WowAccounts = null);
+
+public sealed record WowAccountResponse(
+    [property: JsonPropertyName("id")] int? Id,
+    [property: JsonPropertyName("characters")] IReadOnlyList<AccountCharacterResponse>? Characters = null);
+
+public sealed record AccountCharacterResponse(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("level")] int Level,
+    [property: JsonPropertyName("realm")] RealmRefResponse Realm,
+    [property: JsonPropertyName("playable_class")] NamedRefResponse? PlayableClass = null);
+
+public sealed record RealmRefResponse(
+    [property: JsonPropertyName("slug")] string Slug,
+    [property: JsonPropertyName("name")] string? Name = null);
+
+public sealed record NamedRefResponse(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("name")] string? Name = null);

--- a/api/Services/Blizzard/Models/CharacterMediaSummaryResponse.cs
+++ b/api/Services/Blizzard/Models/CharacterMediaSummaryResponse.cs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Text.Json.Serialization;
+
+namespace Lfm.Api.Services.Blizzard.Models;
+
+/// <summary>
+/// Blizzard <c>/profile/wow/character/{realm}/{name}/character-media</c> response
+/// (HTTP wire shape). STJ-only snake_case mapping from Blizzard. Never stored
+/// directly in Cosmos — translate via <see cref="BlizzardModelTranslator"/> first.
+/// </summary>
+public sealed record CharacterMediaSummaryResponse(
+    [property: JsonPropertyName("assets")] IReadOnlyList<CharacterMediaAssetResponse>? Assets = null);
+
+public sealed record CharacterMediaAssetResponse(
+    [property: JsonPropertyName("key")] string Key,
+    [property: JsonPropertyName("value")] string Value);

--- a/api/Services/Blizzard/Models/CharacterProfileResponse.cs
+++ b/api/Services/Blizzard/Models/CharacterProfileResponse.cs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Text.Json.Serialization;
+
+namespace Lfm.Api.Services.Blizzard.Models;
+
+/// <summary>
+/// Blizzard <c>/profile/wow/character/{realm}/{name}</c> response (HTTP wire shape).
+/// STJ-only snake_case mapping from Blizzard's response payload. Never stored
+/// directly in Cosmos.
+/// </summary>
+public sealed record CharacterProfileResponse(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("level")] int Level,
+    [property: JsonPropertyName("character_class")] NamedRefResponse? CharacterClass = null,
+    [property: JsonPropertyName("race")] NamedRefResponse? Race = null,
+    [property: JsonPropertyName("realm")] RealmRefResponse? Realm = null,
+    [property: JsonPropertyName("guild")] CharacterGuildRefResponse? Guild = null);
+
+public sealed record CharacterGuildRefResponse(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("name")] string? Name = null);

--- a/api/Services/Blizzard/Models/CharacterSpecializationsResponse.cs
+++ b/api/Services/Blizzard/Models/CharacterSpecializationsResponse.cs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Text.Json.Serialization;
+
+namespace Lfm.Api.Services.Blizzard.Models;
+
+/// <summary>
+/// Blizzard <c>/profile/wow/character/{realm}/{name}/specializations</c> response
+/// (HTTP wire shape). STJ-only snake_case mapping. Never stored directly in Cosmos.
+/// </summary>
+public sealed record CharacterSpecializationsResponse(
+    [property: JsonPropertyName("active_specialization")] SpecializationRefResponse? ActiveSpecialization = null,
+    [property: JsonPropertyName("specializations")] IReadOnlyList<SpecializationEntryResponse>? Specializations = null);
+
+public sealed record SpecializationEntryResponse(
+    [property: JsonPropertyName("specialization")] SpecializationRefResponse Specialization);
+
+public sealed record SpecializationRefResponse(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("name")] string? Name = null);

--- a/api/Services/Blizzard/Models/GuildProfileResponse.cs
+++ b/api/Services/Blizzard/Models/GuildProfileResponse.cs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Text.Json.Serialization;
+
+namespace Lfm.Api.Services.Blizzard.Models;
+
+/// <summary>
+/// Blizzard <c>/data/wow/guild/{realm}/{name}</c> response (HTTP wire shape).
+/// STJ-only snake_case mapping. Never stored directly in Cosmos —
+/// translate via <see cref="BlizzardModelTranslator"/> first.
+/// </summary>
+public sealed record GuildProfileResponse(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("realm")] GuildProfileRealmResponse Realm,
+    [property: JsonPropertyName("faction")] GuildProfileFactionResponse? Faction = null,
+    [property: JsonPropertyName("member_count")] int? MemberCount = null,
+    [property: JsonPropertyName("achievement_points")] int? AchievementPoints = null);
+
+public sealed record GuildProfileRealmResponse(
+    [property: JsonPropertyName("slug")] string Slug,
+    [property: JsonPropertyName("name")] string? Name = null);
+
+public sealed record GuildProfileFactionResponse(
+    [property: JsonPropertyName("name")] string? Name = null);

--- a/api/Services/Blizzard/Models/GuildProfileResponse.cs
+++ b/api/Services/Blizzard/Models/GuildProfileResponse.cs
@@ -8,7 +8,13 @@ namespace Lfm.Api.Services.Blizzard.Models;
 /// <summary>
 /// Blizzard <c>/data/wow/guild/{realm}/{name}</c> response (HTTP wire shape).
 /// STJ-only snake_case mapping. Never stored directly in Cosmos —
-/// translate via <see cref="BlizzardModelTranslator"/> first.
+/// translate via <see cref="Lfm.Api.Services.Blizzard.BlizzardModelTranslator.ToStored(GuildProfileResponse)"/>
+/// before persisting.
+///
+/// Reserved for the upcoming guild-roster port — no .NET caller yet; the
+/// TypeScript handler still owns guild roster refresh. Kept here so the
+/// .NET port can adopt the wire/storage split without re-introducing the
+/// dual-roled record shape.
 /// </summary>
 public sealed record GuildProfileResponse(
     [property: JsonPropertyName("name")] string Name,

--- a/api/Services/Blizzard/Models/GuildRosterResponse.cs
+++ b/api/Services/Blizzard/Models/GuildRosterResponse.cs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Text.Json.Serialization;
+
+namespace Lfm.Api.Services.Blizzard.Models;
+
+/// <summary>
+/// Blizzard <c>/data/wow/guild/{realm}/{name}/roster</c> response (HTTP wire shape).
+/// STJ-only snake_case mapping. Never stored directly in Cosmos —
+/// translate via <see cref="BlizzardModelTranslator"/> first.
+/// </summary>
+public sealed record GuildRosterResponse(
+    [property: JsonPropertyName("members")] IReadOnlyList<GuildRosterMemberResponse>? Members = null);
+
+public sealed record GuildRosterMemberResponse(
+    [property: JsonPropertyName("character")] GuildRosterMemberCharacterResponse Character,
+    [property: JsonPropertyName("rank")] int Rank);
+
+public sealed record GuildRosterMemberCharacterResponse(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("realm")] GuildRosterRealmResponse Realm,
+    [property: JsonPropertyName("id")] int? Id = null);
+
+public sealed record GuildRosterRealmResponse(
+    [property: JsonPropertyName("slug")] string Slug);

--- a/api/Services/Blizzard/Models/GuildRosterResponse.cs
+++ b/api/Services/Blizzard/Models/GuildRosterResponse.cs
@@ -8,7 +8,13 @@ namespace Lfm.Api.Services.Blizzard.Models;
 /// <summary>
 /// Blizzard <c>/data/wow/guild/{realm}/{name}/roster</c> response (HTTP wire shape).
 /// STJ-only snake_case mapping. Never stored directly in Cosmos —
-/// translate via <see cref="BlizzardModelTranslator"/> first.
+/// translate via <see cref="Lfm.Api.Services.Blizzard.BlizzardModelTranslator.ToStored(GuildRosterResponse)"/>
+/// before persisting.
+///
+/// Reserved for the upcoming guild-roster port — no .NET caller yet; the
+/// TypeScript handler still owns guild roster refresh. Kept here so the
+/// .NET port can adopt the wire/storage split without re-introducing the
+/// dual-roled record shape.
 /// </summary>
 public sealed record GuildRosterResponse(
     [property: JsonPropertyName("members")] IReadOnlyList<GuildRosterMemberResponse>? Members = null);

--- a/api/Services/BlizzardProfileClient.cs
+++ b/api/Services/BlizzardProfileClient.cs
@@ -4,7 +4,7 @@
 using System.Net.Http.Headers;
 using System.Text.Json;
 using Lfm.Api.Options;
-using Lfm.Api.Repositories;
+using Lfm.Api.Services.Blizzard.Models;
 using Microsoft.Extensions.Options;
 
 namespace Lfm.Api.Services;
@@ -34,7 +34,7 @@ public sealed class BlizzardProfileClient : IBlizzardProfileClient
     }
 
     /// <inheritdoc/>
-    public async Task<BlizzardAccountProfileSummary> GetAccountProfileSummaryAsync(
+    public async Task<AccountProfileSummaryResponse> GetAccountProfileSummaryAsync(
         string accessToken,
         CancellationToken ct)
     {
@@ -47,12 +47,12 @@ public sealed class BlizzardProfileClient : IBlizzardProfileClient
         response.EnsureSuccessStatusCode();
 
         var json = await response.Content.ReadAsStringAsync(ct);
-        return JsonSerializer.Deserialize<BlizzardAccountProfileSummary>(json, _jsonOptions)
+        return JsonSerializer.Deserialize<AccountProfileSummaryResponse>(json, _jsonOptions)
             ?? throw new InvalidOperationException("Blizzard profile endpoint returned empty response.");
     }
 
     /// <inheritdoc/>
-    public async Task<BlizzardCharacterProfileResponse> GetCharacterProfileAsync(
+    public async Task<CharacterProfileResponse> GetCharacterProfileAsync(
         string realm, string name, string accessToken, CancellationToken ct)
     {
         var path = $"profile/wow/character/{Uri.EscapeDataString(realm)}/{Uri.EscapeDataString(name)}" +
@@ -64,12 +64,12 @@ public sealed class BlizzardProfileClient : IBlizzardProfileClient
         response.EnsureSuccessStatusCode();
 
         var json = await response.Content.ReadAsStringAsync(ct);
-        return JsonSerializer.Deserialize<BlizzardCharacterProfileResponse>(json, _jsonOptions)
+        return JsonSerializer.Deserialize<CharacterProfileResponse>(json, _jsonOptions)
             ?? throw new InvalidOperationException("Blizzard character profile returned empty response.");
     }
 
     /// <inheritdoc/>
-    public async Task<BlizzardCharacterSpecializationsResponse> GetCharacterSpecializationsAsync(
+    public async Task<CharacterSpecializationsResponse> GetCharacterSpecializationsAsync(
         string realm, string name, string accessToken, CancellationToken ct)
     {
         var path = $"profile/wow/character/{Uri.EscapeDataString(realm)}/{Uri.EscapeDataString(name)}/specializations" +
@@ -81,12 +81,12 @@ public sealed class BlizzardProfileClient : IBlizzardProfileClient
         response.EnsureSuccessStatusCode();
 
         var json = await response.Content.ReadAsStringAsync(ct);
-        return JsonSerializer.Deserialize<BlizzardCharacterSpecializationsResponse>(json, _jsonOptions)
+        return JsonSerializer.Deserialize<CharacterSpecializationsResponse>(json, _jsonOptions)
             ?? throw new InvalidOperationException("Blizzard character specializations returned empty response.");
     }
 
     /// <inheritdoc/>
-    public async Task<BlizzardCharacterMediaSummary?> GetCharacterMediaAsync(
+    public async Task<CharacterMediaSummaryResponse?> GetCharacterMediaAsync(
         string realm, string name, string accessToken, CancellationToken ct)
     {
         var path = $"profile/wow/character/{Uri.EscapeDataString(realm)}/{Uri.EscapeDataString(name)}/character-media" +
@@ -101,7 +101,7 @@ public sealed class BlizzardProfileClient : IBlizzardProfileClient
                 return null;
 
             var json = await response.Content.ReadAsStringAsync(ct);
-            return JsonSerializer.Deserialize<BlizzardCharacterMediaSummary>(json, _jsonOptions);
+            return JsonSerializer.Deserialize<CharacterMediaSummaryResponse>(json, _jsonOptions);
         }
         catch (HttpRequestException)
         {

--- a/api/Services/IBlizzardProfileClient.cs
+++ b/api/Services/IBlizzardProfileClient.cs
@@ -1,13 +1,16 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
-using Lfm.Api.Repositories;
+using Lfm.Api.Services.Blizzard.Models;
 
 namespace Lfm.Api.Services;
 
 /// <summary>
 /// Typed HTTP client for the Blizzard Game Data / Profile APIs.
 /// Used by the battlenet-characters-refresh endpoint (B2.5) and portrait refresh (B2.6).
+/// Returns Blizzard wire-shape models from <see cref="Blizzard.Models"/>; callers
+/// translate to stored Cosmos shapes via
+/// <see cref="Blizzard.BlizzardModelTranslator"/> before persisting.
 /// </summary>
 public interface IBlizzardProfileClient
 {
@@ -20,7 +23,7 @@ public interface IBlizzardProfileClient
     /// <exception cref="HttpRequestException">
     /// Thrown when the Blizzard API returns a non-success status code.
     /// </exception>
-    Task<BlizzardAccountProfileSummary> GetAccountProfileSummaryAsync(string accessToken, CancellationToken ct);
+    Task<AccountProfileSummaryResponse> GetAccountProfileSummaryAsync(string accessToken, CancellationToken ct);
 
     /// <summary>
     /// Fetches a character's profile (name, level, class, race, realm, guild)
@@ -33,7 +36,7 @@ public interface IBlizzardProfileClient
     /// <exception cref="HttpRequestException">
     /// Thrown when the Blizzard API returns a non-success status code.
     /// </exception>
-    Task<BlizzardCharacterProfileResponse> GetCharacterProfileAsync(
+    Task<CharacterProfileResponse> GetCharacterProfileAsync(
         string realm, string name, string accessToken, CancellationToken ct);
 
     /// <summary>
@@ -46,7 +49,7 @@ public interface IBlizzardProfileClient
     /// <exception cref="HttpRequestException">
     /// Thrown when the Blizzard API returns a non-success status code.
     /// </exception>
-    Task<BlizzardCharacterSpecializationsResponse> GetCharacterSpecializationsAsync(
+    Task<CharacterSpecializationsResponse> GetCharacterSpecializationsAsync(
         string realm, string name, string accessToken, CancellationToken ct);
 
     /// <summary>
@@ -59,6 +62,6 @@ public interface IBlizzardProfileClient
     /// <param name="accessToken">Battle.net OAuth access token (from the raider's session).</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The media summary, or null when the fetch failed for any reason.</returns>
-    Task<BlizzardCharacterMediaSummary?> GetCharacterMediaAsync(
+    Task<CharacterMediaSummaryResponse?> GetCharacterMediaAsync(
         string realm, string name, string accessToken, CancellationToken ct);
 }

--- a/tests/Lfm.Api.Tests/BattleNetCharactersFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/BattleNetCharactersFunctionTests.cs
@@ -73,18 +73,18 @@ public class BattleNetCharactersFunctionTests
             BattleNetId: FakeBattleNetId,
             SelectedCharacterId: null,
             Locale: null,
-            AccountProfileSummary: new BlizzardAccountProfileSummary(
+            AccountProfileSummary: new StoredBlizzardAccountProfile(
                 WowAccounts:
                 [
-                    new BlizzardWowAccount(
+                    new StoredBlizzardWowAccount(
                         Id: 1,
                         Characters:
                         [
-                            new BlizzardAccountCharacter(
+                            new StoredBlizzardAccountCharacter(
                                 Name: "Legolas",
                                 Level: 80,
-                                Realm: new BlizzardRealmRef(Slug: "silvermoon", Name: "Silvermoon"),
-                                PlayableClass: new BlizzardNamedRef(Id: 3, Name: "Hunter"))
+                                Realm: new StoredBlizzardRealmRef(Slug: "silvermoon", Name: "Silvermoon"),
+                                PlayableClass: new StoredBlizzardNamedRef(Id: 3, Name: "Hunter"))
                         ])
                 ]),
             AccountProfileRefreshedAt: refreshedAt);

--- a/tests/Lfm.Api.Tests/BattleNetCharactersRefreshFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/BattleNetCharactersRefreshFunctionTests.cs
@@ -10,6 +10,7 @@ using Lfm.Api.Auth;
 using Lfm.Api.Functions;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;
+using Lfm.Api.Services.Blizzard.Models;
 using Lfm.Contracts.Characters;
 using Xunit;
 
@@ -86,18 +87,18 @@ public class BattleNetCharactersRefreshFunctionTests
         repo.Setup(r => r.UpsertAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        var freshSummary = new BlizzardAccountProfileSummary(
+        var freshSummary = new AccountProfileSummaryResponse(
             WowAccounts:
             [
-                new BlizzardWowAccount(
+                new WowAccountResponse(
                     Id: 1,
                     Characters:
                     [
-                        new BlizzardAccountCharacter(
+                        new AccountCharacterResponse(
                             Name: "Thrall",
                             Level: 80,
-                            Realm: new BlizzardRealmRef(Slug: "draenor", Name: "Draenor"),
-                            PlayableClass: new BlizzardNamedRef(Id: 1, Name: "Warrior"))
+                            Realm: new RealmRefResponse(Slug: "draenor", Name: "Draenor"),
+                            PlayableClass: new NamedRefResponse(Id: 1, Name: "Warrior"))
                     ])
             ]);
 

--- a/tests/Lfm.Api.Tests/GuildMapperTests.cs
+++ b/tests/Lfm.Api.Tests/GuildMapperTests.cs
@@ -16,10 +16,10 @@ public class GuildMapperTests
         RealmSlug: "ravencrest",
         Slogan: "for the alliance",
         BlizzardRosterFetchedAt: DateTimeOffset.UtcNow.ToString("o"),
-        BlizzardProfileRaw: new BlizzardGuildProfileRaw(
+        BlizzardProfileRaw: new StoredGuildProfile(
             Name: "Test Guild",
-            Realm: new BlizzardGuildProfileRealm(Slug: "ravencrest", Name: "Ravencrest"),
-            Faction: new BlizzardGuildProfileFaction(Name: "Alliance"),
+            Realm: new StoredGuildProfileRealm(Slug: "ravencrest", Name: "Ravencrest"),
+            Faction: new StoredGuildProfileFaction(Name: "Alliance"),
             MemberCount: 50),
         RankPermissions: new[]
         {

--- a/tests/Lfm.Api.Tests/GuildPermissionsTests.cs
+++ b/tests/Lfm.Api.Tests/GuildPermissionsTests.cs
@@ -12,7 +12,7 @@ public class GuildPermissionsTests
 {
     private static GuildDocument MakeGuildDoc(
         string id = "42",
-        IReadOnlyList<BlizzardGuildRosterMember>? members = null,
+        IReadOnlyList<StoredGuildRosterMember>? members = null,
         DateTimeOffset? rosterFetchedAt = null,
         IReadOnlyList<GuildRankPermission>? rankPermissions = null)
     {
@@ -23,12 +23,12 @@ public class GuildPermissionsTests
             RealmSlug: "silvermoon",
             BlizzardRosterFetchedAt: resolvedFetched.ToString("o"),
             RankPermissions: rankPermissions,
-            BlizzardRosterRaw: new BlizzardGuildRosterRaw(
+            BlizzardRosterRaw: new StoredGuildRoster(
                 Members: members ?? [
-                    new BlizzardGuildRosterMember(
-                        Character: new BlizzardGuildRosterMemberCharacter(
+                    new StoredGuildRosterMember(
+                        Character: new StoredGuildRosterMemberCharacter(
                             Name: "Gm",
-                            Realm: new BlizzardGuildRosterRealm(Slug: "silvermoon"),
+                            Realm: new StoredGuildRosterRealm(Slug: "silvermoon"),
                             Id: 1),
                         Rank: 0)
                 ]));
@@ -106,10 +106,10 @@ public class GuildPermissionsTests
     public async Task IsAdminAsync_returns_false_when_character_matches_non_zero_rank()
     {
         var guild = MakeGuildDoc(members: [
-            new BlizzardGuildRosterMember(
-                Character: new BlizzardGuildRosterMemberCharacter(
+            new StoredGuildRosterMember(
+                Character: new StoredGuildRosterMemberCharacter(
                     Name: "Gm",
-                    Realm: new BlizzardGuildRosterRealm(Slug: "silvermoon"),
+                    Realm: new StoredGuildRosterRealm(Slug: "silvermoon"),
                     Id: 1),
                 Rank: 3)
         ]);
@@ -168,10 +168,10 @@ public class GuildPermissionsTests
     public async Task CanCreateGuildRunsAsync_returns_false_for_non_zero_rank_by_default()
     {
         var guild = MakeGuildDoc(members: [
-            new BlizzardGuildRosterMember(
-                Character: new BlizzardGuildRosterMemberCharacter(
+            new StoredGuildRosterMember(
+                Character: new StoredGuildRosterMemberCharacter(
                     Name: "Officer",
-                    Realm: new BlizzardGuildRosterRealm(Slug: "silvermoon"),
+                    Realm: new StoredGuildRosterRealm(Slug: "silvermoon"),
                     Id: 1),
                 Rank: 2)
         ]);
@@ -187,10 +187,10 @@ public class GuildPermissionsTests
     {
         var guild = MakeGuildDoc(
             members: [
-                new BlizzardGuildRosterMember(
-                    Character: new BlizzardGuildRosterMemberCharacter(
+                new StoredGuildRosterMember(
+                    Character: new StoredGuildRosterMemberCharacter(
                         Name: "Officer",
-                        Realm: new BlizzardGuildRosterRealm(Slug: "silvermoon"),
+                        Realm: new StoredGuildRosterRealm(Slug: "silvermoon"),
                         Id: 1),
                     Rank: 2)
             ],
@@ -210,10 +210,10 @@ public class GuildPermissionsTests
     public async Task CanSignupGuildRunsAsync_returns_true_for_non_zero_rank_by_default()
     {
         var guild = MakeGuildDoc(members: [
-            new BlizzardGuildRosterMember(
-                Character: new BlizzardGuildRosterMemberCharacter(
+            new StoredGuildRosterMember(
+                Character: new StoredGuildRosterMemberCharacter(
                     Name: "Member",
-                    Realm: new BlizzardGuildRosterRealm(Slug: "silvermoon"),
+                    Realm: new StoredGuildRosterRealm(Slug: "silvermoon"),
                     Id: 1),
                 Rank: 5)
         ]);
@@ -229,10 +229,10 @@ public class GuildPermissionsTests
     {
         var guild = MakeGuildDoc(
             members: [
-                new BlizzardGuildRosterMember(
-                    Character: new BlizzardGuildRosterMemberCharacter(
+                new StoredGuildRosterMember(
+                    Character: new StoredGuildRosterMemberCharacter(
                         Name: "Initiate",
-                        Realm: new BlizzardGuildRosterRealm(Slug: "silvermoon"),
+                        Realm: new StoredGuildRosterRealm(Slug: "silvermoon"),
                         Id: 1),
                     Rank: 7)
             ],
@@ -273,10 +273,10 @@ public class GuildPermissionsTests
     public async Task CanDeleteGuildRunsAsync_returns_false_for_non_zero_rank_by_default()
     {
         var guild = MakeGuildDoc(members: [
-            new BlizzardGuildRosterMember(
-                Character: new BlizzardGuildRosterMemberCharacter(
+            new StoredGuildRosterMember(
+                Character: new StoredGuildRosterMemberCharacter(
                     Name: "Officer",
-                    Realm: new BlizzardGuildRosterRealm(Slug: "silvermoon"),
+                    Realm: new StoredGuildRosterRealm(Slug: "silvermoon"),
                     Id: 1),
                 Rank: 1)
         ]);
@@ -343,10 +343,10 @@ public class GuildPermissionsTests
         // mutation testing flagged at GuildPermissions L99.
         var guild = MakeGuildDoc(
             members: [
-                new BlizzardGuildRosterMember(
-                    Character: new BlizzardGuildRosterMemberCharacter(
+                new StoredGuildRosterMember(
+                    Character: new StoredGuildRosterMemberCharacter(
                         Name: "Member",
-                        Realm: new BlizzardGuildRosterRealm(Slug: "silvermoon"),
+                        Realm: new StoredGuildRosterRealm(Slug: "silvermoon"),
                         Id: 1),
                     Rank: 5)
             ],
@@ -368,10 +368,10 @@ public class GuildPermissionsTests
         // Same shape — for signup the default is true for any matched rank.
         var guild = MakeGuildDoc(
             members: [
-                new BlizzardGuildRosterMember(
-                    Character: new BlizzardGuildRosterMemberCharacter(
+                new StoredGuildRosterMember(
+                    Character: new StoredGuildRosterMemberCharacter(
                         Name: "Member",
-                        Realm: new BlizzardGuildRosterRealm(Slug: "silvermoon"),
+                        Realm: new StoredGuildRosterRealm(Slug: "silvermoon"),
                         Id: 1),
                     Rank: 5)
             ],
@@ -391,10 +391,10 @@ public class GuildPermissionsTests
     {
         var guild = MakeGuildDoc(
             members: [
-                new BlizzardGuildRosterMember(
-                    Character: new BlizzardGuildRosterMemberCharacter(
+                new StoredGuildRosterMember(
+                    Character: new StoredGuildRosterMemberCharacter(
                         Name: "Member",
-                        Realm: new BlizzardGuildRosterRealm(Slug: "silvermoon"),
+                        Realm: new StoredGuildRosterRealm(Slug: "silvermoon"),
                         Id: 1),
                     Rank: 5)
             ],
@@ -420,12 +420,12 @@ public class GuildPermissionsTests
                 GuildId: 123,
                 RealmSlug: "ravencrest",
                 BlizzardRosterFetchedAt: DateTimeOffset.UtcNow.ToString("o"),
-                BlizzardRosterRaw: new BlizzardGuildRosterRaw(Members: new[]
+                BlizzardRosterRaw: new StoredGuildRoster(Members: new[]
                 {
-                    new BlizzardGuildRosterMember(
-                        Character: new BlizzardGuildRosterMemberCharacter(
+                    new StoredGuildRosterMember(
+                        Character: new StoredGuildRosterMemberCharacter(
                             Name: "Alice",
-                            Realm: new BlizzardGuildRosterRealm(Slug: "ravencrest")),
+                            Realm: new StoredGuildRosterRealm(Slug: "ravencrest")),
                         Rank: 0),
                 }),
                 RankPermissions: null));
@@ -482,12 +482,12 @@ public class GuildPermissionsTests
                 RealmSlug: "ravencrest",
                 // 2 hours old — past the 1-hour TTL.
                 BlizzardRosterFetchedAt: DateTimeOffset.UtcNow.AddHours(-2).ToString("o"),
-                BlizzardRosterRaw: new BlizzardGuildRosterRaw(Members: new[]
+                BlizzardRosterRaw: new StoredGuildRoster(Members: new[]
                 {
-                    new BlizzardGuildRosterMember(
-                        Character: new BlizzardGuildRosterMemberCharacter(
+                    new StoredGuildRosterMember(
+                        Character: new StoredGuildRosterMemberCharacter(
                             Name: "Alice",
-                            Realm: new BlizzardGuildRosterRealm(Slug: "ravencrest")),
+                            Realm: new StoredGuildRosterRealm(Slug: "ravencrest")),
                         Rank: 0),
                 }),
                 RankPermissions: null));

--- a/tests/Lfm.Api.Tests/RaiderCharacterAddFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RaiderCharacterAddFunctionTests.cs
@@ -10,6 +10,7 @@ using Lfm.Api.Auth;
 using Lfm.Api.Functions;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;
+using Lfm.Api.Services.Blizzard.Models;
 using Lfm.Contracts.Raiders;
 using System.Text;
 using System.Text.Json;
@@ -72,53 +73,53 @@ public class RaiderCharacterAddFunctionTests
         Mock<IBlizzardProfileClient> profileMock) =>
         new(repoMock.Object, profileMock.Object, NullLogger<RaiderCharacterAddFunction>.Instance);
 
-    private static BlizzardAccountProfileSummary MakeAccountProfileWithCharacter(string name, string realmSlug) =>
-        new BlizzardAccountProfileSummary(
+    private static StoredBlizzardAccountProfile MakeAccountProfileWithCharacter(string name, string realmSlug) =>
+        new StoredBlizzardAccountProfile(
             WowAccounts:
             [
-                new BlizzardWowAccount(
+                new StoredBlizzardWowAccount(
                     Id: 1,
                     Characters:
                     [
-                        new BlizzardAccountCharacter(
+                        new StoredBlizzardAccountCharacter(
                             Name: name,
                             Level: 80,
-                            Realm: new BlizzardRealmRef(Slug: realmSlug, Name: "Silvermoon"),
-                            PlayableClass: new BlizzardNamedRef(Id: 2, Name: "Paladin"))
+                            Realm: new StoredBlizzardRealmRef(Slug: realmSlug, Name: "Silvermoon"),
+                            PlayableClass: new StoredBlizzardNamedRef(Id: 2, Name: "Paladin"))
                     ])
             ]);
 
-    private static BlizzardCharacterProfileResponse MakeProfileResponse(
+    private static CharacterProfileResponse MakeProfileResponse(
         string name = "Aelrin",
         int level = 80,
         int classId = 2,
         string className = "Paladin",
         int? guildId = 42,
         string? guildName = "Midnight") =>
-        new BlizzardCharacterProfileResponse(
+        new CharacterProfileResponse(
             Name: name,
             Level: level,
-            CharacterClass: new BlizzardNamedRef(Id: classId, Name: className),
-            Race: new BlizzardNamedRef(Id: 1, Name: "Human"),
-            Realm: new BlizzardRealmRef(Slug: "silvermoon", Name: "Silvermoon"),
-            Guild: guildId is null ? null : new BlizzardCharacterGuildRef(Id: guildId.Value, Name: guildName));
+            CharacterClass: new NamedRefResponse(Id: classId, Name: className),
+            Race: new NamedRefResponse(Id: 1, Name: "Human"),
+            Realm: new RealmRefResponse(Slug: "silvermoon", Name: "Silvermoon"),
+            Guild: guildId is null ? null : new CharacterGuildRefResponse(Id: guildId.Value, Name: guildName));
 
-    private static BlizzardCharacterSpecializationsResponse MakeSpecsResponse(int activeId = 65, string activeName = "Holy") =>
-        new BlizzardCharacterSpecializationsResponse(
-            ActiveSpecialization: new BlizzardSpecializationRef(Id: activeId, Name: activeName),
+    private static CharacterSpecializationsResponse MakeSpecsResponse(int activeId = 65, string activeName = "Holy") =>
+        new CharacterSpecializationsResponse(
+            ActiveSpecialization: new SpecializationRefResponse(Id: activeId, Name: activeName),
             Specializations:
             [
-                new BlizzardSpecializationEntry(new BlizzardSpecializationRef(Id: activeId, Name: activeName)),
-                new BlizzardSpecializationEntry(new BlizzardSpecializationRef(Id: 66, Name: "Protection")),
-                new BlizzardSpecializationEntry(new BlizzardSpecializationRef(Id: 70, Name: "Retribution")),
+                new SpecializationEntryResponse(new SpecializationRefResponse(Id: activeId, Name: activeName)),
+                new SpecializationEntryResponse(new SpecializationRefResponse(Id: 66, Name: "Protection")),
+                new SpecializationEntryResponse(new SpecializationRefResponse(Id: 70, Name: "Retribution")),
             ]);
 
-    private static BlizzardCharacterMediaSummary MakeMediaSummary(string avatar = "https://render.worldofwarcraft.com/avatar.jpg") =>
-        new BlizzardCharacterMediaSummary(
+    private static CharacterMediaSummaryResponse MakeMediaSummary(string avatar = "https://render.worldofwarcraft.com/avatar.jpg") =>
+        new CharacterMediaSummaryResponse(
             Assets:
             [
-                new BlizzardCharacterMediaAsset(Key: "avatar", Value: avatar),
-                new BlizzardCharacterMediaAsset(Key: "main", Value: "https://render.worldofwarcraft.com/main.jpg"),
+                new CharacterMediaAssetResponse(Key: "avatar", Value: avatar),
+                new CharacterMediaAssetResponse(Key: "main", Value: "https://render.worldofwarcraft.com/main.jpg"),
             ]);
 
     // -------------------------------------------------------------------------
@@ -348,18 +349,18 @@ public class RaiderCharacterAddFunctionTests
     public void IsCharacterOwnedByAccount_does_not_false_positive_on_hyphenated_realm()
     {
         // Account contains aelrin on realm "mg".
-        var profile = new BlizzardAccountProfileSummary(
+        var profile = new StoredBlizzardAccountProfile(
             WowAccounts:
             [
-                new BlizzardWowAccount(
+                new StoredBlizzardWowAccount(
                     Id: 1,
                     Characters:
                     [
-                        new BlizzardAccountCharacter(
+                        new StoredBlizzardAccountCharacter(
                             Name: "Aelrin",
                             Level: 80,
-                            Realm: new BlizzardRealmRef(Slug: "mg", Name: "Moonglade"),
-                            PlayableClass: new BlizzardNamedRef(Id: 2, Name: "Paladin"))
+                            Realm: new StoredBlizzardRealmRef(Slug: "mg", Name: "Moonglade"),
+                            PlayableClass: new StoredBlizzardNamedRef(Id: 2, Name: "Paladin"))
                     ])
             ]);
 
@@ -376,18 +377,18 @@ public class RaiderCharacterAddFunctionTests
     [Fact]
     public void IsCharacterOwnedByAccount_returns_true_for_exact_match()
     {
-        var profile = new BlizzardAccountProfileSummary(
+        var profile = new StoredBlizzardAccountProfile(
             WowAccounts:
             [
-                new BlizzardWowAccount(
+                new StoredBlizzardWowAccount(
                     Id: 1,
                     Characters:
                     [
-                        new BlizzardAccountCharacter(
+                        new StoredBlizzardAccountCharacter(
                             Name: "Aelrin",
                             Level: 80,
-                            Realm: new BlizzardRealmRef(Slug: "silvermoon", Name: "Silvermoon"),
-                            PlayableClass: new BlizzardNamedRef(Id: 2, Name: "Paladin"))
+                            Realm: new StoredBlizzardRealmRef(Slug: "silvermoon", Name: "Silvermoon"),
+                            PlayableClass: new StoredBlizzardNamedRef(Id: 2, Name: "Paladin"))
                     ])
             ]);
 
@@ -428,7 +429,7 @@ public class RaiderCharacterAddFunctionTests
             .ReturnsAsync(MakeSpecsResponse());
         profileClient
             .Setup(p => p.GetCharacterMediaAsync("silvermoon", "aelrin", FakeAccessToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((BlizzardCharacterMediaSummary?)null);
+            .ReturnsAsync((CharacterMediaSummaryResponse?)null);
 
         var fn = MakeFunction(repo, profileClient);
         var ctx = MakeFunctionContext(FakePrincipal());
@@ -563,12 +564,12 @@ public class RaiderCharacterAddFunctionTests
     private static SessionPrincipal MakePrincipal(string? accessToken = FakeAccessToken) =>
         FakePrincipal(accessToken);
 
-    private static BlizzardAccountProfileSummary OwningSummary() =>
+    private static StoredBlizzardAccountProfile OwningSummary() =>
         MakeAccountProfileWithCharacter("Aelrin", "silvermoon");
 
     private static RaiderDocument MakeRaider(
         IReadOnlyList<StoredSelectedCharacter>? characters = null,
-        BlizzardAccountProfileSummary? accountProfile = null) =>
+        StoredBlizzardAccountProfile? accountProfile = null) =>
         new RaiderDocument(
             Id: FakeBattleNetId,
             BattleNetId: FakeBattleNetId,
@@ -603,7 +604,7 @@ public class RaiderCharacterAddFunctionTests
         var repo = RepoReturning(raider);
         var profileClient = new Mock<IBlizzardProfileClient>();
         profileClient.Setup(p => p.GetCharacterSpecializationsAsync("silvermoon", "aelrin", It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                     .ReturnsAsync(new BlizzardCharacterSpecializationsResponse());
+                     .ReturnsAsync(new CharacterSpecializationsResponse());
 
         var fn = new RaiderCharacterAddFunction(repo.Object, profileClient.Object, NullLogger<RaiderCharacterAddFunction>.Instance);
         await fn.Run(MakePostRequest(ValidBody), MakeFunctionContext(MakePrincipal()), CancellationToken.None);

--- a/tests/Lfm.Api.Tests/RaiderCharacterEnrichFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RaiderCharacterEnrichFunctionTests.cs
@@ -6,6 +6,7 @@ using Lfm.Api.Auth;
 using Lfm.Api.Functions;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;
+using Lfm.Api.Services.Blizzard.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
@@ -211,23 +212,23 @@ public class RaiderCharacterEnrichFunctionTests
             Id: "bnet-1", BattleNetId: "bnet-1",
             SelectedCharacterId: selected, Locale: null,
             Characters: characters,
-            AccountProfileSummary: accountChars is null ? null : new BlizzardAccountProfileSummary(
-                WowAccounts: [new BlizzardWowAccount(
+            AccountProfileSummary: accountChars is null ? null : new StoredBlizzardAccountProfile(
+                WowAccounts: [new StoredBlizzardWowAccount(
                     Id: 1,
                     Characters: accountChars.Select(c =>
-                        new BlizzardAccountCharacter(
+                        new StoredBlizzardAccountCharacter(
                             Name: c.Name, Level: 80,
-                            Realm: new BlizzardRealmRef(Slug: c.Realm))).ToList())]));
+                            Realm: new StoredBlizzardRealmRef(Slug: c.Realm))).ToList())]));
 
     private static Mock<IBlizzardProfileClient> MakeProfileClient()
     {
         var m = new Mock<IBlizzardProfileClient>();
         m.Setup(p => p.GetCharacterProfileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-         .ReturnsAsync(new BlizzardCharacterProfileResponse(Name: "Shalena", Level: 80));
+         .ReturnsAsync(new CharacterProfileResponse(Name: "Shalena", Level: 80));
         m.Setup(p => p.GetCharacterSpecializationsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-         .ReturnsAsync(new BlizzardCharacterSpecializationsResponse());
+         .ReturnsAsync(new CharacterSpecializationsResponse());
         m.Setup(p => p.GetCharacterMediaAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-         .ReturnsAsync((BlizzardCharacterMediaSummary?)null);
+         .ReturnsAsync((CharacterMediaSummaryResponse?)null);
         return m;
     }
 }

--- a/tests/Lfm.Api.Tests/Serialization/StoredBlizzardShapesRoundTripTests.cs
+++ b/tests/Lfm.Api.Tests/Serialization/StoredBlizzardShapesRoundTripTests.cs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Repositories;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
+using Xunit;
+
+namespace Lfm.Api.Tests.Serialization;
+
+/// <summary>
+/// Pins the Cosmos JSON keys for the renamed Stored* Blizzard shapes after the
+/// SD-S-5 wire/persistence split. The Cosmos client uses Newtonsoft with a
+/// camelCase property naming policy (see api/Program.cs CosmosSerializationOptions);
+/// these tests exercise the same Newtonsoft path so a future rename of any
+/// .NET property would surface as a key drift here, before reaching production.
+///
+/// Pre-rename, the dual-roled wire/storage records carried explicit STJ
+/// <c>[JsonPropertyName("snake_case")]</c> attributes. Post-rename the storage
+/// records rely on the Newtonsoft camelCase contract resolver alone, so a
+/// regression here would silently change the on-disk Cosmos document layout.
+/// </summary>
+public class StoredBlizzardShapesRoundTripTests
+{
+    private static readonly JsonSerializerSettings CosmosLikeSettings = new()
+    {
+        ContractResolver = new CamelCasePropertyNamesContractResolver(),
+    };
+
+    [Fact]
+    public void StoredBlizzardAccountProfile_RoundTrips_WithCamelCaseKeys()
+    {
+        var src = new StoredBlizzardAccountProfile(
+            WowAccounts: new[]
+            {
+                new StoredBlizzardWowAccount(
+                    Id: 42,
+                    Characters: new[]
+                    {
+                        new StoredBlizzardAccountCharacter(
+                            Name: "Alice",
+                            Level: 80,
+                            Realm: new StoredBlizzardRealmRef(Slug: "ravencrest", Name: "Ravencrest"),
+                            PlayableClass: new StoredBlizzardNamedRef(Id: 1, Name: "Warrior")),
+                    }),
+            });
+
+        var json = JsonConvert.SerializeObject(src, CosmosLikeSettings);
+        var token = JObject.Parse(json);
+
+        // Pin top-level + nested camelCase keys so a property rename in
+        // StoredBlizzard* would surface here, not in production Cosmos drift.
+        Assert.NotNull(token["wowAccounts"]);
+        Assert.Equal(42, (int)token["wowAccounts"]![0]!["id"]!);
+        Assert.NotNull(token["wowAccounts"]![0]!["characters"]);
+        Assert.Equal("Alice", (string?)token["wowAccounts"]![0]!["characters"]![0]!["name"]);
+        Assert.Equal(80, (int)token["wowAccounts"]![0]!["characters"]![0]!["level"]!);
+        Assert.Equal("ravencrest", (string?)token["wowAccounts"]![0]!["characters"]![0]!["realm"]!["slug"]);
+        Assert.Equal("Ravencrest", (string?)token["wowAccounts"]![0]!["characters"]![0]!["realm"]!["name"]);
+        Assert.Equal(1, (int)token["wowAccounts"]![0]!["characters"]![0]!["playableClass"]!["id"]!);
+        Assert.Equal("Warrior", (string?)token["wowAccounts"]![0]!["characters"]![0]!["playableClass"]!["name"]);
+
+        var roundTripped = JsonConvert.DeserializeObject<StoredBlizzardAccountProfile>(json, CosmosLikeSettings);
+        Assert.NotNull(roundTripped);
+        Assert.Single(roundTripped!.WowAccounts!);
+        Assert.Equal(42, roundTripped.WowAccounts![0].Id);
+        Assert.Single(roundTripped.WowAccounts![0].Characters!);
+        var character = roundTripped.WowAccounts![0].Characters![0];
+        Assert.Equal("Alice", character.Name);
+        Assert.Equal(80, character.Level);
+        Assert.Equal("ravencrest", character.Realm.Slug);
+        Assert.Equal("Ravencrest", character.Realm.Name);
+        Assert.Equal(1, character.PlayableClass!.Id);
+        Assert.Equal("Warrior", character.PlayableClass!.Name);
+    }
+
+    [Fact]
+    public void StoredGuildRoster_RoundTrips_WithCamelCaseKeys()
+    {
+        var src = new StoredGuildRoster(
+            Members: new[]
+            {
+                new StoredGuildRosterMember(
+                    Character: new StoredGuildRosterMemberCharacter(
+                        Name: "Bob",
+                        Realm: new StoredGuildRosterRealm(Slug: "stormrage"),
+                        Id: 7),
+                    Rank: 3),
+            });
+
+        var json = JsonConvert.SerializeObject(src, CosmosLikeSettings);
+        var token = JObject.Parse(json);
+
+        // Pin top-level + nested camelCase keys for the guild roster shape.
+        Assert.NotNull(token["members"]);
+        Assert.Equal(3, (int)token["members"]![0]!["rank"]!);
+        Assert.NotNull(token["members"]![0]!["character"]);
+        Assert.Equal("Bob", (string?)token["members"]![0]!["character"]!["name"]);
+        Assert.Equal(7, (int)token["members"]![0]!["character"]!["id"]!);
+        Assert.Equal("stormrage", (string?)token["members"]![0]!["character"]!["realm"]!["slug"]);
+
+        var roundTripped = JsonConvert.DeserializeObject<StoredGuildRoster>(json, CosmosLikeSettings);
+        Assert.NotNull(roundTripped);
+        Assert.Single(roundTripped!.Members!);
+        var member = roundTripped.Members![0];
+        Assert.Equal(3, member.Rank);
+        Assert.Equal("Bob", member.Character.Name);
+        Assert.Equal(7, member.Character.Id);
+        Assert.Equal("stormrage", member.Character.Realm.Slug);
+    }
+
+    [Fact]
+    public void StoredGuildProfile_RoundTrips_WithCamelCaseKeys()
+    {
+        // Note: StoredGuildProfile.Name carries [JsonConverter(LocalizedStringConverter)].
+        // The plain-string write-path emits a JSON string, so the round-trip below
+        // exercises the simple-string case (the legacy localized-object case is
+        // covered separately in LocalizedStringConverterTests).
+        var src = new StoredGuildProfile(
+            Name: "Knights of the Round",
+            Realm: new StoredGuildProfileRealm(Slug: "ravencrest", Name: "Ravencrest"),
+            Faction: new StoredGuildProfileFaction(Name: "Horde"),
+            MemberCount: 250,
+            AchievementPoints: 12345);
+
+        var json = JsonConvert.SerializeObject(src, CosmosLikeSettings);
+        var token = JObject.Parse(json);
+
+        // Pin top-level camelCase keys on the guild profile shape.
+        Assert.Equal("Knights of the Round", (string?)token["name"]);
+        Assert.Equal("Horde", (string?)token["faction"]!["name"]);
+        Assert.Equal("ravencrest", (string?)token["realm"]!["slug"]);
+        Assert.Equal("Ravencrest", (string?)token["realm"]!["name"]);
+        Assert.Equal(250, (int)token["memberCount"]!);
+        Assert.Equal(12345, (int)token["achievementPoints"]!);
+
+        var roundTripped = JsonConvert.DeserializeObject<StoredGuildProfile>(json, CosmosLikeSettings);
+        Assert.NotNull(roundTripped);
+        Assert.Equal("Knights of the Round", roundTripped!.Name);
+        Assert.Equal("ravencrest", roundTripped.Realm.Slug);
+        Assert.Equal("Ravencrest", roundTripped.Realm.Name);
+        Assert.Equal("Horde", roundTripped.Faction!.Name);
+        Assert.Equal(250, roundTripped.MemberCount);
+        Assert.Equal(12345, roundTripped.AchievementPoints);
+    }
+}


### PR DESCRIPTION
## Summary

The `Blizzard*` records in `IRaidersRepository.cs` and `IGuildRepository.cs` carried three roles at once: HTTP wire shape (with STJ snake_case attributes), Cosmos document fragment, and working domain type passed between Functions and Services. This PR splits them into two clean roles, with an explicit translator at the Blizzard adapter boundary:

- **HTTP wire models** in `api/Services/Blizzard/Models/` (`AccountProfileSummaryResponse`, `CharacterMediaSummaryResponse`, `CharacterProfileResponse`, `CharacterSpecializationsResponse`, `GuildProfileResponse`, `GuildRosterResponse`) — STJ-only, snake_case from Blizzard.
- **Stored persistence shapes** kept in the repository files but renamed `Stored*` (e.g. `StoredBlizzardAccountProfile`, `StoredGuildRoster`, `StoredGuildProfile`) — Newtonsoft round-trip + camelCase Cosmos.
- New `BlizzardModelTranslator` (`internal static`) at `api/Services/Blizzard/BlizzardModelTranslator.cs` converts each HTTP response to its stored shape.

Consumers updated: `RaiderCharacterAddFunction`, `RaiderCharacterEnrichFunction`, `BattleNetCharactersFunction`, `BattleNetCharactersRefreshFunction`, `CharacterPortraitService`, `EnrichmentPlanner`, `GuildPermissions`, `GuildResolver`, plus tests. The translator is invoked at the boundary BEFORE persisting (e.g. `BattleNetCharactersRefreshFunction` translates the Blizzard response then assigns to `RaiderDocument.AccountProfileSummary`).

Three new Cosmos round-trip tests in `tests/Lfm.Api.Tests/Serialization/StoredBlizzardShapesRoundTripTests.cs` pin the JSON keys (`wowAccounts`, `playableClass`, `members`, `memberCount`, etc.) using the same Newtonsoft `CamelCasePropertyNamesContractResolver` Cosmos uses — any future .NET property rename will surface as a key drift here, before reaching production.

Resolves finding `SD-S-5` (Blizzard wire shapes ARE the persistence model) from `docs/superpowersreviews/2026-04-29-software-design-deep-review.md`. Tracked as Task F in `docs/superpowers/plans/2026-04-30-software-design-review-followup.md`.

`GuildProfileResponse` and `GuildRosterResponse` are forward-prepared (no current .NET caller — TS handler still owns guild roster refresh); the translator is wired up but unused, ready for the next port iteration.

## Test plan

- [x] `dotnet build lfm.sln -c Release` clean (0 warnings)
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` — 752 passed (was 749 + 3 new round-trip tests)
- [x] `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release` — 186 passed
- [x] `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release` — 188 passed
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error` exit 0
- [x] Spec compliance review ✅ (20/20 — Cosmos JSON key preservation verified row-by-row)
- [x] Code quality review ✅ (after fix added Newtonsoft round-trip tests pinning the JSON keys + doc-comments noting GuildProfileResponse / GuildRosterResponse are forward-prepared)