### PR TITLE
Fail closed audit hashing

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -78,6 +78,20 @@ jobs:
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Verify required Key Vault secrets
+        env:
+          KEY_VAULT_NAME: ${{ vars.KEY_VAULT_NAME }}
+        run: |
+          set -euo pipefail
+          if ! az keyvault secret show \
+            --vault-name "$KEY_VAULT_NAME" \
+            --name audit-hash-salt \
+            --query id \
+            -o tsv >/dev/null; then
+            echo "FAIL: required Key Vault secret 'audit-hash-salt' is missing or inaccessible." >&2
+            exit 1
+          fi
+
       - name: Deploy to Azure Functions
         uses: Azure/functions-action@bc63708cc6539760eea18d8a7de4ce8ef5fdf593 # v1
         with:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Edit `.env` and fill in the required values. See the table below for details.
 | `Blizzard__Region` | Default ok | `eu` |
 | `Blizzard__RedirectUri` | Default ok | `http://localhost:7071/api/battlenet/callback` |
 | `Blizzard__AppBaseUrl` | Default ok | `http://localhost:5138` (Blazor dev server port, no trailing slash) |
+| `AZURE_FUNCTIONS_ENVIRONMENT` | Default ok | `Development`; required when `Audit__HashSalt` is empty |
 | `Cors__AllowedOrigins__0` | Default ok | `http://localhost:5138` |
 | `COSMOS_KEY_CONTENT` | Yes | Cosmos emulator master key (base64). Generate: `openssl rand -base64 32` |
 | `Cosmos__Endpoint` | Default ok | `http://cosmosdb:8081` for the compose network |
@@ -46,7 +47,7 @@ Edit `.env` and fill in the required values. See the table below for details.
 | `Auth__CookieMaxAgeHours` | Default ok | `24` |
 | `Auth__KeyVaultUrl` | No | Leave empty for local dev |
 | `PrivacyContact__Email` | Default ok | Privacy contact returned by the API |
-| `Audit__HashSalt` | No | Empty logs plaintext actor IDs locally; set a base64 salt outside local dev |
+| `Audit__HashSalt` | No | Empty logs plaintext actor IDs only in Development/E2E; deployed environments fail closed unless this is a resolved secret |
 
 ### 3. Start local stack
 

--- a/api/Options/AuditOptions.cs
+++ b/api/Options/AuditOptions.cs
@@ -19,8 +19,9 @@ public sealed class AuditOptions
     /// <c>openssl rand -base64 32</c>, store in Key Vault, and wire to this
     /// setting via a <c>@Microsoft.KeyVault(...)</c> reference in Bicep.
     /// Leaving this empty disables hashing — actor ids are logged as
-    /// plaintext. Acceptable in local dev; MUST be set in any deployed
-    /// environment that ingests logs to App Insights.
+    /// plaintext. Startup validation permits that only in local development
+    /// and E2E/test mode; any deployed environment that ingests logs to App
+    /// Insights must set this to a resolved secret value.
     /// </summary>
     public string HashSalt { get; init; } = string.Empty;
 }

