### PR TITLE
Add browser Web Vitals telemetry

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -102,7 +102,10 @@ jobs:
         env:
           API_HOSTNAME: ${{ vars.API_HOSTNAME }}
         run: |
-          jq --arg url "https://${API_HOSTNAME}" '.ApiBaseUrl = $url' \
+          jq --arg url "https://${API_HOSTNAME}" \
+            '.ApiBaseUrl = $url
+             | .Diagnostics.WebVitalsEnabled = true
+             | .Diagnostics.WebVitalsSampleRate = 1.0' \
             ./publish/app/wwwroot/appsettings.json > tmp.json \
             && mv tmp.json ./publish/app/wwwroot/appsettings.json
           rm -f ./publish/app/wwwroot/appsettings.json.br \

--- a/api/Functions/WebVitalsFunction.cs
+++ b/api/Functions/WebVitalsFunction.cs
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Text.Json;
+using Lfm.Api.Helpers;
+using Lfm.Api.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+
+namespace Lfm.Api.Functions;
+
+/// <summary>
+/// Anonymous browser diagnostics endpoint for Core Web Vitals RUM. The payload
+/// is deliberately narrow and non-identifying: no user ids, Battle.net ids,
+/// query strings, fragments, or raw URLs are accepted into telemetry.
+/// </summary>
+public sealed class WebVitalsFunction(IWebVitalsTelemetry telemetry)
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private static readonly HashSet<string> AllowedConnectionTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "slow-2g", "2g", "3g", "4g", "unknown"
+    };
+
+    private static readonly Dictionary<string, MetricPolicy> MetricPolicies = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["lcp"] = new("webvital_lcp", 600_000),
+        ["inp"] = new("webvital_inp", 600_000),
+        ["cls"] = new("webvital_cls", 100),
+        ["fcp"] = new("webvital_fcp", 600_000),
+        ["ttfb"] = new("webvital_ttfb", 600_000),
+    };
+
+    [Function("diagnostics-web-vitals")]
+    public async Task<IActionResult> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "v1/diagnostics/web-vitals")] HttpRequest req,
+        CancellationToken ct)
+    {
+        WebVitalsRequest? body;
+        try
+        {
+            body = await JsonSerializer.DeserializeAsync<WebVitalsRequest>(req.Body, JsonOptions, ct);
+        }
+        catch (JsonException)
+        {
+            return Problem.BadRequest(req.HttpContext, "invalid-body", "Request body is invalid or missing.");
+        }
+
+        if (body is null)
+            return Problem.BadRequest(req.HttpContext, "invalid-body", "Request body is invalid or missing.");
+
+        var validation = BuildMetric(body);
+        if (validation.Error is { } error)
+            return Problem.BadRequest(req.HttpContext, error.Code, error.Message);
+
+        telemetry.Track(validation.Metric!);
+        return new StatusCodeResult(StatusCodes.Status202Accepted);
+    }
+
+    private static MetricValidation BuildMetric(WebVitalsRequest body)
+    {
+        var name = body.Name?.Trim().ToLowerInvariant();
+        if (string.IsNullOrWhiteSpace(name) || !MetricPolicies.TryGetValue(name, out var policy))
+            return Error("invalid-web-vital-metric", "Web vital metric name is not supported.");
+
+        if (!body.Value.HasValue || !double.IsFinite(body.Value.Value) || body.Value.Value < 0 || body.Value.Value > policy.MaxValue)
+            return Error("invalid-web-vital-value", "Web vital metric value is outside the accepted range.");
+
+        if (IsTooLong(body.Id, 128) || IsTooLong(body.NavigationType, 32) || IsTooLong(body.EffectiveConnectionType, 16))
+            return Error("invalid-web-vital-field", "Web vital metadata field is too long.");
+
+        if (body.Viewport is { } viewport
+            && (!IsViewportDimension(viewport.Width) || !IsViewportDimension(viewport.Height)))
+        {
+            return Error("invalid-web-vital-viewport", "Web vital viewport dimensions are outside the accepted range.");
+        }
+
+        var connection = string.IsNullOrWhiteSpace(body.EffectiveConnectionType)
+            ? "unknown"
+            : body.EffectiveConnectionType.Trim().ToLowerInvariant();
+        if (!AllowedConnectionTypes.Contains(connection))
+            connection = "unknown";
+
+        var path = SanitizePath(body.Path);
+        var metric = new WebVitalsMetric(
+            MetricName: policy.TelemetryName,
+            WebVitalName: name,
+            Value: body.Value.Value,
+            Id: Truncate(body.Id, 128),
+            NavigationType: Truncate(body.NavigationType, 32),
+            Path: path,
+            ViewportWidth: body.Viewport?.Width,
+            ViewportHeight: body.Viewport?.Height,
+            EffectiveConnectionType: connection,
+            ClientTimestamp: body.Timestamp);
+
+        return new MetricValidation(metric, null);
+    }
+
+    private static string SanitizePath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return "/";
+
+        var trimmed = path.Trim();
+        var queryIndex = trimmed.IndexOfAny(['?', '#']);
+        if (queryIndex >= 0)
+            trimmed = trimmed[..queryIndex];
+
+        if (!trimmed.StartsWith('/'))
+            trimmed = "/";
+
+        return Truncate(trimmed, 256);
+    }
+
+    private static bool IsViewportDimension(int? value) => value is >= 1 and <= 10_000;
+
+    private static bool IsTooLong(string? value, int maxLength) => value?.Length > maxLength;
+
+    private static string Truncate(string? value, int maxLength)
+    {
+        var trimmed = value?.Trim() ?? string.Empty;
+        return trimmed.Length <= maxLength ? trimmed : trimmed[..maxLength];
+    }
+
+    private static MetricValidation Error(string code, string message) =>
+        new(null, new ValidationError(code, message));
+
+    private sealed record MetricPolicy(string TelemetryName, double MaxValue);
+    private sealed record MetricValidation(WebVitalsMetric? Metric, ValidationError? Error);
+    private sealed record ValidationError(string Code, string Message);
+}
+
+public sealed record WebVitalsRequest(
+    string? Name,
+    double? Value,
+    string? Id,
+    string? NavigationType,
+    string? Path,
+    WebVitalsViewport? Viewport,
+    string? EffectiveConnectionType,
+    DateTimeOffset? Timestamp);
+
+public sealed record WebVitalsViewport(int? Width, int? Height);

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -180,6 +180,7 @@ builder.Services.AddScoped<Lfm.Api.Repositories.IGuildRepository, Lfm.Api.Reposi
 builder.Services.AddSingleton<Lfm.Api.Services.ISecretResolver, Lfm.Api.Services.KeyVaultSecretResolver>();
 builder.Services.AddSingleton<Lfm.Api.Services.ISiteAdminService, Lfm.Api.Services.SiteAdminService>();
 builder.Services.AddSingleton<Lfm.Api.Services.IIdempotencyStore, Lfm.Api.Services.IdempotencyStore>();
