### PR TITLE
Add performance testing lanes and evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,15 @@ jobs:
         # tighten this to 2-3 MB.
         run: ./scripts/check-bundle-size.sh ./publish/app/wwwroot 5
 
+      - name: Upload bundle size report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: bundle-size-report
+          path: ./artifacts/bundle-size
+          if-no-files-found: ignore
+          retention-days: 14
+
       - name: Audit dependencies
         shell: bash
         run: |

--- a/.github/workflows/deploy-app-build.yml
+++ b/.github/workflows/deploy-app-build.yml
@@ -85,6 +85,15 @@ jobs:
       - name: Check bundle size budget
         run: ./scripts/check-bundle-size.sh ./publish/app/wwwroot 5
 
+      - name: Upload bundle size report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: deploy-app-bundle-size-report
+          path: ./artifacts/bundle-size
+          if-no-files-found: ignore
+          retention-days: 1
+
       # dotnet publish emits `.azurefunctions/` (FunctionMetadataLoader + worker
       # extensions). upload-artifact defaults `include-hidden-files: false` on
       # purpose — setting it to true would widen the artifact to any hidden

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,6 +31,7 @@ on:
         options:
           - full
           - smoke
+          - performance
 
 permissions:
   contents: read
@@ -93,6 +94,8 @@ jobs:
           filter_args=()
           if [ "${{ github.event_name }}" = "pull_request" ] || [ "${{ inputs.lane }}" = "smoke" ]; then
             filter_args+=(--filter "Category=Smoke")
+          elif [ "${{ inputs.lane }}" = "performance" ]; then
+            filter_args+=(--filter "Category=Performance")
           fi
 
           dotnet test tests/Lfm.E2E/Lfm.E2E.csproj \

--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ Requires a running Docker engine — Testcontainers spins up Cosmos + Azurite; t
 
 Maintenance guidance: see [E2E Maintenance](docs/testing/e2e-maintenance.md)
 for lane selection, seed mutation rules, drift checks, and diagnostics
-expectations.
+expectations. Performance policy and production query guidance lives in
+[Performance Testing](docs/testing/performance.md).
 
 ## Deployment
 

--- a/docs/testing/bundle-size-baseline.json
+++ b/docs/testing/bundle-size-baseline.json
@@ -1,0 +1,49 @@
+{
+  "generatedAt": "2026-05-02T21:09:33Z",
+  "totalBrotliBytes": 3655812,
+  "budgetBytes": 5242880,
+  "assetCount": 118,
+  "assets": [
+    {
+      "path": "_framework/dotnet.native.4zyobjtzg3.wasm",
+      "brotliBytes": 977166
+    },
+    {
+      "path": "_framework/System.Private.CoreLib.67h9thw2p8.wasm",
+      "brotliBytes": 568347
+    },
+    {
+      "path": "_framework/icudt_CJK.tjcz0u77k5.dat",
+      "brotliBytes": 248840
+    },
+    {
+      "path": "_framework/icudt_no_CJK.lfu7j35m59.dat",
+      "brotliBytes": 222250
+    },
+    {
+      "path": "_framework/icudt_EFIGS.tptq2av103.dat",
+      "brotliBytes": 143983
+    },
+    {
+      "path": "_framework/Microsoft.FluentUI.AspNetCore.Components.ke65hkz4g4.wasm",
+      "brotliBytes": 141213
+    },
+    {
+      "path": "_framework/System.Text.Json.jx89emn5zu.wasm",
+      "brotliBytes": 133143
+    },
+    {
+      "path": "_framework/System.Linq.Expressions.v81oi5wpes.wasm",
+      "brotliBytes": 113422
+    },
+    {
+      "path": "_framework/Microsoft.AspNetCore.Components.78wjyfg7td.wasm",
+      "brotliBytes": 100070
+    },
+    {
+      "path": "_content/Microsoft.FluentUI.AspNetCore.Components/Microsoft.FluentUI.AspNetCore.Components.lib.module.js",
+      "brotliBytes": 74825
+    }
+  ],
+  "note": "Baseline for scripts/check-bundle-size.sh growth warnings; update only after intentional bundle changes."
+}

