### PR TITLE
Add scheduled synthetic performance workflow

### DIFF
--- a/.github/workflows/performance-synthetic.yml
+++ b/.github/workflows/performance-synthetic.yml
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 LFM contributors
+
+name: Performance Synthetic
+
+on:
+  schedule:
+    - cron: '17 3 * * *'   # 03:17 UTC daily - off-hours, low-frequency baseline sample
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: performance-synthetic
+  cancel-in-progress: false
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  NUGET_XMLDOC_MODE: skip
+  PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/ms-playwright
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-dotnet-cached
+
+      - name: Install Azure Functions Core Tools
+        run: |
+          curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
+          sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
+          sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-$(lsb_release -cs)-prod $(lsb_release -cs) main" > /etc/apt/sources.list.d/dotnetdev.list'
+          sudo apt-get update
+          sudo apt-get install -y azure-functions-core-tools-4
+
+      - name: Restore
+        run: dotnet restore lfm.sln -m:1
+
+      - name: Build
+        run: dotnet build lfm.sln -c Release --no-restore
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
+          key: playwright-dotnet-${{ runner.os }}-${{ hashFiles('**/packages.lock.json', '**/*.csproj') }}
+          restore-keys: playwright-dotnet-${{ runner.os }}-
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pwsh tests/Lfm.E2E/bin/Release/net10.0/playwright.ps1 install --with-deps chromium
+
+      - name: Install Playwright system deps (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pwsh tests/Lfm.E2E/bin/Release/net10.0/playwright.ps1 install-deps chromium
+
+      - name: Run local-stack performance lanes
+        run: |
+          dotnet test tests/Lfm.E2E/Lfm.E2E.csproj \
+            -c Release --no-build \
+            --filter "Category=Performance|Category=PerformanceLoad" \
+            --logger "trx;LogFileName=performance-synthetic.trx" \
+            --logger "console;verbosity=normal" \
+            --results-directory ./artifacts/e2e-results
+
+      - name: Run anonymous production synthetic checks
+        if: always()
+        env:
+          FRONTEND_HOSTNAME: ${{ vars.FRONTEND_HOSTNAME }}
+          API_HOSTNAME: ${{ vars.API_HOSTNAME }}
+          SYNTHETIC_OUTPUT: artifacts/production-synthetic/production-synthetic-report.json
+          SYNTHETIC_TIMEOUT_SECONDS: 10
+        run: bash ./scripts/production-synthetic-check.sh
+
+      - name: Upload performance reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: performance-synthetic-reports
+          path: |
+            ./artifacts/e2e-results/performance-report.json
+            ./artifacts/e2e-results/performance-load-report.json
+            ./artifacts/e2e-results/performance-synthetic.trx
+            ./artifacts/production-synthetic/production-synthetic-report.json
+          if-no-files-found: ignore
+          retention-days: 30

--- a/docs/testing/performance.md
+++ b/docs/testing/performance.md
@@ -11,6 +11,7 @@ Application Insights remains the operational production signal.
 | Bundle size | `scripts/check-bundle-size.sh` after `dotnet publish app/Lfm.App.csproj -c Release` | Every CI and deploy-app build | Hard fail over 5 MB brotli; warning over 10% growth from baseline |
 | Browser journey timing | `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --filter "Category=Performance"` | Manual dispatch and local investigation | Advisory timing guard with loose budgets; hard fail on browser/network errors |
 | Local load smoke | `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --filter "Category=PerformanceLoad"` | Manual dispatch and local investigation | Hard fail only when bounded local-stack requests exceed the explicit error threshold |
+| Scheduled synthetic | `.github/workflows/performance-synthetic.yml` | Daily at 03:17 UTC and manual dispatch | Visible workflow status; not wired into PR, deploy, or release blocking |
 | Backend latency | API tests plus Application Insights queries below | Unit/API tests on PR; production queries during operations | Operation-count tests are hard gates; production percentiles are operational evidence |
 | Manual load/investigation | Temporary local harnesses documented here before use | Only when a regression needs diagnosis | Advisory; no always-on paid load service without an explicit cost note |
 
@@ -53,6 +54,26 @@ status codes, and raw samples. Timing percentiles are evidence for comparison;
 the gate fails only when request errors or unexpected statuses exceed the
 explicit threshold.
 
+## Scheduled Synthetic Collection
+
+`Performance Synthetic` runs once per day at 03:17 UTC and can also be started
+manually from GitHub Actions. It runs the local-stack `Performance` and
+`PerformanceLoad` E2E categories in one test invocation, then performs three
+anonymous production GET checks: the public frontend root, `/api/health`, and
+`/api/v1/health`.
+
+The workflow uploads `performance-synthetic-reports` for 30 days. The artifact
+contains the browser timing report, load-smoke report, TRX result, and
+production synthetic report when those files are available. Daily runner cost is
+capped by a 45-minute timeout and is expected to stay in the same range as a
+manual performance E2E run; production checks add only three anonymous requests
+with a 10-second per-request timeout.
+
+Scheduled synthetic failures are intentionally visible in their own workflow
+status but initially non-blocking for deploys, releases, and PR smoke E2E. Do
+not add authenticated production flows or managed test credentials here without
+a separate approved issue.
+
 ## Evidence Rules
 
 - Bundle-size output is a hard build signal. The report should show total bytes,
@@ -68,6 +89,9 @@ explicit threshold.
   records bounded request counts, failure counts, p50, p95, max, tested
   endpoints/journeys, expected status codes, and raw samples. It is not a
   capacity test and must not be used as a production SLO.
+- Scheduled synthetic production checks are anonymous availability probes only.
+  They collect a small JSON report and must stay low-volume, unauthenticated,
+  and outside PR/deploy blocking until a separate issue promotes the signal.
 - Backend elapsed-ms logs and dependency telemetry are operational evidence.
   They are not a full load test and should be read as percentiles, not anecdotes.
 - Bundle optimization belongs in #27 after approved production evidence or

--- a/scripts/production-synthetic-check.sh
+++ b/scripts/production-synthetic-check.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 LFM contributors
+#
+# Runs low-volume anonymous production synthetic checks and writes a JSON report.
+# Intended for scheduled performance evidence, not load testing.
+
+set -euo pipefail
+
+timeout_seconds="${SYNTHETIC_TIMEOUT_SECONDS:-10}"
+output_path="${SYNTHETIC_OUTPUT:-artifacts/production-synthetic/production-synthetic-report.json}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "FAIL: jq is required to write the synthetic report." >&2
+  exit 2
+fi
+
+case "$timeout_seconds" in
+  ''|*[!0-9]*)
+    echo "FAIL: SYNTHETIC_TIMEOUT_SECONDS must be an integer." >&2
+    exit 2
+    ;;
+esac
+
+normalize_base_url() {
+  local value="${1%/}"
+  if [[ "$value" == http://* || "$value" == https://* ]]; then
+    printf '%s' "$value"
+  else
+    printf 'https://%s' "$value"
+  fi
+}
+
+frontend_base_url="${FRONTEND_BASE_URL:-}"
+api_base_url="${API_BASE_URL:-}"
+
+if [ -z "$frontend_base_url" ]; then
+  frontend_host="${FRONTEND_HOSTNAME:-}"
+  if [ -z "$frontend_host" ]; then
+    echo "FAIL: set FRONTEND_BASE_URL or FRONTEND_HOSTNAME." >&2
+    exit 2
+  fi
+  frontend_base_url="$(normalize_base_url "$frontend_host")"
+else
+  frontend_base_url="$(normalize_base_url "$frontend_base_url")"
+fi
+
+if [ -z "$api_base_url" ]; then
+  api_host="${API_HOSTNAME:-}"
+  if [ -z "$api_host" ]; then
+    echo "FAIL: set API_BASE_URL or API_HOSTNAME." >&2
+    exit 2
+  fi
+  api_base_url="$(normalize_base_url "$api_host")"
+else
+  api_base_url="$(normalize_base_url "$api_base_url")"
+fi
+
+output_dir="$(dirname "$output_path")"
+mkdir -p "$output_dir"
+
+samples_file="${output_dir}/.production-synthetic-samples-$$.json"
+curl_error_file="${output_dir}/.production-synthetic-curl-$$.err"
+trap 'rm -f "$samples_file" "$samples_file.tmp" "$curl_error_file"' EXIT
+printf '[]\n' > "$samples_file"
+
+append_sample() {
+  local name="$1"
+  local url="$2"
+  local expected_status="$3"
+  local status_code="$4"
+  local elapsed_ms="$5"
+  local success="$6"
+  local error="$7"
+  local status_json="null"
+
+  if [[ "$status_code" =~ ^[0-9]+$ ]]; then
+    status_json="$status_code"
+  fi
+
+  jq \
+    --arg name "$name" \
+    --arg method "GET" \
+    --arg url "$url" \
+    --argjson expectedStatus "$expected_status" \
+    --argjson statusCode "$status_json" \
+    --argjson elapsedMs "$elapsed_ms" \
+    --argjson success "$success" \
+    --arg error "$error" \
+    '. += [{
+      name: $name,
+      method: $method,
+      url: $url,
+      expectedStatus: $expectedStatus,
+      statusCode: $statusCode,
+      elapsedMs: $elapsedMs,
+      success: $success,
+      error: ($error | if length == 0 then null else . end)
+    }]' "$samples_file" > "$samples_file.tmp"
+  mv "$samples_file.tmp" "$samples_file"
+}
+
+probes=(
+  "frontend-root|${frontend_base_url}/|200"
+  "api-health|${api_base_url}/api/health|200"
+  "api-v1-health|${api_base_url}/api/v1/health|200"
+)
+
+for probe in "${probes[@]}"; do
+  IFS='|' read -r name url expected_status <<< "$probe"
+  start_ns="$(date +%s%N)"
+  status_code=""
+  error=""
+  success=false
+
+  if status_code="$(curl \
+    --silent \
+    --show-error \
+    --location \
+    --max-time "$timeout_seconds" \
+    --output /dev/null \
+    --write-out "%{http_code}" \
+    "$url" 2>"$curl_error_file")"; then
+    if [ "$status_code" = "$expected_status" ]; then
+      success=true
+    else
+      error="expected HTTP ${expected_status}, got ${status_code}"
+    fi
+  else
+    status_code="${status_code:-000}"
+    error="$(tr '\n' ' ' < "$curl_error_file")"
+  fi
+
+  end_ns="$(date +%s%N)"
+  elapsed_ms=$(((end_ns - start_ns) / 1000000))
+  append_sample "$name" "$url" "$expected_status" "$status_code" "$elapsed_ms" "$success" "$error"
+done
+
+generated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+request_count="${#probes[@]}"
+failure_count="$(jq '[.[] | select(.success != true)] | length' "$samples_file")"
+
+jq -n \
+  --arg generatedAt "$generated_at" \
+  --arg policy "Anonymous production availability only; low volume and not a load test, capacity test, or production SLO." \
+  --argjson timeoutSeconds "$timeout_seconds" \
+  --argjson requestCount "$request_count" \
+  --argjson failureCount "$failure_count" \
+  --slurpfile probes "$samples_file" \
+  '{
+    schemaVersion: 1,
+    generatedAt: $generatedAt,
+    policy: $policy,
+    run: {
+      target: "production",
+      timeoutSeconds: $timeoutSeconds,
+      requestCount: $requestCount,
+      failureCount: $failureCount
+    },
+    probes: $probes[0]
+  }' > "$output_path"
+
+jq '.' "$output_path"
+
+if [ "$failure_count" -gt 0 ]; then
+  echo "FAIL: production synthetic check had ${failure_count} failure(s)." >&2
+  exit 1
+fi
+
+echo "Production synthetic check passed (${request_count} anonymous requests)."


### PR DESCRIPTION
## Summary
- Add a daily/manual `Performance Synthetic` workflow for local-stack `Category=Performance|Category=PerformanceLoad` report collection.
- Add an anonymous production synthetic probe script for the public frontend root plus API health endpoints.
- Document cadence, artifact retention, runner-cost bounds, low-volume production scope, and the initial non-blocking status.

## Verification
- `dotnet build lfm.sln -c Release`
- `dotnet build lfm.sln -c Release --no-restore`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `git diff --check`
- `yq eval '.' .github/workflows/performance-synthetic.yml`
- `bash -n scripts/production-synthetic-check.sh`
- `shellcheck scripts/production-synthetic-check.sh`
- `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --no-build --filter "Category=Performance|Category=PerformanceLoad" --list-tests`
- `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --no-build --filter "Category=Performance|Category=PerformanceLoad" --logger "console;verbosity=normal" --results-directory ./artifacts/e2e-results`
- Loopback self-test of `scripts/production-synthetic-check.sh` produced 3 anonymous requests and 0 failures.

Closes #243