### PR TITLE
Allow site admins to create guild runs

### DIFF
--- a/api/Runs/RunCreateService.cs
+++ b/api/Runs/RunCreateService.cs
@@ -20,7 +20,8 @@ namespace Lfm.Api.Runs;
 public sealed class RunCreateService(
     IRunsRepository runsRepo,
     IRaidersRepository raidersRepo,
-    IGuildPermissions guildPermissions) : IRunCreateService
+    IGuildPermissions guildPermissions,
+    ISiteAdminService siteAdmin) : IRunCreateService
 {
     private const long RunTtlAfterStartMs = 7L * 24 * 3600 * 1000;
     private const int MinTtlSeconds = 86400; // 1 day minimum
@@ -45,7 +46,7 @@ public sealed class RunCreateService(
                 "A run requires an active character in a guild.");
 
         var canCreate = await guildPermissions.CanCreateGuildRunsAsync(raider, ct);
-        if (!canCreate)
+        if (!canCreate && !await siteAdmin.IsAdminAsync(principal.BattleNetId, ct))
             return new RunOperationResult.Forbidden(
                 "guild-rank-denied",
                 "Guild run creation is not enabled for your rank.",

--- a/app/Pages/CreateRunPage.razor
+++ b/app/Pages/CreateRunPage.razor
@@ -1,5 +1,6 @@
 @page "/runs/new"
 @attribute [Authorize]
+@using Microsoft.AspNetCore.Components.Authorization
 @using Lfm.App.Components
 @using Lfm.App.Runs
 @using Lfm.App.Services
@@ -14,6 +15,7 @@
 @inject IRunsClient RunsClient
 @inject NavigationManager Nav
 @inject IStringLocalizer Loc
+@inject AuthenticationStateProvider AuthStateProvider
 
 <PageTitle>@Loc["createRun.title"]</PageTitle>
 
@@ -158,7 +160,7 @@
                     </FluentButton>
                 }
 
-                @if (!_form.CanCreateGuildRuns)
+                @if (!CanCreateRun)
                 {
                     <FluentMessageBar Intent="MessageIntent.Warning">
                         @Loc["createRun.visibility.guildDisabledReason"]
@@ -193,7 +195,7 @@
                 <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="8" Wrap="true">
                     <FluentButton Appearance="Appearance.Accent"
                                   OnClick="@HandleSubmit"
-                                  Disabled="@(!_form.CanSubmit || !_form.CanCreateGuildRuns || _submitting)">
+                                  Disabled="@(!_form.CanSubmit || !CanCreateRun || _submitting)">
                         @(_submitting ? Loc["createRun.creating"] : Loc["createRun.submit"])
                     </FluentButton>
                     <FluentButton Appearance="Appearance.Outline"
@@ -215,8 +217,11 @@
     // ── Page state ─────────────────────────────────────────────────────────
     private bool _loading = true;
     private bool _submitting;
+    private bool _isSiteAdmin;
     private string? _loadError;
     private RunError? _inlineError;
+
+    private bool CanCreateRun => _form.CanCreateGuildRuns || _isSiteAdmin;
 
     // ── Options for the ToggleGroups ───────────────────────────────────────
     private IReadOnlyList<(ActivityKind, string)> _activityOptions = [];
@@ -237,9 +242,11 @@
             var expansionsTask = ExpansionsClient.ListAsync(CancellationToken.None);
             var instancesTask = InstancesClient.ListAsync(CancellationToken.None);
             var guildTask = GuildClient.GetAsync(CancellationToken.None);
+            var authTask = AuthStateProvider.GetAuthenticationStateAsync();
             await Task.WhenAll(expansionsTask, instancesTask);
 
             _form.LoadOptions(InstanceOptions.Build(await instancesTask), await expansionsTask);
+            _isSiteAdmin = (await authTask).User.IsInRole("SiteAdmin");
 
             try { _guild = await guildTask; }
             catch { _guild = null; }

--- a/tests/Lfm.Api.Tests/Runs/RunCreateServiceTests.cs
+++ b/tests/Lfm.Api.Tests/Runs/RunCreateServiceTests.cs
@@ -84,8 +84,44 @@ public class RunCreateServiceTests
         var runsRepo = new Mock<IRunsRepository>();
         var raidersRepo = new Mock<IRaidersRepository>();
         var guildPermissions = new Mock<IGuildPermissions>();
-        var sut = new RunCreateService(runsRepo.Object, raidersRepo.Object, guildPermissions.Object);
+        var siteAdmin = new Mock<ISiteAdminService>();
+        var sut = new RunCreateService(
+            runsRepo.Object,
+            raidersRepo.Object,
+            guildPermissions.Object,
+            siteAdmin.Object);
         return (runsRepo, raidersRepo, guildPermissions, sut);
+    }
+
+    [Fact]
+    public async Task CreateAsync_SiteAdminWithGuild_BypassesGuildRankCreatePermission()
+    {
+        var runsRepo = new Mock<IRunsRepository>();
+        var raidersRepo = new Mock<IRaidersRepository>();
+        var guildPermissions = new Mock<IGuildPermissions>();
+        var siteAdmin = new Mock<ISiteAdminService>();
+        var sut = new RunCreateService(
+            runsRepo.Object,
+            raidersRepo.Object,
+            guildPermissions.Object,
+            siteAdmin.Object);
+        var principal = MakePrincipal("bnet-site-admin");
+        var raider = MakeRaiderWithGuild("bnet-site-admin", guildId: 123, guildName: "Test Guild");
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-site-admin", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(raider);
+        guildPermissions.Setup(p => p.CanCreateGuildRunsAsync(raider, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        siteAdmin.Setup(s => s.IsAdminAsync("bnet-site-admin", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        runsRepo.Setup(r => r.CreateAsync(It.IsAny<RunDocument>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RunDocument doc, CancellationToken _) => doc);
+
+        var result = await sut.CreateAsync(MakeRequest(), principal, CancellationToken.None);
+
+        var ok = Assert.IsType<RunOperationResult.Ok>(result);
+        Assert.Equal("bnet-site-admin", ok.Run.CreatorBattleNetId);
+        Assert.Equal(123, ok.Run.CreatorGuildId);
+        Assert.Equal("GUILD", ok.Run.Visibility);
     }
 
     [Fact]

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
 using Bunit;
+using Bunit.TestDoubles;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Lfm.App.Pages;
@@ -646,8 +647,14 @@ public class RunsPagesTests : ComponentTestBase
         IReadOnlyList<ExpansionDto>? expansions = null,
         GuildDto? guild = null,
         TaskCompletionSource<IReadOnlyList<InstanceDto>>? instancesPending = null,
-        bool guildThrows = false)
+        bool guildThrows = false,
+        bool siteAdmin = false)
     {
+        var auth = this.AddAuthorization();
+        auth.SetAuthorized("player#1234");
+        if (siteAdmin)
+            auth.SetRoles("SiteAdmin");
+
         var instancesClient = new Mock<IInstancesClient>();
         if (instancesPending is not null)
             instancesClient.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
@@ -727,6 +734,21 @@ public class RunsPagesTests : ComponentTestBase
     }
 
     [Fact]
+    public void CreateRunPage_SiteAdmin_DoesNotShowGuildRankMessage_WhenRankCannotCreateRuns()
+    {
+        WireCreateRunServices(
+            instances: [MakeInstanceFixture()],
+            guild: MakeGuildDto(canCreateGuildRuns: false),
+            siteAdmin: true);
+
+        var cut = Render<CreateRunPage>();
+
+        cut.WaitForAssertion(() =>
+            Assert.Contains(Loc("createRun.submit"), cut.Markup));
+        Assert.DoesNotContain(Loc("createRun.visibility.guildDisabledReason"), cut.Markup);
+    }
+
+    [Fact]
     public void CreateRunPage_DoesNotRenderExpansionSelector()
     {
         // The create-run form scopes its instance list to the Blizzard
@@ -758,6 +780,8 @@ public class RunsPagesTests : ComponentTestBase
     [Fact]
     public void CreateRunPage_HandleSubmit_Resets_Submitting_Flag_On_Success_Path()
     {
+        this.AddAuthorization().SetAuthorized("player#1234");
+
         var runsClient = new Mock<IRunsClient>();
         runsClient.Setup(c => c.CreateAsync(It.IsAny<CreateRunRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(MakeDetail());


### PR DESCRIPTION
## Summary
- Allow site admins to bypass the guild-rank create permission when creating guild-scoped runs.
- Keep the active-guild requirement for run creation so site-admin-created runs remain guild-scoped.
- Update CreateRunPage and regression tests so site admins do not see the guild-rank create warning when their rank lacks create permission.

## Test Plan
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- [x] `dotnet build lfm.sln -c Release`
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release` — 789 passed
- [x] `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release` — 191 passed