--- a/docs/testing/performance.md
+++ b/docs/testing/performance.md
@@ -1,0 +1,120 @@
+# Performance Testing
+
+LFM treats performance as several cheap regression signals plus production
+telemetry. Local and CI checks should catch obvious regressions before merge;
+Application Insights and future Web Vitals/RUM data remain the product truth.
+
+## Lanes
+
+| Lane | Runner | Cadence | Gate |
+|------|--------|---------|------|
+| Bundle size | `scripts/check-bundle-size.sh` after `dotnet publish app/Lfm.App.csproj -c Release` | Every CI and deploy-app build | Hard fail over 5 MB brotli; warning over 10% growth from baseline |
+| Browser journey timing | `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --filter "Category=Performance"` | Manual dispatch and local investigation | Advisory regression guard with loose budgets and JSON artifact |
+| RUM/Core Web Vitals | Issue #189 | Production once instrumented | Product truth; review percentile trends before optimization work |
+| Backend latency | API tests plus Application Insights queries below | Unit/API tests on PR; production queries during operations | Operation-count tests are hard gates; production percentiles are operational evidence |
+| Manual load/investigation | Temporary local harnesses documented here before use | Only when a regression needs diagnosis | Advisory; no always-on paid load service without an explicit cost note |
+
+Every-PR gates must stay cheap for this hobby/free-tier project. Do not add
+always-on hosted load tests or paid monitoring dependencies without discussing
+the recurring cost first.
+
+## Current Budgets
+
+| Signal | Initial budget | Meaning |
+|--------|----------------|---------|
+| Brotli bundle total | 5 MB hard budget | Regression ceiling, not a target |
+| Bundle growth | Warn above 10% over `docs/testing/bundle-size-baseline.json` | Review prompt while under the hard budget |
+| Cold public landing load | 60 seconds | Local-stack browser guard |
+| Authenticated `/runs` load | 60 seconds | Local-stack browser guard |
+| `/runs/new` form load | 45 seconds | Local-stack browser guard |
+| `/characters` list load | 45 seconds | Local-stack browser guard |
+| Warm route navigation | 20 seconds | Local-stack browser guard |
+| Backend p95/p99 | Placeholder until production baseline exists | Use the KQL below to establish normal ranges |
+
+The browser budgets intentionally allow slow CI machines and first-run WASM
+startup. Tighten them only after several clean baseline runs.
+
+## Evidence Rules
+
+- Bundle-size output is a hard build signal. The report should show total bytes,
+  top assets, baseline total, and growth percentage on every run.
+- Browser performance E2E is a regression signal. It records timing artifacts,
+  request failures, and loose budget results, but it is not a production SLO.
+- RUM/Core Web Vitals from #189 will be the source of client-side product truth.
+- Backend elapsed-ms logs and dependency telemetry are operational evidence.
+  They are not a full load test and should be read as percentiles, not anecdotes.
+- Bundle optimization belongs in #27 after RUM establishes a real-user baseline.
+
+## Feature Ownership
+
+Update performance coverage when a change adds a new user-critical journey,
+materially changes the Blazor boot path, adds large static assets, changes a hot
+API path, adds Cosmos queries, or changes reference-data lookup behavior.
+Prefer deterministic operation-count assertions for backend PR gates. Use
+wall-clock checks only where the browser is the behavior being protected.
+
+## Bundle Baseline Updates
+
+Regenerate the app publish output, run the bundle check, inspect the report, and
+commit `docs/testing/bundle-size-baseline.json` only when the growth is
+intentional.
+
+```bash
+dotnet publish app/Lfm.App.csproj -c Release -o ./publish/app
+BUNDLE_UPDATE_BASELINE=1 ./scripts/check-bundle-size.sh ./publish/app/wwwroot 5
+```
+
+## Production Queries
+
+Run these in the Application Insights or Log Analytics workspace connected to
+the production Function App. Keep alerting conservative until the normal traffic
+shape is known.
+
+API latency percentiles by function:
+
+```kusto
+traces
+| where timestamp > ago(24h)
+| where customDimensions.FunctionName != ""
+| extend elapsedMs = todouble(customDimensions.ElapsedMs)
+| where isnotnull(elapsedMs)
+| summarize count(), p50=percentile(elapsedMs, 50), p95=percentile(elapsedMs, 95), p99=percentile(elapsedMs, 99) by tostring(customDimensions.FunctionName)
+| order by p95 desc
+```
+
+Dependency duration and failures:
+
+```kusto
+dependencies
+| where timestamp > ago(24h)
+| summarize count(), failures=countif(success == false), p95=percentile(duration, 95), p99=percentile(duration, 99) by type, target, name
+| order by p95 desc
+```
+
+HTTP 429 and Retry-After signals:
+
+```kusto
+requests
+| where timestamp > ago(24h)
+| where resultCode == "429"
+| summarize count() by name, bin(timestamp, 15m)
+| order by timestamp desc
+```
+
+Web Vitals percentiles after #189:
+
+```kusto
+customMetrics
+| where timestamp > ago(24h)
+| where name in ("webvital_lcp", "webvital_inp", "webvital_cls")
+| summarize p50=percentile(value, 50), p75=percentile(value, 75), p95=percentile(value, 95) by name, bin(timestamp, 1h)
+| order by timestamp desc
+```
+
+## Alert Boundaries
+
+Page or block release only for sustained production-impacting signals: repeated
+function failures, elevated 429s, dependency failures, or p95/p99 latency that is
+both sustained and tied to user-visible errors. Treat isolated slow samples,
+manual E2E timing drift, and bundle growth warnings as advisory review signals
+unless they cross an existing hard gate.

