### PR TITLE
Add App.Core mutation survivor coverage

### DIFF
--- a/tests/Lfm.App.Core.Tests/Runs/RunErrorParserTests.cs
+++ b/tests/Lfm.App.Core.Tests/Runs/RunErrorParserTests.cs
@@ -20,6 +20,33 @@ public class RunErrorParserTests
     }
 
     [Fact]
+    public void BadRequest_with_errors_array_keeps_only_non_empty_strings()
+    {
+        var body = """{"errors":["startTime is required","",42,null,"modeKey is required"]}""";
+        var result = RunErrorParser.Parse(HttpStatusCode.BadRequest, body);
+        Assert.Equal(RunErrorKind.Validation, result.Kind);
+        Assert.Equal(["startTime is required", "modeKey is required"], result.Messages);
+    }
+
+    [Fact]
+    public void BadRequest_with_non_array_errors_uses_detail_message()
+    {
+        var body = """{"errors":"not an array","detail":"Request body failed validation."}""";
+        var result = RunErrorParser.Parse(HttpStatusCode.BadRequest, body);
+        Assert.Equal(RunErrorKind.Validation, result.Kind);
+        Assert.Equal("Request body failed validation.", Assert.Single(result.Messages));
+    }
+
+    [Fact]
+    public void BadRequest_with_non_string_detail_falls_back_to_raw_body()
+    {
+        var body = """{"detail":42}""";
+        var result = RunErrorParser.Parse(HttpStatusCode.BadRequest, body);
+        Assert.Equal(RunErrorKind.Validation, result.Kind);
+        Assert.Equal(body, Assert.Single(result.Messages));
+    }
+
+    [Fact]
     public void BadRequest_with_detail_only_classifies_as_Validation_with_that_message()
     {
         var body = """{"type":"https://github.com/lfm-org/lfm/errors#guild-required","title":"Bad Request","status":400,"detail":"A guild run requires an active character in a guild."}""";
@@ -47,6 +74,15 @@ public class RunErrorParserTests
     }
 
     [Fact]
+    public void Forbidden_with_rank_denied_type_without_detail_uses_rank_fallback()
+    {
+        var body = """{"type":"https://github.com/lfm-org/lfm/errors#guild-rank-denied","title":"Forbidden","status":403}""";
+        var result = RunErrorParser.Parse(HttpStatusCode.Forbidden, body);
+        Assert.Equal(RunErrorKind.GuildRankDenied, result.Kind);
+        Assert.Equal("Guild run creation is not enabled for your rank.", Assert.Single(result.Messages));
+    }
+
+    [Fact]
     public void Forbidden_with_detail_but_unknown_type_still_surfaces_server_detail()
     {
         var body = """{"type":"https://github.com/lfm-org/lfm/errors#some-other-thing","title":"Forbidden","status":403,"detail":"Specific reason."}""";
@@ -56,11 +92,37 @@ public class RunErrorParserTests
     }
 
     [Fact]
+    public void Forbidden_with_non_string_type_still_surfaces_server_detail()
+    {
+        var body = """{"type":42,"detail":"Specific reason."}""";
+        var result = RunErrorParser.Parse(HttpStatusCode.Forbidden, body);
+        Assert.Equal(RunErrorKind.GuildRankDenied, result.Kind);
+        Assert.Equal("Specific reason.", Assert.Single(result.Messages));
+    }
+
+    [Fact]
+    public void Forbidden_with_non_string_detail_uses_forbidden_fallback()
+    {
+        var body = """{"type":"https://github.com/lfm-org/lfm/errors#some-other-thing","detail":42}""";
+        var result = RunErrorParser.Parse(HttpStatusCode.Forbidden, body);
+        Assert.Equal(RunErrorKind.GuildRankDenied, result.Kind);
+        Assert.Equal("Forbidden.", Assert.Single(result.Messages));
+    }
+
+    [Fact]
     public void Forbidden_with_empty_body_still_classifies_as_GuildRankDenied()
     {
         var result = RunErrorParser.Parse(HttpStatusCode.Forbidden, null);
         Assert.Equal(RunErrorKind.GuildRankDenied, result.Kind);
         Assert.NotEmpty(result.Messages);
+    }
+
+    [Fact]
+    public void Forbidden_with_malformed_body_uses_forbidden_fallback()
+    {
+        var result = RunErrorParser.Parse(HttpStatusCode.Forbidden, "not json at all");
+        Assert.Equal(RunErrorKind.GuildRankDenied, result.Kind);
+        Assert.Equal("Forbidden.", Assert.Single(result.Messages));
     }
 
     [Theory]