+builder.Services.AddSingleton<Lfm.Api.Services.IWebVitalsTelemetry, Lfm.Api.Services.ApplicationInsightsWebVitalsTelemetry>();
 builder.Services.AddScoped<Lfm.Api.Services.IGuildPermissions, Lfm.Api.Services.GuildPermissions>();
 builder.Services.AddScoped<Lfm.Api.Runs.IRunCreateService, Lfm.Api.Runs.RunCreateService>();
 builder.Services.AddScoped<Lfm.Api.Runs.IRunUpdateService, Lfm.Api.Runs.RunUpdateService>();

--- a/api/Services/WebVitalsTelemetry.cs
+++ b/api/Services/WebVitalsTelemetry.cs
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.Extensions.Logging;
+
+namespace Lfm.Api.Services;
+
+public interface IWebVitalsTelemetry
+{
+    void Track(WebVitalsMetric metric);
+}
+
+public sealed record WebVitalsMetric(
+    string MetricName,
+    string WebVitalName,
+    double Value,
+    string Id,
+    string NavigationType,
+    string Path,
+    int? ViewportWidth,
+    int? ViewportHeight,
+    string EffectiveConnectionType,
+    DateTimeOffset? ClientTimestamp);
+
+public sealed class ApplicationInsightsWebVitalsTelemetry(
+    TelemetryClient telemetry,
+    ILogger<ApplicationInsightsWebVitalsTelemetry> logger) : IWebVitalsTelemetry
+{
+    public void Track(WebVitalsMetric metric)
+    {
+        var item = new MetricTelemetry(metric.MetricName, metric.Value);
+        item.Properties["webVitalName"] = metric.WebVitalName;
+        item.Properties["id"] = metric.Id;
+        item.Properties["navigationType"] = metric.NavigationType;
+        item.Properties["path"] = metric.Path;
+        item.Properties["effectiveConnectionType"] = metric.EffectiveConnectionType;
+        if (metric.ViewportWidth is { } width)
+            item.Properties["viewportWidth"] = width.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        if (metric.ViewportHeight is { } height)
+            item.Properties["viewportHeight"] = height.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        if (metric.ClientTimestamp is { } timestamp)
+            item.Properties["clientTimestamp"] = timestamp.ToString("O", System.Globalization.CultureInfo.InvariantCulture);
+
+        telemetry.TrackMetric(item);
+        logger.LogInformation(
+            "Web vital {WebVitalName} value={WebVitalValue} path={WebVitalPath}",
+            metric.WebVitalName,
+            metric.Value,
+            metric.Path);
+    }
+}

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -29,8 +29,9 @@ info:
 
     Authentication is a Battle.net OAuth 2.1 code flow that culminates in
     an encrypted session cookie. All endpoints except `/api/battlenet/login`,