--- a/scripts/check-bundle-size.sh
+++ b/scripts/check-bundle-size.sh
@@ -7,6 +7,9 @@ set -euo pipefail
 
 PUBLISH_DIR="${1:-./publish/app/wwwroot}"
 BUDGET_MB="${2:-2}"
+OUTPUT_DIR="${3:-./artifacts/bundle-size}"
+BASELINE_PATH="${BUNDLE_BASELINE_PATH:-docs/testing/bundle-size-baseline.json}"
+GROWTH_WARNING_PERCENT="${BUNDLE_GROWTH_WARNING_PERCENT:-10}"
 
 if [ ! -d "$PUBLISH_DIR" ]; then
   echo "FAIL: publish directory not found: $PUBLISH_DIR" >&2
@@ -18,14 +21,22 @@ if ! command -v brotli >/dev/null 2>&1; then
   exit 2
 fi
 
+if ! command -v jq >/dev/null 2>&1; then
+  echo "FAIL: jq not installed" >&2
+  exit 2
+fi
+
 # Assets SWA will serve. We measure brotli because SWA negotiates br > gzip > identity.
 mapfile -t assets < <(find "$PUBLISH_DIR" \
   -type f \( -name '*.js' -o -name '*.wasm' -o -name '*.dat' -o -name '*.dll' -o -name '*.css' -o -name '*.html' \) \
   ! -name '*.br' ! -name '*.gz' | sort)
 
 total_bytes=0
-tmp_breakdown=$(mktemp)
+mkdir -p "$OUTPUT_DIR"
+tmp_breakdown=$(mktemp "$OUTPUT_DIR/bundle-size.XXXXXX")
 trap 'rm -f "$tmp_breakdown"' EXIT