@@ -73,6 +135,7 @@ public class RunErrorParserTests
         var result = RunErrorParser.Parse(status, "doesn't matter");
         Assert.Equal(RunErrorKind.Network, result.Kind);
         Assert.True(result.IsNetwork);
+        Assert.Equal("Server error. Try again.", Assert.Single(result.Messages));
     }
 
     [Fact]
@@ -80,6 +143,7 @@ public class RunErrorParserTests
     {
         var result = RunErrorParser.Parse(HttpStatusCode.NotFound, null);
         Assert.Equal(RunErrorKind.Unknown, result.Kind);
+        Assert.Equal("Unexpected response (404).", Assert.Single(result.Messages));
     }
 
     [Fact]
@@ -88,6 +152,14 @@ public class RunErrorParserTests
         var result = RunErrorParser.Network(new HttpRequestException("connection refused"));
         Assert.Equal(RunErrorKind.Network, result.Kind);
         Assert.Equal("connection refused", Assert.Single(result.Messages));
+    }
+
+    [Fact]
+    public void Network_uses_fallback_when_exception_message_is_empty()
+    {
+        var result = RunErrorParser.Network(new Exception(""));
+        Assert.Equal(RunErrorKind.Network, result.Kind);
+        Assert.Equal("Network error.", Assert.Single(result.Messages));
     }
 
     [Fact]

--- a/tests/Lfm.App.Core.Tests/Runs/RunFormStateTests.cs
+++ b/tests/Lfm.App.Core.Tests/Runs/RunFormStateTests.cs
@@ -42,6 +42,81 @@ public class RunFormStateTests
     };
 
     [Fact]
+    public void Defaults_match_create_form_initial_state()
+    {
+        var state = new RunFormState();
+
+        Assert.Equal(ActivityKind.Dungeon, state.Activity);
+        Assert.Equal("MYTHIC_KEYSTONE", state.Difficulty);
+        Assert.Equal(5, state.Size);
+        Assert.True(state.AnyDungeon);
+        Assert.Equal("GUILD", state.Visibility);
+        Assert.Equal("", state.Description);
+    }
+
+    [Fact]
+    public void FilteredInstances_include_global_options_and_match_activity_and_expansion()
+    {
+        var globalDungeon = new InstanceOption(
+            InstanceId: 1001,
+            Name: "Global Dungeon",
+            Activity: ActivityKind.Dungeon,
+            ExpansionId: null,
+            Difficulties: [new DifficultyOption("MYTHIC_KEYSTONE", 5, "Mythic+ (5)")]);
+        var oldDungeon = new InstanceOption(
+            InstanceId: 1002,
+            Name: "Old Dungeon",
+            Activity: ActivityKind.Dungeon,
+            ExpansionId: 11,
+            Difficulties: [new DifficultyOption("MYTHIC_KEYSTONE", 5, "Mythic+ (5)")]);
+        var currentRaid = new InstanceOption(
+            InstanceId: 1003,
+            Name: "Current Raid",
+            Activity: ActivityKind.Raid,
+            ExpansionId: 14,
+            Difficulties: [new DifficultyOption("NORMAL", 10, "Normal (10)")]);
+        var state = new RunFormState();
+        state.LoadOptions([globalDungeon, oldDungeon, currentRaid], Expansions);
+
+        var dungeonIds = state.FilteredInstances.Select(i => i.InstanceId).ToArray();
+
+        Assert.Equal(new[] { 1001 }, dungeonIds);
+
+        state.OnActivityChanged(ActivityKind.Raid);
+        Assert.Equal(new[] { 1003 }, state.FilteredInstances.Select(i => i.InstanceId).ToArray());
+    }
+
+    [Fact]
+    public void Visibility_properties_follow_activity_scope_and_instance_selection()
+    {
+        var state = new RunFormState();
+        state.LoadOptions(Instances, Expansions);
+
+        Assert.False(state.ShowInstanceDropdown);
+        Assert.True(state.ShowDifficultyToggle);
+
+        state.OnDungeonScopeChanged(false);
+
+        Assert.True(state.ShowInstanceDropdown);
+        Assert.False(state.ShowDifficultyToggle);
+
+        state.OnInstanceChanged(1023);
+
+        Assert.True(state.ShowInstanceDropdown);
+        Assert.True(state.ShowDifficultyToggle);
+
+        state.OnActivityChanged(ActivityKind.Raid);
+
+        Assert.True(state.ShowInstanceDropdown);
+        Assert.False(state.ShowDifficultyToggle);
+
+        state.OnActivityChanged(ActivityKind.Dungeon);
+        state.SetMode("HEROIC", 5, null);
+
+        Assert.True(state.ShowInstanceDropdown);
+    }
+
+    [Fact]
     public void OnActivityChanged_ToRaid_ClearsInstanceAndKeystone()
     {
         var state = new RunFormState();
@@ -55,6 +130,47 @@ public class RunFormStateTests
         Assert.Equal(0, state.InstanceId);
         Assert.Null(state.KeystoneLevel);
         Assert.Equal("", state.Difficulty);
+        Assert.Equal(0, state.Size);
+        Assert.Empty(state.DifficultyOptions);
+    }
+
+    [Fact]
+    public void OnActivityChanged_ToDungeon_RestoresMythicPlusDefaults()
+    {
+        var state = new RunFormState();
+        state.LoadOptions(Instances, Expansions);
+        state.OnActivityChanged(ActivityKind.Raid);
+        state.InstanceId = 2055;
+        state.OnDifficultyChanged("HEROIC");
+
+        state.OnActivityChanged(ActivityKind.Dungeon);
+
+        Assert.Equal(ActivityKind.Dungeon, state.Activity);
+        Assert.Equal(0, state.InstanceId);
+        Assert.True(state.AnyDungeon);
+        Assert.Equal("MYTHIC_KEYSTONE", state.Difficulty);
+        Assert.Equal(5, state.Size);
+        Assert.Null(state.KeystoneLevel);
+        Assert.Empty(state.DifficultyOptions);
+    }
+
+    [Fact]
+    public void OnDungeonScopeChanged_clears_instance_only_for_any_dungeon()
+    {
+        var state = new RunFormState();
+        state.LoadOptions(Instances, Expansions);
+        state.OnDungeonScopeChanged(false);
+        state.OnInstanceChanged(1023);
+
+        state.OnDungeonScopeChanged(false);
+
+        Assert.Equal(1023, state.InstanceId);
+        Assert.NotEmpty(state.DifficultyOptions);
+
+        state.OnDungeonScopeChanged(true);
+
+        Assert.Equal(0, state.InstanceId);
+        Assert.Empty(state.DifficultyOptions);
     }
 
     [Fact]
