### PR TITLE
Add layout integrity E2E coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: ./.github/actions/setup-dotnet-cached
 
       - name: Restore
-        run: dotnet restore lfm.sln
+        run: dotnet restore lfm.sln -m:1
 
       - name: Format
         run: dotnet format lfm.sln --verify-no-changes --no-restore --severity error

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,7 +60,7 @@ jobs:
         uses: ./.github/actions/setup-dotnet-cached
 
       - name: Restore
-        run: dotnet restore lfm.sln
+        run: dotnet restore lfm.sln -m:1
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4

--- a/.github/workflows/dep-license-check.yml
+++ b/.github/workflows/dep-license-check.yml
@@ -40,7 +40,7 @@ jobs:
         run: dotnet tool restore
 
       - name: Restore NuGet packages
-        run: dotnet restore lfm.sln
+        run: dotnet restore lfm.sln -m:1
 
       - name: Run nuget-license against allowlist
         run: |

--- a/.github/workflows/deploy-app-build.yml
+++ b/.github/workflows/deploy-app-build.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: ./.github/actions/setup-dotnet-cached
 
       - name: Restore
-        run: dotnet restore lfm.sln
+        run: dotnet restore lfm.sln -m:1
 
       - name: Audit dependencies
         shell: bash

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,7 +44,7 @@ jobs:
           sudo apt-get install -y azure-functions-core-tools-4
 
       - name: Restore
-        run: dotnet restore lfm.sln
+        run: dotnet restore lfm.sln -m:1
 
       - name: Build
         run: dotnet build lfm.sln -c Release --no-restore

--- a/.github/workflows/stryker-nightly.yml
+++ b/.github/workflows/stryker-nightly.yml
@@ -38,7 +38,7 @@ jobs:
         run: dotnet tool restore
 
       - name: Restore solution
-        run: dotnet restore lfm.sln
+        run: dotnet restore lfm.sln -m:1
 
       - name: Build (Release)
         run: dotnet build lfm.sln -c Release --no-restore

--- a/app/Pages/CharactersPage.razor
+++ b/app/Pages/CharactersPage.razor
@@ -12,7 +12,7 @@
 <PageTitle>@Loc["characters.title"] — @Loc["nav.logo"]</PageTitle>
 
 <FluentStack Orientation="Orientation.Vertical" VerticalGap="16">
-    <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="12" Style="align-items:center">
+    <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="12" Wrap="true" Style="align-items:center">
         <FluentLabel Typo="Typography.H1" Style="flex:1">@Loc["characters.title"]</FluentLabel>
         <FluentButton Appearance="Appearance.Outline" OnClick="@RefreshCharacters" Disabled="@loading">
             @Loc["characters.refresh"]

--- a/app/packages.lock.json
+++ b/app/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.AspNetCore.App.Internal.Assets": {
         "type": "Direct",
-        "requested": "[10.0.4, )",
-        "resolved": "10.0.4",
-        "contentHash": "M942X5Vy726SlvFBuoAC4cDczEMlPAFt1mmyFlrkw/QcpdVwVU0DkF4P9JabxX6eWNm9RvaYZHe25FN7oXoxpQ=="
+        "requested": "[10.0.6, )",
+        "resolved": "10.0.6",
+        "contentHash": "3jRLKtAXwSCVDX0vUmGTDwcbSmL05jtf5vUHB9QXpw3wDbT0qU0dUJyKAOKgvwW3j0FI+aHHMbKIZCM63SPkOA=="
       },
       "Microsoft.AspNetCore.Components.WebAssembly": {
         "type": "Direct",
@@ -39,9 +39,9 @@
       },
       "Microsoft.DotNet.HotReload.WebAssembly.Browser": {
         "type": "Direct",
-        "requested": "[10.0.104, )",
-        "resolved": "10.0.104",
-        "contentHash": "OkWFygvFdm9emwxRW5ahcsU6saKO9EOYCFVNEXWl+23A4ssZy40VCQuqPhyurU7IyaPEhgA4iXh0/o7fhyNngA=="
+        "requested": "[10.0.106, )",
+        "resolved": "10.0.106",
+        "contentHash": "8MzC43QmkOaut7+LL44MrLhtM3rcNeZOmqGtq92m5tbzJ+61bHExfWzE/6SL77ebzq8W+HVD58u+5pov6T1apg=="
       },
       "Microsoft.Extensions.Http": {
         "type": "Direct",
@@ -99,15 +99,15 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.4, )",
-        "resolved": "10.0.4",
-        "contentHash": "CCx8ojW3mOL150/LnP0DK7qpMrJEt6xxNCmJFKoX89v1h0FwpsEHqennowGPYDxp6zIkIO4f9PxynjOeLF+1zw=="
+        "requested": "[10.0.6, )",
+        "resolved": "10.0.6",
+        "contentHash": "QKuvS0LWX4fjFqeDkyM7Kqt8P3wYTiPD4nwU+9y59n0sCiG714fxDgbbN82vDnzq89AF/PiHl92TP2C4aFDUQA=="
       },
       "Microsoft.NET.Sdk.WebAssembly.Pack": {
         "type": "Direct",
-        "requested": "[10.0.4, )",
-        "resolved": "10.0.4",
-        "contentHash": "6PVJDzxzz2gvKLSWKHNrmmHfoDcTNJixKMHXDf2Ztv8bvpLiIsDe4QahFvnVcWtZ74nIlaOKU2sR+nYk+/K2bg=="
+        "requested": "[10.0.6, )",
+        "resolved": "10.0.6",
+        "contentHash": "oFYqOGIx/6iD4IapqC6nk1MhjhdVMjLcMNoUbbwEt9zIGsUnJWQsUhSOoN+mY6HSIE35J3QVsxiCzkCMpLKM7A=="
       },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",