+breakdown_file="$OUTPUT_DIR/bundle-size-breakdown.txt"
+report_file="$OUTPUT_DIR/bundle-size-report.json"
 
 for asset in "${assets[@]}"; do
   if [ -f "${asset}.br" ]; then
@@ -37,14 +48,88 @@ for asset in "${assets[@]}"; do
   printf '%10d  %s\n' "$size" "${asset#"$PUBLISH_DIR"/}" >> "$tmp_breakdown"
 done
 
+sort -rn "$tmp_breakdown" > "$breakdown_file"
+
 budget_bytes=$(( BUDGET_MB * 1024 * 1024 ))
 total_mb=$(awk "BEGIN {printf \"%.2f\", $total_bytes/1024/1024}")
+baseline_bytes=""
+growth_warning=false
+growth_percent_json=null
+
+if [ -f "$BASELINE_PATH" ]; then
+  baseline_bytes=$(jq -r '.totalBrotliBytes // empty' "$BASELINE_PATH")
+  if [ -n "$baseline_bytes" ] && [ "$baseline_bytes" -gt 0 ]; then
+    threshold_bytes=$(( baseline_bytes * (100 + GROWTH_WARNING_PERCENT) / 100 ))
+    growth_percent=$(awk "BEGIN {printf \"%.1f\", (($total_bytes-$baseline_bytes)*100)/$baseline_bytes}")
+    growth_percent_json="$growth_percent"
+    if [ "$total_bytes" -gt "$threshold_bytes" ]; then
+      growth_warning=true
+    fi
+  fi
+fi
+
+baseline_bytes_json=null
+if [ -n "$baseline_bytes" ]; then
+  baseline_bytes_json="$baseline_bytes"
+fi
+
+jq -n \
+  --arg generatedAt "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+  --arg baselinePath "$BASELINE_PATH" \
+  --argjson totalBrotliBytes "$total_bytes" \
+  --argjson budgetBytes "$budget_bytes" \
+  --argjson assetCount "${#assets[@]}" \
+  --argjson baselineTotalBrotliBytes "$baseline_bytes_json" \
+  --argjson growthWarningPercent "$GROWTH_WARNING_PERCENT" \
+  --argjson growthPercent "$growth_percent_json" \
+  --argjson growthWarning "$growth_warning" \
+  --rawfile breakdown "$breakdown_file" \
+  '{
+    generatedAt: $generatedAt,
+    totalBrotliBytes: $totalBrotliBytes,
+    budgetBytes: $budgetBytes,
+    assetCount: $assetCount,
+    baselinePath: $baselinePath,
+    baselineTotalBrotliBytes: $baselineTotalBrotliBytes,
+    growthWarningPercent: $growthWarningPercent,
+    growthPercent: $growthPercent,
+    growthWarning: $growthWarning,
+    assets: (
+      $breakdown
+      | split("\n")
+      | map(select(length > 0))
+      | map(capture("^\\s*(?<brotliBytes>\\d+)\\s+(?<path>.*)$") | {path, brotliBytes: (.brotliBytes | tonumber)})
+    )
+  }' > "$report_file"
 
 echo "Total brotli bundle: ${total_mb} MB (budget: ${BUDGET_MB} MB, ${#assets[@]} assets)"
+echo "Bundle breakdown: $breakdown_file"
+echo "Bundle report: $report_file"
+
+if [ "$growth_warning" = true ]; then
+  echo "WARN: bundle is ${growth_percent}% over baseline (${baseline_bytes} bytes) with warning threshold ${GROWTH_WARNING_PERCENT}%"
+elif [ -n "$baseline_bytes" ]; then
+  echo "Bundle growth vs baseline: ${growth_percent_json}%"
+else
+  echo "Bundle baseline not found at $BASELINE_PATH; growth warning skipped"
+fi
+
+echo "Top 10 largest assets (brotli bytes):"
+head -10 "$breakdown_file"
+
+if [ "${BUNDLE_UPDATE_BASELINE:-false}" = "1" ]; then
+  jq '{
+    generatedAt,
+    totalBrotliBytes,
+    budgetBytes,
+    assetCount,
+    assets: .assets[:10],
+    note: "Baseline for scripts/check-bundle-size.sh growth warnings; update only after intentional bundle changes."
+  }' "$report_file" > "$BASELINE_PATH"
+  echo "Updated baseline: $BASELINE_PATH"
+fi
 
 if [ "$total_bytes" -gt "$budget_bytes" ]; then
   echo "FAIL: bundle exceeds ${BUDGET_MB} MB budget" >&2
