### PR TITLE
Add performance load smoke lane

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,6 +32,7 @@ on:
           - full
           - smoke
           - performance
+          - performance-load
 
 permissions:
   contents: read
@@ -96,6 +97,8 @@ jobs:
             filter_args+=(--filter "Category=Smoke")
           elif [ "${{ inputs.lane }}" = "performance" ]; then
             filter_args+=(--filter "Category=Performance")
+          elif [ "${{ inputs.lane }}" = "performance-load" ]; then
+            filter_args+=(--filter "Category=PerformanceLoad")
           fi
 
           dotnet test tests/Lfm.E2E/Lfm.E2E.csproj \

--- a/docs/testing/performance.md
+++ b/docs/testing/performance.md
@@ -10,6 +10,7 @@ Application Insights remains the operational production signal.
 |------|--------|---------|------|
 | Bundle size | `scripts/check-bundle-size.sh` after `dotnet publish app/Lfm.App.csproj -c Release` | Every CI and deploy-app build | Hard fail over 5 MB brotli; warning over 10% growth from baseline |
 | Browser journey timing | `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --filter "Category=Performance"` | Manual dispatch and local investigation | Advisory timing guard with loose budgets; hard fail on browser/network errors |
+| Local load smoke | `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --filter "Category=PerformanceLoad"` | Manual dispatch and local investigation | Hard fail only when bounded local-stack requests exceed the explicit error threshold |
 | Backend latency | API tests plus Application Insights queries below | Unit/API tests on PR; production queries during operations | Operation-count tests are hard gates; production percentiles are operational evidence |
 | Manual load/investigation | Temporary local harnesses documented here before use | Only when a regression needs diagnosis | Advisory; no always-on paid load service without an explicit cost note |
 
@@ -36,6 +37,22 @@ samples per journey by default. Override locally with
 budgets intentionally allow slow CI machines and first-run WASM startup.
 Tighten them only after several clean baseline runs.
 
+## Local Load Smoke
+
+The `PerformanceLoad` E2E lane is a smoke probe for local-stack request health,
+not a capacity test and not a production SLO. It uses the seeded E2E stack only:
+local app host, local API container, Cosmos emulator, Azurite, and test-mode
+auth. It must not call real Battle.net or any hosted load provider.
+
+The lane keeps load bounded by code constants: low concurrency, a fixed request
+count per probe, a total request limit, a per-request timeout, and a per-probe
+timeout. Its JSON report is written to
+`artifacts/e2e-results/performance-load-report.json` and records each tested
+endpoint/journey with request count, failure count, p50, p95, max, expected
+status codes, and raw samples. Timing percentiles are evidence for comparison;
+the gate fails only when request errors or unexpected statuses exceed the
+explicit threshold.
+
 ## Evidence Rules
 
 - Bundle-size output is a hard build signal. The report should show total bytes,
@@ -47,6 +64,10 @@ Tighten them only after several clean baseline runs.
 - Browser performance E2E fails on unexpected request failures, unexpected HTTP
   4xx/5xx responses, and console errors unless the spec has a narrow commented
   allowlist for the expected case.
+- Local load smoke E2E is a request-health probe. Its versioned JSON report
+  records bounded request counts, failure counts, p50, p95, max, tested
+  endpoints/journeys, expected status codes, and raw samples. It is not a
+  capacity test and must not be used as a production SLO.
 - Backend elapsed-ms logs and dependency telemetry are operational evidence.
   They are not a full load test and should be read as percentiles, not anecdotes.
 - Bundle optimization belongs in #27 after approved production evidence or

--- a/tests/Lfm.E2E/Infrastructure/E2ETestMetadata.cs
+++ b/tests/Lfm.E2E/Infrastructure/E2ETestMetadata.cs
@@ -12,4 +12,5 @@ public static class E2ELanes
     public const string Security = "Security";
     public const string AuthFlow = "Auth flow";
     public const string Performance = "Performance";
+    public const string PerformanceLoad = "PerformanceLoad";
 }