-    `/api/battlenet/callback`, `/api/health`, `/api/health/ready`, and
-    `/api/privacy-contact/email` require the session cookie.
+    `/api/battlenet/callback`, `/api/health`, `/api/health/ready`,
+    `/api/privacy-contact/email`, and `/api/v1/diagnostics/web-vitals`
+    require the session cookie.
   license:
     name: AGPL-3.0-or-later
     identifier: AGPL-3.0-or-later
@@ -65,6 +66,8 @@ tags:
     description: Site-administrator-only endpoints.
   - name: Privacy
     description: Privacy-policy helper endpoints (contact email reveal).
+  - name: Diagnostics
+    description: Anonymous browser runtime diagnostics.
 
 security:
   - sessionCookie: []
@@ -275,6 +278,34 @@ paths:
               schema: { $ref: '#/components/schemas/PrivacyEmailResponse' }
         '404':
           $ref: '#/components/responses/ProblemNotFound'
+        '429':
+          $ref: '#/components/responses/ProblemTooManyRequests'
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Diagnostics
+  # ─────────────────────────────────────────────────────────────────────────
+
+  /api/v1/diagnostics/web-vitals:
+    post:
+      tags: [Diagnostics]
+      summary: Capture anonymous browser Web Vitals.
+      description: |
+        Accepts capped, non-identifying Core Web Vitals measurements from the
+        SPA and emits them to Application Insights. The API records only a
+        path without query string or fragment; user ids, Battle.net ids, and
+        raw URLs are not part of the contract.
+      operationId: postDiagnosticsWebVitals
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/WebVitalsRequest' }
+      responses:
+        '202':
+          description: Metric accepted for telemetry ingestion.
+        '400':
+          $ref: '#/components/responses/ProblemBadRequest'
         '429':
           $ref: '#/components/responses/ProblemTooManyRequests'
 
@@ -959,6 +990,50 @@ components:
       required: [email]
       properties:
         email: { type: string, format: email }
+
+    # ── Diagnostics ────────────────────────────────────────────────────────
+    WebVitalsRequest:
+      type: object
+      required: [name, value]
+      properties:
+        name:
+          type: string
+          enum: [lcp, inp, cls, fcp, ttfb]
+        value:
+          type: number
+          minimum: 0
+        id:
+          type: string
+          maxLength: 128
+        navigationType:
+          type: string
+          maxLength: 32
+        path:
+          type: string
+          description: Browser path only; query strings and fragments are stripped before telemetry.
+          maxLength: 256
+        viewport:
+          $ref: '#/components/schemas/WebVitalsViewport'
+        effectiveConnectionType:
+          type: string
+          enum: [slow-2g, 2g, 3g, 4g, unknown]
+        timestamp:
+          type: string
+          format: date-time
+      additionalProperties: false
+
+    WebVitalsViewport:
+      type: object
+      properties:
+        width:
+          type: integer
+          minimum: 1
+          maximum: 10000
+        height:
+          type: integer
+          minimum: 1
+          maximum: 10000
+      additionalProperties: false
 
     # ── Guild ─────────────────────────────────────────────────────────────
     GuildDto:

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -108,4 +108,20 @@ catch
     // Keep the ThemeService default (Dark).
 }
 
