### PR TITLE
Harden CI DevSecOps gates

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,6 +15,13 @@
         "nuget-license"
       ],
       "rollForward": false
+    },
+    "cyclonedx": {
+      "version": "6.2.0",
+      "commands": [
+        "dotnet-CycloneDX"
+      ],
+      "rollForward": false
     }
   }
 }

--- a/.github/workflows/analyze-infra.yml
+++ b/.github/workflows/analyze-infra.yml
@@ -17,6 +17,7 @@ jobs:
   analyze:
     name: PSRule for Azure
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 LFM contributors
+
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'api/**'
+      - 'app/**'
+      - 'shared/**'
+      - 'tests/**'
+      - '*.sln'
+      - '**/*.csproj'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'global.json'
+      - 'NuGet.config'
+      - '.config/dotnet-tools.json'
+      - '.github/workflows/codeql.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'api/**'
+      - 'app/**'
+      - 'shared/**'
+      - 'tests/**'
+      - '*.sln'
+      - '**/*.csproj'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'global.json'
+      - 'NuGet.config'
+      - '.config/dotnet-tools.json'
+      - '.github/workflows/codeql.yml'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze C#
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet-cached
+
+      - name: Restore
+        run: dotnet restore lfm.sln
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
+        with:
+          languages: csharp
+          build-mode: manual
+
+      - name: Build
+        run: dotnet build lfm.sln -c Release --no-restore -p:TreatWarningsAsErrors=true
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
+        with:
+          category: /language:csharp

--- a/.github/workflows/deploy-app-build.yml
+++ b/.github/workflows/deploy-app-build.yml
@@ -9,6 +9,8 @@ on:
 
 permissions:
   contents: read
+  id-token: write
+  attestations: write
 
 concurrency:
   group: deploy-app-build-${{ github.ref }}
@@ -64,6 +66,19 @@ jobs:
           API_HOSTNAME: ${{ vars.API_HOSTNAME }}
         run: dotnet publish app/Lfm.App.csproj -c Release -o ./publish/app --no-build
 
+      - name: Generate SBOM
+        run: |
+          set -euo pipefail
+          dotnet tool restore
+          dotnet tool run dotnet-CycloneDX -- lfm.sln \
+            --configuration Release \
+            --disable-package-restore \
+            --exclude-test-projects \
+            --filename sbom.cdx.json \
+            --output ./publish \
+            --output-format Json
+          test -s ./publish/sbom.cdx.json
+
       - name: Install brotli
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends brotli
 
@@ -83,11 +98,20 @@ jobs:
           tar -cf ./publish/api/azurefunctions.tar -C ./publish/api .azurefunctions
           rm -rf ./publish/api/.azurefunctions
 
+      - name: Package deploy artifacts
+        run: |
+          set -euo pipefail
+          mkdir -p ./publish/artifacts
+          tar -cf ./publish/artifacts/deploy-api.tar -C ./publish/api .
+          tar -cf ./publish/artifacts/deploy-app.tar -C ./publish/app .
+          test -s ./publish/artifacts/deploy-api.tar
+          test -s ./publish/artifacts/deploy-app.tar
+
       - name: Upload API publish artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: deploy-app-publish-api
-          path: ./publish/api
+          path: ./publish/artifacts/deploy-api.tar
           if-no-files-found: error
           retention-days: 1
 
@@ -95,6 +119,44 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: deploy-app-publish-app
-          path: ./publish/app
+          path: ./publish/artifacts/deploy-app.tar
           if-no-files-found: error
           retention-days: 1
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: deploy-app-sbom
+          path: ./publish/sbom.cdx.json
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Attest API deploy artifact
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+        with:
+          subject-path: ./publish/artifacts/deploy-api.tar
+          create-storage-record: false
+          show-summary: false
+
+      - name: Attest App deploy artifact
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+        with:
+          subject-path: ./publish/artifacts/deploy-app.tar
+          create-storage-record: false
+          show-summary: false
+
+      - name: Attest API SBOM
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+        with:
+          subject-path: ./publish/artifacts/deploy-api.tar
+          sbom-path: ./publish/sbom.cdx.json
+          create-storage-record: false
+          show-summary: false
+
+      - name: Attest App SBOM
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+        with:
+          subject-path: ./publish/artifacts/deploy-app.tar
+          sbom-path: ./publish/sbom.cdx.json
+          create-storage-record: false
+          show-summary: false

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -5,11 +5,11 @@ name: Deploy App
 
 on:
   workflow_call:
-  workflow_dispatch:
 
 permissions:
   id-token: write
   contents: read
+  attestations: read
 
 concurrency:
   group: deploy-app
