### PR TITLE
Harden performance E2E report

### DIFF
--- a/docs/testing/performance.md
+++ b/docs/testing/performance.md
@@ -2,15 +2,14 @@
 
 LFM treats performance as several cheap regression signals plus production
 telemetry. Local and CI checks should catch obvious regressions before merge;
-Application Insights and future Web Vitals/RUM data remain the product truth.
+Application Insights remains the operational production signal.
 
 ## Lanes
 
 | Lane | Runner | Cadence | Gate |
 |------|--------|---------|------|
 | Bundle size | `scripts/check-bundle-size.sh` after `dotnet publish app/Lfm.App.csproj -c Release` | Every CI and deploy-app build | Hard fail over 5 MB brotli; warning over 10% growth from baseline |
-| Browser journey timing | `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --filter "Category=Performance"` | Manual dispatch and local investigation | Advisory regression guard with loose budgets and JSON artifact |
-| RUM/Core Web Vitals | Issue #189 | Production once instrumented | Product truth; review percentile trends before optimization work |
+| Browser journey timing | `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --filter "Category=Performance"` | Manual dispatch and local investigation | Advisory timing guard with loose budgets; hard fail on browser/network errors |
 | Backend latency | API tests plus Application Insights queries below | Unit/API tests on PR; production queries during operations | Operation-count tests are hard gates; production percentiles are operational evidence |
 | Manual load/investigation | Temporary local harnesses documented here before use | Only when a regression needs diagnosis | Advisory; no always-on paid load service without an explicit cost note |
 
@@ -31,19 +30,27 @@ the recurring cost first.
 | Warm route navigation | 20 seconds | Local-stack browser guard |
 | Backend p95/p99 | Placeholder until production baseline exists | Use the KQL below to establish normal ranges |
 
-The browser budgets intentionally allow slow CI machines and first-run WASM
-startup. Tighten them only after several clean baseline runs.
+Browser journeys run in desktop and mobile viewport profiles and collect two
+samples per journey by default. Override locally with
+`LFM_E2E_PERFORMANCE_SAMPLES` when investigating a regression. The browser
+budgets intentionally allow slow CI machines and first-run WASM startup.
+Tighten them only after several clean baseline runs.
 
 ## Evidence Rules
 
 - Bundle-size output is a hard build signal. The report should show total bytes,
   top assets, baseline total, and growth percentage on every run.
-- Browser performance E2E is a regression signal. It records timing artifacts,
-  request failures, and loose budget results, but it is not a production SLO.
-- RUM/Core Web Vitals from #189 will be the source of client-side product truth.
+- Browser performance E2E is a regression signal. Its versioned JSON report
+  records browser metadata, viewport profile, p50/max timing, raw samples,
+  request failures, unexpected HTTP 4xx/5xx responses, and console errors. It
+  is not a production SLO.
+- Browser performance E2E fails on unexpected request failures, unexpected HTTP
+  4xx/5xx responses, and console errors unless the spec has a narrow commented
+  allowlist for the expected case.
 - Backend elapsed-ms logs and dependency telemetry are operational evidence.
   They are not a full load test and should be read as percentiles, not anecdotes.
-- Bundle optimization belongs in #27 after RUM establishes a real-user baseline.
+- Bundle optimization belongs in #27 after approved production evidence or
+  scheduled synthetic baselines establish the problem shape.
 
 ## Feature Ownership
 
@@ -98,16 +105,6 @@ requests
 | where timestamp > ago(24h)
 | where resultCode == "429"
 | summarize count() by name, bin(timestamp, 15m)