@@ -72,6 +188,29 @@ public class RunFormStateTests
     }
 
     [Fact]
+    public void OnDifficultyChanged_MatchingMode_updates_size_and_preserves_mythic_plus_keystone()
+    {
+        var state = new RunFormState();
+        state.LoadOptions(Instances, Expansions);
+        state.OnDungeonScopeChanged(false);
+        state.OnInstanceChanged(1023);
+        state.KeystoneLevel = 12;
+
+        state.OnDifficultyChanged("HEROIC");
+
+        Assert.Equal("HEROIC", state.Difficulty);
+        Assert.Equal(5, state.Size);
+        Assert.Null(state.KeystoneLevel);
+
+        state.KeystoneLevel = 10;
+        state.OnDifficultyChanged("MYTHIC_KEYSTONE");
+
+        Assert.Equal("MYTHIC_KEYSTONE", state.Difficulty);
+        Assert.Equal(5, state.Size);
+        Assert.Equal(10, state.KeystoneLevel);
+    }
+
+    [Fact]
     public void CanSubmit_AnyDungeon_RequiresKeystoneInRange()
     {
         var state = new RunFormState();
@@ -86,11 +225,78 @@ public class RunFormStateTests
         state.KeystoneLevel = 1;
         Assert.False(state.CanSubmit);
 
+        state.KeystoneLevel = 2;
+        Assert.True(state.CanSubmit);
+
         state.KeystoneLevel = 12;
+        Assert.True(state.CanSubmit);
+
+        state.KeystoneLevel = 30;
         Assert.True(state.CanSubmit);
 
         state.KeystoneLevel = 31;
         Assert.False(state.CanSubmit);
+    }
+
+    [Fact]
+    public void CanSubmit_SpecificMythicPlus_requires_start_time_instance_and_valid_optional_keystone()
+    {
+        var state = new RunFormState();
+        state.LoadOptions(Instances, Expansions);
+        state.OnDungeonScopeChanged(false);
+        state.StartTimeLocal = null;
+        state.OnInstanceChanged(1023);
+
+        Assert.False(state.CanSubmit);
+
+        state.StartTimeLocal = DateTime.Now.AddDays(1);
+        state.InstanceId = 0;
+        Assert.False(state.CanSubmit);
+
+        state.OnInstanceChanged(1023);
+
+        state.KeystoneLevel = null;
+        Assert.True(state.CanSubmit);
+
+        state.KeystoneLevel = 1;
+        Assert.False(state.CanSubmit);
+
+        state.KeystoneLevel = 2;
+        Assert.True(state.CanSubmit);
+
+        state.KeystoneLevel = 30;
+        Assert.True(state.CanSubmit);
+
+        state.KeystoneLevel = 31;
+        Assert.False(state.CanSubmit);
+    }
+
+    [Fact]
+    public void CanSubmit_NonMythicPlus_requires_start_time_and_instance()
+    {
+        var state = new RunFormState();
+        state.LoadOptions(Instances, Expansions);
+        state.OnActivityChanged(ActivityKind.Raid);
+        state.OnInstanceChanged(2055);
+        state.OnDifficultyChanged("NORMAL");
+
+        Assert.False(state.CanSubmit);
+
+        state.StartTimeLocal = DateTime.Now.AddDays(1);
+
+        Assert.True(state.CanSubmit);
+    }
+
+    [Fact]
+    public void CanSubmit_DungeonHeroicWithInstance_does_not_require_keystone()
+    {
+        var state = new RunFormState();
+        state.LoadOptions(Instances, Expansions);
+        state.OnInstanceChanged(1023);
+        state.OnDifficultyChanged("HEROIC");
+        state.StartTimeLocal = DateTime.Now.AddDays(1);
+
+        Assert.True(state.CanSubmit);
     }
 
     [Fact]