@@ -17,6 +17,8 @@ concurrency:
 
 jobs:
   deploy:
+    if: github.ref == 'refs/heads/main'
+    environment: production
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -28,7 +30,39 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: deploy-app-publish-api
-          path: ./publish/api
+          path: ./publish/artifacts
+
+      - name: Download App publish artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: deploy-app-publish-app
+          path: ./publish/artifacts
+
+      - name: Download SBOM artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: deploy-app-sbom
+          path: ./publish
+
+      - name: Verify artifact attestations
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh attestation verify ./publish/artifacts/deploy-api.tar -R "$GITHUB_REPOSITORY"
+          gh attestation verify ./publish/artifacts/deploy-app.tar -R "$GITHUB_REPOSITORY"
+          gh attestation verify ./publish/artifacts/deploy-api.tar -R "$GITHUB_REPOSITORY" --predicate-type https://cyclonedx.org/bom
+          gh attestation verify ./publish/artifacts/deploy-app.tar -R "$GITHUB_REPOSITORY" --predicate-type https://cyclonedx.org/bom
+          test -s ./publish/sbom.cdx.json
+
+      - name: Extract deploy artifacts
+        run: |
+          set -euo pipefail
+          mkdir -p ./publish/api ./publish/app
+          tar -xf ./publish/artifacts/deploy-api.tar -C ./publish/api
+          tar -xf ./publish/artifacts/deploy-app.tar -C ./publish/app
+          test -d ./publish/api
+          test -d ./publish/app
 
       # Reverses deploy-app-build.yml's `Archive .azurefunctions metadata`
       # step. See that step for the why.
@@ -37,12 +71,6 @@ jobs:
           set -euo pipefail
           tar -xf ./publish/api/azurefunctions.tar -C ./publish/api
           rm ./publish/api/azurefunctions.tar
-
-      - name: Download App publish artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: deploy-app-publish-app
-          path: ./publish/app
 
       - uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -5,7 +5,6 @@ name: Deploy Infrastructure
 
 on:
   workflow_call:
-  workflow_dispatch:
 
 permissions:
   id-token: write
@@ -13,7 +12,10 @@ permissions:
 
 jobs:
   infra:
+    if: github.ref == 'refs/heads/main'
+    environment: production
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -189,9 +191,9 @@ jobs:
               battleNetRegion="${{ vars.BATTLE_NET_REGION }}" \
               tags='{"project":"${{ vars.AZURE_RESOURCE_GROUP }}","environment":"production"}'
 
-      - name: Deploy metric alerts (tolerates first-run failure)
-        continue-on-error: true
+      - name: Deploy metric alerts
         run: |
+          set -euo pipefail
           az deployment group create \
             --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
             --template-file infra/modules/alerts.bicep \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,7 @@ on:
       - 'Directory.Packages.props'
       - 'scripts/check-bundle-size.sh'
       - '.github/workflows/deploy.yml'
+      - '.github/workflows/deploy-app-build.yml'
       - '.github/workflows/deploy-infra.yml'
       - '.github/workflows/deploy-app.yml'
 
@@ -65,6 +66,7 @@ jobs:
               - 'global.json'
               - 'Directory.Packages.props'
               - 'scripts/check-bundle-size.sh'
+              - '.github/workflows/deploy-app-build.yml'
               - '.github/workflows/deploy-app.yml'
 
       - name: Resolve change flags
@@ -104,6 +106,7 @@ jobs:
   build-app:
     needs: [detect-changes, secrets-scan]
     if: |
+      github.ref == 'refs/heads/main' &&
       needs.secrets-scan.result == 'success' &&
       needs.detect-changes.outputs.app == 'true'
     uses: ./.github/workflows/deploy-app-build.yml
@@ -112,6 +115,7 @@ jobs:
   deploy-infra:
     needs: [detect-changes, secrets-scan, analyze-infra]
     if: |
+      github.ref == 'refs/heads/main' &&
       needs.secrets-scan.result == 'success' &&
       needs.analyze-infra.result == 'success' &&
       needs.detect-changes.outputs.infra == 'true'
@@ -122,6 +126,7 @@ jobs:
     needs: [detect-changes, secrets-scan, analyze-infra, build-app, deploy-infra]
     if: |
       always() &&
+      github.ref == 'refs/heads/main' &&
       needs.secrets-scan.result == 'success' &&
       (needs.analyze-infra.result == 'success' || needs.analyze-infra.result == 'skipped') &&
       needs.build-app.result == 'success' &&