-  echo "Top 10 largest assets (brotli bytes):" >&2
-  sort -rn "$tmp_breakdown" | head -10 >&2
   exit 1
 fi

--- a/tests/Lfm.Api.Tests/Runs/RunSignupOptionsServiceTests.cs
+++ b/tests/Lfm.Api.Tests/Runs/RunSignupOptionsServiceTests.cs
@@ -234,4 +234,68 @@ public class RunSignupOptionsServiceTests
         var notFound = Assert.IsType<RunSignupOptionsResult.NotFound>(result);
         Assert.Equal("run-not-found", notFound.Code);
     }
+
+    [Fact]
+    public async Task GetAsync_large_roster_uses_single_lookup_per_dependency()
+    {
+        var accountCharacters = Enumerable.Range(1, 75)
+            .Select(i => new StoredBlizzardAccountCharacter(
+                Name: $"Guildmain{i}",
+                Level: 80,
+                Realm: new StoredBlizzardRealmRef("silvermoon", "Silvermoon"),
+                PlayableClass: new StoredBlizzardNamedRef(5, "Priest")))
+            .ToArray();
+        var selectedCharacters = accountCharacters
+            .Select((character, index) => new StoredSelectedCharacter(
+                Id: $"char-{index + 1}",
+                Region: "eu",
+                Realm: character.Realm.Slug,
+                Name: character.Name,
+                GuildId: 123,
+                GuildName: "Test Guild",
+                ClassId: 5,
+                ClassName: "Priest"))
+            .ToArray();
+        var rosterMembers = accountCharacters
+            .Select(character => new StoredGuildRosterMember(
+                new StoredGuildRosterMemberCharacter(
+                    Name: character.Name,
+                    Realm: new StoredGuildRosterRealm("silvermoon")),
+                Rank: 4))
+            .ToArray();
+
+        var raider = new RaiderDocument(
+            Id: "bnet-user",
+            BattleNetId: "bnet-user",
+            SelectedCharacterId: "char-1",
+            Locale: null,
+            Characters: selectedCharacters,
+            AccountProfileSummary: new StoredBlizzardAccountProfile([
+                new StoredBlizzardWowAccount(1, accountCharacters)
+            ]),
+            AccountProfileRefreshedAt: DateTimeOffset.UtcNow.AddMinutes(-2).ToString("o"));
+        var guild = new GuildDocument(
+            Id: "123",
+            GuildId: 123,
+            RealmSlug: "silvermoon",
+            BlizzardRosterFetchedAt: DateTimeOffset.UtcNow.AddMinutes(-5).ToString("o"),
+            BlizzardRosterRaw: new StoredGuildRoster(rosterMembers));
+
+        var (runsRepo, raidersRepo, guildRepo, guildPermissions, sut) = MakeSut();
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-user", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(raider);
+        runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRun());
+        guildRepo.Setup(r => r.GetAsync("123", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(guild);
+
+        var result = await sut.GetAsync("run-1", MakePrincipal(), CancellationToken.None);
+
+        var ok = Assert.IsType<RunSignupOptionsResult.Ok>(result);
+        Assert.Equal(75, ok.Options.Characters.Count);
+        raidersRepo.Verify(r => r.GetByBattleNetIdAsync("bnet-user", It.IsAny<CancellationToken>()), Times.Once);
+        runsRepo.Verify(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()), Times.Once);
+        guildPermissions.Verify(p => p.CanSignupGuildRunsAsync(raider, It.IsAny<CancellationToken>()), Times.Once);
+        guildRepo.Verify(r => r.GetAsync("123", It.IsAny<CancellationToken>()), Times.Once);
+    }
 }