@@ -104,6 +310,72 @@ public class RunFormStateTests
     public void ResolveCurrentSeason_PrefersCanonicalMatch()
     {
         Assert.Equal(14, RunFormState.ResolveCurrentSeasonId(Expansions));
+    }
+
+    [Fact]
+    public void ResolveCurrentSeason_ReturnsZeroWhenNoExpansionsExist()
+    {
+        Assert.Equal(0, RunFormState.ResolveCurrentSeasonId([]));
+    }
+
+    [Fact]
+    public void LoadOptions_refreshes_difficulty_options_for_existing_instance()
+    {
+        var state = new RunFormState
+        {
+            InstanceId = 1023,
+        };
+
+        state.LoadOptions(Instances, Expansions);
+
+        Assert.Contains(state.DifficultyOptions, d => d.DifficultyId == "MYTHIC_KEYSTONE");
+    }
+
+    [Fact]
+    public void OnInstanceChanged_PreservesCurrentDifficulty_WhenAvailable()
+    {
+        var state = new RunFormState();
+        state.LoadOptions(Instances, Expansions);
+        state.OnDungeonScopeChanged(false);
+
+        state.OnInstanceChanged(1023);
+
+        Assert.Equal("MYTHIC_KEYSTONE", state.Difficulty);
+        Assert.Equal(5, state.Size);
+    }
+
+    [Fact]
+    public void OnDifficultyChanged_without_instance_or_match_sets_size_to_zero()
+    {
+        var customInstances = new[]
+        {
+            new InstanceOption(
+                InstanceId: 3001,
+                Name: "Flexible Dungeon",
+                Activity: ActivityKind.Dungeon,
+                ExpansionId: 14,
+                Difficulties: new[]
+                {
+                    new DifficultyOption("SMALL", 5, "Small (5)"),
+                    new DifficultyOption("LARGE", 10, "Large (10)"),
+                }),
+        };
+        var state = new RunFormState();
+        state.LoadOptions(customInstances, Expansions);
+
+        state.OnDifficultyChanged("SMALL");
+
+        Assert.Equal(0, state.Size);
+
+        state.OnInstanceChanged(3001);
+        state.OnDifficultyChanged("UNKNOWN");
+
+        Assert.Equal("UNKNOWN", state.Difficulty);
+        Assert.Equal(0, state.Size);
+
+        state.OnDifficultyChanged("SMALL");
+
+        Assert.Equal(5, state.Size);
     }
 
     [Fact]