+try
+{
+    var diagnostics = builder.Configuration.GetSection("Diagnostics");
+    var endpoint = new Uri(new Uri(apiBaseUrl), "api/v1/diagnostics/web-vitals").ToString();
+    await js.InvokeVoidAsync("lfmStartWebVitals", new
+    {
+        enabled = diagnostics.GetValue("WebVitalsEnabled", false),
+        sampleRate = diagnostics.GetValue("WebVitalsSampleRate", 0.0),
+        endpoint
+    });
+}
+catch
+{
+    // Diagnostics must never block app startup.
+}
+
 await host.RunAsync();

--- a/app/wwwroot/appsettings.json
+++ b/app/wwwroot/appsettings.json
@@ -1,6 +1,10 @@
 {
   "ApiBaseUrl": "http://localhost:7183",
   "SourceRepositoryUrl": "https://github.com/lfm-org/lfm",
+  "Diagnostics": {
+    "WebVitalsEnabled": false,
+    "WebVitalsSampleRate": 0
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Warning",

--- a/app/wwwroot/index.html.template
+++ b/app/wwwroot/index.html.template
@@ -30,6 +30,7 @@
         <button type="button" class="dismiss" aria-label="Dismiss">×</button>
     </div>
     <script src="js/lfm-interop.js"></script>
+    <script src="js/web-vitals.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>
 </body>
 

--- a/app/wwwroot/js/web-vitals.js
+++ b/app/wwwroot/js/web-vitals.js
@@ -1,0 +1,131 @@
+// Minimal first-party Web Vitals RUM wrapper. It uses browser PerformanceObserver
+// APIs directly to avoid adding a package to the Blazor WASM bundle. Payloads
+// are intentionally anonymous: path only, never query string or fragment.
+window.lfmStartWebVitals = function (options) {
+    const cfg = options || {};
+    if (!cfg.enabled || !cfg.endpoint) return;
+
+    const sampleRate = Math.max(0, Math.min(1, Number(cfg.sampleRate || 0)));
+    if (sampleRate <= 0 || Math.random() > sampleRate) return;
+
+    const metricIds = {};
+    const reported = new Set();
+    let latestLcp = null;
+    let cumulativeCls = 0;
+    let maxInp = 0;
+    let fcpReported = false;
+    let ttfbReported = false;
+
+    function metricId(name) {
+        if (!metricIds[name]) {
+            metricIds[name] = `${name}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+        }
+        return metricIds[name];
+    }
+
+    function navigationType() {
+        const nav = performance.getEntriesByType("navigation")[0];
+        return (nav && nav.type) || "navigate";
+    }
+
+    function pathOnly() {
+        return window.location.pathname || "/";
+    }
+
+    function connectionType() {
+        const connection = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+        return (connection && connection.effectiveType) || "unknown";
+    }
+
+    function payload(name, value) {
+        return {
+            name,
+            value,
+            id: metricId(name),
+            navigationType: navigationType(),
+            path: pathOnly(),
+            viewport: {
+                width: window.innerWidth || document.documentElement.clientWidth || null,
+                height: window.innerHeight || document.documentElement.clientHeight || null
+            },
+            effectiveConnectionType: connectionType(),
+            timestamp: new Date().toISOString()
+        };
+    }
+
+    function post(name, value, once) {
+        if (!Number.isFinite(value) || value < 0) return;
+        if (once && reported.has(name)) return;
+        if (once) reported.add(name);
+
+        const body = JSON.stringify(payload(name, value));
+        const blob = new Blob([body], { type: "application/json" });
+        if (navigator.sendBeacon && navigator.sendBeacon(cfg.endpoint, blob)) return;
+
+        fetch(cfg.endpoint, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body,
+            keepalive: true,
+            credentials: "omit"
+        }).catch(() => {});
+    }
+
+    function observe(type, callback) {
+        if (!("PerformanceObserver" in window)) return;
+        try {
+            const observer = new PerformanceObserver((list) => {
+                list.getEntries().forEach(callback);
+            });
+            observer.observe({ type, buffered: true });
+        } catch {
+            // Unsupported metric type in this browser; skip it.
+        }
+    }
+
+    observe("largest-contentful-paint", (entry) => {
+        latestLcp = entry.startTime;
+    });
+
+    observe("layout-shift", (entry) => {
+        if (!entry.hadRecentInput) cumulativeCls += entry.value || 0;
+    });
+
+    observe("event", (entry) => {
+        if (entry.interactionId && entry.duration > maxInp) {
+            maxInp = entry.duration;
+        }
+    });
+
+    observe("paint", (entry) => {
+        if (entry.name === "first-contentful-paint") {
+            fcpReported = true;
+            post("fcp", entry.startTime, true);
+        }
+    });
+
+    function reportTtfb() {
+        if (ttfbReported) return;
+        const nav = performance.getEntriesByType("navigation")[0];
+        if (!nav) return;
+        ttfbReported = true;
+        post("ttfb", Math.max(0, nav.responseStart - nav.requestStart), true);
+    }
+
+    function flushFinalMetrics() {
+        if (latestLcp !== null) post("lcp", latestLcp, true);
+        post("cls", cumulativeCls, true);
+        if (maxInp > 0) post("inp", maxInp, true);
+        if (!fcpReported) {
+            const fcp = performance.getEntriesByName("first-contentful-paint")[0];
+            if (fcp) post("fcp", fcp.startTime, true);
+        }
+        reportTtfb();
+    }
+
+    reportTtfb();
+    document.addEventListener("visibilitychange", () => {
+        if (document.visibilityState === "hidden") flushFinalMetrics();
+    });
+    window.addEventListener("pagehide", flushFinalMetrics);
+};

--- a/tests/Lfm.Api.Tests/FunctionAuthorizationContractTests.cs
+++ b/tests/Lfm.Api.Tests/FunctionAuthorizationContractTests.cs
@@ -47,6 +47,9 @@ public class FunctionAuthorizationContractTests
         // Public privacy contact — the SPA reveals this only on user click.
         "privacy-email",
         "privacy-email-v1",
+        // Anonymous browser RUM ingestion. Payload is capped and non-identifying:
+        // no user ids, Battle.net ids, query strings, fragments, or raw URLs.
+        "diagnostics-web-vitals",
         // Catch-all OPTIONS preflight handler — short-circuited by CorsMiddleware.
         "cors-preflight",
     };

--- a/tests/Lfm.Api.Tests/WebVitalsFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/WebVitalsFunctionTests.cs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Text;
+using System.Text.Json;
+using Lfm.Api.Functions;
+using Lfm.Api.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Lfm.Api.Tests;
+
+public class WebVitalsFunctionTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private sealed class CapturingTelemetry : IWebVitalsTelemetry
+    {
+        public List<WebVitalsMetric> Metrics { get; } = [];
+        public void Track(WebVitalsMetric metric) => Metrics.Add(metric);
+    }
+
+    private static (WebVitalsFunction Function, CapturingTelemetry Telemetry) MakeFunction()
+    {
+        var telemetry = new CapturingTelemetry();
+        return (new WebVitalsFunction(telemetry), telemetry);
+    }
+
+    private static HttpRequest MakeRequest(object body)
+        => MakeRequest(JsonSerializer.Serialize(body, JsonOptions));
+
+    private static HttpRequest MakeRequest(string rawJson)
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Method = "POST";
+        ctx.Request.ContentType = "application/json";
+        ctx.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(rawJson));
+        return ctx.Request;
+    }
+
+    [Theory]
+    [InlineData("lcp", "webvital_lcp")]
+    [InlineData("inp", "webvital_inp")]
+    [InlineData("cls", "webvital_cls")]
+    public async Task Run_accepts_core_web_vitals_and_tracks_metric_name(string name, string metricName)
+    {
+        var (fn, telemetry) = MakeFunction();
+        var value = name == "cls" ? 0.123 : 123.4;
+
+        var result = await fn.Run(MakeRequest(new
+        {
+            name,
+            value,
+            id = "vital-id",
+            navigationType = "navigate",
+            path = "/runs",
+            viewport = new { width = 390, height = 844 },
+            effectiveConnectionType = "4g",
+            timestamp = DateTimeOffset.Parse("2026-05-02T22:00:00Z", System.Globalization.CultureInfo.InvariantCulture)
+        }), CancellationToken.None);
+
+        var accepted = Assert.IsType<StatusCodeResult>(result);
+        Assert.Equal(StatusCodes.Status202Accepted, accepted.StatusCode);
+        var metric = Assert.Single(telemetry.Metrics);
+        Assert.Equal(metricName, metric.MetricName);
+        Assert.Equal(name, metric.WebVitalName);
+        Assert.Equal(value, metric.Value);
+        Assert.Equal("/runs", metric.Path);
+        Assert.Equal(390, metric.ViewportWidth);
+        Assert.Equal(844, metric.ViewportHeight);
+        Assert.Equal("4g", metric.EffectiveConnectionType);
+    }
+
+    [Fact]
+    public async Task Run_strips_query_string_and_fragment_before_tracking_path()
+    {
+        var (fn, telemetry) = MakeFunction();
+
+        var result = await fn.Run(MakeRequest(new
+        {
+            name = "lcp",
+            value = 10,
+            id = "id",
+            navigationType = "navigate",
+            path = "/runs?battleNetId=secret#section",
+        }), CancellationToken.None);
+
+        Assert.IsType<StatusCodeResult>(result);
+        var metric = Assert.Single(telemetry.Metrics);
+        Assert.Equal("/runs", metric.Path);
+        Assert.DoesNotContain("secret", metric.Path);
+        Assert.DoesNotContain("?", metric.Path);
+        Assert.DoesNotContain("#", metric.Path);
+    }
+
+    [Theory]
+    [InlineData("unknown", 10, "invalid-web-vital-metric")]
+    [InlineData("lcp", -1, "invalid-web-vital-value")]
+    [InlineData("cls", 101, "invalid-web-vital-value")]
+    public async Task Run_rejects_invalid_metric_payloads(string name, double value, string errorCode)
+    {
+        var (fn, telemetry) = MakeFunction();
+
+        var result = await fn.Run(MakeRequest(new { name, value, id = "id", path = "/" }), CancellationToken.None);
+
+        var badRequest = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status400BadRequest, badRequest.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(badRequest.Value);
+        Assert.Equal($"https://github.com/lfm-org/lfm/errors#{errorCode}", problem.Type);
+        Assert.Empty(telemetry.Metrics);
+    }
+
+    [Fact]
+    public async Task Run_rejects_oversized_metadata_fields()
+    {
+        var (fn, telemetry) = MakeFunction();
+
+        var result = await fn.Run(MakeRequest(new
+        {
+            name = "lcp",
+            value = 10,
+            id = new string('x', 129),
+            path = "/"
+        }), CancellationToken.None);
+
+        var badRequest = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status400BadRequest, badRequest.StatusCode);
+        Assert.Empty(telemetry.Metrics);
+    }
+
+    [Fact]
+    public async Task Run_rejects_invalid_json_without_tracking()
+    {
+        var (fn, telemetry) = MakeFunction();
+
+        var result = await fn.Run(MakeRequest("{not json"), CancellationToken.None);
+
+        var badRequest = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status400BadRequest, badRequest.StatusCode);
+        Assert.Empty(telemetry.Metrics);
+    }
+}


### PR DESCRIPTION
## Summary
- Add anonymous `POST /api/v1/diagnostics/web-vitals` ingestion for capped LCP, INP, CLS, FCP, and TTFB measurements, with path sanitization and no user ids, Battle.net ids, query strings, fragments, or raw URLs in telemetry.
- Track accepted measurements as Application Insights metrics and document the endpoint in OpenAPI.
- Add a first-party browser `PerformanceObserver` wrapper gated by `Diagnostics` app configuration; production deploy enables the lane and sets the sample rate.

## Verification
- `dotnet restore lfm.sln -m:1`
- `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release --no-restore` (809 passed)
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --no-restore` (191 passed)
- `dotnet format lfm.sln --no-restore --severity error`
- `dotnet build lfm.sln -c Release --no-restore`
- `dotnet publish app/Lfm.App.csproj -c Release -o ./publish/app --no-build`
- `./scripts/check-bundle-size.sh ./publish/app/wwwroot 5` (3.49 MB brotli, 0.2% growth)
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `jq . app/wwwroot/appsettings.json`
- `yq eval . .github/workflows/deploy-app.yml`
- `git diff --check`

## Config / Schema
- Adds SPA config keys `Diagnostics:WebVitalsEnabled` and `Diagnostics:WebVitalsSampleRate`.
- No database schema changes.
- No new package dependency; the browser lane uses native PerformanceObserver APIs.

Fixes #189.

Follow-up lanes remain tracked in #241, #242, #243, and #244.