### PR TITLE
Fix site admin run signup

### DIFF
--- a/api/Runs/RunSignupOptionsService.cs
+++ b/api/Runs/RunSignupOptionsService.cs
@@ -33,15 +33,24 @@ public sealed class RunSignupOptionsService(
         if (run is null)
             return new RunSignupOptionsResult.NotFound("run-not-found", "Run not found.");
 
+        bool? callerIsSiteAdmin = null;
         var (callerGuildId, _) = GuildResolver.FromRaider(raider);
         if (!RunAccessPolicy.CanView(run, principal.BattleNetId, callerGuildId))
-            return new RunSignupOptionsResult.NotFound("run-not-found", "Run not found.");
+        {
+            callerIsSiteAdmin = await siteAdmin.IsAdminAsync(principal.BattleNetId, ct);
+            if (!callerIsSiteAdmin.Value)
+                return new RunSignupOptionsResult.NotFound("run-not-found", "Run not found.");
+        }
 
         var canSignup = await guildPermissions.CanSignupGuildRunsAsync(raider, ct);
-        if (!canSignup && !await siteAdmin.IsAdminAsync(principal.BattleNetId, ct))
-            return new RunSignupOptionsResult.Forbidden(
-                "guild-rank-denied",
-                "Guild signup is not enabled for your rank.");
+        if (!canSignup)
+        {
+            callerIsSiteAdmin ??= await siteAdmin.IsAdminAsync(principal.BattleNetId, ct);
+            if (!callerIsSiteAdmin.Value)
+                return new RunSignupOptionsResult.Forbidden(
+                    "guild-rank-denied",
+                    "Guild signup is not enabled for your rank.");
+        }
 
         if (!BattleNetCharactersFunction.ShouldServeCachedAccountProfile(raider))
             return new RunSignupOptionsResult.NeedsRefresh();
@@ -53,7 +62,9 @@ public sealed class RunSignupOptionsService(
             raider.Characters,
             raider.PortraitCache);
 
-        var filtered = await FilterGuildCharactersAsync(run, characters, ct);
+        var filtered = callerIsSiteAdmin == true
+            ? characters
+            : await FilterGuildCharactersAsync(run, characters, ct);
         return new RunSignupOptionsResult.Ok(new RunSignupOptionsDto(filtered));
     }
 

--- a/api/Runs/RunSignupService.cs
+++ b/api/Runs/RunSignupService.cs
@@ -13,8 +13,8 @@ namespace Lfm.Api.Runs;
 /// <summary>
 /// Implements the run-signup policy: load the raider, verify character
 /// ownership, and run a read-modify-write loop with optimistic concurrency
-/// that loads the run, gates every signup on guild view + canSignupGuildRuns
-/// rank permission with a site-admin override, upserts the
+/// that loads the run, gates every signup on guild view, canSignupGuildRuns
+/// rank permission, and roster eligibility with a site-admin override, upserts the
 /// <see cref="RunCharacterEntry"/> (handling the rejection-list IN->OUT
 /// default flip), and persists the document.
 ///
@@ -95,7 +95,11 @@ public sealed class RunSignupService(
 
             // 3c. Guild-only visibility and rank checks.
             if (!RunAccessPolicy.CanView(run, principal.BattleNetId, callerGuildId))
-                return new RunOperationResult.NotFound("run-not-found", "Run not found.");
+            {
+                callerIsSiteAdmin ??= await siteAdmin.IsAdminAsync(principal.BattleNetId, ct);
+                if (!callerIsSiteAdmin.Value)
+                    return new RunOperationResult.NotFound("run-not-found", "Run not found.");
+            }
 
             var canSignup = await guildPermissions.CanSignupGuildRunsAsync(raider, ct);
             if (!canSignup)
@@ -116,9 +120,13 @@ public sealed class RunSignupService(
                 ct);
             if (!signupCharacterInGuild)
             {
-                return new RunOperationResult.BadRequest(
-                    "character-not-in-guild",
-                    "Character is not on this guild roster.");
+                callerIsSiteAdmin ??= await siteAdmin.IsAdminAsync(principal.BattleNetId, ct);
+                if (!callerIsSiteAdmin.Value)
+                {
+                    return new RunOperationResult.BadRequest(
+                        "character-not-in-guild",
+                        "Character is not on this guild roster.");
+                }
             }
 
             // 3d. Upsert the RunCharacterEntry — one per battleNetId per run.

--- a/tests/Lfm.Api.Tests/Runs/RunSignupOptionsServiceTests.cs
+++ b/tests/Lfm.Api.Tests/Runs/RunSignupOptionsServiceTests.cs
@@ -92,7 +92,7 @@ public class RunSignupOptionsServiceTests
             Difficulty: "NORMAL",
             Size: 10);
 