@@ -161,5 +433,17 @@ public class RunFormStateTests
         // The Mythic raid difficulty options for instance 2055 must be loaded
         // (RefreshDifficultyOptions ran).
         Assert.Contains(state.DifficultyOptions, d => d.DifficultyId == "MYTHIC");
+    }
+
+    [Fact]
+    public void SetMode_replaces_difficulty_size_and_keystone()
+    {
+        var state = new RunFormState();
+
+        state.SetMode("HEROIC", 10, 7);
+
+        Assert.Equal("HEROIC", state.Difficulty);
+        Assert.Equal(10, state.Size);
+        Assert.Equal(7, state.KeystoneLevel);
     }
 }

--- a/tests/Lfm.App.Core.Tests/Runs/RunVisualizationTests.cs
+++ b/tests/Lfm.App.Core.Tests/Runs/RunVisualizationTests.cs
@@ -81,6 +81,19 @@ public class RunVisualizationTests
     }
 
     [Theory]
+    [InlineData(-1, 0, false)]
+    [InlineData(1, 1, false)]
+    [InlineData(1, 2, true)]
+    [InlineData(2, 1, false)]
+    public void RoleCount_shortage_requires_positive_target_and_attending_below_target(
+        int attending,
+        int target,
+        bool expected)
+    {
+        Assert.Equal(expected, new RoleCount(attending, target).IsShortage);
+    }
+
+    [Theory]
     [InlineData("IN", true)]
     [InlineData("LATE", true)]
     [InlineData("BENCH", true)]
@@ -91,6 +104,22 @@ public class RunVisualizationTests
     public void IsAttending_covers_all_states(string? attendance, bool expected)
     {
         Assert.Equal(expected, RunVisualization.IsAttending(attendance));
+    }
+
+    [Theory]
+    [InlineData("TANK", "TANK")]
+    [InlineData("tank", "TANK")]
+    [InlineData("HEALER", "HEALER")]
+    [InlineData("HEAL", "HEALER")]
+    [InlineData("MELEE", "DPS")]
+    [InlineData("RANGED", "DPS")]
+    [InlineData("DPS", "DPS")]
+    [InlineData("unknown", "DPS")]
+    [InlineData("", "DPS")]
+    [InlineData(null, "DPS")]
+    public void NormalizeRole_maps_aliases_and_defaults_to_dps(string? role, string expected)
+    {
+        Assert.Equal(expected, RunVisualization.NormalizeRole(role));
     }
 
     [Fact]
@@ -119,6 +148,16 @@ public class RunVisualizationTests
         Assert.Equal(TimeHorizon.ThisWeek, RunVisualization.GetHorizon("2026-04-23T19:00:00+00:00", now));
         Assert.Equal(TimeHorizon.NextWeek, RunVisualization.GetHorizon("2026-04-29T19:00:00+00:00", now));
         Assert.Equal(TimeHorizon.Later, RunVisualization.GetHorizon("2026-05-15T19:00:00+00:00", now));
+    }
+
+    [Fact]
+    public void GetHorizon_uses_exclusive_week_boundaries()
+    {
+        var now = new DateTimeOffset(2026, 4, 20, 12, 0, 0, TimeSpan.Zero);
+
+        Assert.Equal(TimeHorizon.ThisWeek, RunVisualization.GetHorizon("2026-04-20T12:00:00+00:00", now));
+        Assert.Equal(TimeHorizon.NextWeek, RunVisualization.GetHorizon("2026-04-27T12:00:00+00:00", now));
+        Assert.Equal(TimeHorizon.Later, RunVisualization.GetHorizon("2026-05-04T12:00:00+00:00", now));
     }
 
     [Fact]

--- a/tests/Lfm.App.Core.Tests/Services/MeClientTests.cs
+++ b/tests/Lfm.App.Core.Tests/Services/MeClientTests.cs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
 using System.Net;
+using System.Net.Http.Json;
 using Lfm.App.Services;
 using Lfm.Contracts.Characters;
 using Lfm.Contracts.Me;
@@ -94,6 +95,53 @@ public class MeClientTests
         Assert.Equal(2, handler.CallCount);
     }
 
