### PR TITLE
Allow site admin signup

### DIFF
--- a/api/Runs/RunSignupOptionsService.cs
+++ b/api/Runs/RunSignupOptionsService.cs
@@ -18,6 +18,7 @@ public sealed class RunSignupOptionsService(
     IRaidersRepository raidersRepo,
     IGuildRepository guildRepo,
     IGuildPermissions guildPermissions,
+    ISiteAdminService siteAdmin,
     IOptions<BlizzardOptions> blizzardOptions) : IRunSignupOptionsService
 {
     private readonly BlizzardOptions _blizzardOptions = blizzardOptions.Value;
@@ -37,7 +38,7 @@ public sealed class RunSignupOptionsService(
             return new RunSignupOptionsResult.NotFound("run-not-found", "Run not found.");
 
         var canSignup = await guildPermissions.CanSignupGuildRunsAsync(raider, ct);
-        if (!canSignup)
+        if (!canSignup && !await siteAdmin.IsAdminAsync(principal.BattleNetId, ct))
             return new RunSignupOptionsResult.Forbidden(
                 "guild-rank-denied",
                 "Guild signup is not enabled for your rank.");

--- a/api/Runs/RunSignupService.cs
+++ b/api/Runs/RunSignupService.cs
@@ -14,8 +14,9 @@ namespace Lfm.Api.Runs;
 /// Implements the run-signup policy: load the raider, verify character
 /// ownership, and run a read-modify-write loop with optimistic concurrency
 /// that loads the run, gates every signup on guild view + canSignupGuildRuns
-/// rank permission, upserts the <see cref="RunCharacterEntry"/> (handling the
-/// rejection-list IN->OUT default flip), and persists the document.
+/// rank permission with a site-admin override, upserts the
+/// <see cref="RunCharacterEntry"/> (handling the rejection-list IN->OUT
+/// default flip), and persists the document.
 ///
 /// Returns a <see cref="RunOperationResult"/> that the Function adapter
 /// translates to HTTP. Audit emission for the success and forbidden paths
@@ -28,6 +29,7 @@ public sealed class RunSignupService(
     IRunsRepository runsRepo,
     IRaidersRepository raidersRepo,
     IGuildPermissions guildPermissions,
+    ISiteAdminService siteAdmin,
     IRunSignupEligibility signupEligibility,
     ILogger<RunSignupService> logger) : IRunSignupService
 {
@@ -75,6 +77,7 @@ public sealed class RunSignupService(
 
         // 3. Read-modify-write loop with optimistic concurrency.
         //    On ConcurrencyConflictException the loop re-reads the run and retries.
+        bool? callerIsSiteAdmin = null;
         for (var attempt = 0; attempt < MaxAttempts; attempt++)
         {
             // 3a. Load existing run.
@@ -97,10 +100,14 @@ public sealed class RunSignupService(
             var canSignup = await guildPermissions.CanSignupGuildRunsAsync(raider, ct);
             if (!canSignup)
             {
-                return new RunOperationResult.Forbidden(
-                    "guild-rank-denied",
-                    "Guild signup is not enabled for your rank.",
-                    AuditReason: "guild rank denied");
+                callerIsSiteAdmin ??= await siteAdmin.IsAdminAsync(principal.BattleNetId, ct);
+                if (!callerIsSiteAdmin.Value)
+                {
+                    return new RunOperationResult.Forbidden(
+                        "guild-rank-denied",
+                        "Guild signup is not enabled for your rank.",
+                        AuditReason: "guild rank denied");
+                }
             }
 
             var signupCharacterInGuild = await signupEligibility.IsSignupCharacterInRunGuildAsync(

--- a/tests/Lfm.Api.Tests/Runs/RunSignupOptionsServiceTests.cs
+++ b/tests/Lfm.Api.Tests/Runs/RunSignupOptionsServiceTests.cs
@@ -111,7 +111,7 @@ public class RunSignupOptionsServiceTests
         Mock<IRaidersRepository> raidersRepo,
         Mock<IGuildRepository> guildRepo,
         Mock<IGuildPermissions> guildPermissions,
-        RunSignupOptionsService sut) MakeSut()
+        RunSignupOptionsService sut) MakeSut(bool siteAdmin = false)
     {
         var runsRepo = new Mock<IRunsRepository>();
         var raidersRepo = new Mock<IRaidersRepository>();
@@ -120,12 +120,17 @@ public class RunSignupOptionsServiceTests
         guildPermissions
             .Setup(p => p.CanSignupGuildRunsAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
+        var siteAdminService = new Mock<ISiteAdminService>();
+        siteAdminService
+            .Setup(s => s.IsAdminAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(siteAdmin);
 
         var sut = new RunSignupOptionsService(
             runsRepo.Object,
             raidersRepo.Object,
             guildRepo.Object,
             guildPermissions.Object,
+            siteAdminService.Object,
             Microsoft.Extensions.Options.Options.Create(new BlizzardOptions
             {
                 ClientId = "client",
@@ -189,6 +194,30 @@ public class RunSignupOptionsServiceTests
 
         var forbidden = Assert.IsType<RunSignupOptionsResult.Forbidden>(result);
         Assert.Equal("guild-rank-denied", forbidden.Code);
+    }
+
+    [Fact]
+    public async Task GetAsync_site_admin_bypasses_rank_signup_permission()
+    {
+        var (runsRepo, raidersRepo, guildRepo, guildPermissions, sut) = MakeSut(siteAdmin: true);
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-site-admin", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRaider(
+                battleNetId: "bnet-site-admin",
+                accountProfile: AccountProfile(),
+                refreshedAt: DateTimeOffset.UtcNow.AddMinutes(-2).ToString("o")));
+        runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRun());
+        guildPermissions
+            .Setup(p => p.CanSignupGuildRunsAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        guildRepo.Setup(r => r.GetAsync("123", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeGuild());
+
+        var result = await sut.GetAsync("run-1", MakePrincipal("bnet-site-admin"), CancellationToken.None);
+
+        var ok = Assert.IsType<RunSignupOptionsResult.Ok>(result);
+        var character = Assert.Single(ok.Options.Characters);
+        Assert.Equal("Guildmain", character.Name);
     }
 
     [Fact]

--- a/tests/Lfm.Api.Tests/Runs/RunSignupServiceTests.cs
+++ b/tests/Lfm.Api.Tests/Runs/RunSignupServiceTests.cs
@@ -97,7 +97,7 @@ public class RunSignupServiceTests
         Mock<IGuildPermissions> guildPermissions,
         Mock<IRunSignupEligibility> signupEligibility,
         Mock<ILogger<RunSignupService>> logger,
-        RunSignupService sut) MakeSut()
+        RunSignupService sut) MakeSut(bool siteAdmin = false)
     {
         var runsRepo = new Mock<IRunsRepository>();
         var raidersRepo = new Mock<IRaidersRepository>();
@@ -112,11 +112,16 @@ public class RunSignupServiceTests
                 It.IsAny<StoredSelectedCharacter>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
+        var siteAdminService = new Mock<ISiteAdminService>();
+        siteAdminService
+            .Setup(s => s.IsAdminAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(siteAdmin);
         var logger = new Mock<ILogger<RunSignupService>>();
         var sut = new RunSignupService(
             runsRepo.Object,
             raidersRepo.Object,
             guildPermissions.Object,
+            siteAdminService.Object,
             signupEligibility.Object,
             logger.Object);
         return (runsRepo, raidersRepo, guildPermissions, signupEligibility, logger, sut);
@@ -381,6 +386,33 @@ public class RunSignupServiceTests
         runsRepo.Verify(
             r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    [Fact]
+    public async Task SignupAsync_SiteAdminWithGuild_BypassesGuildRankSignupPermission()
+    {
+        var (runsRepo, raidersRepo, guildPermissions, _, _, sut) = MakeSut(siteAdmin: true);
+        var principal = MakePrincipal("bnet-site-admin");
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-site-admin", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRaider("bnet-site-admin", characterId: "char-1", guildId: 123));
+        runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeOpenRun(visibility: "GUILD", creatorGuildId: 123));
+        guildPermissions
+            .Setup(g => g.CanSignupGuildRunsAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        runsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RunDocument doc, string? _, CancellationToken _) => doc);
+
+        var result = await sut.SignupAsync(
+            "run-1",
+            MakeBody(characterId: "char-1", desiredAttendance: "IN"),
+            principal,
+            CancellationToken.None);
+
+        var ok = Assert.IsType<RunOperationResult.Ok>(result);
+        var entry = Assert.Single(ok.Run.RunCharacters);
+        Assert.Equal("bnet-site-admin", entry.RaiderBattleNetId);
+        Assert.Equal("char-1", entry.CharacterId);
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- allow site admins to bypass the guild-rank signup permission in signup options and signup submission
- keep run visibility and submitted-character guild roster checks intact
- add API service regressions for both signup options and signup submit

## Verification
- `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release`
- `dotnet build lfm.sln -c Release --no-restore`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `git diff --check`

## Env/schema changes
- None