--- a/tests/Lfm.Api.Tests/RunsListFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RunsListFunctionTests.cs
@@ -339,4 +339,33 @@ public class RunsListFunctionTests
         Assert.Single(response.Items);
         Assert.Equal("next-page-token", response.ContinuationToken);
     }
+
+    [Fact]
+    public async Task Run_large_page_uses_single_raider_read_and_single_runs_query()
+    {
+        var principal = MakePrincipal(battleNetId: "bnet-1", guildId: "12345");
+        var docs = Enumerable.Range(1, 200)
+            .Select(i => MakeRunDoc(id: $"run-{i}", creatorGuildId: 12345))
+            .ToList();
+
+        var repo = new Mock<IRunsRepository>();
+        repo.Setup(r => r.ListForGuildAsync("12345", "bnet-1", 200, "page-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunsPage(docs, "page-2"));
+        var raidersRepo = new Mock<IRaidersRepository>();
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRaiderDoc("bnet-1", guildId: 12345));
+
+        var ctx = new DefaultHttpContext();
+        ctx.Request.QueryString = new Microsoft.AspNetCore.Http.QueryString("?continuationToken=page-1");
+
+        var fn = new RunsListFunction(repo.Object, raidersRepo.Object);
+        var result = await fn.Run(ctx.Request, MakeFunctionContext(principal), CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<RunsListResponse>(ok.Value);
+        Assert.Equal(200, response.Items.Count);
+        Assert.Equal("page-2", response.ContinuationToken);
+        raidersRepo.Verify(r => r.GetByBattleNetIdAsync("bnet-1", It.IsAny<CancellationToken>()), Times.Once);
+        repo.Verify(r => r.ListForGuildAsync("12345", "bnet-1", 200, "page-1", It.IsAny<CancellationToken>()), Times.Once);
+    }
 }

--- a/tests/Lfm.E2E/Infrastructure/E2ETestMetadata.cs
+++ b/tests/Lfm.E2E/Infrastructure/E2ETestMetadata.cs
@@ -11,4 +11,5 @@ public static class E2ELanes
     public const string LayoutIntegrity = "Layout integrity";
     public const string Security = "Security";
     public const string AuthFlow = "Auth flow";
+    public const string Performance = "Performance";
 }