--- a/tests/Lfm.E2E/Specs/PerformanceLoadSpec.cs
+++ b/tests/Lfm.E2E/Specs/PerformanceLoadSpec.cs
@@ -1,0 +1,338 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Diagnostics;
+using System.Net;
+using System.Text.Json;
+using Lfm.E2E.Fixtures;
+using Lfm.E2E.Infrastructure;
+using Lfm.E2E.Seeds;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Lfm.E2E.Specs;
+
+[Collection("Runs")]
+[Trait("Category", E2ELanes.PerformanceLoad)]
+public sealed class PerformanceLoadSpec(RunsFixture fixture, ITestOutputHelper output)
+{
+    private const int ReportSchemaVersion = 1;
+    private const int Concurrency = 2;
+    private const int RequestsPerProbe = 6;
+    private const int AllowedFailureThreshold = 0;
+
+    private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(20);
+    private static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(10);
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    [Fact]
+    [Trait("Category", E2ELanes.PerformanceLoad)]
+    public async Task Local_stack_smoke_load_probe_reports_request_health()
+    {
+        using var anonymousHandler = new HttpClientHandler();
+        using var anonymousClient = new HttpClient(anonymousHandler);
+        using var authenticatedHandler = new HttpClientHandler
+        {
+            AllowAutoRedirect = false,
+            CookieContainer = new CookieContainer(),
+            UseCookies = true,
+        };
+        using var authenticatedClient = new HttpClient(authenticatedHandler);
+
+        await AuthenticateAsync(authenticatedClient, authenticatedHandler.CookieContainer);
+
+        var appBaseUri = new Uri(fixture.Stack.AppBaseUrl);
+        var apiBaseUri = new Uri(fixture.Stack.ApiBaseUrl);
+        var probes = new[]
+        {
+            new LoadProbe(
+                "public-landing",
+                "anonymous public landing static host",
+                anonymousClient,
+                HttpMethod.Get,
+                new Uri(appBaseUri, "/"),
+                [200]),
+            new LoadProbe(
+                "api-live-health",
+                "anonymous API live health",
+                anonymousClient,
+                HttpMethod.Get,
+                new Uri(apiBaseUri, "/api/health"),
+                [200]),
+            new LoadProbe(
+                "api-ready-health",
+                "anonymous API readiness",
+                anonymousClient,
+                HttpMethod.Get,
+                new Uri(apiBaseUri, "/api/health/ready"),
+                [200]),
+            new LoadProbe(
+                "authenticated-runs-api",
+                "authenticated runs list",
+                authenticatedClient,
+                HttpMethod.Get,
+                new Uri(apiBaseUri, "/api/v1/runs"),
+                [200]),
+            new LoadProbe(
+                "run-create-guild-dependency",
+                "authenticated create-run guild dependency",
+                authenticatedClient,
+                HttpMethod.Get,
+                new Uri(apiBaseUri, "/api/v1/guild"),
+                [200]),
+            new LoadProbe(
+                "run-create-expansions-dependency",
+                "authenticated create-run expansions dependency",
+                authenticatedClient,
+                HttpMethod.Get,
+                new Uri(apiBaseUri, "/api/v1/wow/reference/expansions"),
+                [200]),
+            new LoadProbe(
+                "run-create-instances-dependency",
+                "authenticated create-run instances dependency",
+                authenticatedClient,
+                HttpMethod.Get,
+                new Uri(apiBaseUri, "/api/v1/wow/reference/instances"),
+                [200]),
+            new LoadProbe(
+                "characters-list-api",
+                "authenticated cached characters list",
+                authenticatedClient,
+                HttpMethod.Get,
+                new Uri(apiBaseUri, "/api/v1/battlenet/characters"),
+                [200]),
+            new LoadProbe(
+                "signup-options-api",
+                "authenticated seeded run signup options",
+                authenticatedClient,
+                HttpMethod.Get,
+                new Uri(apiBaseUri, $"/api/v1/runs/{DefaultSeed.TestRunId}/signup/options"),
+                [200, 204]),
+        };
+
+        var probeReports = new List<ProbeReport>();
+        foreach (var probe in probes)
+        {
+            var report = await RunProbeAsync(probe);
+            probeReports.Add(report);
+            output.WriteLine(
+                $"[PERFLOAD] {report.Name}: requests={report.RequestCount}, failures={report.FailureCount}, " +
+                $"p50={report.P50Ms}ms, p95={report.P95Ms}ms, max={report.MaxMs}ms");
+        }
+
+        var loadReport = new PerformanceLoadReport(
+            ReportSchemaVersion,
+            DateTimeOffset.UtcNow,
+            new LoadRunMetadata(
+                "local-stack",
+                Concurrency,
+                RequestsPerProbe,
+                RequestsPerProbe * probes.Length,
+                (long)ProbeTimeout.TotalMilliseconds,
+                (long)RequestTimeout.TotalMilliseconds,
+                AllowedFailureThreshold,
+                "Fails on request errors/status mismatches only; timing percentiles are report evidence, not budgets."),
+            probeReports);
+
+        var reportPath = WriteReport(loadReport);
+        output.WriteLine($"[ARTIFACT] Performance load report: {reportPath}");
+
+        var failures = probeReports
+            .Where(report => report.FailureCount > AllowedFailureThreshold)
+            .Select(report =>
+                $"{report.Name} had {report.FailureCount} failures over explicit threshold " +
+                $"{AllowedFailureThreshold}: " +
+                string.Join("; ", report.Samples.Where(sample => !sample.Success)
+                    .Select(sample => sample.Error ?? $"{sample.StatusCode} {sample.StatusDescription}")))
+            .ToArray();
+
+        Assert.True(
+            failures.Length == 0,
+            "Performance load smoke probe exceeded request-failure threshold:\n" +
+            string.Join("\n", failures));
+    }
+
+    private async Task AuthenticateAsync(HttpClient client, CookieContainer cookies)
+    {
+        var apiBaseUri = new Uri(fixture.Stack.ApiBaseUrl);
+        var loginUri = new Uri(
+            apiBaseUri,
+            "/api/e2e/login"
+            + $"?battleNetId={Uri.EscapeDataString(DefaultSeed.PrimaryBattleNetId)}"
+            + $"&redirect={Uri.EscapeDataString("/runs")}");
+
+        using var response = await client.GetAsync(loginUri);
+        Assert.True(
+            response.StatusCode is HttpStatusCode.Redirect or HttpStatusCode.RedirectKeepVerb,
+            $"Expected E2E login redirect but got {(int)response.StatusCode} {response.ReasonPhrase}");
+
+        var authCookies = cookies.GetCookies(apiBaseUri);
+        Assert.Contains(authCookies.Cast<Cookie>(), cookie => cookie.Name == "battlenet_token");
+    }
+
+    private static async Task<ProbeReport> RunProbeAsync(LoadProbe probe)
+    {
+        using var probeTimeout = new CancellationTokenSource(ProbeTimeout);
+        using var gate = new SemaphoreSlim(Concurrency, Concurrency);
+
+        var tasks = Enumerable.Range(1, RequestsPerProbe)
+            .Select(index => RunSampleAsync(probe, index, gate, probeTimeout.Token))
+            .ToArray();
+
+        var samples = await Task.WhenAll(tasks);
+        var elapsed = samples.Select(sample => sample.ElapsedMs).ToArray();
+
+        return new ProbeReport(
+            probe.Name,
+            probe.Journey,
+            probe.Method.Method,
+            probe.Url.AbsolutePath,
+            probe.Url.GetLeftPart(UriPartial.Authority),
+            probe.ExpectedStatusCodes,
+            samples.Length,
+            samples.Count(sample => !sample.Success),
+            Percentile(elapsed, 50),
+            Percentile(elapsed, 95),
+            elapsed.Max(),
+            samples);
+    }
+
+    private static async Task<LoadSample> RunSampleAsync(
+        LoadProbe probe,
+        int sequence,
+        SemaphoreSlim gate,
+        CancellationToken probeCancellationToken)
+    {
+        await gate.WaitAsync(probeCancellationToken);
+        try
+        {
+            using var requestTimeout = CancellationTokenSource.CreateLinkedTokenSource(probeCancellationToken);
+            requestTimeout.CancelAfter(RequestTimeout);
+
+            var sw = Stopwatch.StartNew();
+            try
+            {
+                using var request = new HttpRequestMessage(probe.Method, probe.Url);
+                using var response = await probe.Client.SendAsync(
+                    request,
+                    HttpCompletionOption.ResponseHeadersRead,
+                    requestTimeout.Token);
+                var body = await response.Content.ReadAsByteArrayAsync(requestTimeout.Token);
+                sw.Stop();
+
+                var statusCode = (int)response.StatusCode;
+                return new LoadSample(
+                    sequence,
+                    (long)sw.Elapsed.TotalMilliseconds,
+                    statusCode,
+                    response.ReasonPhrase,
+                    body.Length,
+                    probe.ExpectedStatusCodes.Contains(statusCode),
+                    null);
+            }
+            catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)
+            {
+                sw.Stop();
+                return new LoadSample(
+                    sequence,
+                    (long)sw.Elapsed.TotalMilliseconds,
+                    null,
+                    null,
+                    null,
+                    false,
+                    ex.Message);
+            }
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    private static string WriteReport(PerformanceLoadReport report)
+    {
+        var repoRoot = FindRepoRoot();
+        var outputDir = Path.Combine(repoRoot, "artifacts", "e2e-results");
+        Directory.CreateDirectory(outputDir);
+
+        var path = Path.Combine(outputDir, "performance-load-report.json");
+        File.WriteAllText(path, JsonSerializer.Serialize(report, JsonOptions));
+        return path;
+    }
+
+    private static long Percentile(IReadOnlyList<long> values, int percentile)
+    {
+        if (values.Count == 0)
+            return 0;
+
+        var sorted = values.OrderBy(value => value).ToArray();
+        var rank = (percentile / 100d) * (sorted.Length - 1);
+        var lower = (int)Math.Floor(rank);
+        var upper = (int)Math.Ceiling(rank);
+        if (lower == upper)
+            return sorted[lower];
+
+        return (long)Math.Round(sorted[lower] + ((sorted[upper] - sorted[lower]) * (rank - lower)));
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir, "lfm.sln")))
+                return dir;
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new InvalidOperationException(
+            "Could not find lfm.sln walking up from " + AppContext.BaseDirectory);
+    }
+
+    private sealed record LoadProbe(
+        string Name,
+        string Journey,
+        HttpClient Client,
+        HttpMethod Method,
+        Uri Url,
+        int[] ExpectedStatusCodes);
+
+    private sealed record PerformanceLoadReport(
+        int SchemaVersion,
+        DateTimeOffset GeneratedAt,
+        LoadRunMetadata Run,
+        IReadOnlyList<ProbeReport> Probes);
+
+    private sealed record LoadRunMetadata(
+        string StackTarget,
+        int Concurrency,
+        int RequestsPerProbe,
+        int TotalRequestLimit,
+        long ProbeTimeoutMs,
+        long RequestTimeoutMs,
+        int AllowedFailureThreshold,
+        string GatePolicy);
+
+    private sealed record ProbeReport(
+        string Name,
+        string Journey,
+        string Method,
+        string Endpoint,
+        string Origin,
+        IReadOnlyList<int> ExpectedStatusCodes,
+        int RequestCount,
+        int FailureCount,
+        long P50Ms,
+        long P95Ms,
+        long MaxMs,
+        IReadOnlyList<LoadSample> Samples);
+
+    private sealed record LoadSample(
+        int Sequence,
+        long ElapsedMs,
+        int? StatusCode,
+        string? StatusDescription,
+        int? ResponseBytes,
+        bool Success,
+        string? Error);
+}


### PR DESCRIPTION
## Summary
- Add a `PerformanceLoad` E2E category with a bounded local-stack smoke load probe.
- Emit `artifacts/e2e-results/performance-load-report.json` with request counts, failures, p50, p95, max, endpoints/journeys, and raw samples.
- Wire the lane into manual E2E workflow dispatch and document that it is smoke-load only, not a capacity test or production SLO.

## Verification
- `dotnet build lfm.sln -c Release`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `git diff --check`
- `yq eval '.' .github/workflows/e2e.yml`
- `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --no-build --filter "Category=PerformanceLoad" --list-tests`
- `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --no-build --filter "Category=PerformanceLoad" --logger "console;verbosity=normal" --results-directory ./artifacts/e2e-results`

Closes #242