--- a/api/Options/AuditOptionsValidator.cs
+++ b/api/Options/AuditOptionsValidator.cs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Lfm.Api.Options;
+
+public sealed class AuditOptionsValidator(
+    IHostEnvironment environment,
+    IConfiguration configuration) : IValidateOptions<AuditOptions>
+{
+    private const string Failure =
+        "Audit:HashSalt must be configured with a resolved secret value outside local development and E2E/test mode.";
+
+    public ValidateOptionsResult Validate(string? name, AuditOptions options)
+    {
+        if (HasUsableHashSalt(options.HashSalt) || AllowsIdentityHasher())
+        {
+            return ValidateOptionsResult.Success;
+        }
+
+        return ValidateOptionsResult.Fail(Failure);
+    }
+
+    internal static bool HasUsableHashSalt(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        return !value.TrimStart().StartsWith("@Microsoft.KeyVault(", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private bool AllowsIdentityHasher()
+    {
+        return environment.IsDevelopment()
+            || string.Equals(environment.EnvironmentName, "Local", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(environment.EnvironmentName, "Test", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(environment.EnvironmentName, "Testing", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(configuration["E2E_TEST_MODE"], "true", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -13,6 +13,7 @@ using Lfm.Api.Options;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 
 var builder = FunctionsApplication.CreateBuilder(args);
 
@@ -81,7 +82,9 @@ builder.Services.AddOptions<PrivacyContactOptions>()
     .ValidateDataAnnotations()
     .ValidateOnStart();
 builder.Services.AddOptions<AuditOptions>()
-    .Bind(builder.Configuration.GetSection(AuditOptions.SectionName));
+    .Bind(builder.Configuration.GetSection(AuditOptions.SectionName))
+    .ValidateOnStart();
+builder.Services.AddSingleton<IValidateOptions<AuditOptions>, AuditOptionsValidator>();
 builder.Services.AddOptions<RequestSizeLimitOptions>()
     .Bind(builder.Configuration.GetSection(RequestSizeLimitOptions.SectionName))
     .ValidateDataAnnotations()
@@ -181,14 +184,14 @@ builder.Services.AddScoped<Lfm.Api.Runs.IRunCreateService, Lfm.Api.Runs.RunCreat
 builder.Services.AddScoped<Lfm.Api.Runs.IRunUpdateService, Lfm.Api.Runs.RunUpdateService>();
 builder.Services.AddScoped<Lfm.Api.Runs.IRunSignupService, Lfm.Api.Runs.RunSignupService>();
 
-// Audit-log actor hasher. If a salt is configured we HMAC-hash every
-// AuditActorId before it reaches Application Insights; otherwise (local
-// dev, tests) we fall back to logging the raw id. Selected here so the
-// singleton can be disposed with the process.
+// Audit-log actor hasher. If a usable salt is configured we HMAC-hash every
+// AuditActorId before it reaches Application Insights; otherwise explicit
+// local/test modes fall back to logging the raw id. Production-like startup
+// fails before this singleton is resolved when AuditOptions is invalid.
 builder.Services.AddSingleton<Lfm.Api.Services.IActorHasher>(sp =>
 {
-    var auditOpts = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<AuditOptions>>().Value;
-    if (string.IsNullOrEmpty(auditOpts.HashSalt))
+    var auditOpts = sp.GetRequiredService<IOptions<AuditOptions>>().Value;
+    if (!AuditOptionsValidator.HasUsableHashSalt(auditOpts.HashSalt))
     {
         return new Lfm.Api.Services.IdentityActorHasher();
     }

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -66,6 +66,7 @@ services:
     tmpfs:
       - /tmp
     environment:
+      AZURE_FUNCTIONS_ENVIRONMENT: Development
       AzureWebJobsStorage: ${AzureWebJobsStorage}
       Cosmos__Endpoint: ${Cosmos__Endpoint}
       Cosmos__AuthKey: ${Cosmos__AuthKey}

--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -45,16 +45,16 @@ ops escape hatch when the cookie flow is unavailable.
 The Functions app reads four secrets from Key Vault (one role grant,
 `Key Vault Secrets User`, scoped to the vault). Bicep references them but
 does **not** create them — operators must populate the vault before the
-first deploy and on rotation. Until a secret exists the Functions runtime
-shows the corresponding app setting as "Not Resolved" and falls back to
-the in-code default for that setting, which is **not** the secure path.
+first deploy and on rotation. Deploy and startup checks fail closed for
+secrets where falling back to an in-code default would weaken the security
+boundary.
 
 | Secret name | Bound app setting | Resolver | Effect when missing |
 |---|---|---|---|
 | `battlenet-client-id` | `Blizzard__ClientId` | Platform `@Microsoft.KeyVault(...)` | Battle.net OAuth + Game Data calls fail at startup. |
 | `battlenet-client-secret` | `Blizzard__ClientSecret` | Platform `@Microsoft.KeyVault(...)` | Same. |
 | `site-admin-battle-net-ids` | (read at runtime by `KeyVaultSecretResolver`) | `Azure.Security.KeyVault.Secrets.SecretClient` | `SiteAdminService.IsAdminAsync` returns `false` for everyone — admin endpoints become unreachable. Fail-closed. |
-| `audit-hash-salt` | `Audit__HashSalt` | Platform `@Microsoft.KeyVault(...)` | `AuditLog` falls back to `IdentityActorHasher` and emits **plaintext** `battleNetId` (PII) into Application Insights. **Fail-open.** |
+| `audit-hash-salt` | `Audit__HashSalt` | Platform `@Microsoft.KeyVault(...)` | `deploy-app.yml` preflight fails if the secret is missing or inaccessible; production-like startup also fails if the setting is empty, whitespace, or still an unresolved Key Vault reference. **Fail-closed.** |
 
 Generate `audit-hash-salt` with `openssl rand -base64 32` and store in the
 `audit-hash-salt` secret. Rotation breaks linkage of historical audit

--- a/example.env
+++ b/example.env
@@ -3,6 +3,7 @@ Blizzard__ClientSecret=
 Blizzard__Region=eu
 Blizzard__RedirectUri=http://localhost:7071/api/battlenet/callback
 Blizzard__AppBaseUrl=http://localhost:5138
+AZURE_FUNCTIONS_ENVIRONMENT=Development
 Cors__AllowedOrigins__0=http://localhost:5138
 Cosmos__Endpoint=http://cosmosdb:8081
 Cosmos__AuthKey=
@@ -25,8 +26,9 @@ PRIVACY_EMAIL=privacy@example.com
 # sync with PRIVACY_EMAIL above — a future slice can collapse them.
 PrivacyContact__Email=privacy@example.com
 # HMAC salt for AuditLog actor-id hashing (api/Options/AuditOptions.cs).
-# Empty = fall back to plaintext, acceptable for local dev. Any deployed
-# environment MUST set this (Bicep wires it from KV secret "audit-hash-salt").
+# Empty = fall back to plaintext only in Development or E2E/test mode. Any
+# deployed environment MUST set this (Bicep wires it from KV secret
+# "audit-hash-salt", and deploy-app.yml preflights that secret).
 # Generate with: openssl rand -base64 32
 Audit__HashSalt=
 EXPIRES_SECURITY_TXT=2027-04-16T00:00:00.000Z

--- a/tests/Lfm.Api.Tests/LocalConfigurationContractTests.cs
+++ b/tests/Lfm.Api.Tests/LocalConfigurationContractTests.cs
@@ -29,6 +29,7 @@ public sealed class LocalConfigurationContractTests
         "Blizzard__Region",
         "Blizzard__RedirectUri",
         "Blizzard__AppBaseUrl",
+        "AZURE_FUNCTIONS_ENVIRONMENT",
         "Cosmos__Endpoint",
         "Cosmos__AuthKey",
         "Cosmos__DatabaseName",

--- a/tests/Lfm.Api.Tests/Options/AuditOptionsValidatorTests.cs
+++ b/tests/Lfm.Api.Tests/Options/AuditOptionsValidatorTests.cs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Options;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using Xunit;
+
+namespace Lfm.Api.Tests.Options;
+
+public sealed class AuditOptionsValidatorTests
+{
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("@Microsoft.KeyVault(VaultName=lfm-kv;SecretName=audit-hash-salt)")]
+    [InlineData("@Microsoft.KeyVault(SecretUri=https://lfm-kv.vault.azure.net/secrets/audit-hash-salt/)")]
+    public void Validate_rejects_missing_or_unresolved_hash_salt_in_production(string hashSalt)
+    {
+        var validator = CreateValidator(Environments.Production);
+
+        var result = validator.Validate(null, new AuditOptions { HashSalt = hashSalt });
+
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures, failure => failure.Contains("Audit:HashSalt", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_accepts_configured_hash_salt_in_production()
+    {
+        var validator = CreateValidator(Environments.Production);
+
+        var result = validator.Validate(null, new AuditOptions { HashSalt = "configured-salt" });
+
+        Assert.False(result.Failed);
+    }
+
+    [Fact]
+    public void Validate_allows_missing_hash_salt_in_development()
+    {
+        var validator = CreateValidator(Environments.Development);
+
+        var result = validator.Validate(null, new AuditOptions { HashSalt = string.Empty });
+
+        Assert.False(result.Failed);
+    }
+
+    [Fact]
+    public void Validate_allows_missing_hash_salt_in_e2e_test_mode()
+    {
+        var validator = CreateValidator(Environments.Production, e2eTestMode: true);
+
+        var result = validator.Validate(null, new AuditOptions { HashSalt = string.Empty });
+
+        Assert.False(result.Failed);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("@Microsoft.KeyVault(VaultName=lfm-kv;SecretName=audit-hash-salt)")]
+    public void HasUsableHashSalt_rejects_values_that_would_not_hash_actors(string hashSalt)
+    {
+        Assert.False(AuditOptionsValidator.HasUsableHashSalt(hashSalt));
+    }
+
+    [Fact]
+    public void HasUsableHashSalt_accepts_resolved_secret_value()
+    {
+        Assert.True(AuditOptionsValidator.HasUsableHashSalt("resolved-secret-value"));
+    }
+
+    private static AuditOptionsValidator CreateValidator(string environmentName, bool e2eTestMode = false)
+    {
+        var hostEnvironment = new Mock<IHostEnvironment>();
+        hostEnvironment.SetupGet(x => x.EnvironmentName).Returns(environmentName);
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["E2E_TEST_MODE"] = e2eTestMode ? "true" : "false",
+            })
+            .Build();
+
+        return new AuditOptionsValidator(hostEnvironment.Object, config);
+    }
+}


### PR DESCRIPTION
## Summary
- Add startup validation so production-like environments reject empty, whitespace, or unresolved Key Vault `Audit:HashSalt` values.
- Add a deploy-app Key Vault preflight for `audit-hash-salt` before the Functions package is deployed.
- Keep local/E2E identity hashing explicit via `AZURE_FUNCTIONS_ENVIRONMENT=Development` / `E2E_TEST_MODE`, with docs and config contract coverage.

## Test Plan
- [x] `yq eval '.' .github/workflows/deploy-app.yml`
- [x] `yq eval '.' docker-compose.local.yml`
- [x] `git -C /home/souroldgeezer/repos/lfm/.worktrees/fail-closed-audit-hash diff --check`
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release`
- [x] `dotnet build lfm.sln -c Release`

Closes #211