--- a/tests/Lfm.E2E/Specs/PerformanceSpec.cs
+++ b/tests/Lfm.E2E/Specs/PerformanceSpec.cs
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Text.Json;
+using Lfm.E2E.Fixtures;
+using Lfm.E2E.Helpers;
+using Lfm.E2E.Infrastructure;
+using Lfm.E2E.Pages;
+using Lfm.E2E.Seeds;
+using Microsoft.Playwright;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Lfm.E2E.Specs;
+
+[Collection("Runs")]
+[Trait("Category", E2ELanes.Performance)]
+public class PerformanceSpec(RunsFixture fixture, ITestOutputHelper output)
+    : E2ETestBase(output), IAsyncLifetime
+{
+    private readonly List<PerformanceJourneyResult> _results = [];
+    private readonly ConcurrentQueue<string> _requestFailures = new();
+
+    public override Task InitializeAsync() => base.InitializeAsync();
+
+    public override async Task DisposeAsync()
+    {
+        WriteReport();
+        await base.DisposeAsync();
+    }
+
+    [Fact]
+    [Trait("Category", E2ELanes.Performance)]
+    public async Task Stable_journeys_emit_timing_report()
+    {
+        await MeasureColdPublicLandingAsync();
+        await MeasureAuthenticatedRoutesAsync();
+
+        Assert.All(_results, result =>
+            Assert.True(
+                result.ElapsedMs <= result.BudgetMs,
+                $"{result.Name} took {result.ElapsedMs} ms, above loose budget {result.BudgetMs} ms"));
+    }
+
+    private async Task MeasureColdPublicLandingAsync()
+    {
+        var context = await AuthHelper.AnonymousContextAsync(fixture.Stack.Browser);
+        var page = await context.NewPageAsync();
+        try
+        {
+            WatchRequestFailures(page);
+
+            await MeasureAsync(
+                "cold-public-landing",
+                TimeSpan.FromSeconds(60),
+                page,
+                async () =>
+                {
+                    await page.GotoAsync(fixture.Stack.AppBaseUrl + "/", new() { WaitUntil = WaitUntilState.NetworkIdle });
+                    await Assertions.Expect(new LandingPage(page).Heading).ToBeVisibleAsync(new() { Timeout = 15000 });
+                });
+        }
+        finally
+        {
+            await context.CloseAsync();
+        }
+    }
+
+    private async Task MeasureAuthenticatedRoutesAsync()
+    {
+        var context = await AuthHelper.AuthenticatedContextAsync(
+            fixture.Stack.Browser,
+            fixture.Stack.ApiBaseUrl,
+            fixture.Stack.AppBaseUrl);
+        var page = await context.NewPageAsync();
+        try
+        {
+            WatchRequestFailures(page);
+
+            await page.RouteAsync("**/api/v1/battlenet/character-portraits", async route =>
+            {
+                await route.FulfillAsync(new()
+                {
+                    Status = 200,
+                    ContentType = "application/json",
+                    Body = "{\"portraits\":{}}",
+                });
+            });
+
+            var runsPage = new RunsPage(page);
+            await MeasureAsync(
+                "authenticated-runs-load",
+                TimeSpan.FromSeconds(60),
+                page,
+                async () =>
+                {
+                    await runsPage.GotoAsync(fixture.Stack.AppBaseUrl);
+                    await Assertions.Expect(runsPage.CreateRunButton).ToBeVisibleAsync(new() { Timeout = 15000 });
+                    await Assertions.Expect(runsPage.RunItem(DefaultSeed.TestRunId)).ToBeVisibleAsync(new() { Timeout = 15000 });
+                });
+
+            await MeasureAsync(
+                "run-create-form-load",
+                TimeSpan.FromSeconds(45),
+                page,
+                async () =>
+                {
+                    await runsPage.NavigateToCreateRunAsync(fixture.Stack.AppBaseUrl);
+                    await Assertions.Expect(runsPage.KeyLevelInput).ToBeVisibleAsync(new() { Timeout = 15000 });
+                });
+
+            await MeasureAsync(
+                "characters-list-load",
+                TimeSpan.FromSeconds(45),
+                page,
+                async () =>
+                {
+                    var charactersPage = new CharactersPage(page);
+                    await charactersPage.GotoAsync(fixture.Stack.AppBaseUrl);
+                    await Assertions.Expect(charactersPage.Heading).ToBeVisibleAsync(new() { Timeout = 15000 });
+                });
+
+            await page.GotoAsync(fixture.Stack.AppBaseUrl + "/runs", new() { WaitUntil = WaitUntilState.NetworkIdle });
+            await MeasureAsync(
+                "warm-route-navigation",
+                TimeSpan.FromSeconds(20),
+                page,
+                async () =>
+                {
+                    await new NavBar(page).CharactersLink.ClickAsync();
+                    await Assertions.Expect(new CharactersPage(page).Heading).ToBeVisibleAsync(new() { Timeout = 15000 });
+                });
+        }
+        finally
+        {
+            await context.CloseAsync();
+        }
+    }
+
+    private async Task MeasureAsync(
+        string name,
+        TimeSpan budget,
+        IPage page,
+        Func<Task> action)
+    {
+        var beforeFailures = _requestFailures.Count;
+        var sw = Stopwatch.StartNew();
+        await action();
+        sw.Stop();
+
+        var navigationDurationMs = await ReadNavigationDurationMsAsync(page);
+        var failedRequests = _requestFailures.Skip(beforeFailures).ToArray();
+        _results.Add(new PerformanceJourneyResult(
+            name,
+            (long)sw.Elapsed.TotalMilliseconds,
+            (long)budget.TotalMilliseconds,
+            navigationDurationMs,
+            failedRequests));
+    }
+
+    private void WatchRequestFailures(IPage page)
+    {
+        page.RequestFailed += (_, request) =>
+        {
+            _requestFailures.Enqueue($"{request.Method} {request.Url} {request.Failure}");
+        };
+    }
+
+    private static async Task<double?> ReadNavigationDurationMsAsync(IPage page)
+    {
+        try
+        {
+            return await page.EvaluateAsync<double?>(
+                """
+                () => {
+                  const nav = performance.getEntriesByType("navigation").at(-1);
+                  return nav ? Math.round(nav.duration) : null;
+                }
+                """);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private void WriteReport()
+    {
+        var repoRoot = FindRepoRoot();
+        var outputDir = Path.Combine(repoRoot, "artifacts", "e2e-results");
+        Directory.CreateDirectory(outputDir);
+
+        var report = new PerformanceReport(
+            DateTimeOffset.UtcNow,
+            "Loose local-stack regression guards; production truth comes from RUM and telemetry.",
+            _results);
+
+        var path = Path.Combine(outputDir, "performance-report.json");
+        File.WriteAllText(path, JsonSerializer.Serialize(report, new JsonSerializerOptions { WriteIndented = true }));
+        Log($"[ARTIFACT] Performance report: {path}");
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir, "lfm.sln")))
+                return dir;
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new InvalidOperationException(
+            "Could not find lfm.sln walking up from " + AppContext.BaseDirectory);
+    }
+
+    private sealed record PerformanceReport(
+        DateTimeOffset GeneratedAt,
+        string BudgetPolicy,
+        IReadOnlyList<PerformanceJourneyResult> Journeys);
+
+    private sealed record PerformanceJourneyResult(
+        string Name,
+        long ElapsedMs,
+        long BudgetMs,
+        double? NavigationDurationMs,
+        IReadOnlyList<string> RequestFailures);
+}