--- a/app/wwwroot/css/app.css
+++ b/app/wwwroot/css/app.css
@@ -381,6 +381,9 @@ a, .btn-link {
  * `scrollbar-gutter: stable both-edges` prevents content jump when the
  * scrollbar appears. */
 .scroll-region {
+    inline-size: 100%;
+    max-inline-size: 100%;
+    min-inline-size: 0;
     overflow-x: auto;
     scrollbar-gutter: stable both-edges;
 }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "10.0.104",
-    "rollForward": "latestPatch",
+    "version": "10.0.106",
+    "rollForward": "disable",
     "allowPrerelease": false
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "10.0.104",
-    "rollForward": "disable",
+    "rollForward": "latestPatch",
     "allowPrerelease": false
   }
 }

--- a/tests/Lfm.App.Tests/packages.lock.json
+++ b/tests/Lfm.App.Tests/packages.lock.json
@@ -195,8 +195,8 @@
       },
       "Microsoft.DotNet.HotReload.WebAssembly.Browser": {
         "type": "Transitive",
-        "resolved": "10.0.104",
-        "contentHash": "OkWFygvFdm9emwxRW5ahcsU6saKO9EOYCFVNEXWl+23A4ssZy40VCQuqPhyurU7IyaPEhgA4iXh0/o7fhyNngA=="
+        "resolved": "10.0.106",
+        "contentHash": "8MzC43QmkOaut7+LL44MrLhtM3rcNeZOmqGtq92m5tbzJ+61bHExfWzE/6SL77ebzq8W+HVD58u+5pov6T1apg=="
       },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "Transitive",
@@ -514,7 +514,7 @@
           "Lfm.Contracts": "[1.0.0, )",
           "Microsoft.AspNetCore.Components.WebAssembly": "[10.0.7, )",
           "Microsoft.AspNetCore.Components.WebAssembly.Authentication": "[10.0.7, )",
-          "Microsoft.DotNet.HotReload.WebAssembly.Browser": "[10.0.104, )",
+          "Microsoft.DotNet.HotReload.WebAssembly.Browser": "[10.0.106, )",
           "Microsoft.Extensions.Http": "[10.0.7, )",
           "Microsoft.Extensions.Localization": "[10.0.7, )",
           "Microsoft.Extensions.Logging.Configuration": "[10.0.7, )",

