### PR TITLE
Tighten frontend style guide

### DIFF
--- a/docs/frontend-style-guide.md
+++ b/docs/frontend-style-guide.md
@@ -86,7 +86,7 @@ the rendered markup contains the intended heading element.
 | Purpose | Semantic element and visual style |
 | --- | --- |
 | Route title | One rendered `<h1>` per routable page, styled as `Typography.H1` or equivalent |
-| Product mark / compact page brand | Non-heading text unless it is the page title; style like `Typography.H3` |
+| Product mark / compact page brand | Native non-heading text, or a component whose rendered markup is proven not to be a heading, styled like `Typography.H3`; use a heading-rendering wrapper only when the mark is the page title |
 | Card or section title | Native heading at the next valid level, styled like `Typography.H4` or `Typography.H5` |
 | Body copy | `Typography.Body` or default `FluentLabel` |
 | Metadata / helper text | `--neutral-foreground-hint-rest`, usually `0.85em` to `0.9em` |
@@ -134,8 +134,8 @@ through text or another non-color cue.
 | Domain cue | Visual treatment | Required non-color cue |
 | --- | --- | --- |
 | Character class | `WowClasses.GetColor(classId)` as a row/card side accent or compact text chip | Character name plus class/spec text |
-| Dungeon run kind | `#0070dd` side accent | Run-kind label or role-composition context |
-| Raid run kind | `#1eff00` side accent | Run-kind label or role-composition context |
+| Dungeon run kind | `#0070dd` side accent | Explicit dungeon label, icon with accessible name, or row/card accessible name |
+| Raid run kind | `#1eff00` side accent | Explicit raid label, icon with accessible name, or row/card accessible name |
 | Mythic / Mythic+ difficulty | `#ff8000` filled difficulty pill | Difficulty label inside the pill |
 | Heroic difficulty | `#a335ee` filled difficulty pill | Difficulty label inside the pill |
 | Normal / LFR difficulty | Neutral outline pill | Difficulty label inside the pill |

--- a/docs/frontend-style-guide.md
+++ b/docs/frontend-style-guide.md
@@ -294,8 +294,19 @@ Run list items use:
   reusable-component visual systems. This is the current accepted practice;
   prefer scoped CSS when the styling belongs to one page/component, needs
   local state variants, or should not become a global primitive.
-- Inline `Style` is acceptable for small Fluent composition tweaks and
-  one-off token usage.
+- Inline `Style` is acceptable only for small, non-repeated Fluent composition
+  tweaks or one-off token plumbing, and it must use logical properties when it
+  affects spacing or placement. Examples: `Style="flex:1"` on a local title in
+  a `FluentStack`, or `Style="margin-inline-start:auto"` for a single toolbar
+  spacer.
+- Do not use inline `Style` for state variants, selected states, domain colors,
+  badges, repeated layout patterns, or reusable density decisions. Those belong
+  in named CSS classes or shared helpers.
+- Inline custom-property plumbing is allowed when it feeds a named CSS class or
+  shared helper that owns the visual treatment. Example:
+  `style="--class-color:..."` may provide a per-character color value to
+  `.character-row`; the inline style must not directly apply the domain color
+  treatment itself.
 - Move styles from `.razor.css` to `app.css` when the class becomes shared
   vocabulary, app-shell structure, or a cross-page helper.
 - Prefer named CSS classes when styling has state variants, domain meaning, or

--- a/docs/frontend-style-guide.md
+++ b/docs/frontend-style-guide.md
@@ -77,14 +77,17 @@ is for accent-colored text or icons on a neutral surface.
 
 ## Typography
 
-Use Fluent typography through `FluentLabel` unless the element must be a native
-heading or control label.
+Use semantic HTML for document structure. Route titles and section titles must
+render as the appropriate native heading level (`<h1>`, `<h2>`, `<h3>`, and so
+on). Fluent typography is the visual treatment, not the proof of heading
+semantics. If a Fluent component is used for a heading, bUnit coverage must prove
+the rendered markup contains the intended heading element.
 
-| Purpose | Style |
+| Purpose | Semantic element and visual style |
 | --- | --- |