-| order by timestamp desc
-```
-
-Web Vitals percentiles after #189:
-
-```kusto
-customMetrics
-| where timestamp > ago(24h)
-| where name in ("webvital_lcp", "webvital_inp", "webvital_cls")
-| summarize p50=percentile(value, 50), p75=percentile(value, 75), p95=percentile(value, 95) by name, bin(timestamp, 1h)
 | order by timestamp desc
 ```
 

--- a/tests/Lfm.E2E/Specs/PerformanceSpec.cs
+++ b/tests/Lfm.E2E/Specs/PerformanceSpec.cs
@@ -20,8 +20,17 @@ namespace Lfm.E2E.Specs;
 public class PerformanceSpec(RunsFixture fixture, ITestOutputHelper output)
     : E2ETestBase(output), IAsyncLifetime
 {
+    private const int ReportSchemaVersion = 1;
+    private const int DefaultSampleCount = 2;
+
+    private static readonly PerformanceViewport[] Viewports =
+    [
+        new("desktop", 1366, 768),
+        new("mobile", 390, 844),
+    ];
+
     private readonly List<PerformanceJourneyResult> _results = [];
-    private readonly ConcurrentQueue<string> _requestFailures = new();
+    private readonly int _sampleCount = ReadSampleCount();
 
     public override Task InitializeAsync() => base.InitializeAsync();
 
@@ -35,103 +44,155 @@ public class PerformanceSpec(RunsFixture fixture, ITestOutputHelper output)
     [Trait("Category", E2ELanes.Performance)]
     public async Task Stable_journeys_emit_timing_report()
     {
-        await MeasureColdPublicLandingAsync();
-        await MeasureAuthenticatedRoutesAsync();
+        foreach (var viewport in Viewports)
+        {
+            await MeasureColdPublicLandingAsync(viewport);
+            await MeasureAuthenticatedRoutesAsync(viewport);
+        }
 
         Assert.All(_results, result =>
             Assert.True(
-                result.ElapsedMs <= result.BudgetMs,
-                $"{result.Name} took {result.ElapsedMs} ms, above loose budget {result.BudgetMs} ms"));
+                result.MaxElapsedMs <= result.BudgetMs,
+                $"{result.Name} [{result.Viewport.Name}] max {result.MaxElapsedMs} ms, " +
+                $"above loose budget {result.BudgetMs} ms; samples: " +
+                string.Join(", ", result.Samples.Select(sample => sample.ElapsedMs))));
+
+        var diagnosticFailures = _results
+            .SelectMany(result => result.Samples.SelectMany(sample =>
+                sample.RequestFailures
+                    .Concat(sample.HttpFailures)
+                    .Concat(sample.ConsoleErrors)
+                    .Select(failure =>
+                        $"{result.Name} [{result.Viewport.Name}] sample {sample.Sample}: " +
+                        $"{failure.Type}: {failure.Message}")))
+            .ToArray();
+
+        Assert.True(
+            diagnosticFailures.Length == 0,
+            "Performance journeys emitted unexpected browser/network failures:\n"
+            + string.Join("\n", diagnosticFailures));
     }
 
-    private async Task MeasureColdPublicLandingAsync()
+    private async Task MeasureColdPublicLandingAsync(PerformanceViewport viewport)
     {
-        var context = await AuthHelper.AnonymousContextAsync(fixture.Stack.Browser);
-        var page = await context.NewPageAsync();
-        try
+        var samples = new List<PerformanceSample>();
+        for (var i = 1; i <= _sampleCount; i++)
         {
-            WatchRequestFailures(page);
-
-            await MeasureAsync(
-                "cold-public-landing",
-                TimeSpan.FromSeconds(60),
-                page,
-                async () =>
-                {
-                    await page.GotoAsync(fixture.Stack.AppBaseUrl + "/", new() { WaitUntil = WaitUntilState.NetworkIdle });
-                    await Assertions.Expect(new LandingPage(page).Heading).ToBeVisibleAsync(new() { Timeout = 15000 });
-                });
-        }
-        finally
-        {
-            await context.CloseAsync();
-        }
-    }
-
-    private async Task MeasureAuthenticatedRoutesAsync()
-    {
-        var context = await AuthHelper.AuthenticatedContextAsync(
-            fixture.Stack.Browser,
-            fixture.Stack.ApiBaseUrl,
-            fixture.Stack.AppBaseUrl);
-        var page = await context.NewPageAsync();
-        try
-        {
-            WatchRequestFailures(page);
-
-            await page.RouteAsync("**/api/v1/battlenet/character-portraits", async route =>
+            var context = await CreateContextAsync(viewport);
+            var page = await context.NewPageAsync();
+            try
             {
-                await route.FulfillAsync(new()
-                {
-                    Status = 200,
-                    ContentType = "application/json",
-                    Body = "{\"portraits\":{}}",
-                });
-            });
+                samples.Add(await MeasureAsync(
+                    "cold-public-landing",
+                    i,
+                    TimeSpan.FromSeconds(60),
+                    page,
+                    async measuredPage =>
+                    {
+                        await measuredPage.GotoAsync(
+                            fixture.Stack.AppBaseUrl + "/",
+                            new() { WaitUntil = WaitUntilState.NetworkIdle });
+                        await Assertions.Expect(new LandingPage(measuredPage).Heading)
+                            .ToBeVisibleAsync(new() { Timeout = 15000 });
+                        await WaitForNetworkIdleAsync(measuredPage);
+                    }));
+            }
+            finally
+            {
+                await context.CloseAsync();
+            }
+        }
 
-            var runsPage = new RunsPage(page);
-            await MeasureAsync(
+        AddResult("cold-public-landing", TimeSpan.FromSeconds(60), viewport, samples);
+    }
+
+    private async Task MeasureAuthenticatedRoutesAsync(PerformanceViewport viewport)
+    {
+        var context = await CreateAuthenticatedContextAsync(viewport);
+        try
+        {
+            await MeasureAuthenticatedJourneyAsync(
+                context,
                 "authenticated-runs-load",
                 TimeSpan.FromSeconds(60),
-                page,
-                async () =>
+                viewport,
+                null,
+                async page =>
                 {
+                    var runsPage = new RunsPage(page);
                     await runsPage.GotoAsync(fixture.Stack.AppBaseUrl);
-                    await Assertions.Expect(runsPage.CreateRunButton).ToBeVisibleAsync(new() { Timeout = 15000 });
-                    await Assertions.Expect(runsPage.RunItem(DefaultSeed.TestRunId)).ToBeVisibleAsync(new() { Timeout = 15000 });
-                });
+                    await Assertions.Expect(runsPage.CreateRunButton)
+                        .ToBeVisibleAsync(new() { Timeout = 15000 });
+                    await Assertions.Expect(runsPage.RunItem(DefaultSeed.TestRunId))
+                        .ToBeVisibleAsync(new() { Timeout = 15000 });
+                    await WaitForNetworkIdleAsync(page);
+                },
+                measureRouteTransition: false);
 
-            await MeasureAsync(
+            await MeasureAuthenticatedJourneyAsync(
+                context,
                 "run-create-form-load",
                 TimeSpan.FromSeconds(45),
-                page,
-                async () =>
+                viewport,
+                null,
+                async page =>
                 {
+                    var dependencyResponses = new[]
+                    {
+                        WaitForApiResponseAsync(page, "/api/v1/guild"),
+                        WaitForApiResponseAsync(page, "/api/v1/wow/reference/expansions"),
+                        WaitForApiResponseAsync(page, "/api/v1/wow/reference/instances"),
+                    };
+                    var runsPage = new RunsPage(page);
                     await runsPage.NavigateToCreateRunAsync(fixture.Stack.AppBaseUrl);
-                    await Assertions.Expect(runsPage.KeyLevelInput).ToBeVisibleAsync(new() { Timeout = 15000 });
-                });
+                    await Assertions.Expect(runsPage.KeyLevelInput)
+                        .ToBeVisibleAsync(new() { Timeout = 15000 });
+                    await Task.WhenAll(dependencyResponses);
+                    await WaitForNetworkIdleAsync(page);
+                },
+                measureRouteTransition: false);
 
-            await MeasureAsync(
+            await MeasureAuthenticatedJourneyAsync(
+                context,
                 "characters-list-load",
                 TimeSpan.FromSeconds(45),
-                page,
-                async () =>
+                viewport,
+                null,
+                async page =>
                 {
                     var charactersPage = new CharactersPage(page);
                     await charactersPage.GotoAsync(fixture.Stack.AppBaseUrl);
-                    await Assertions.Expect(charactersPage.Heading).ToBeVisibleAsync(new() { Timeout = 15000 });
-                });
+                    await Assertions.Expect(charactersPage.Heading)
+                        .ToBeVisibleAsync(new() { Timeout = 15000 });
+                    await WaitForNetworkIdleAsync(page);
+                },
+                measureRouteTransition: false);
 
-            await page.GotoAsync(fixture.Stack.AppBaseUrl + "/runs", new() { WaitUntil = WaitUntilState.NetworkIdle });
-            await MeasureAsync(
+            await MeasureAuthenticatedJourneyAsync(
+                context,
                 "warm-route-navigation",
                 TimeSpan.FromSeconds(20),
-                page,
-                async () =>
+                viewport,
+                page => page.GotoAsync(
+                    fixture.Stack.AppBaseUrl + "/runs",
+                    new() { WaitUntil = WaitUntilState.NetworkIdle }),
+                async page =>
                 {
-                    await new NavBar(page).CharactersLink.ClickAsync();
-                    await Assertions.Expect(new CharactersPage(page).Heading).ToBeVisibleAsync(new() { Timeout = 15000 });
-                });
+                    var navBar = new NavBar(page);
+                    if (!await navBar.CharactersLink.IsVisibleAsync())
+                    {
+                        await page.GetByRole(AriaRole.Button, new() { Name = "Toggle navigation menu" })
+                            .ClickAsync();
+                        await Assertions.Expect(navBar.CharactersLink)
+                            .ToBeVisibleAsync(new() { Timeout = 5000 });
+                    }
+
+                    await navBar.CharactersLink.ClickAsync();
+                    await Assertions.Expect(new CharactersPage(page).Heading)
+                        .ToBeVisibleAsync(new() { Timeout = 15000 });
+                    await WaitForNetworkIdleAsync(page);
+                },
+                measureRouteTransition: true);
         }
         finally
         {
@@ -139,33 +200,191 @@ public class PerformanceSpec(RunsFixture fixture, ITestOutputHelper output)
         }
     }
 
-    private async Task MeasureAsync(
+    private async Task<IBrowserContext> CreateAuthenticatedContextAsync(PerformanceViewport viewport)
+    {
+        var context = await CreateContextAsync(viewport);
+        var authPage = await context.NewPageAsync();
+        try
+        {
+            await AuthHelper.AuthenticatePageAsync(
+                authPage,
+                fixture.Stack.ApiBaseUrl,
+                fixture.Stack.AppBaseUrl);
+        }
+        catch
+        {
+            await context.CloseAsync();
+            throw;
+        }
+        finally
+        {
+            await authPage.CloseAsync();
+        }
+
+        return context;
+    }
+
+    private Task<IBrowserContext> CreateContextAsync(PerformanceViewport viewport) =>
+        fixture.Stack.Browser.NewContextAsync(new()
+        {
+            ViewportSize = new()
+            {
+                Width = viewport.Width,
+                Height = viewport.Height,
+            },
+        });
+
+    private async Task MeasureAuthenticatedJourneyAsync(
+        IBrowserContext context,
         string name,
         TimeSpan budget,
-        IPage page,
-        Func<Task> action)
+        PerformanceViewport viewport,
+        Func<IPage, Task>? setup,
+        Func<IPage, Task> action,
+        bool measureRouteTransition)
     {
-        var beforeFailures = _requestFailures.Count;
+        var samples = new List<PerformanceSample>();
+        for (var i = 1; i <= _sampleCount; i++)
+        {
+            var page = await context.NewPageAsync();
+            try
+            {
+                await StubCharacterPortraitsAsync(page);
+                if (setup is not null)
+                {
+                    await setup(page);
+                    await WaitForNetworkIdleAsync(page);
+                }
+
+                samples.Add(await MeasureAsync(
+                    name,
+                    i,
+                    budget,
+                    page,
+                    action,
+                    measureRouteTransition));
+            }
+            finally
+            {
+                await page.CloseAsync();
+            }
+        }
+
+        AddResult(name, budget, viewport, samples);
+    }
+
+    private static async Task StubCharacterPortraitsAsync(IPage page)
+    {
+        await page.RouteAsync("**/api/v1/battlenet/character-portraits", async route =>
+        {
+            await route.FulfillAsync(new()
+            {
+                Status = 200,
+                ContentType = "application/json",
+                Body = "{\"portraits\":{}}",
+            });
+        });
+    }
+
+    private async Task<PerformanceSample> MeasureAsync(
+        string name,
+        int sample,
+        TimeSpan budget,
+        IPage page,
+        Func<IPage, Task> action,
+        bool measureRouteTransition = false)
+    {
+        var diagnostics = new BrowserDiagnostics(name);
+        diagnostics.Attach(page);
+
+        double? routeTransitionDurationMs = null;
+        if (measureRouteTransition)
+        {
+            await StartRouteMeasureAsync(page);
+        }
+
         var sw = Stopwatch.StartNew();
-        await action();
+        await action(page);
         sw.Stop();
 
-        var navigationDurationMs = await ReadNavigationDurationMsAsync(page);
-        var failedRequests = _requestFailures.Skip(beforeFailures).ToArray();
-        _results.Add(new PerformanceJourneyResult(
-            name,
+        if (measureRouteTransition)
+        {
+            routeTransitionDurationMs = await FinishRouteMeasureAsync(page);
+        }
+
+        var navigationDurationMs = measureRouteTransition
+            ? null
+            : await ReadNavigationDurationMsAsync(page);
+
+        return new PerformanceSample(
+            sample,
             (long)sw.Elapsed.TotalMilliseconds,
             (long)budget.TotalMilliseconds,
             navigationDurationMs,
-            failedRequests));
+            routeTransitionDurationMs,
+            diagnostics.RequestFailures.ToArray(),
+            diagnostics.HttpFailures.ToArray(),
+            diagnostics.ConsoleErrors.ToArray());
     }
 
-    private void WatchRequestFailures(IPage page)
+    private void AddResult(
+        string name,
+        TimeSpan budget,
+        PerformanceViewport viewport,
+        IReadOnlyList<PerformanceSample> samples)
     {
-        page.RequestFailed += (_, request) =>
+        var elapsedValues = samples.Select(sample => sample.ElapsedMs).ToArray();
+        var routeValues = samples
+            .Select(sample => sample.RouteTransitionDurationMs)
+            .OfType<double>()
+            .ToArray();
+        var navigationValues = samples
+            .Select(sample => sample.NavigationDurationMs)
+            .OfType<double>()
+            .ToArray();
+
+        _results.Add(new PerformanceJourneyResult(
+            name,
+            viewport,
+            (long)budget.TotalMilliseconds,
+            Percentile(elapsedValues, 50),
+            elapsedValues.Max(),
+            PercentileOrNull(navigationValues, 50),
+            MaxOrNull(navigationValues),
+            PercentileOrNull(routeValues, 50),
+            MaxOrNull(routeValues),
+            samples));
+    }
+
+    private static Task StartRouteMeasureAsync(IPage page) =>
+        page.EvaluateAsync(
+            """
+            () => {
+              performance.clearMarks("lfm-route-start");
+              performance.clearMarks("lfm-route-end");
+              performance.clearMeasures("lfm-route-transition");
+              performance.mark("lfm-route-start");
+            }
+            """);
+
+    private static async Task<double?> FinishRouteMeasureAsync(IPage page)
+    {
+        try
         {
-            _requestFailures.Enqueue($"{request.Method} {request.Url} {request.Failure}");
-        };
+            return await page.EvaluateAsync<double?>(
+                """
+                () => {
+                  performance.mark("lfm-route-end");
+                  performance.measure("lfm-route-transition", "lfm-route-start", "lfm-route-end");
+                  const measure = performance.getEntriesByName("lfm-route-transition").at(-1);
+                  return measure ? Math.round(measure.duration) : null;
+                }
+                """);
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private static async Task<double?> ReadNavigationDurationMsAsync(IPage page)
@@ -186,6 +405,218 @@ public class PerformanceSpec(RunsFixture fixture, ITestOutputHelper output)
         }
     }
 
+    private static Task WaitForNetworkIdleAsync(IPage page) =>
+        page.WaitForLoadStateAsync(
+            LoadState.NetworkIdle,
+            new() { Timeout = 10000 });
+
+    private static Task<IResponse> WaitForApiResponseAsync(IPage page, string path) =>
+        page.WaitForResponseAsync(
+            response => Uri.TryCreate(response.Url, UriKind.Absolute, out var uri)
+                && uri.AbsolutePath == path,
+            new() { Timeout = 15000 });
+
+    private static long Percentile(IReadOnlyList<long> values, int percentile)
+    {
+        if (values.Count == 0)
+            return 0;
+
+        return (long)Math.Round(Percentile(values.Select(value => (double)value).ToArray(), percentile));
+    }
+
+    private static double? PercentileOrNull(IReadOnlyList<double> values, int percentile)
+    {
+        if (values.Count == 0)
+            return null;
+
+        return Math.Round(Percentile(values, percentile));
+    }
+
+    private static double Percentile(IReadOnlyList<double> values, int percentile)
+    {
+        var sorted = values.OrderBy(value => value).ToArray();
+        var rank = (percentile / 100d) * (sorted.Length - 1);
+        var lower = (int)Math.Floor(rank);
+        var upper = (int)Math.Ceiling(rank);
+        if (lower == upper)
+            return sorted[lower];
+
+        return sorted[lower] + ((sorted[upper] - sorted[lower]) * (rank - lower));
+    }
+
+    private static double? MaxOrNull(IReadOnlyList<double> values) =>
+        values.Count == 0 ? null : Math.Round(values.Max());
+
+    private static int ReadSampleCount()
+    {
+        var value = Environment.GetEnvironmentVariable("LFM_E2E_PERFORMANCE_SAMPLES");
+        if (int.TryParse(value, out var samples))
+            return Math.Clamp(samples, DefaultSampleCount, 10);
+
+        return DefaultSampleCount;
+    }
+
+    private sealed class BrowserDiagnostics(string journey)
+    {
+        private readonly ConcurrentQueue<PerformanceDiagnostic> _requestFailures = new();
+        private readonly ConcurrentQueue<PerformanceDiagnostic> _httpFailures = new();
+        private readonly ConcurrentQueue<PerformanceDiagnostic> _consoleErrors = new();
+
+        public IReadOnlyCollection<PerformanceDiagnostic> RequestFailures => _requestFailures.ToArray();
+        public IReadOnlyCollection<PerformanceDiagnostic> HttpFailures => _httpFailures.ToArray();
+        public IReadOnlyCollection<PerformanceDiagnostic> ConsoleErrors => _consoleErrors.ToArray();
+
+        public void Attach(IPage page)
+        {
+            page.RequestFailed += (_, request) =>
+            {
+                if (IsAllowedRequestFailure(request))
+                    return;
+
+                _requestFailures.Enqueue(new(
+                    "request-failed",
+                    $"{request.Method} {request.Url} {request.Failure}"));
+            };
+
+            page.Response += (_, response) =>
+            {
+                if (response.Status < 400 || IsAllowedHttpFailure(response))
+                    return;
+
+                _httpFailures.Enqueue(new(
+                    "http",
+                    $"{response.Status} {response.Request.Method} {response.Url}"));
+            };
+
+            page.Console += (_, message) =>
+            {
+                if (message.Type != "error" || IsAllowedConsoleError(message.Text))
+                    return;
+
+                _consoleErrors.Enqueue(new("console", message.Text));
+            };
+        }
+
+        private bool IsAllowedHttpFailure(IResponse response)
+        {
+            // The anonymous landing page probes identity at startup; 401 from
+            // /api/v1/me is the expected unauthenticated contract for that page.
+            return journey == "cold-public-landing"
+                && response.Status == 401
+                && Uri.TryCreate(response.Url, UriKind.Absolute, out var uri)
+                && uri.AbsolutePath == "/api/v1/me";
+        }
+
+        private bool IsAllowedRequestFailure(IRequest request)
+        {
+            if (request.Failure?.Contains("net::ERR_ABORTED", StringComparison.OrdinalIgnoreCase) != true
+                || !Uri.TryCreate(request.Url, UriKind.Absolute, out var uri))
+            {
+                return false;
+            }
+
+            // The SPA auth-state probe can be cancelled by route transitions or
+            // context close after the page contract is visible. Completed
+            // /api/v1/me 4xx/5xx responses still go through the HTTP check.
+            if (uri.AbsolutePath == "/api/v1/me")
+                return true;
+
+            // Create-run loads reference/guild dependencies during render.
+            // Playwright can report the fetch as aborted after the form is
+            // already usable; HTTP responses on these paths are still checked.
+            return journey == "run-create-form-load"
+                && uri.AbsolutePath is "/api/v1/guild"
+                    or "/api/v1/wow/reference/expansions"
+                    or "/api/v1/wow/reference/instances";
+        }
+
+        private bool IsAllowedConsoleError(string text)
+        {
+            // Chromium can surface the same expected anonymous /api/v1/me 401
+            // fetch as a generic console error without the URL in message text.
+            return journey == "cold-public-landing"
+                && text.Contains("401", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    private sealed record PerformanceDiagnostic(string Type, string Message);
+
+    private sealed record PerformanceViewport(string Name, int Width, int Height);
+
+    private sealed record PerformanceSample(
+        int Sample,
+        long ElapsedMs,
+        long BudgetMs,
+        double? NavigationDurationMs,
+        double? RouteTransitionDurationMs,
+        IReadOnlyCollection<PerformanceDiagnostic> RequestFailures,
+        IReadOnlyCollection<PerformanceDiagnostic> HttpFailures,
+        IReadOnlyCollection<PerformanceDiagnostic> ConsoleErrors);
+
+    private sealed record PerformanceRunMetadata(
+        string StackTarget,
+        string BrowserName,
+        string BrowserVersion,
+        string? Commit,
+        string? Ref,
+        int SampleCount,
+        IReadOnlyList<PerformanceViewport> Viewports);
+
+    private sealed record PerformanceReport(
+        int SchemaVersion,
+        DateTimeOffset GeneratedAt,
+        PerformanceRunMetadata Run,
+        string BudgetPolicy,
+        IReadOnlyList<PerformanceJourneyResult> Journeys);
+
+    private sealed record PerformanceJourneyResult(
+        string Name,
+        PerformanceViewport Viewport,
+        long BudgetMs,
+        long P50ElapsedMs,
+        long MaxElapsedMs,
+        double? P50NavigationDurationMs,
+        double? MaxNavigationDurationMs,
+        double? P50RouteTransitionDurationMs,
+        double? MaxRouteTransitionDurationMs,
+        IReadOnlyList<PerformanceSample> Samples);
+
+    private PerformanceRunMetadata CreateRunMetadata()
+    {
+        return new(
+            "local-stack",
+            ReadBrowserName(fixture.Stack.Browser),
+            ReadBrowserVersion(fixture.Stack.Browser),
+            ReadFirstEnvironmentValue("GITHUB_SHA", "BUILD_SOURCEVERSION"),
+            ReadFirstEnvironmentValue("GITHUB_REF", "GITHUB_HEAD_REF", "BUILD_SOURCEBRANCH"),
+            _sampleCount,
+            Viewports);
+    }
+
+    private static string ReadBrowserName(IBrowser browser)
+    {
+        var value = browser.BrowserType.Name;
+        return string.IsNullOrWhiteSpace(value) ? "chromium" : value;
+    }
+
+    private static string ReadBrowserVersion(IBrowser browser)
+    {
+        var value = browser.Version;
+        return string.IsNullOrWhiteSpace(value) ? "unknown" : value;
+    }
+
+    private static string? ReadFirstEnvironmentValue(params string[] names)
+    {
+        foreach (var name in names)
+        {
+            var value = Environment.GetEnvironmentVariable(name);
+            if (!string.IsNullOrWhiteSpace(value))
+                return value;
+        }
+
+        return null;
+    }
+
     private void WriteReport()
     {
         var repoRoot = FindRepoRoot();
@@ -193,8 +624,10 @@ public class PerformanceSpec(RunsFixture fixture, ITestOutputHelper output)
         Directory.CreateDirectory(outputDir);
 
         var report = new PerformanceReport(
+            ReportSchemaVersion,
             DateTimeOffset.UtcNow,
-            "Loose local-stack regression guards; production truth comes from RUM and telemetry.",
+            CreateRunMetadata(),
+            "Catastrophic local-stack regression guard; timing drift remains advisory until baseline promotion.",
             _results);
 
         var path = Path.Combine(outputDir, "performance-report.json");
@@ -215,16 +648,4 @@ public class PerformanceSpec(RunsFixture fixture, ITestOutputHelper output)
         throw new InvalidOperationException(
             "Could not find lfm.sln walking up from " + AppContext.BaseDirectory);
     }
-
-    private sealed record PerformanceReport(
-        DateTimeOffset GeneratedAt,
-        string BudgetPolicy,
-        IReadOnlyList<PerformanceJourneyResult> Journeys);
-
-    private sealed record PerformanceJourneyResult(
-        string Name,
-        long ElapsedMs,
-        long BudgetMs,
-        double? NavigationDurationMs,
-        IReadOnlyList<string> RequestFailures);
 }


### PR DESCRIPTION
## Summary
- run browser performance journeys across desktop and mobile viewport profiles with repeated samples
- version `performance-report.json` and include run metadata, p50/max summaries, raw samples, and diagnostic failures
- fail performance E2E on unexpected request failures, HTTP 4xx/5xx responses, and console errors while keeping timing budgets catastrophic-only
- update performance testing docs to remove the abandoned RUM foundation and describe the local-stack signal

Closes #241.

## Verification
- `dotnet build lfm.sln -c Release`
- `dotnet build lfm.sln -c Release --no-restore`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `git diff --check`
- `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --no-build --filter Category=Performance --list-tests`
- `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --no-build --filter Category=Performance --logger "console;verbosity=normal" --results-directory ./artifacts/e2e-results`