--- a/tests/Lfm.E2E/Fixtures/LayoutIntegrityFixture.cs
+++ b/tests/Lfm.E2E/Fixtures/LayoutIntegrityFixture.cs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.E2E.Infrastructure;
+using Xunit;
+
+namespace Lfm.E2E.Fixtures;
+
+[CollectionDefinition("LayoutIntegrity")]
+public class LayoutIntegrityCollection : ICollectionFixture<LayoutIntegrityFixture> { }
+
+public class LayoutIntegrityFixture : IAsyncLifetime
+{
+    public StackFixture Stack { get; private set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        Stack = await SharedStack.GetAsync();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+}

--- a/tests/Lfm.E2E/Helpers/LayoutIntegrityHelper.cs
+++ b/tests/Lfm.E2E/Helpers/LayoutIntegrityHelper.cs
@@ -1,0 +1,355 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Globalization;
+using System.Text;
+using Microsoft.Playwright;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Lfm.E2E.Helpers;
+
+/// <summary>
+/// Browser-computed layout checks for overlap and reflow regressions that axe
+/// cannot detect. The detector intentionally checks user-facing and semantic
+/// surfaces, not every internal node in a component tree.
+/// </summary>
+public static class LayoutIntegrityHelper
+{
+    public static async Task AssertNoOverlapsAsync(
+        IPage page,
+        ITestOutputHelper output,
+        string? context = null)
+    {
+        var result = await page.EvaluateAsync<LayoutIntegrityResult>(AuditScript);
+        if (result.Issues.Length == 0)
+            return;
+
+        var message = BuildMessage(result, context ?? page.Url);
+        output.WriteLine(message);
+        throw new XunitException(message);
+    }
+
+    private static string BuildMessage(LayoutIntegrityResult result, string context)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine(CultureInfo.InvariantCulture,
+            $"Layout integrity failed for {context}: {result.Issues.Length} issue(s)");
+        builder.AppendLine(CultureInfo.InvariantCulture,
+            $"Viewport: {result.ViewportWidth:0}x{result.ViewportHeight:0}, document: {result.DocumentWidth:0}x{result.DocumentHeight:0}");
+
+        foreach (var issue in result.Issues)
+        {
+            if (issue.Kind == "horizontal-overflow")
+            {
+                builder.AppendLine(CultureInfo.InvariantCulture,
+                    $"- horizontal overflow: document width {result.DocumentWidth:0}px exceeds viewport {result.ViewportWidth:0}px");
+                continue;
+            }
+
+            var first = issue.First;
+            var second = issue.Second;
+            if (first is null || second is null)
+                continue;
+
+            builder.AppendLine(CultureInfo.InvariantCulture,
+                $"- overlap {issue.Area:0.#}px2 at ({issue.SampleX:0.#}, {issue.SampleY:0.#}); top hit: {issue.TopHit}");
+            builder.AppendLine(CultureInfo.InvariantCulture,
+                $"  first:  {first.Selector} \"{first.Text}\" {Format(first.Rect)} position={first.Position} z-index={first.ZIndex}");
+            builder.AppendLine(CultureInfo.InvariantCulture,
+                $"  second: {second.Selector} \"{second.Text}\" {Format(second.Rect)} position={second.Position} z-index={second.ZIndex}");
+        }
+
+        return builder.ToString();
+    }
+
+    private static string Format(LayoutRect rect)
+        => string.Create(CultureInfo.InvariantCulture,
+            $"x={rect.X:0.#}, y={rect.Y:0.#}, w={rect.Width:0.#}, h={rect.Height:0.#}");
+
+    private const string AuditScript =
+        """
+        () => {
+          const overlapTolerance = 2;
+          const issues = [];
+          const selector = [
+            'a[href]',
+            'button',
+            'input:not([type="hidden"])',
+            'select',
+            'textarea',
+            '[role]',
+            '[tabindex]:not([tabindex="-1"])',
+            '[data-testid]',
+            'h1',
+            'h2',
+            'h3',
+            'h4',
+            'h5',
+            'h6',
+            'label',
+            'p',
+            'li',
+            'th',
+            'td',
+            'fluent-anchor',
+            'fluent-button',
+            'fluent-card',
+            'fluent-label',
+            'fluent-select',
+            'fluent-text-area',
+            'fluent-text-field'
+          ].join(',');
+
+          const ignoredSelector = [
+            'script',
+            'style',
+            'template',
+            'svg',
+            'path',
+            '[hidden]',
+            '[aria-hidden="true"]',
+            '[data-layout-integrity-ignore]'
+          ].join(',');
+
+          const viewportWidth = document.documentElement.clientWidth;
+          const viewportHeight = document.documentElement.clientHeight;
+          const documentWidth = Math.max(
+            document.documentElement.scrollWidth,
+            document.body ? document.body.scrollWidth : 0);
+          const documentHeight = Math.max(
+            document.documentElement.scrollHeight,
+            document.body ? document.body.scrollHeight : 0);
+
+          if (documentWidth > viewportWidth + overlapTolerance) {
+            issues.push({
+              kind: 'horizontal-overflow',
+              area: documentWidth - viewportWidth,
+              sampleX: viewportWidth,
+              sampleY: 0,
+              topHit: 'document',
+              first: null,
+              second: null
+            });
+          }
+
+          const elements = Array.from(document.querySelectorAll(selector));
+          const candidates = elements
+            .filter(el => !el.closest(ignoredSelector))
+            .map((el, index) => toCandidate(el, index))
+            .filter(Boolean);
+
+          for (let i = 0; i < candidates.length; i += 1) {
+            for (let j = i + 1; j < candidates.length; j += 1) {
+              const first = candidates[i];
+              const second = candidates[j];
+              if (first.el.contains(second.el) || second.el.contains(first.el)) {
+                continue;
+              }
+
+              const intersection = intersect(first.rect, second.rect);
+              if (!intersection) {
+                continue;
+              }
+
+              const hit = hitTestPair(first, second, intersection, candidates);
+              if (!hit) {
+                continue;
+              }
+
+              outline(first.el, '#d13438');
+              outline(second.el, '#0078d4');
+              issues.push({
+                kind: 'overlap',
+                area: intersection.width * intersection.height,
+                sampleX: hit.x,
+                sampleY: hit.y,
+                topHit: hit.topHit,
+                first: serializable(first),
+                second: serializable(second)
+              });
+            }
+          }
+
+          return {
+            viewportWidth,
+            viewportHeight,
+            documentWidth,
+            documentHeight,
+            issues
+          };
+
+          function toCandidate(el, index) {
+            const style = getComputedStyle(el);
+            if (style.display === 'none' ||
+                style.visibility === 'hidden' ||
+                Number(style.opacity) === 0 ||
+                style.pointerEvents === 'none') {
+              return null;
+            }
+
+            const rect = el.getBoundingClientRect();
+            if (rect.width < 2 || rect.height < 2) {
+              return null;
+            }
+            if (rect.bottom < 0 || rect.right < 0 ||
+                rect.top > window.innerHeight || rect.left > window.innerWidth) {
+              return null;
+            }
+
+            return {
+              el,
+              index,
+              selector: describe(el),
+              text: textOf(el),
+              position: style.position,
+              zIndex: style.zIndex,
+              rect: {
+                x: rect.x,
+                y: rect.y,
+                width: rect.width,
+                height: rect.height
+              }
+            };
+          }
+
+          function intersect(a, b) {
+            const left = Math.max(a.x, b.x);
+            const top = Math.max(a.y, b.y);
+            const right = Math.min(a.x + a.width, b.x + b.width);
+            const bottom = Math.min(a.y + a.height, b.y + b.height);
+            const width = right - left;
+            const height = bottom - top;
+            if (width <= overlapTolerance || height <= overlapTolerance) {
+              return null;
+            }
+            return { left, top, right, bottom, width, height };
+          }
+
+          function hitTestPair(first, second, intersection, allCandidates) {
+            const points = [
+              { x: intersection.left + intersection.width / 2, y: intersection.top + intersection.height / 2 },
+              { x: intersection.left + 1, y: intersection.top + 1 },
+              { x: intersection.right - 1, y: intersection.top + 1 },
+              { x: intersection.left + 1, y: intersection.bottom - 1 },
+              { x: intersection.right - 1, y: intersection.bottom - 1 }
+            ];
+
+            for (const point of points) {
+              if (point.x < 0 || point.y < 0 ||
+                  point.x > window.innerWidth || point.y > window.innerHeight) {
+                continue;
+              }
+
+              const owners = [];
+              for (const hitElement of document.elementsFromPoint(point.x, point.y)) {
+                const owner = allCandidates.find(candidate =>
+                  candidate.el === hitElement || candidate.el.contains(hitElement));
+                if (owner && !owners.includes(owner)) {
+                  owners.push(owner);
+                }
+              }
+
+              if (owners.includes(first) && owners.includes(second)) {
+                return {
+                  x: point.x,
+                  y: point.y,
+                  topHit: owners[0] ? owners[0].selector : 'unknown'
+                };
+              }
+            }
+
+            return null;
+          }
+
+          function describe(el) {
+            if (el.id) {
+              return '#' + CSS.escape(el.id);
+            }
+
+            const testId = el.getAttribute('data-testid');
+            if (testId) {
+              return '[data-testid="' + testId.replaceAll('"', '\\"') + '"]';
+            }
+
+            const role = el.getAttribute('role');
+            const tag = el.tagName.toLowerCase();
+            if (role) {
+              return tag + '[role="' + role.replaceAll('"', '\\"') + '"]';
+            }
+
+            return tag + ':nth-of-type(' + nthOfType(el) + ')';
+          }
+
+          function nthOfType(el) {
+            let index = 1;
+            let sibling = el;
+            while ((sibling = sibling.previousElementSibling) !== null) {
+              if (sibling.tagName === el.tagName) {
+                index += 1;
+              }
+            }
+            return index;
+          }
+
+          function textOf(el) {
+            return (el.innerText || el.getAttribute('aria-label') || el.textContent || '')
+              .replace(/\s+/g, ' ')
+              .trim()
+              .slice(0, 80);
+          }
+
+          function outline(el, color) {
+            el.style.outline = '3px solid ' + color;
+            el.style.outlineOffset = '-3px';
+          }
+
+          function serializable(candidate) {
+            return {
+              selector: candidate.selector,
+              text: candidate.text,
+              position: candidate.position,
+              zIndex: candidate.zIndex,
+              rect: candidate.rect
+            };
+          }
+        }
+        """;
+
+    private sealed class LayoutIntegrityResult
+    {
+        public double ViewportWidth { get; set; }
+        public double ViewportHeight { get; set; }
+        public double DocumentWidth { get; set; }
+        public double DocumentHeight { get; set; }
+        public LayoutIntegrityIssue[] Issues { get; set; } = [];
+    }
+
+    private sealed class LayoutIntegrityIssue
+    {
+        public string Kind { get; set; } = string.Empty;
+        public double Area { get; set; }
+        public double SampleX { get; set; }
+        public double SampleY { get; set; }
+        public string TopHit { get; set; } = string.Empty;
+        public LayoutElement? First { get; set; }
+        public LayoutElement? Second { get; set; }
+    }
+
+    private sealed class LayoutElement
+    {
+        public string Selector { get; set; } = string.Empty;
+        public string Text { get; set; } = string.Empty;
+        public string Position { get; set; } = string.Empty;
+        public string ZIndex { get; set; } = string.Empty;
+        public LayoutRect Rect { get; set; } = new();
+    }
+
+    private sealed class LayoutRect
+    {
+        public double X { get; set; }
+        public double Y { get; set; }
+        public double Width { get; set; }
+        public double Height { get; set; }
+    }
+}