--- a/.github/workflows/license-compliance.yml
+++ b/.github/workflows/license-compliance.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   reuse-lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -69,20 +69,25 @@ The `protect-main` ruleset is active on `main` in the `lfm-org/lfm` public repo.
 
 Defense-in-depth layers on top of the ruleset:
 
-1. **Inline security gates in the deploy workflow.** `secrets-scan.yml` (gitleaks) and `analyze-infra.yml` (PSRule) run as `workflow_call` jobs inside `deploy.yml`, gating `deploy-infra` and `deploy-app` via `needs:`. A secret leak or IaC misconfiguration blocks the deploy even after a PR lands.
-2. **Signed commits.** Local `commit.gpgsign=true` with an SSH signing key. GitHub renders "Verified" badges for these commits.
-3. **Opt-in pre-push hook.** `scripts/pre-push` runs format + build + vulnerability audit locally before a push reaches GitHub.
-4. **Enforcing dependency audit.** `ci.yml` and `deploy-app.yml` both exit-1 on any vulnerable transitive NuGet package.
-5. **Lockfile-enforced restore on CI.** `RestoreLockedMode` via `$(CI)` in `Directory.Build.props` fails CI on any drift between `packages.lock.json` and the resolved graph.
-6. **TOTP MFA on the GitHub personal account.**
+1. **Production deploy entrypoint control.** Only `.github/workflows/deploy.yml` has a manual production deploy entry point. Leaf deploy workflows are reusable-only, and their deploy jobs require `github.ref == 'refs/heads/main'`.
+2. **Protected production environment.** `deploy-infra.yml` and `deploy-app.yml` both bind deploy jobs to the `production` GitHub environment. Configure that environment to allow deployments only from `main`; keep required reviewers optional unless a second trusted reviewer can approve without blocking solo-maintainer recovery.
+3. **Inline security gates in the deploy workflow.** `secrets-scan.yml` (gitleaks) and `analyze-infra.yml` (PSRule) run as `workflow_call` jobs inside `deploy.yml`, gating `deploy-infra` and `deploy-app` via `needs:`. A secret leak or IaC misconfiguration blocks the deploy even after a PR lands.
+4. **Enforced monitoring deploy.** Metric alert deployment is part of `deploy-infra.yml` and must fail the deployment if alert resources cannot be deployed.
+5. **Signed commits.** Local `commit.gpgsign=true` with an SSH signing key. GitHub renders "Verified" badges for these commits.
+6. **Opt-in pre-push hook.** `scripts/pre-push` runs format + build + vulnerability audit locally before a push reaches GitHub.
+7. **Enforcing dependency audit.** `ci.yml` and `deploy-app-build.yml` both exit-1 on any vulnerable transitive NuGet package before deploy.
+8. **Lockfile-enforced restore on CI.** `RestoreLockedMode` via `$(CI)` in `Directory.Build.props` fails CI on any drift between `packages.lock.json` and the resolved graph.
+9. **TOTP MFA on the GitHub personal account.**
 
 ### No CODEOWNERS file
 
 No `CODEOWNERS` file is committed. Sole maintainer, so auto-review assignment adds no value; the `protect-main` ruleset already requires explicit PR approval. Re-evaluate and add pathed ownership when a second committer joins.
 
-### Code Scanning / CodeQL is not available
+### CodeQL is public-repo only
 
-GitHub Code Scanning requires GitHub Advanced Security, which is not included on the Free plan for private repos. The PSRule for Azure job runs and produces a SARIF artifact; `analyze-infra.yml` additionally writes a severity-count summary to `$GITHUB_STEP_SUMMARY` so a human reviewing the run page sees findings at a glance. The SARIF is not ingested into a Code Scanning dashboard.
+CodeQL runs through `.github/workflows/codeql.yml` for code-affecting pull requests, code-affecting pushes to `main`, and manual dispatch. This is acceptable on the current cost stance because `lfm-org/lfm` is public. If the repository becomes private, revisit CodeQL before enabling any paid GitHub Code Security or GitHub Advanced Security feature.
+
+Scheduled CodeQL scans are intentionally omitted to avoid extra runner usage on a hobby-project free-tier posture. The PSRule for Azure job still runs and produces a SARIF artifact; `analyze-infra.yml` additionally writes a severity-count summary to `$GITHUB_STEP_SUMMARY` so a human reviewing the run page sees findings at a glance.
 
 ### Dependabot alerts are not enabled
 
@@ -100,7 +105,7 @@ The Azure Functions `dotnet-isolated` prebuilt base image runs as the base image
 
 ### `SWA_DEPLOYMENT_TOKEN` long-lived static token
 
