### PR TITLE
Use signup attendance toggle

### DIFF
--- a/app/Pages/RunsPage.razor
+++ b/app/Pages/RunsPage.razor
@@ -178,17 +178,16 @@
                                                 }
                                             </FluentSelect>
 
-                                            <FluentSelect Id="signup-attendance-select"
-                                                          Label="@Loc["runs.signup.attendance"]"
-                                                          TOption="string"
-                                                          Value="@_selectedAttendance"
-                                                          ValueChanged="@OnSignupAttendanceChanged"
-                                                          Disabled="@_signupSubmitting">
-                                                @foreach (var option in SignupAttendanceOptions)
-                                                {
-                                                    <FluentOption TOption="string" Value="@option.Value">@Loc[option.LocKey]</FluentOption>
-                                                }
-                                            </FluentSelect>
+                                            <div class="run-signup-attendance-field">
+                                                <span id="signup-attendance-label" class="field__label">@Loc["runs.signup.attendance"]</span>
+                                                <ToggleGroup TValue="string"
+                                                             Options="@SignupAttendanceToggleOptions"
+                                                             Value="@_selectedAttendance"
+                                                             ValueChanged="@OnSignupAttendanceChanged"
+                                                             AriaLabelledBy="signup-attendance-label"
+                                                             Disabled="@_signupSubmitting"
+                                                             Class="run-signup-attendance-toggle" />
+                                            </div>
 
                                             <FluentButton Appearance="Appearance.Accent"
                                                           OnClick="@SubmitSignup"
@@ -276,6 +275,11 @@
         ("AWAY", "runs.attendance.away"),
         ("OUT", "runs.attendance.out"),
     ];
+
+    private IReadOnlyList<(string Value, string Label)> SignupAttendanceToggleOptions =>
+        SignupAttendanceOptions
+            .Select(option => (option.Value, Loc[option.LocKey].Value))
+            .ToList();
 
     private static readonly (string Key, string LocKey)[] RoleColumnKeys =
     [

--- a/app/Pages/RunsPage.razor.css
+++ b/app/Pages/RunsPage.razor.css
@@ -187,8 +187,19 @@
 
 @media (min-width: 48em) {
     .run-signup-form {
-        grid-template-columns: minmax(12rem, 1fr) minmax(10rem, 0.7fr) auto;
+        grid-template-columns: minmax(12rem, 1fr) minmax(18rem, max-content) auto;
     }
+}
+
+.run-signup-attendance-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    min-inline-size: 0;
+}
+
+::deep .run-signup-attendance-toggle {
+    max-inline-size: 100%;
 }
 
 .run-signup-status {

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -273,6 +273,76 @@ public class RunsPagesTests : ComponentTestBase
     }
 
     [Fact]
+    public void RunsPage_Signup_Renders_Attendance_As_Radiogroup()
+    {
+        var client = new Mock<IRunsClient>();
+        client.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<RunSummaryDto> { MakeSummary() });
+        client.Setup(c => c.GetAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeDetail());
+        Services.AddSingleton(client.Object);
+        WireSignupSupport(client);
+
+        var cut = Render<RunsPage>(p => p.Add(x => x.RunId, "run-1"));
+
+        cut.WaitForAssertion(() =>
+            Assert.Contains(Loc("runs.signup.action"), cut.Markup));
+
+        var group = cut.Find("[role='radiogroup'][aria-labelledby='signup-attendance-label']");
+        Assert.Contains("run-signup-attendance-toggle", group.ClassName ?? string.Empty);
+
+        var radios = cut.FindAll("[role='radiogroup'][aria-labelledby='signup-attendance-label'] [role='radio']");
+        Assert.Equal(5, radios.Count);
+        Assert.Equal(Loc("runs.attendance.in"), radios[0].TextContent.Trim());
+        Assert.Equal(Loc("runs.attendance.late"), radios[1].TextContent.Trim());
+        Assert.Equal(Loc("runs.attendance.bench"), radios[2].TextContent.Trim());
+        Assert.Equal(Loc("runs.attendance.away"), radios[3].TextContent.Trim());
+        Assert.Equal(Loc("runs.attendance.out"), radios[4].TextContent.Trim());
+        Assert.Equal("true", radios[0].GetAttribute("aria-checked"));
+        Assert.Empty(cut.FindAll("#signup-attendance-select"));
+    }
+
+    [Fact]
+    public void RunsPage_Signup_Submits_Attendance_Selected_From_Radiogroup()
+    {
+        var client = new Mock<IRunsClient>();
+        client.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<RunSummaryDto> { MakeSummary() });
+        client.Setup(c => c.GetAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeDetail());
+        client.Setup(c => c.SignupAsync("run-1", It.IsAny<SignupRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeDetailWithRoster(new List<RunCharacterDto>
+            {
+                MakeCharacter("Aelrin", classId: 5, className: "Priest", role: "HEALER", spec: "Holy", isCurrentUser: true),
+            }));
+        Services.AddSingleton(client.Object);
+        WireSignupSupport(client);
+
+        var cut = Render<RunsPage>(p => p.Add(x => x.RunId, "run-1"));
+
+        cut.WaitForAssertion(() =>
+            Assert.Contains(Loc("runs.signup.action"), cut.Markup));
+
+        var bench = cut.FindAll("[role='radio']")
+            .Single(r => r.TextContent.Trim() == Loc("runs.attendance.bench"));
+        bench.Click();
+
+        var signupButton = cut.FindAll("fluent-button")
+            .Single(b => b.TextContent.Contains(Loc("runs.signup.action"), StringComparison.Ordinal));
+        signupButton.Click();
+
+        cut.WaitForAssertion(() =>
+            client.Verify(c => c.SignupAsync(
+                "run-1",
+                It.Is<SignupRequest>(r =>
+                    r.CharacterId == "eu-silvermoon-aelrin" &&
+                    r.DesiredAttendance == "BENCH" &&
+                    r.SpecId == 257),
+                It.IsAny<CancellationToken>()),
+                Times.Once));
+    }
+
+    [Fact]
     public void RunsPage_Signup_AutoRefreshes_Characters_When_Cache_NeedsRefresh()
     {
         var client = new Mock<IRunsClient>();


### PR DESCRIPTION
## Summary
- Replace the run signup attendance dropdown with the existing Blazor ToggleGroup radiogroup.
- Keep character selection and explicit signup submission unchanged.
- Add bUnit coverage for the radiogroup shape and selected attendance submission.

## Test Plan
- [x] `dotnet test /home/souroldgeezer/repos/lfm/.worktrees/signup-toggle-group/tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --no-restore`
- [x] `dotnet build /home/souroldgeezer/repos/lfm/.worktrees/signup-toggle-group/lfm.sln -c Release --no-restore`
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error` *(run after temporarily pointing the worktree `global.json` at installed SDK 10.0.106, then restored to 10.0.104)*
- [x] `git diff --check`