--- a/tests/Lfm.E2E/Infrastructure/E2ETestMetadata.cs
+++ b/tests/Lfm.E2E/Infrastructure/E2ETestMetadata.cs
@@ -7,6 +7,7 @@ public static class E2ELanes
 {
     public const string Functional = "Functional";
     public const string Accessibility = "Accessibility";
+    public const string LayoutIntegrity = "Layout integrity";
     public const string Security = "Security";
     public const string AuthFlow = "Auth flow";
 }

--- a/tests/Lfm.E2E/Specs/LayoutIntegrityHelperSpec.cs
+++ b/tests/Lfm.E2E/Specs/LayoutIntegrityHelperSpec.cs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.E2E.Helpers;
+using Microsoft.Playwright;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Lfm.E2E.Specs;
+
+[Trait("Category", "Layout integrity")]
+public sealed class LayoutIntegrityHelperSpec(ITestOutputHelper output) : IAsyncLifetime
+{
+    private IPlaywright? _playwright;
+    private IBrowser? _browser;
+    private IPage? _page;
+
+    public async Task InitializeAsync()
+    {
+        _playwright = await Playwright.CreateAsync();
+        var chromiumExecutablePath = Environment.GetEnvironmentVariable("LFM_E2E_CHROMIUM_PATH");
+        _browser = await _playwright.Chromium.LaunchAsync(new()
+        {
+            Headless = true,
+            ExecutablePath = string.IsNullOrWhiteSpace(chromiumExecutablePath) ? null : chromiumExecutablePath,
+        });
+        var context = await _browser.NewContextAsync(new()
+        {
+            ViewportSize = new() { Width = 320, Height = 568 },
+        });
+        _page = await context.NewPageAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_browser is not null)
+            await _browser.CloseAsync();
+        _playwright?.Dispose();
+    }
+
+    [Fact]
+    public async Task AssertNoOverlapsAsync_Fails_WhenVisibleInteractiveSiblingsOverlap()
+    {
+        await Page.SetContentAsync(
+            """
+            <main>
+              <button id="first" style="position:absolute;left:20px;top:20px;width:120px;height:44px">First</button>
+              <button id="second" style="position:absolute;left:80px;top:30px;width:120px;height:44px">Second</button>
+            </main>
+            """);
+
+        var ex = await Assert.ThrowsAsync<XunitException>(
+            () => LayoutIntegrityHelper.AssertNoOverlapsAsync(Page, output, "synthetic overlap"));
+
+        Assert.Contains("#first", ex.Message);
+        Assert.Contains("#second", ex.Message);
+    }
+
+    [Fact]
+    public async Task AssertNoOverlapsAsync_AllowsParentChildContainment()
+    {
+        await Page.SetContentAsync(
+            """
+            <main>
+              <button id="parent" style="width:180px;height:48px">
+                <span id="child">Contained label</span>
+              </button>
+            </main>
+            """);
+
+        await LayoutIntegrityHelper.AssertNoOverlapsAsync(Page, output, "synthetic containment");
+    }
+
+    [Fact]
+    public async Task AssertNoOverlapsAsync_IgnoresHiddenAndPointerlessDecoration()
+    {
+        await Page.SetContentAsync(
+            """
+            <main>
+              <button id="action" style="position:relative;width:180px;height:48px">Action</button>
+              <span id="badge" aria-hidden="true"
+                    style="position:absolute;left:130px;top:0;width:64px;height:32px;pointer-events:none">
+                Active
+              </span>
+              <button id="hidden" hidden style="position:absolute;left:20px;top:10px;width:180px;height:48px">
+                Hidden
+              </button>
+            </main>
+            """);
+
+        await LayoutIntegrityHelper.AssertNoOverlapsAsync(Page, output, "synthetic decoration");
+    }
+
+    [Fact]
+    public async Task AssertNoOverlapsAsync_Fails_WhenDocumentHasHorizontalOverflow()
+    {
+        await Page.SetContentAsync(
+            """
+            <main style="width:420px">
+              <button id="wide">Wide content</button>
+            </main>
+            """);
+
+        var ex = await Assert.ThrowsAsync<XunitException>(
+            () => LayoutIntegrityHelper.AssertNoOverlapsAsync(Page, output, "synthetic overflow"));
+
+        Assert.Contains("horizontal overflow", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private IPage Page => _page ?? throw new InvalidOperationException("Page has not been initialized.");
+}

--- a/tests/Lfm.E2E/Specs/LayoutIntegritySpec.cs
+++ b/tests/Lfm.E2E/Specs/LayoutIntegritySpec.cs
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.E2E.Fixtures;
+using Lfm.E2E.Helpers;
+using Lfm.E2E.Infrastructure;
+using Lfm.E2E.Pages;
+using Lfm.E2E.Seeds;
+using Microsoft.Playwright;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Lfm.E2E.Specs;
+
+[Collection("LayoutIntegrity")]
+[Trait("Category", E2ELanes.LayoutIntegrity)]
+public sealed class LayoutIntegritySpec(LayoutIntegrityFixture fixture, ITestOutputHelper output)
+    : E2ETestBase(output), IAsyncLifetime
+{
+    private static readonly LayoutViewport[] Viewports =
+    [
+        new(320, 568, "mobile-floor"),
+        new(375, 667, "narrow-phone"),
+        new(767, 900, "below-tablet-breakpoint"),
+        new(768, 900, "tablet-breakpoint"),
+        new(1023, 768, "below-wide-breakpoint"),
+        new(1024, 768, "wide-breakpoint"),
+        new(1280, 720, "desktop")
+    ];
+
+    protected override string[] IgnoredConsolePatterns => ["401", "/api/v1/me"];
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+        Context = await AuthHelper.AnonymousContextAsync(fixture.Stack.Browser);
+        Page = await Context.NewPageAsync();
+        AttachDiagnosticListeners();
+        await StartTracingAsync();
+    }
+
+    public override async Task DisposeAsync()
+    {
+        await base.DisposeAsync();
+        if (Context is not null)
+            await Context.CloseAsync();
+    }
+
+    // E2E scope: proves public pages have no browser-computed element overlap
+    // or document-level horizontal overflow at the responsive breakpoint edges.
+    [Fact]
+    public async Task PublicRoutes_HaveNoLayoutOverlaps()
+    {
+        foreach (var viewport in Viewports)
+        {
+            await ScanPublicRouteAsync(viewport, "/", async page =>
+            {
+                await Assertions.Expect(page.GetByRole(
+                    AriaRole.Button,
+                    new() { Name = "Sign in with Battle.net" }))
+                    .ToBeVisibleAsync(new() { Timeout = 15000 });
+            });
+
+            await ScanPublicRouteAsync(viewport, "/login", async page =>
+            {
+                await Assertions.Expect(page.GetByRole(
+                    AriaRole.Heading,
+                    new() { Name = "Sign In" }))
+                    .ToBeVisibleAsync(new() { Timeout = 15000 });
+            });
+
+            await ScanPublicRouteAsync(viewport, "/privacy", async page =>
+            {
+                await Assertions.Expect(page.GetByRole(
+                    AriaRole.Heading,
+                    new() { Name = "Privacy Policy" }))
+                    .ToBeVisibleAsync(new() { Timeout = 15000 });
+            });
+
+            await ScanPublicRouteAsync(viewport, "/auth/failure", async page =>
+            {
+                var failedPage = new LoginFailedPage(page);
+                await Assertions.Expect(failedPage.ErrorHeading).ToBeVisibleAsync(new() { Timeout = 30000 });
+            });
+        }
+    }
+
+    // E2E scope: proves authenticated dense pages and dynamic states have no
+    // browser-computed element overlap or document-level horizontal overflow.
+    [Fact]
+    public async Task AuthenticatedDenseRoutes_HaveNoLayoutOverlaps()
+    {
+        var page = Page!;
+        await StubPortraitsAsync(page);
+        await AuthHelper.AuthenticatePageAsync(page, fixture.Stack.ApiBaseUrl, fixture.Stack.AppBaseUrl);
+
+        foreach (var viewport in Viewports)
+        {
+            await ScanRunsSelectedAsync(viewport);
+            await ScanCreateRunDungeonAsync(viewport);
+            await ScanCharactersAsync(viewport);
+            await ScanGuildAdminDirtyAsync(viewport);
+            await ScanInstancesAsync(viewport);
+        }
+    }
+
+    // E2E scope: proves text expansion in the supported Finnish locale does
+    // not introduce mobile-floor overlap in the densest authenticated states.
+    [Fact]
+    public async Task FinnishDenseStates_HaveNoMobileLayoutOverlaps()
+    {
+        await ResetContextAsync(new()
+        {
+            Locale = "fi-FI",
+            ViewportSize = new() { Width = 320, Height = 568 },
+        });
+
+        var page = Page!;
+        await StubPortraitsAsync(page);
+        await AuthHelper.AuthenticatePageAsync(page, fixture.Stack.ApiBaseUrl, fixture.Stack.AppBaseUrl);
+
+        await ScanRunsSelectedAsync(new(320, 568, "mobile-floor-fi"));
+        await ScanCreateRunDungeonAsync(new(320, 568, "mobile-floor-fi"));
+        await ScanCharactersAsync(new(320, 568, "mobile-floor-fi"));
+        await ScanGuildAdminDirtyAsync(new(320, 568, "mobile-floor-fi"));
+    }
+
+    private async Task ScanPublicRouteAsync(
+        LayoutViewport viewport,
+        string route,
+        Func<IPage, Task> waitForReady)
+    {
+        await SetViewportAsync(viewport);
+        await Page!.GotoAsync($"{fixture.Stack.AppBaseUrl}{route}", new() { WaitUntil = WaitUntilState.NetworkIdle });
+        await waitForReady(Page);
+        await ScanCurrentPageAsync($"{route} ({viewport.Name})");
+    }
+
+    private async Task ScanRunsSelectedAsync(LayoutViewport viewport)
+    {
+        await SetViewportAsync(viewport);
+        var page = Page!;
+        var runsPage = new RunsPage(page);
+        await runsPage.GotoAsync(fixture.Stack.AppBaseUrl);
+        await Assertions.Expect(page.GetByRole(
+            AriaRole.Heading,
+            new() { NameRegex = new("Runs|Runit") }))
+            .ToBeVisibleAsync(new() { Timeout = 15000 });
+        await runsPage.SelectRunAsync(DefaultSeed.TestRunId);
+        await Assertions.Expect(runsPage.AttendingHeading).ToBeVisibleAsync(new() { Timeout = 15000 });
+        await ScanCurrentPageAsync($"/runs selected ({viewport.Name})");
+    }
+
+    private async Task ScanCreateRunDungeonAsync(LayoutViewport viewport)
+    {
+        await SetViewportAsync(viewport);
+        var page = Page!;
+        await page.GotoAsync($"{fixture.Stack.AppBaseUrl}/runs/new", new() { WaitUntil = WaitUntilState.NetworkIdle });
+        await Assertions.Expect(page.GetByRole(
+            AriaRole.Heading,
+            new() { NameRegex = new("Schedule a run|Uusi runi") }))
+            .ToBeVisibleAsync(new() { Timeout = 15000 });
+        await page.GetByRole(AriaRole.Radio, new() { NameRegex = new("Dungeon|Luolasto") }).ClickAsync();
+        await ScanCurrentPageAsync($"/runs/new dungeon ({viewport.Name})");
+    }
+
+    private async Task ScanCharactersAsync(LayoutViewport viewport)
+    {
+        await SetViewportAsync(viewport);
+        var page = Page!;
+        await page.GotoAsync($"{fixture.Stack.AppBaseUrl}/characters", new() { WaitUntil = WaitUntilState.NetworkIdle });
+        await Assertions.Expect(page.GetByRole(
+            AriaRole.Heading,
+            new() { NameRegex = new("My Characters|Hahmoni") }))
+            .ToBeVisibleAsync(new() { Timeout = 15000 });
+        await ScanCurrentPageAsync($"/characters ({viewport.Name})");
+    }
+
+    private async Task ScanGuildAdminDirtyAsync(LayoutViewport viewport)
+    {
+        await SetViewportAsync(viewport);
+        var page = Page!;
+        await page.GotoAsync($"{fixture.Stack.AppBaseUrl}/guild/admin", new() { WaitUntil = WaitUntilState.NetworkIdle });
+        await Assertions.Expect(page.GetByRole(
+            AriaRole.Heading,
+            new() { NameRegex = new("Guild Admin|Killan hallinta") }))
+            .ToBeVisibleAsync(new() { Timeout = 15000 });
+        var guildAdminPage = new GuildAdminPage(page);
+        await Assertions.Expect(guildAdminPage.SloganField).ToBeVisibleAsync(new() { Timeout = 10000 });
+        await guildAdminPage.SloganField.FillAsync($"E2E layout dirty {Guid.NewGuid():N}");
+        await page.Keyboard.PressAsync("Tab");
+        await ScanCurrentPageAsync($"/guild/admin dirty ({viewport.Name})");
+    }
+
+    private async Task ScanInstancesAsync(LayoutViewport viewport)
+    {
+        await SetViewportAsync(viewport);
+        var page = Page!;
+        await page.GotoAsync($"{fixture.Stack.AppBaseUrl}/instances", new() { WaitUntil = WaitUntilState.NetworkIdle });
+        await Assertions.Expect(page.GetByRole(
+            AriaRole.Heading,
+            new() { NameRegex = new("Instances|Instanssit") }))
+            .ToBeVisibleAsync(new() { Timeout = 15000 });
+        await ScanCurrentPageAsync($"/instances ({viewport.Name})");
+    }
+
+    private async Task ResetContextAsync(BrowserNewContextOptions options)
+    {
+        if (Context is not null)
+            await Context.CloseAsync();
+
+        Context = await fixture.Stack.Browser.NewContextAsync(options);
+        Page = await Context.NewPageAsync();
+        AttachDiagnosticListeners();
+        await StartTracingAsync();
+    }
+
+    private async Task SetViewportAsync(LayoutViewport viewport)
+    {
+        await Page!.SetViewportSizeAsync(viewport.Width, viewport.Height);
+    }
+
+    private async Task ScanCurrentPageAsync(string context)
+    {
+        await WaitForLayoutReadyAsync(Page!);
+        await LayoutIntegrityHelper.AssertNoOverlapsAsync(Page!, Output, context);
+    }
+
+    private static async Task StubPortraitsAsync(IPage page)
+    {
+        await page.RouteAsync("**/api/v1/battlenet/character-portraits", async route =>
+        {
+            await route.FulfillAsync(new()
+            {
+                Status = 200,
+                ContentType = "application/json",
+                Body = "{\"portraits\":{}}",
+            });
+        });
+    }
+
+    private static async Task WaitForLayoutReadyAsync(IPage page)
+    {
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await page.EvaluateAsync("() => document.fonts ? document.fonts.ready : Promise.resolve()");
+    }
+
+    private readonly record struct LayoutViewport(int Width, int Height, string Name);
+}


### PR DESCRIPTION
## Summary
- Add a layout-integrity E2E lane that detects browser-computed element overlap and document-level horizontal overflow across breakpoint edges and Finnish text expansion.
- Add synthetic Playwright tests for the layout detector's overlap, containment, decoration, and overflow behavior.
- Fix mobile reflow issues found by the new lane on the Characters header and scrollable data-grid regions.
- Pin the .NET SDK patch to 10.0.106, refresh SDK-sensitive lockfiles, and make GitHub Actions solution restore single-node for deterministic locked restore.

## Env / schema changes
- None.

## Test Plan
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- [x] `dotnet build lfm.sln -c Release --no-restore`
- [x] `env CI=true dotnet restore lfm.sln -m:1`
- [x] `bash scripts/check-e2e-drift.sh` (exit 0; existing review-only notices)
- [x] `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --no-restore` (65/65 passed)
- [x] GitHub Actions: `verify`, `Analyze C#`, `CodeQL`, `dep-license-check`, `Gitleaks`, `reuse-lint`