### PR DESCRIPTION
## Summary
- Document the performance testing policy, budgets, feature ownership rules, and production KQL/alert boundaries.
- Add a manual E2E `Performance` lane that emits `artifacts/e2e-results/performance-report.json` for stable browser journeys.
- Improve the bundle-size gate with always-on breakdown/report artifacts, a committed baseline, and growth warnings below the hard 5 MB budget.
- Add deterministic backend operation-count guards for runs listing and signup option filtering hot paths.

## Verification
- `dotnet restore lfm.sln -m:1`
- `dotnet publish app/Lfm.App.csproj -c Release -o ./publish/app --no-restore`
- `BUNDLE_UPDATE_BASELINE=1 ./scripts/check-bundle-size.sh ./publish/app/wwwroot 5`
- `dotnet format lfm.sln --no-restore --severity error`
- `dotnet build lfm.sln -c Release --no-restore -p:TreatWarningsAsErrors=true`
- `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~RunsListFunctionTests|FullyQualifiedName~RunSignupOptionsServiceTests"`
- `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --no-build --filter "Category=Performance" --list-tests`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `./scripts/check-bundle-size.sh ./publish/app/wwwroot 5`
- `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release --no-build`
- `git diff --check`

Full performance E2E execution was not run locally because `func` is not installed in this environment; the project builds and the `Category=Performance` test is discoverable.

Closes #231
Closes #232
Closes #233
Closes #234
Closes #235