-    private static GuildDocument MakeGuild() =>
+    private static GuildDocument MakeGuild(string memberName = "Guildmain") =>
         new(
             Id: "123",
             GuildId: 123,
@@ -101,7 +101,7 @@ public class RunSignupOptionsServiceTests
             BlizzardRosterRaw: new StoredGuildRoster([
                 new StoredGuildRosterMember(
                     new StoredGuildRosterMemberCharacter(
-                        Name: "Guildmain",
+                        Name: memberName,
                         Realm: new StoredGuildRosterRealm("silvermoon")),
                     Rank: 4)
             ]));
@@ -216,8 +216,67 @@ public class RunSignupOptionsServiceTests
         var result = await sut.GetAsync("run-1", MakePrincipal("bnet-site-admin"), CancellationToken.None);
 
         var ok = Assert.IsType<RunSignupOptionsResult.Ok>(result);
-        var character = Assert.Single(ok.Options.Characters);
-        Assert.Equal("Guildmain", character.Name);
+        Assert.Equal(2, ok.Options.Characters.Count);
+        Assert.Contains(ok.Options.Characters, c => c.Name == "Guildmain");
+        Assert.Contains(ok.Options.Characters, c => c.Name == "Unguildedalt");
+    }
+
+    [Fact]
+    public async Task GetAsync_site_admin_can_load_options_when_selected_character_is_not_run_guild()
+    {
+        var (runsRepo, raidersRepo, guildRepo, guildPermissions, sut) = MakeSut(siteAdmin: true);
+        var raider = MakeRaider(
+            battleNetId: "bnet-site-admin",
+            accountProfile: AccountProfile(),
+            refreshedAt: DateTimeOffset.UtcNow.AddMinutes(-2).ToString("o")) with
+        {
+            SelectedCharacterId = "char-alt",
+        };
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-site-admin", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(raider);
+        runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRun());
+        guildPermissions
+            .Setup(p => p.CanSignupGuildRunsAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        guildRepo.Setup(r => r.GetAsync("123", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeGuild());
+
+        var result = await sut.GetAsync("run-1", MakePrincipal("bnet-site-admin"), CancellationToken.None);
+
+        var ok = Assert.IsType<RunSignupOptionsResult.Ok>(result);
+        Assert.Equal(2, ok.Options.Characters.Count);
+        Assert.Contains(ok.Options.Characters, c => c.Name == "Guildmain");
+        Assert.Contains(ok.Options.Characters, c => c.Name == "Unguildedalt");
+    }
+
+    [Fact]
+    public async Task GetAsync_site_admin_gets_account_characters_when_run_guild_roster_has_no_matches()
+    {
+        var (runsRepo, raidersRepo, guildRepo, guildPermissions, sut) = MakeSut(siteAdmin: true);
+        var raider = MakeRaider(
+            battleNetId: "bnet-site-admin",
+            accountProfile: AccountProfile(),
+            refreshedAt: DateTimeOffset.UtcNow.AddMinutes(-2).ToString("o")) with
+        {
+            SelectedCharacterId = "char-alt",
+        };
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-site-admin", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(raider);
+        runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRun());
+        guildPermissions
+            .Setup(p => p.CanSignupGuildRunsAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        guildRepo.Setup(r => r.GetAsync("123", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeGuild(memberName: "Othermember"));
+
+        var result = await sut.GetAsync("run-1", MakePrincipal("bnet-site-admin"), CancellationToken.None);
+
+        var ok = Assert.IsType<RunSignupOptionsResult.Ok>(result);
+        Assert.Equal(2, ok.Options.Characters.Count);
+        Assert.Contains(ok.Options.Characters, c => c.Name == "Guildmain");
+        Assert.Contains(ok.Options.Characters, c => c.Name == "Unguildedalt");
     }
 
     [Fact]

--- a/tests/Lfm.Api.Tests/Runs/RunSignupServiceTests.cs
+++ b/tests/Lfm.Api.Tests/Runs/RunSignupServiceTests.cs
@@ -415,6 +415,92 @@ public class RunSignupServiceTests
         Assert.Equal("char-1", entry.CharacterId);
     }
 
+    [Fact]
+    public async Task SignupAsync_SiteAdminWithRosteredCharacter_BypassesSelectedCharacterVisibility()
+    {
+        var (runsRepo, raidersRepo, guildPermissions, signupEligibility, _, sut) = MakeSut(siteAdmin: true);
+        var principal = MakePrincipal("bnet-site-admin");
+        var raider = MakeRaider("bnet-site-admin", characterId: "char-run-guild", guildId: 123) with
+        {
+            SelectedCharacterId = "char-alt",
+            Characters = [
+                new StoredSelectedCharacter(
+                    Id: "char-run-guild",
+                    Region: "eu",
+                    Realm: "silvermoon",
+                    Name: "Guildmain",
+                    GuildId: 123,
+                    GuildName: "Test Guild"),
+                new StoredSelectedCharacter(
+                    Id: "char-alt",
+                    Region: "eu",
+                    Realm: "silvermoon",
+                    Name: "Unguildedalt")
+            ],
+        };
+
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-site-admin", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(raider);
+        runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeOpenRun(visibility: "GUILD", creatorGuildId: 123));
+        guildPermissions
+            .Setup(g => g.CanSignupGuildRunsAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        runsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RunDocument doc, string? _, CancellationToken _) => doc);
+
+        var result = await sut.SignupAsync(
+            "run-1",
+            MakeBody(characterId: "char-run-guild", desiredAttendance: "IN"),
+            principal,
+            CancellationToken.None);
+
+        var ok = Assert.IsType<RunOperationResult.Ok>(result);
+        var entry = Assert.Single(ok.Run.RunCharacters);
+        Assert.Equal("bnet-site-admin", entry.RaiderBattleNetId);
+        Assert.Equal("char-run-guild", entry.CharacterId);
+        signupEligibility.Verify(
+            s => s.IsSignupCharacterInRunGuildAsync(
+                It.IsAny<RunDocument>(),
+                It.Is<StoredSelectedCharacter>(c => c.Id == "char-run-guild"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SignupAsync_SiteAdmin_BypassesRosterEligibilityForOwnedCharacter()
+    {
+        var (runsRepo, raidersRepo, guildPermissions, signupEligibility, _, sut) = MakeSut(siteAdmin: true);
+        var principal = MakePrincipal("bnet-site-admin");
+        var raider = MakeRaider("bnet-site-admin", characterId: "char-alt", guildId: null);
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-site-admin", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(raider);
+        runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeOpenRun(visibility: "GUILD", creatorGuildId: 123));
+        guildPermissions
+            .Setup(g => g.CanSignupGuildRunsAsync(It.IsAny<RaiderDocument>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        signupEligibility
+            .Setup(s => s.IsSignupCharacterInRunGuildAsync(
+                It.IsAny<RunDocument>(),
+                It.Is<StoredSelectedCharacter>(c => c.Id == "char-alt"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        runsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RunDocument doc, string? _, CancellationToken _) => doc);
+
+        var result = await sut.SignupAsync(
+            "run-1",
+            MakeBody(characterId: "char-alt", desiredAttendance: "IN"),
+            principal,
+            CancellationToken.None);
+
+        var ok = Assert.IsType<RunOperationResult.Ok>(result);
+        var entry = Assert.Single(ok.Run.RunCharacters);
+        Assert.Equal("bnet-site-admin", entry.RaiderBattleNetId);
+        Assert.Equal("char-alt", entry.CharacterId);
+    }
+
     // ------------------------------------------------------------------
     // GUILD visibility — happy path: same guild + rank permission allows
     // the signup to land.


### PR DESCRIPTION
## Summary
- allow site-admin callers through run signup visibility, rank, and roster gates
- return account-owned signup options for site-admin callers instead of run-guild filtered options
- add API regressions for site-admin signup option and submit paths

## Verification
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release --no-restore` (799 passed)
- `dotnet build lfm.sln -c Release --no-restore`
- `git diff --check`