+    [Theory]
+    [InlineData(HttpStatusCode.RequestTimeout)]
+    [InlineData(HttpStatusCode.TooManyRequests)]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    [InlineData(HttpStatusCode.BadGateway)]
+    [InlineData(HttpStatusCode.GatewayTimeout)]
+    public async Task GetAsync_retries_each_transient_status_and_returns_me_response(HttpStatusCode transientStatus)
+    {
+        var responses = new Queue<HttpResponseMessage>([
+            new HttpResponseMessage(transientStatus),
+            StubHttpMessageHandler.CreateJsonResponse(HttpStatusCode.OK, MakeMeResponse())
+        ]);
+        var (client, handler) = MakeClient(new StubHttpMessageHandler(_ => responses.Dequeue()));
+
+        var result = await client.GetAsync(CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(2, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task GetAsync_does_not_retry_non_transient_status()
+    {
+        var (client, handler) = MakeClient(new StubHttpMessageHandler(HttpStatusCode.BadRequest));
+
+        var result = await client.GetAsync(CancellationToken.None);
+
+        Assert.Null(result);
+        Assert.Equal(1, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task GetAsync_returns_null_when_retry_delay_is_canceled()
+    {
+        using var cts = new CancellationTokenSource();
+        var (client, handler) = MakeClient(new StubHttpMessageHandler(_ =>
+        {
+            cts.Cancel();
+            return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+        }));
+
+        var result = await client.GetAsync(cts.Token);
+
+        Assert.Null(result);
+        Assert.Equal(1, handler.CallCount);
+    }
+
     [Fact]
     public async Task GetAsync_does_not_retry_401()
     {
@@ -103,6 +151,60 @@ public class MeClientTests
 
         Assert.Null(result);
         Assert.Equal(1, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task GetAsync_unauthorized_clears_cached_etag_before_later_update()
+    {
+        var requests = new List<HttpRequestMessage>();
+        var getResponse = StubHttpMessageHandler.CreateJsonResponse(HttpStatusCode.OK, MakeMeResponse());
+        getResponse.Headers.TryAddWithoutValidation("ETag", "\"me-etag-v1\"");
+        var responses = new Queue<HttpResponseMessage>([
+            getResponse,
+            new HttpResponseMessage(HttpStatusCode.Unauthorized),
+            StubHttpMessageHandler.CreateJsonResponse(HttpStatusCode.OK, new UpdateMeResponse("en"))
+        ]);
+        var (client, _) = MakeClient(new StubHttpMessageHandler(request =>
+        {
+            requests.Add(request);
+            return responses.Dequeue();
+        }));
+
+        await client.GetAsync(CancellationToken.None);
+        await client.GetAsync(CancellationToken.None);
+        await client.UpdateAsync(new UpdateMeRequest("en"), CancellationToken.None);
+
+        Assert.False(requests[2].Headers.Contains("If-Match"));
+    }
+
+    [Fact]
+    public async Task GetAsync_null_json_body_clears_cached_etag()
+    {
+        var requests = new List<HttpRequestMessage>();
+        var getResponse = StubHttpMessageHandler.CreateJsonResponse(HttpStatusCode.OK, MakeMeResponse());
+        getResponse.Headers.TryAddWithoutValidation("ETag", "\"me-etag-v1\"");
+        var nullGetResponse = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create<MeResponse?>(null),
+        };
+        nullGetResponse.Headers.TryAddWithoutValidation("ETag", "\"me-etag-v2\"");
+        var responses = new Queue<HttpResponseMessage>([
+            getResponse,
+            nullGetResponse,
+            StubHttpMessageHandler.CreateJsonResponse(HttpStatusCode.OK, new UpdateMeResponse("en"))
+        ]);
+        var (client, _) = MakeClient(new StubHttpMessageHandler(request =>
+        {
+            requests.Add(request);
+            return responses.Dequeue();
+        }));
+
+        await client.GetAsync(CancellationToken.None);
+        var nullResult = await client.GetAsync(CancellationToken.None);
+        await client.UpdateAsync(new UpdateMeRequest("en"), CancellationToken.None);
+
+        Assert.Null(nullResult);
+        Assert.False(requests[2].Headers.Contains("If-Match"));
     }
 
     // ── UpdateAsync ──────────────────────────────────────────────────────────
@@ -169,6 +271,37 @@ public class MeClientTests
 
         Assert.True(requests[2].Headers.TryGetValues("If-Match", out var ifMatch));
         Assert.Equal("\"me-etag-v2\"", ifMatch!.Single());
+    }
+
+    [Fact]
+    public async Task UpdateAsync_null_json_body_clears_cached_etag()
+    {
+        var requests = new List<HttpRequestMessage>();
+        var getResponse = StubHttpMessageHandler.CreateJsonResponse(HttpStatusCode.OK, MakeMeResponse());
+        getResponse.Headers.TryAddWithoutValidation("ETag", "\"me-etag-v1\"");
+        var nullPatchResponse = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create<UpdateMeResponse?>(null),
+        };
+        nullPatchResponse.Headers.TryAddWithoutValidation("ETag", "\"me-etag-v2\"");
+        var responses = new Queue<HttpResponseMessage>([
+            getResponse,
+            nullPatchResponse,
+            StubHttpMessageHandler.CreateJsonResponse(HttpStatusCode.OK, new UpdateMeResponse("en"))
+        ]);
+        var (client, _) = MakeClient(new StubHttpMessageHandler(request =>
+        {
+            requests.Add(request);
+            return responses.Dequeue();
+        }));
+
+        await client.GetAsync(CancellationToken.None);
+        var nullResult = await client.UpdateAsync(new UpdateMeRequest("fi"), CancellationToken.None);
+        await client.UpdateAsync(new UpdateMeRequest("en"), CancellationToken.None);
+
+        Assert.Null(nullResult);
+        Assert.True(requests[1].Headers.Contains("If-Match"));
+        Assert.False(requests[2].Headers.Contains("If-Match"));
     }
 
     [Fact]
@@ -293,6 +426,17 @@ public class MeClientTests
     public async Task EnrichCharacterAsync_returns_null_on_non_success()
     {
         var (client, handler) = MakeClient(new StubHttpMessageHandler(HttpStatusCode.NotFound));
+
+        var result = await client.EnrichCharacterAsync("eu-silvermoon-sourgeezer", CancellationToken.None);
+
+        Assert.Null(result);
+        Assert.Equal(1, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task EnrichCharacterAsync_returns_null_on_HttpRequestException()
+    {
+        var (client, handler) = MakeClient(StubHttpMessageHandler.Throws(new HttpRequestException("network error")));
 
         var result = await client.EnrichCharacterAsync("eu-silvermoon-sourgeezer", CancellationToken.None);
 


### PR DESCRIPTION
## Summary
- Add focused App.Core unit tests for the #215 Stryker survivor clusters in `RunFormState`, `RunErrorParser`, `RunVisualization`, and `MeClient`.
- Cover form defaults/filtering/visibility/submit boundaries, parser malformed/problem+json fallbacks, role shortage/normalization/time boundaries, and MeClient ETag/retry/null-body/exception edges.

## Mutation triage
Baseline before this branch:
- App.Core Stryker score: 71.79%.
- 609 mutants created; 59 compile errors, 41 no coverage, 82 ignored, 427 tested.
- Target clusters: `RunFormState` 27 survived / 25 no coverage; `RunErrorParser` 13 survived / 5 no coverage; `RunVisualization` 13 survived; `MeClient` 14 survived / 4 no coverage / 2 timeout.

Final Stryker run:
- App.Core Stryker score: 88.89%.
- 609 mutants created; 59 compile errors, 11 no coverage, 82 ignored, 457 tested.
- Target clusters: `RunFormState` 84 killed / 3 survived / 0 no coverage; `RunErrorParser` 44 killed / 1 survived / 3 no coverage; `RunVisualization` 51 killed / 5 survived / 0 no coverage; `MeClient` 53 killed / 8 survived / 1 no coverage / 2 timeout.

Residual classification:
- Equivalent or low-value mutants: `RunVisualization` DPS alias/default mutants where `DPS`, `MELEE`, `RANGED`, unknown, and default all intentionally normalize to DPS; `RunFormState` `FirstOrDefault` to `First` cases after the positive option path is already established; parser fallback string/null-coalesce variants that preserve the same user-facing fallback.
- Runtime-cost or brittle mutants: `MeClient` retry-loop decrement and retry-delay arithmetic mutants time out or would require asserting sleep implementation details rather than public behavior.
- Remaining residual risk is low: the remaining no-coverage items are defensive parser/record-accessor paths and a cancellation catch-block edge around retry delay; public API outcomes are covered by the added tests.

## Verification
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `dotnet build lfm.sln -c Release`
- `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release --no-restore` (244 passed)
- `dotnet stryker --reporter json --reporter cleartext` from `tests/Lfm.App.Core.Tests` (88.89%)
- `git diff --check`

Closes #215