-`Azure/static-web-apps-deploy` does not yet support OIDC federation. The `SWA_DEPLOYMENT_TOKEN` GitHub secret is a long-lived static token kept for this reason alone. Every other Azure deploy path (Functions, Bicep) uses OIDC.
+`Azure/static-web-apps-deploy` does not yet support OIDC federation. The `SWA_DEPLOYMENT_TOKEN` GitHub secret is a long-lived static token kept for this reason alone. Store it as a `production` environment secret so it is released only after environment protection rules pass. Every other Azure deploy path (Functions, Bicep) uses OIDC.
 
 **Rotation cadence:** quarterly. Next rotation: track in project calendar.
 
@@ -118,12 +123,15 @@ The Azure Functions `dotnet-isolated` prebuilt base image runs as the base image
 
 ## Supply-chain evidence
 
-This project does not publish release artifacts. It is intended to be cloned or forked and deployed via the consumer's own CI/CD. Supply-chain evidence is therefore repository-level, always in place on `main`:
+This project does not publish release artifacts outside GitHub Actions. It is intended to be cloned or forked and deployed via the consumer's own CI/CD. Supply-chain evidence is therefore repository-level, always in place on `main`; production deploy builds also produce one-day internal deploy artifacts:
 
 - Lockfile-enforced restore on CI (`RestoreLockedMode` gated on `$(CI)` in [`Directory.Build.props`](Directory.Build.props)) — transitive package drift fails the CI build. Enforced on 7 of 8 projects; the Blazor WASM project ([`app/Lfm.App.csproj`](app/Lfm.App.csproj)) opts out because its SDK-bundled implicit refs (`Microsoft.NET.Sdk.WebAssembly.Pack`, `Microsoft.DotNet.HotReload.WebAssembly.Browser`) drift independently of the pinned SDK version, making locked-mode impractical there. SDK version itself is pinned via `rollForward: disable` in [`global.json`](global.json).
 - [`NuGet.config`](NuGet.config) — `<clear />` + `nuget.org` only, plus `<packageSourceMapping>` pinning every package ID to `nuget.org` (defense against dependency confusion)
 - `persist-credentials: false` on every `actions/checkout` step in every workflow — `GITHUB_TOKEN` is not left on disk for subsequent steps to reuse
 - Gitleaks release asset integrity verified via SHA-256 checksum file before extraction
+- `.github/workflows/codeql.yml` — CodeQL C# analysis for the public repository without paid Code Security features
+- `.github/workflows/deploy-app-build.yml` — deploy build generates a CycloneDX SBOM, packages API/app publish outputs as tar files, and creates provenance plus SBOM attestations for those tar files using GitHub public-repo artifact attestations
+- `.github/workflows/deploy-app.yml` — deploy verifies provenance and CycloneDX SBOM attestations before extracting API/app tar files and deploying to Azure
 - [`LICENSE`](LICENSE) — AGPL-3.0-or-later, project license
 - [`NOTICE`](NOTICE) — copyright and "how to apply" pointer
 - [`REUSE.toml`](REUSE.toml) — collective license coverage for files


### PR DESCRIPTION
## Summary
- Add free-tier CodeQL scanning with pinned actions and scoped permissions.
- Add CycloneDX SBOM generation, build-time provenance/SBOM attestations, and deploy-time attestation verification.
- Harden deploy workflows by making leaf deploys main-only, production-environment scoped, non-manual, time-bounded, and fail-fast for metric alert deployment.
- Update SECURITY.md with the current low-cost posture and remaining production environment secret guidance.

## Test Plan
- [x] `dotnet tool restore`
- [x] `dotnet restore lfm.sln`
- [x] `dotnet tool run dotnet-CycloneDX -- lfm.sln --configuration Release --disable-package-restore --exclude-test-projects --filename lfm-plan-check.cdx.json --output /tmp --output-format Json`
- [x] `jq -e '.bomFormat == "CycloneDX"' /tmp/lfm-plan-check.cdx.json >/dev/null`
- [x] `yq eval '.' .github/workflows/*.yml >/dev/null`
- [x] `jq '.' .config/dotnet-tools.json >/dev/null`
- [x] `dotnet build lfm.sln -c Release --no-restore`
- [x] `./scripts/run-tests-parallel.sh ./artifacts/test-results`
- [x] `dotnet list lfm.sln package --vulnerable --include-transitive`
- [x] `git diff --check`
- [x] Manual `devsecops-audit` quick pass on changed workflow surfaces

## Follow-up
- Create or verify the GitHub `production` environment.
- Restrict the environment deployment branch to `main`.
- Move `SWA_DEPLOYMENT_TOKEN` to the `production` environment secret.
- Add required reviewers only if that does not block solo-maintainer deployment recovery.