### PR TITLE
Fix run signup character refresh

### DIFF
--- a/app/Pages/RunsPage.razor
+++ b/app/Pages/RunsPage.razor
@@ -397,13 +397,27 @@
                 _signupOptionsLoaded = true;
                 SelectDefaultSignupCharacter(me?.SelectedCharacterId);
             }
+            else if (charactersResult is CharactersFetchResult.NeedsRefresh)
+            {
+                var fresh = await BattleNetClient.RefreshCharactersAsync(CancellationToken.None);
+                if (fresh is null)
+                {
+                    _signupCharacters = [];
+                    _signupOptionsLoaded = true;
+                    _signupError = Loc["runs.signup.charactersLoadFailed"].Value;
+                }
+                else
+                {
+                    _signupCharacters = fresh;
+                    _signupOptionsLoaded = true;
+                    SelectDefaultSignupCharacter(me?.SelectedCharacterId);
+                }
+            }
             else
             {
                 _signupCharacters = [];
                 _signupOptionsLoaded = true;
-                _signupError = charactersResult is CharactersFetchResult.NeedsRefresh
-                    ? Loc["runs.signup.charactersNeedRefresh"].Value
-                    : Loc["runs.signup.charactersLoadFailed"].Value;
+                _signupError = Loc["runs.signup.charactersLoadFailed"].Value;
             }
         }
         catch

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -243,6 +243,38 @@ public class RunsPagesTests : ComponentTestBase
     }
 
     [Fact]
+    public void RunsPage_Signup_AutoRefreshes_Characters_When_Cache_NeedsRefresh()
+    {
+        var client = new Mock<IRunsClient>();
+        client.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<RunSummaryDto> { MakeSummary() });
+        client.Setup(c => c.GetAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeDetail());
+        Services.AddSingleton(client.Object);
+
+        var battleNet = new Mock<IBattleNetClient>();
+        battleNet.Setup(c => c.GetCharactersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CharactersFetchResult.NeedsRefresh());
+        battleNet.Setup(c => c.RefreshCharactersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CharacterDto> { MakeAppCharacter() });
+        Services.AddSingleton(battleNet.Object);
+
+        var me = new Mock<IMeClient>();
+        me.Setup(c => c.GetAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MeResponse("bnet-1", null, "eu-silvermoon-aelrin", false, "en"));
+        Services.AddSingleton(me.Object);
+
+        var cut = Render<RunsPage>(p => p.Add(x => x.RunId, "run-1"));
+
+        cut.WaitForAssertion(() =>
+        {
+            battleNet.Verify(c => c.RefreshCharactersAsync(It.IsAny<CancellationToken>()), Times.Once);
+            Assert.Contains(Loc("runs.signup.action"), cut.Markup);
+            Assert.DoesNotContain(Loc("runs.signup.charactersNeedRefresh"), cut.Markup);
+        });
+    }
+
+    [Fact]
     public void RunsPage_CancelSignup_Removes_Current_User_Signup()
     {
         var client = new Mock<IRunsClient>();


### PR DESCRIPTION
## Summary
- Auto-refresh Battle.net characters from the run signup panel when the cached profile needs refresh.
- Keep users on the run detail page instead of requiring a detour to Characters.
- Add a bUnit regression test for the `NeedsRefresh` signup flow.

## Test Plan
- [x] `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --no-restore`
- [x] `dotnet build lfm.sln -c Release`
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- [x] `git diff --check`