-| Route title | `Typography.H1` |
-| Product mark / compact page brand | `Typography.H3` |
-| Card or section title | `Typography.H4` or `Typography.H5` |
+| Route title | One rendered `<h1>` per routable page, styled as `Typography.H1` or equivalent |
+| Product mark / compact page brand | Non-heading text unless it is the page title; style like `Typography.H3` |
+| Card or section title | Native heading at the next valid level, styled like `Typography.H4` or `Typography.H5` |
 | Body copy | `Typography.Body` or default `FluentLabel` |
 | Metadata / helper text | `--neutral-foreground-hint-rest`, usually `0.85em` to `0.9em` |
 | Numeric role counts | `font-variant-numeric: tabular-nums` |

--- a/docs/frontend-style-guide.md
+++ b/docs/frontend-style-guide.md
@@ -124,20 +124,32 @@ These colors are domain constants. Do not tune them to fit a page palette.
 Apply them through named helpers, CSS classes, or shared domain functions rather
 than scattering literals through Razor markup.
 
-| Domain cue | Visual treatment |
-| --- | --- |
-| Character class | `WowClasses.GetColor(classId)` as a row/card side accent or compact text chip |
-| Dungeon run kind | `#0070dd` side accent |
-| Raid run kind | `#1eff00` side accent |
-| Mythic / Mythic+ difficulty | `#ff8000` filled difficulty pill |
-| Heroic difficulty | `#a335ee` filled difficulty pill |
-| Normal / LFR difficulty | Neutral outline pill |
-| Signed-up marker | Compact star/glyph in the run row metadata area |
+Domain colors must not be the only source of meaning. Pair them with text,
+shape, position, iconography, or component structure so the cue survives low
+contrast, color-vision differences, and `forced-colors: active`. When a
+brand-canonical WoW color cannot meet contrast as a meaningful UI boundary,
+treat it as decorative reinforcement and make the actual meaning available
+through text or another non-color cue.
+
+| Domain cue | Visual treatment | Required non-color cue |
+| --- | --- | --- |
+| Character class | `WowClasses.GetColor(classId)` as a row/card side accent or compact text chip | Character name plus class/spec text |
+| Dungeon run kind | `#0070dd` side accent | Run-kind label or role-composition context |
+| Raid run kind | `#1eff00` side accent | Run-kind label or role-composition context |
+| Mythic / Mythic+ difficulty | `#ff8000` filled difficulty pill | Difficulty label inside the pill |
+| Heroic difficulty | `#a335ee` filled difficulty pill | Difficulty label inside the pill |
+| Normal / LFR difficulty | Neutral outline pill | Difficulty label inside the pill |
+| Signed-up marker | Compact star/glyph in the run row metadata area | Signup text or status metadata in the detail pane |
 
 ### Attendance Status
 
 Attendance status is shown as a filled rounded pill. Keep labels short and use
 the existing status vocabulary.
+
+The status label is mandatory; the fill color is supporting evidence. Do not
+render attendance as a color-only dot or border. In forced-colors mode, the pill
+must keep a visible boundary and readable label using system colors or inherited
+Fluent contrast pairs.
 
 | Status | Fill |
 | --- | --- |

--- a/docs/frontend-style-guide.md
+++ b/docs/frontend-style-guide.md
@@ -162,9 +162,14 @@ Fluent contrast pairs.
 
 ## Spacing And Density
 
-Prefer compact, repeated spacing over large editorial gaps.
+Prefer compact, repeated spacing over large editorial gaps. The values below
+are design-reference equivalents at the default root size. In authored CSS,
+prefer Fluent component spacing, logical properties (`gap`, `padding-inline`,
+`padding-block`, `margin-inline`, `margin-block`), and scalable units where the
+value affects text or layout. Use fixed `px` intentionally for borders, bitmap
+media dimensions, and small visual details that should not scale with text.
 
-| Use | Value |
+| Use | Default visual equivalent |
 | --- | --- |
 | Inline icon/text gap | `4px` |
 | Compact stack gap | `8px` |
@@ -177,6 +182,9 @@ Prefer compact, repeated spacing over large editorial gaps.
 
 Let Fluent components provide their own internal control spacing unless a
 component-specific style already exists.
+
+When a spacing value becomes shared vocabulary, move it into a CSS class or
+Fluent token usage instead of repeating inline numbers across Razor markup.
 
 ## Component Styling
 


### PR DESCRIPTION
## Summary
- Clarify semantic heading expectations versus Fluent visual typography.
- Require explicit non-color cues for domain colors and attendance status.
- Clarify spacing units and inline `Style` ownership for Blazor UI work.

## Verification
- `git diff --check main...HEAD`
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --filter FullyQualifiedName~HeadingStructureTests`
- `./scripts/check-locale-readiness.sh`

Docs-only change; full build intentionally skipped.