### PR TITLE
Improve E2E performance evidence

### DIFF
--- a/.github/workflows/performance-synthetic.yml
+++ b/.github/workflows/performance-synthetic.yml
@@ -21,6 +21,7 @@ env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   NUGET_XMLDOC_MODE: skip
   PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/ms-playwright
+  LFM_E2E_PERFORMANCE_SAMPLES: 4
 
 jobs:
   collect:
@@ -79,7 +80,12 @@ jobs:
           API_HOSTNAME: ${{ vars.API_HOSTNAME }}
           SYNTHETIC_OUTPUT: artifacts/production-synthetic/production-synthetic-report.json
           SYNTHETIC_TIMEOUT_SECONDS: 10
+          SYNTHETIC_PROBE_SAMPLES: 3
         run: bash ./scripts/production-synthetic-check.sh
+
+      - name: Write performance summary
+        if: always()
+        run: bash ./scripts/write-performance-summary.sh
 
       - name: Upload performance reports
         if: always()

--- a/docs/testing/e2e-maintenance.md
+++ b/docs/testing/e2e-maintenance.md
@@ -25,6 +25,12 @@ disposal removes its own run directory. Diagnostics are written under
 | Accessibility | axe scans and keyboard/focus states that need browser rendering | Static labels or component markup can be checked in bUnit |
 | Security | Browser-enforced CORS, CSP, iframe, cookie, and redirect behavior | Server-only status/header logic can be tested in API tests |
 | Auth flow | Real redirect/callback/session behavior | `/api/e2e/login` is enough and the browser adds no signal |
+| Performance | Browser Web Vitals-style lab metrics, route interaction timing, resource/API counts, and local request-health probes | A bundle check, API operation-count assertion, or production telemetry query proves the same regression |
+
+Performance E2E reports local lab signals, not production SLOs. Browser metrics
+and local load-smoke timing can fail only at documented hybrid gates; production
+timing remains advisory unless promoted by a separate issue with enough
+baseline evidence.
 
 ## Required Test Comment
 
@@ -51,6 +57,8 @@ Centralize these in helpers rather than specs:
 - Selectors: page objects under `tests/Lfm.E2E/Pages/`.
 - Cosmos seed shapes: typed builders under `tests/Lfm.E2E/Seeds/`.
 - Artifact naming and capture: `tests/Lfm.E2E/Infrastructure/E2ETestBase.cs`.
+- Performance metric injection, aggregation, and thresholds:
+  `tests/Lfm.E2E/Helpers/PerformanceMetricsHelper.cs`.
 
 ## Drift Audit
 

--- a/docs/testing/performance.md
+++ b/docs/testing/performance.md
@@ -9,8 +9,8 @@ Application Insights remains the operational production signal.
 | Lane | Runner | Cadence | Gate |
 |------|--------|---------|------|
 | Bundle size | `scripts/check-bundle-size.sh` after `dotnet publish app/Lfm.App.csproj -c Release` | Every CI and deploy-app build | Hard fail over 5 MB brotli; warning over 10% growth from baseline |
-| Browser journey timing | `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --filter "Category=Performance"` | Manual dispatch and local investigation | Advisory timing guard with loose budgets; hard fail on browser/network errors |
-| Local load smoke | `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --filter "Category=PerformanceLoad"` | Manual dispatch and local investigation | Hard fail only when bounded local-stack requests exceed the explicit error threshold |
+| Browser journey timing | `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --filter "Category=Performance"` | Manual dispatch and local investigation | Hybrid gate: hard fail on browser/network errors and p75 local poor-threshold regressions; other timing drift advisory |
+| Local load smoke | `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --filter "Category=PerformanceLoad"` | Manual dispatch and local investigation | Hard fail only when bounded local-stack requests exceed the explicit error threshold; timing percentiles advisory |
 | Scheduled synthetic | `.github/workflows/performance-synthetic.yml` | Daily at 03:17 UTC and manual dispatch | Visible workflow status; not wired into PR, deploy, or release blocking |
 | Backend latency | API tests plus Application Insights queries below | Unit/API tests on PR; production queries during operations | Operation-count tests are hard gates; production percentiles are operational evidence |
 | Manual load/investigation | Temporary local harnesses documented here before use | Only when a regression needs diagnosis | Advisory; no always-on paid load service without an explicit cost note |
@@ -30,13 +30,25 @@ the recurring cost first.
 | `/runs/new` form load | 45 seconds | Local-stack browser guard |
 | `/characters` list load | 45 seconds | Local-stack browser guard |
 | Warm route navigation | 20 seconds | Local-stack browser guard |
+| Local LCP p75 | 4000 ms poor threshold | Hard browser regression gate when supported |
+| Local CLS p75 | 0.25 poor threshold | Hard browser regression gate when supported |
+| Controlled interaction p75 | 500 ms poor-threshold proxy | Hard local lab gate for measured route/form interactions |
 | Backend p95/p99 | Placeholder until production baseline exists | Use the KQL below to establish normal ranges |
 
 Browser journeys run in desktop and mobile viewport profiles and collect two
-samples per journey by default. Override locally with
-`LFM_E2E_PERFORMANCE_SAMPLES` when investigating a regression. The browser
-budgets intentionally allow slow CI machines and first-run WASM startup.
-Tighten them only after several clean baseline runs.
+samples per journey by default; scheduled synthetic collection sets
+`LFM_E2E_PERFORMANCE_SAMPLES=4` so p75 is meaningful enough for trend evidence.
+Override locally with `LFM_E2E_PERFORMANCE_SAMPLES` when investigating a
+regression. The elapsed-time budgets intentionally allow slow CI machines and
+first-run WASM startup. Tighten them only after several clean baseline runs.
+
+The browser report is schema v2 at
+`artifacts/e2e-results/performance-report.json`. It records cache state, user
+state, browser and runner metadata, p50/p75/max elapsed timing, Web
+Vitals-style lab metrics, API resource timing summaries, support flags, raw
+samples, gate policy, and threshold source. LCP/CLS thresholds are based on
+web.dev Core Web Vitals poor thresholds. Controlled interaction duration is a
+local lab proxy for route/form responsiveness, not a claim of production INP.
 
 ## Local Load Smoke
 
@@ -50,9 +62,9 @@ count per probe, a total request limit, a per-request timeout, and a per-probe
 timeout. Its JSON report is written to
 `artifacts/e2e-results/performance-load-report.json` and records each tested
 endpoint/journey with request count, failure count, p50, p95, max, expected
-status codes, and raw samples. Timing percentiles are evidence for comparison;
-the gate fails only when request errors or unexpected statuses exceed the
-explicit threshold.
+status codes, endpoint group, p50, p75, p95, max, and raw samples. Timing
+percentiles are evidence for comparison; the gate fails only when request
+errors or unexpected statuses exceed the explicit threshold.
 
 ## Scheduled Synthetic Collection
 
@@ -66,8 +78,10 @@ The workflow uploads `performance-synthetic-reports` for 30 days. The artifact
 contains the browser timing report, load-smoke report, TRX result, and
 production synthetic report when those files are available. Daily runner cost is
 capped by a 45-minute timeout and is expected to stay in the same range as a
-manual performance E2E run; production checks add only three anonymous requests
-with a 10-second per-request timeout.
+manual performance E2E run; production checks add three samples per anonymous
+probe with a 10-second per-request timeout. The workflow also writes a compact
+GitHub step summary from the browser, load-smoke, and production synthetic
+reports.
 
 Scheduled synthetic failures are intentionally visible in their own workflow
 status but initially non-blocking for deploys, releases, and PR smoke E2E. Do
@@ -79,19 +93,22 @@ a separate approved issue.
 - Bundle-size output is a hard build signal. The report should show total bytes,
   top assets, baseline total, and growth percentage on every run.
 - Browser performance E2E is a regression signal. Its versioned JSON report
-  records browser metadata, viewport profile, p50/max timing, raw samples,
-  request failures, unexpected HTTP 4xx/5xx responses, and console errors. It
-  is not a production SLO.
+  records browser metadata, runner metadata, viewport profile, cache/user state,
+  p50/p75/max timing, Web Vitals-style lab metrics, resource/API timing
+  summaries, raw samples, request failures, unexpected HTTP 4xx/5xx responses,
+  and console errors. It is not a production SLO.
 - Browser performance E2E fails on unexpected request failures, unexpected HTTP
-  4xx/5xx responses, and console errors unless the spec has a narrow commented
-  allowlist for the expected case.
+  4xx/5xx responses, console errors, and supported p75 local poor-threshold
+  regressions unless the spec has a narrow commented allowlist for the expected
+  case.
 - Local load smoke E2E is a request-health probe. Its versioned JSON report
-  records bounded request counts, failure counts, p50, p95, max, tested
-  endpoints/journeys, expected status codes, and raw samples. It is not a
-  capacity test and must not be used as a production SLO.
+  records bounded request counts, failure counts, p50, p75, p95, max, tested
+  endpoint groups and journeys, expected status codes, and raw samples. It is
+  not a capacity test and must not be used as a production SLO.
 - Scheduled synthetic production checks are anonymous availability probes only.
-  They collect a small JSON report and must stay low-volume, unauthenticated,
-  and outside PR/deploy blocking until a separate issue promotes the signal.
+  They collect a small multi-sample JSON report with advisory p50/p75/max timing
+  and must stay low-volume, unauthenticated, and outside PR/deploy blocking until
+  a separate issue promotes the signal.
 - Backend elapsed-ms logs and dependency telemetry are operational evidence.
   They are not a full load test and should be read as percentiles, not anecdotes.
 - Bundle optimization belongs in #27 after approved production evidence or
@@ -104,6 +121,17 @@ materially changes the Blazor boot path, adds large static assets, changes a hot
 API path, adds Cosmos queries, or changes reference-data lookup behavior.
 Prefer deterministic operation-count assertions for backend PR gates. Use
 wall-clock checks only where the browser is the behavior being protected.
+
+## Lab vs Production
+
+Local Playwright metrics are lab data: useful for catching regressions in the
+same harness, but not a replacement for field data. The local E2E stack uses
+published Blazor assets, a local Kestrel static host, an API container, Cosmos
+emulator, Azurite, and synthetic seed data. Production uses Static Web Apps,
+Azure Functions, real network paths, managed storage, live caches, and real user
+devices. Compare local runs against local baselines and production synthetics
+against production history; do not compare the raw numbers as if the
+environments were equivalent.
 
 ## Bundle Baseline Updates
 

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -20,6 +20,7 @@ shell_scripts=(
   scripts/pre-push
   scripts/run-tests-parallel.sh
   scripts/wait-api-ready.sh
+  scripts/write-performance-summary.sh
 )
 
 echo "[pre-push] Shell script lint..."

--- a/scripts/production-synthetic-check.sh
+++ b/scripts/production-synthetic-check.sh
@@ -8,6 +8,7 @@
 set -euo pipefail
 
 timeout_seconds="${SYNTHETIC_TIMEOUT_SECONDS:-10}"
+probe_samples="${SYNTHETIC_PROBE_SAMPLES:-3}"
 output_path="${SYNTHETIC_OUTPUT:-artifacts/production-synthetic/production-synthetic-report.json}"
 
 if ! command -v jq >/dev/null 2>&1; then
@@ -18,6 +19,17 @@ fi
 case "$timeout_seconds" in
   ''|*[!0-9]*)
     echo "FAIL: SYNTHETIC_TIMEOUT_SECONDS must be an integer." >&2
+    exit 2
+    ;;
+esac
+
+case "$probe_samples" in
+  ''|*[!0-9]*)
+    echo "FAIL: SYNTHETIC_PROBE_SAMPLES must be an integer." >&2
+    exit 2
+    ;;
+  0)
+    echo "FAIL: SYNTHETIC_PROBE_SAMPLES must be greater than zero." >&2
     exit 2
     ;;
 esac
@@ -66,12 +78,13 @@ printf '[]\n' > "$samples_file"
 
 append_sample() {
   local name="$1"
-  local url="$2"
-  local expected_status="$3"
-  local status_code="$4"
-  local elapsed_ms="$5"
-  local success="$6"
-  local error="$7"
+  local sequence="$2"
+  local url="$3"
+  local expected_status="$4"
+  local status_code="$5"
+  local elapsed_ms="$6"
+  local success="$7"
+  local error="$8"
   local status_json="null"
 
   if [[ "$status_code" =~ ^[0-9]+$ ]]; then
@@ -80,6 +93,7 @@ append_sample() {
 
   jq \
     --arg name "$name" \
+    --argjson sequence "$sequence" \
     --arg method "GET" \
     --arg url "$url" \
     --argjson expectedStatus "$expected_status" \
@@ -89,6 +103,7 @@ append_sample() {
     --arg error "$error" \
     '. += [{
       name: $name,
+      sequence: $sequence,
       method: $method,
       url: $url,
       expectedStatus: $expectedStatus,
@@ -108,56 +123,88 @@ probes=(
 
 for probe in "${probes[@]}"; do
   IFS='|' read -r name url expected_status <<< "$probe"
-  start_ns="$(date +%s%N)"
-  status_code=""
-  error=""
-  success=false
+  for sequence in $(seq 1 "$probe_samples"); do
+    start_ns="$(date +%s%N)"
+    status_code=""
+    error=""
+    success=false
 
-  if status_code="$(curl \
-    --silent \
-    --show-error \
-    --location \
-    --max-time "$timeout_seconds" \
-    --output /dev/null \
-    --write-out "%{http_code}" \
-    "$url" 2>"$curl_error_file")"; then
-    if [ "$status_code" = "$expected_status" ]; then
-      success=true
+    if status_code="$(curl \
+      --silent \
+      --show-error \
+      --location \
+      --max-time "$timeout_seconds" \
+      --output /dev/null \
+      --write-out "%{http_code}" \
+      "$url" 2>"$curl_error_file")"; then
+      if [ "$status_code" = "$expected_status" ]; then
+        success=true
+      else
+        error="expected HTTP ${expected_status}, got ${status_code}"
+      fi
     else
-      error="expected HTTP ${expected_status}, got ${status_code}"
+      status_code="${status_code:-000}"
+      error="$(tr '\n' ' ' < "$curl_error_file")"
     fi
-  else
-    status_code="${status_code:-000}"
-    error="$(tr '\n' ' ' < "$curl_error_file")"
-  fi
 
-  end_ns="$(date +%s%N)"
-  elapsed_ms=$(((end_ns - start_ns) / 1000000))
-  append_sample "$name" "$url" "$expected_status" "$status_code" "$elapsed_ms" "$success" "$error"
+    end_ns="$(date +%s%N)"
+    elapsed_ms=$(((end_ns - start_ns) / 1000000))
+    append_sample "$name" "$sequence" "$url" "$expected_status" "$status_code" "$elapsed_ms" "$success" "$error"
+  done
 done
 
 generated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-request_count="${#probes[@]}"
+request_count=$((${#probes[@]} * probe_samples))
 failure_count="$(jq '[.[] | select(.success != true)] | length' "$samples_file")"
 
 jq -n \
   --arg generatedAt "$generated_at" \
-  --arg policy "Anonymous production availability only; low volume and not a load test, capacity test, or production SLO." \
+  --arg policy "Anonymous production availability plus advisory timing percentiles; low volume and not a load test, capacity test, or production SLO." \
   --argjson timeoutSeconds "$timeout_seconds" \
+  --argjson samplesPerProbe "$probe_samples" \
   --argjson requestCount "$request_count" \
   --argjson failureCount "$failure_count" \
-  --slurpfile probes "$samples_file" \
-  '{
-    schemaVersion: 1,
+  --slurpfile samples "$samples_file" \
+  'def percentile($p):
+    sort as $sorted
+    | if ($sorted | length) == 0 then null
+      else
+        (($p / 100) * (($sorted | length) - 1)) as $rank
+        | ($rank | floor) as $lower
+        | (if $rank == ($rank | floor) then ($rank | floor) else (($rank | floor) + 1) end) as $upper
+        | if $lower == $upper then $sorted[$lower]
+          else (($sorted[$lower] + (($sorted[$upper] - $sorted[$lower]) * ($rank - $lower))) | round)
+          end
+      end;
+  ($samples[0]) as $all
+  | {
+    schemaVersion: 2,
     generatedAt: $generatedAt,
     policy: $policy,
     run: {
       target: "production",
       timeoutSeconds: $timeoutSeconds,
+      samplesPerProbe: $samplesPerProbe,
       requestCount: $requestCount,
-      failureCount: $failureCount
+      failureCount: $failureCount,
+      gatePolicy: "Availability/status failures fail; timing percentiles are advisory."
     },
-    probes: $probes[0]
+    probes: (
+      $all
+      | group_by(.name)
+      | map({
+        name: .[0].name,
+        method: .[0].method,
+        url: .[0].url,
+        expectedStatus: .[0].expectedStatus,
+        requestCount: length,
+        failureCount: ([.[] | select(.success != true)] | length),
+        p50Ms: (map(.elapsedMs) | percentile(50)),
+        p75Ms: (map(.elapsedMs) | percentile(75)),
+        maxMs: (map(.elapsedMs) | max),
+        samples: .
+      })
+    )
   }' > "$output_path"
 
 jq '.' "$output_path"

--- a/scripts/write-performance-summary.sh
+++ b/scripts/write-performance-summary.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 LFM contributors
+
+set -euo pipefail
+
+browser_report="${1:-artifacts/e2e-results/performance-report.json}"
+load_report="${2:-artifacts/e2e-results/performance-load-report.json}"
+production_report="${3:-artifacts/production-synthetic/production-synthetic-report.json}"
+summary_path="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "FAIL: jq is required to write the performance summary." >&2
+  exit 2
+fi
+
+write_browser_summary() {
+  local report="$1"
+  if [ ! -f "$report" ]; then
+    echo "Local browser report not found: $report"
+    return
+  fi
+
+  echo "### Local Browser Journeys"
+  echo
+  echo "| Journey | Viewport | p75 elapsed | p75 LCP | p75 CLS | p75 interaction | p75 API count |"
+  echo "|---|---:|---:|---:|---:|---:|---:|"
+  jq -r '
+    def value($v; $suffix):
+      if $v == null then "n/a" else (($v | tostring) + $suffix) end;
+    (.Journeys // .journeys // [])[] as $j
+    | ($j.Viewport // $j.viewport // {}) as $v
+    | ($j.BrowserMetrics // $j.browserMetrics // {}) as $m
+    | "| \($j.Name // $j.name) | \($v.Name // $v.name) | \(value($j.P75ElapsedMs // $j.p75ElapsedMs; " ms")) | \(value($m.P75LargestContentfulPaintMs // $m.p75LargestContentfulPaintMs; " ms")) | \(value($m.P75CumulativeLayoutShift // $m.p75CumulativeLayoutShift; "")) | \(value($m.P75ControlledInteractionDurationMs // $m.p75ControlledInteractionDurationMs; " ms")) | \(value($m.P75ApiRequestCount // $m.p75ApiRequestCount; "")) |"
+  ' "$report"
+}
+
+write_load_summary() {
+  local report="$1"
+  if [ ! -f "$report" ]; then
+    echo "Local load-smoke report not found: $report"
+    return
+  fi
+
+  echo "### Local Load Smoke"
+  echo
+  echo "| Group | Probe | Requests | Failures | p75 | Max |"
+  echo "|---|---|---:|---:|---:|---:|"
+  jq -r '
+    def value($v; $suffix):
+      if $v == null then "n/a" else (($v | tostring) + $suffix) end;
+    (.Probes // .probes // [])[] as $p
+    | "| \($p.Group // $p.group // "n/a") | \($p.Name // $p.name) | \($p.RequestCount // $p.requestCount) | \($p.FailureCount // $p.failureCount) | \(value($p.P75Ms // $p.p75Ms; " ms")) | \(value($p.MaxMs // $p.maxMs; " ms")) |"
+  ' "$report"
+}
+
+write_production_summary() {
+  local report="$1"
+  if [ ! -f "$report" ]; then
+    echo "Production synthetic report not found: $report"
+    return
+  fi
+
+  echo "### Anonymous Production Synthetic"
+  echo
+  echo "| Probe | Requests | Failures | p75 | Max |"
+  echo "|---|---:|---:|---:|---:|"
+  jq -r '
+    def value($v; $suffix):
+      if $v == null then "n/a" else (($v | tostring) + $suffix) end;
+    (.probes // .Probes // [])[] as $p
+    | "| \($p.name // $p.Name) | \($p.requestCount // $p.RequestCount) | \($p.failureCount // $p.FailureCount) | \(value($p.p75Ms // $p.P75Ms; " ms")) | \(value($p.maxMs // $p.MaxMs; " ms")) |"
+  ' "$report"
+}
+
+{
+  echo "## Performance Summary"
+  echo
+  echo "Timing percentiles are advisory unless a report's gate policy says otherwise."
+  echo
+  write_browser_summary "$browser_report"
+  echo
+  write_load_summary "$load_report"
+  echo
+  write_production_summary "$production_report"
+} >> "$summary_path"

--- a/tests/Lfm.E2E/Helpers/PerformanceMetricsHelper.cs
+++ b/tests/Lfm.E2E/Helpers/PerformanceMetricsHelper.cs
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Globalization;
+using Microsoft.Playwright;
+
+namespace Lfm.E2E.Helpers;
+
+internal static class PerformanceMetricsHelper
+{
+    public const string MetricSource =
+        "Chromium lab PerformanceObserver/resource timing captured by Playwright against the local E2E stack.";
+
+    public const string ThresholdSource =
+        "web.dev Core Web Vitals poor thresholds: LCP > 4000 ms, CLS > 0.25, INP poor proxy > 500 ms at p75.";
+
+    public const string GatePolicy =
+        "Hybrid gate: request/browser failures and local p75 poor-threshold regressions fail; good thresholds and timing drift stay advisory.";
+
+    private const long LargestContentfulPaintPoorThresholdMs = 4000;
+    private const double CumulativeLayoutShiftPoorThreshold = 0.25;
+    private const long ControlledInteractionPoorThresholdMs = 500;
+
+    public static async Task StartCollectionAsync(IPage page)
+    {
+        await page.AddInitScriptAsync(ObserverScript);
+        await page.EvaluateAsync(ObserverScript);
+        await page.EvaluateAsync(
+            """
+            () => {
+              window.__lfmPerf?.reset?.();
+              performance.clearResourceTimings?.();
+            }
+            """);
+    }
+
+    public static async Task<BrowserPerformanceMetrics> ReadAsync(
+        IPage page,
+        double? controlledInteractionDurationMs)
+    {
+        var snapshot = await page.EvaluateAsync<BrowserPerformanceSnapshot>(
+            """
+            () => {
+              const perf = window.__lfmPerf;
+              return {
+                supportsLargestContentfulPaint: !!perf?.supportsLargestContentfulPaint,
+                supportsLayoutShift: !!perf?.supportsLayoutShift,
+                supportsEventTiming: !!perf?.supportsEventTiming,
+                largestContentfulPaintMs: perf?.largestContentfulPaintMs ?? null,
+                cumulativeLayoutShift: perf?.cumulativeLayoutShift ?? 0
+              };
+            }
+            """);
+
+        var resources = await page.EvaluateAsync<ResourceTimingMetric[]>(
+            """
+            () => performance.getEntriesByType("resource").map(entry => ({
+              name: entry.name,
+              initiatorType: entry.initiatorType || "",
+              durationMs: Math.round(entry.duration),
+              transferSize: Math.max(0, Math.round(entry.transferSize || 0))
+            }))
+            """);
+
+        var apiResources = resources
+            .Where(resource => Uri.TryCreate(resource.Name, UriKind.Absolute, out var uri)
+                && uri.AbsolutePath.StartsWith("/api/", StringComparison.Ordinal))
+            .ToArray();
+
+        return new BrowserPerformanceMetrics(
+            snapshot.SupportsLargestContentfulPaint,
+            snapshot.SupportsLayoutShift,
+            snapshot.SupportsEventTiming,
+            RoundToLong(snapshot.LargestContentfulPaintMs),
+            Math.Round(snapshot.CumulativeLayoutShift, 4),
+            RoundToLong(controlledInteractionDurationMs),
+            resources.Length,
+            apiResources.Length,
+            apiResources.Sum(resource => resource.TransferSize),
+            PercentileOrNull(apiResources.Select(resource => resource.DurationMs).ToArray(), 75),
+            MaxOrNull(apiResources.Select(resource => (long)resource.DurationMs).ToArray()));
+    }
+
+    public static BrowserPerformanceMetricSummary Summarize(
+        IReadOnlyCollection<BrowserPerformanceMetrics> samples)
+    {
+        var lcp = samples
+            .Where(sample => sample.SupportsLargestContentfulPaint)
+            .Select(sample => sample.LargestContentfulPaintMs)
+            .OfType<long>()
+            .ToArray();
+        var cls = samples
+            .Where(sample => sample.SupportsLayoutShift)
+            .Select(sample => sample.CumulativeLayoutShift)
+            .ToArray();
+        var interactions = samples
+            .Select(sample => sample.ControlledInteractionDurationMs)
+            .OfType<long>()
+            .ToArray();
+        var requestCounts = samples.Select(sample => (long)sample.ApiRequestCount).ToArray();
+        var transferBytes = samples.Select(sample => sample.ApiTransferBytes).ToArray();
+        var apiDurations = samples
+            .Select(sample => sample.P75ApiDurationMs)
+            .OfType<long>()
+            .ToArray();
+
+        return new BrowserPerformanceMetricSummary(
+            samples.Count,
+            samples.Any(sample => sample.SupportsLargestContentfulPaint),
+            samples.Any(sample => sample.SupportsLayoutShift),
+            samples.Any(sample => sample.SupportsEventTiming),
+            PercentileOrNull(lcp, 50),
+            PercentileOrNull(lcp, 75),
+            MaxOrNull(lcp),
+            PercentileOrNull(cls, 50),
+            PercentileOrNull(cls, 75),
+            MaxOrNull(cls),
+            PercentileOrNull(interactions, 50),
+            PercentileOrNull(interactions, 75),
+            MaxOrNull(interactions),
+            PercentileOrNull(requestCounts, 50),
+            PercentileOrNull(requestCounts, 75),
+            MaxOrNull(requestCounts),
+            PercentileOrNull(transferBytes, 50),
+            PercentileOrNull(transferBytes, 75),
+            MaxOrNull(transferBytes),
+            PercentileOrNull(apiDurations, 50),
+            PercentileOrNull(apiDurations, 75),
+            MaxOrNull(apiDurations));
+    }
+
+    public static IReadOnlyList<string> EvaluatePoorThresholds(
+        string journey,
+        string viewport,
+        BrowserPerformanceMetricSummary summary)
+    {
+        var failures = new List<string>();
+
+        if (summary.P75LargestContentfulPaintMs > LargestContentfulPaintPoorThresholdMs)
+        {
+            failures.Add(
+                $"{journey} [{viewport}] LCP p75 {summary.P75LargestContentfulPaintMs.Value.ToString(CultureInfo.InvariantCulture)} ms " +
+                $"exceeds local poor threshold {LargestContentfulPaintPoorThresholdMs} ms");
+        }
+
+        if (summary.P75CumulativeLayoutShift > CumulativeLayoutShiftPoorThreshold)
+        {
+            failures.Add(
+                $"{journey} [{viewport}] CLS p75 {summary.P75CumulativeLayoutShift.Value.ToString("0.####", CultureInfo.InvariantCulture)} " +
+                $"exceeds local poor threshold {CumulativeLayoutShiftPoorThreshold.ToString("0.##", CultureInfo.InvariantCulture)}");
+        }
+
+        if (summary.P75ControlledInteractionDurationMs > ControlledInteractionPoorThresholdMs)
+        {
+            failures.Add(
+                $"{journey} [{viewport}] controlled interaction p75 {summary.P75ControlledInteractionDurationMs.Value.ToString(CultureInfo.InvariantCulture)} ms " +
+                $"exceeds local poor threshold {ControlledInteractionPoorThresholdMs} ms");
+        }
+
+        return failures;
+    }
+
+    public static long Percentile(IReadOnlyList<long> values, int percentile)
+    {
+        if (values.Count == 0)
+            return 0;
+
+        return RoundToLong(Percentile(values.Select(value => (double)value).ToArray(), percentile)) ?? 0;
+    }
+
+    private static long? PercentileOrNull(IReadOnlyList<long> values, int percentile) =>
+        values.Count == 0 ? null : Percentile(values, percentile);
+
+    private static long? PercentileOrNull(IReadOnlyList<int> values, int percentile) =>
+        values.Count == 0 ? null : Percentile(values.Select(value => (long)value).ToArray(), percentile);
+
+    private static double? PercentileOrNull(IReadOnlyList<double> values, int percentile) =>
+        values.Count == 0 ? null : Math.Round(Percentile(values, percentile), 4);
+
+    private static double Percentile(IReadOnlyList<double> values, int percentile)
+    {
+        var sorted = values.OrderBy(value => value).ToArray();
+        var rank = (percentile / 100d) * (sorted.Length - 1);
+        var lower = (int)Math.Floor(rank);
+        var upper = (int)Math.Ceiling(rank);
+        if (lower == upper)
+            return sorted[lower];
+
+        return sorted[lower] + ((sorted[upper] - sorted[lower]) * (rank - lower));
+    }
+
+    private static long? MaxOrNull(IReadOnlyList<long> values) =>
+        values.Count == 0 ? null : values.Max();
+
+    private static double? MaxOrNull(IReadOnlyList<double> values) =>
+        values.Count == 0 ? null : Math.Round(values.Max(), 4);
+
+    private static long? RoundToLong(double? value) =>
+        value is null ? null : (long)Math.Round(value.Value);
+
+    private sealed class BrowserPerformanceSnapshot
+    {
+        public bool SupportsLargestContentfulPaint { get; set; }
+        public bool SupportsLayoutShift { get; set; }
+        public bool SupportsEventTiming { get; set; }
+        public double? LargestContentfulPaintMs { get; set; }
+        public double CumulativeLayoutShift { get; set; }
+    }
+
+    private sealed class ResourceTimingMetric
+    {
+        public string Name { get; set; } = string.Empty;
+        public string InitiatorType { get; set; } = string.Empty;
+        public int DurationMs { get; set; }
+        public long TransferSize { get; set; }
+    }
+
+    private const string ObserverScript =
+        """
+        (() => {
+          if (window.__lfmPerf?.version === 1) return;
+
+          const supported = PerformanceObserver.supportedEntryTypes || [];
+          const state = {
+            version: 1,
+            supportsLargestContentfulPaint: supported.includes("largest-contentful-paint"),
+            supportsLayoutShift: supported.includes("layout-shift"),
+            supportsEventTiming: supported.includes("event"),
+            largestContentfulPaintMs: null,
+            cumulativeLayoutShift: 0,
+            reset() {
+              this.largestContentfulPaintMs = null;
+              this.cumulativeLayoutShift = 0;
+            }
+          };
+
+          const observe = (type, callback) => {
+            try {
+              new PerformanceObserver(list => {
+                for (const entry of list.getEntries()) {
+                  callback(entry);
+                }
+              }).observe({ type, buffered: true });
+            } catch {
+              // Unsupported metrics stay marked through the support flags.
+            }
+          };
+
+          if (state.supportsLargestContentfulPaint) {
+            observe("largest-contentful-paint", entry => {
+              state.largestContentfulPaintMs =
+                Math.round(entry.renderTime || entry.loadTime || entry.startTime || 0);
+            });
+          }
+
+          if (state.supportsLayoutShift) {
+            observe("layout-shift", entry => {
+              if (!entry.hadRecentInput) {
+                state.cumulativeLayoutShift += entry.value || 0;
+              }
+            });
+          }
+
+          window.__lfmPerf = state;
+        })();
+        """;
+}
+
+internal sealed record BrowserPerformanceMetrics(
+    bool SupportsLargestContentfulPaint,
+    bool SupportsLayoutShift,
+    bool SupportsEventTiming,
+    long? LargestContentfulPaintMs,
+    double CumulativeLayoutShift,
+    long? ControlledInteractionDurationMs,
+    int ResourceCount,
+    int ApiRequestCount,
+    long ApiTransferBytes,
+    long? P75ApiDurationMs,
+    long? MaxApiDurationMs);
+
+internal sealed record BrowserPerformanceMetricSummary(
+    int SampleCount,
+    bool SupportsLargestContentfulPaint,
+    bool SupportsLayoutShift,
+    bool SupportsEventTiming,
+    long? P50LargestContentfulPaintMs,
+    long? P75LargestContentfulPaintMs,
+    long? MaxLargestContentfulPaintMs,
+    double? P50CumulativeLayoutShift,
+    double? P75CumulativeLayoutShift,
+    double? MaxCumulativeLayoutShift,
+    long? P50ControlledInteractionDurationMs,
+    long? P75ControlledInteractionDurationMs,
+    long? MaxControlledInteractionDurationMs,
+    long? P50ApiRequestCount,
+    long? P75ApiRequestCount,
+    long? MaxApiRequestCount,
+    long? P50ApiTransferBytes,
+    long? P75ApiTransferBytes,
+    long? MaxApiTransferBytes,
+    long? P50ApiDurationMs,
+    long? P75ApiDurationMs,
+    long? MaxApiDurationMs);

--- a/tests/Lfm.E2E/Specs/PerformanceLoadSpec.cs
+++ b/tests/Lfm.E2E/Specs/PerformanceLoadSpec.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Net;
 using System.Text.Json;
 using Lfm.E2E.Fixtures;
+using Lfm.E2E.Helpers;
 using Lfm.E2E.Infrastructure;
 using Lfm.E2E.Seeds;
 using Xunit;
@@ -16,7 +17,7 @@ namespace Lfm.E2E.Specs;
 [Trait("Category", E2ELanes.PerformanceLoad)]
 public sealed class PerformanceLoadSpec(RunsFixture fixture, ITestOutputHelper output)
 {
-    private const int ReportSchemaVersion = 1;
+    private const int ReportSchemaVersion = 2;
     private const int Concurrency = 2;
     private const int RequestsPerProbe = 6;
     private const int AllowedFailureThreshold = 0;
@@ -47,6 +48,7 @@ public sealed class PerformanceLoadSpec(RunsFixture fixture, ITestOutputHelper o
         {
             new LoadProbe(
                 "public-landing",
+                "frontend",
                 "anonymous public landing static host",
                 anonymousClient,
                 HttpMethod.Get,
@@ -54,6 +56,7 @@ public sealed class PerformanceLoadSpec(RunsFixture fixture, ITestOutputHelper o
                 [200]),
             new LoadProbe(
                 "api-live-health",
+                "api-health",
                 "anonymous API live health",
                 anonymousClient,
                 HttpMethod.Get,
@@ -61,6 +64,7 @@ public sealed class PerformanceLoadSpec(RunsFixture fixture, ITestOutputHelper o
                 [200]),
             new LoadProbe(
                 "api-ready-health",
+                "api-health",
                 "anonymous API readiness",
                 anonymousClient,
                 HttpMethod.Get,
@@ -68,6 +72,7 @@ public sealed class PerformanceLoadSpec(RunsFixture fixture, ITestOutputHelper o
                 [200]),
             new LoadProbe(
                 "authenticated-runs-api",
+                "authenticated-api",
                 "authenticated runs list",
                 authenticatedClient,
                 HttpMethod.Get,
@@ -75,6 +80,7 @@ public sealed class PerformanceLoadSpec(RunsFixture fixture, ITestOutputHelper o
                 [200]),
             new LoadProbe(
                 "run-create-guild-dependency",
+                "authenticated-api",
                 "authenticated create-run guild dependency",
                 authenticatedClient,
                 HttpMethod.Get,
@@ -82,6 +88,7 @@ public sealed class PerformanceLoadSpec(RunsFixture fixture, ITestOutputHelper o
                 [200]),
             new LoadProbe(
                 "run-create-expansions-dependency",
+                "authenticated-reference-api",
                 "authenticated create-run expansions dependency",
                 authenticatedClient,
                 HttpMethod.Get,
@@ -89,6 +96,7 @@ public sealed class PerformanceLoadSpec(RunsFixture fixture, ITestOutputHelper o
                 [200]),
             new LoadProbe(
                 "run-create-instances-dependency",
+                "authenticated-reference-api",
                 "authenticated create-run instances dependency",
                 authenticatedClient,
                 HttpMethod.Get,
@@ -96,6 +104,7 @@ public sealed class PerformanceLoadSpec(RunsFixture fixture, ITestOutputHelper o
                 [200]),
             new LoadProbe(
                 "characters-list-api",
+                "authenticated-api",
                 "authenticated cached characters list",
                 authenticatedClient,
                 HttpMethod.Get,
@@ -103,6 +112,7 @@ public sealed class PerformanceLoadSpec(RunsFixture fixture, ITestOutputHelper o
                 [200]),
             new LoadProbe(
                 "signup-options-api",
+                "authenticated-api",
                 "authenticated seeded run signup options",
                 authenticatedClient,
                 HttpMethod.Get,
@@ -117,7 +127,7 @@ public sealed class PerformanceLoadSpec(RunsFixture fixture, ITestOutputHelper o
             probeReports.Add(report);
             output.WriteLine(
                 $"[PERFLOAD] {report.Name}: requests={report.RequestCount}, failures={report.FailureCount}, " +
-                $"p50={report.P50Ms}ms, p95={report.P95Ms}ms, max={report.MaxMs}ms");
+                $"p50={report.P50Ms}ms, p75={report.P75Ms}ms, p95={report.P95Ms}ms, max={report.MaxMs}ms");
         }
 
         var loadReport = new PerformanceLoadReport(
@@ -184,6 +194,7 @@ public sealed class PerformanceLoadSpec(RunsFixture fixture, ITestOutputHelper o
 
         return new ProbeReport(
             probe.Name,
+            probe.Group,
             probe.Journey,
             probe.Method.Method,
             probe.Url.AbsolutePath,
@@ -191,8 +202,9 @@ public sealed class PerformanceLoadSpec(RunsFixture fixture, ITestOutputHelper o
             probe.ExpectedStatusCodes,
             samples.Length,
             samples.Count(sample => !sample.Success),
-            Percentile(elapsed, 50),
-            Percentile(elapsed, 95),
+            PerformanceMetricsHelper.Percentile(elapsed, 50),
+            PerformanceMetricsHelper.Percentile(elapsed, 75),
+            PerformanceMetricsHelper.Percentile(elapsed, 95),
             elapsed.Max(),
             samples);
     }
@@ -260,21 +272,6 @@ public sealed class PerformanceLoadSpec(RunsFixture fixture, ITestOutputHelper o
         return path;
     }
 
-    private static long Percentile(IReadOnlyList<long> values, int percentile)
-    {
-        if (values.Count == 0)
-            return 0;
-
-        var sorted = values.OrderBy(value => value).ToArray();
-        var rank = (percentile / 100d) * (sorted.Length - 1);
-        var lower = (int)Math.Floor(rank);
-        var upper = (int)Math.Ceiling(rank);
-        if (lower == upper)
-            return sorted[lower];
-
-        return (long)Math.Round(sorted[lower] + ((sorted[upper] - sorted[lower]) * (rank - lower)));
-    }
-
     private static string FindRepoRoot()
     {
         var dir = AppContext.BaseDirectory;
@@ -291,6 +288,7 @@ public sealed class PerformanceLoadSpec(RunsFixture fixture, ITestOutputHelper o
 
     private sealed record LoadProbe(
         string Name,
+        string Group,
         string Journey,
         HttpClient Client,
         HttpMethod Method,
@@ -315,6 +313,7 @@ public sealed class PerformanceLoadSpec(RunsFixture fixture, ITestOutputHelper o
 
     private sealed record ProbeReport(
         string Name,
+        string Group,
         string Journey,
         string Method,
         string Endpoint,
@@ -323,6 +322,7 @@ public sealed class PerformanceLoadSpec(RunsFixture fixture, ITestOutputHelper o
         int RequestCount,
         int FailureCount,
         long P50Ms,
+        long P75Ms,
         long P95Ms,
         long MaxMs,
         IReadOnlyList<LoadSample> Samples);

--- a/tests/Lfm.E2E/Specs/PerformanceMetricsHelperSpec.cs
+++ b/tests/Lfm.E2E/Specs/PerformanceMetricsHelperSpec.cs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.E2E.Helpers;
+using Xunit;
+
+namespace Lfm.E2E.Specs;
+
+[Trait("Category", "Performance policy")]
+public class PerformanceMetricsHelperSpec
+{
+    [Fact]
+    public void Percentile_InterpolatesP75ForSmallLocalSamples()
+    {
+        var p75 = PerformanceMetricsHelper.Percentile([100, 200, 400, 800], 75);
+
+        Assert.Equal(500, p75);
+    }
+
+    [Fact]
+    public void SummarizeBrowserMetrics_ReportsP75AndSupportFlags()
+    {
+        var samples = new[]
+        {
+            new BrowserPerformanceMetrics(true, true, true, 1000, 0.01, 100, 3, 2, 1024, 40, 80),
+            new BrowserPerformanceMetrics(true, true, true, 2000, 0.02, 200, 4, 2, 2048, 80, 120),
+            new BrowserPerformanceMetrics(true, true, true, 3000, 0.04, 400, 5, 3, 4096, 120, 200),
+            new BrowserPerformanceMetrics(true, true, true, 5000, 0.08, 800, 6, 4, 8192, 160, 240),
+        };
+
+        var summary = PerformanceMetricsHelper.Summarize(samples);
+
+        Assert.True(summary.SupportsLargestContentfulPaint);
+        Assert.True(summary.SupportsLayoutShift);
+        Assert.True(summary.SupportsEventTiming);
+        Assert.Equal(3500, summary.P75LargestContentfulPaintMs);
+        Assert.Equal(0.05, summary.P75CumulativeLayoutShift);
+        Assert.Equal(500, summary.P75ControlledInteractionDurationMs);
+        Assert.Equal(3, summary.P75ApiRequestCount);
+        Assert.Equal(5120, summary.P75ApiTransferBytes);
+        Assert.Equal(130, summary.P75ApiDurationMs);
+    }
+
+    [Fact]
+    public void EvaluatePoorThresholds_FailsOnlySupportedMetricsAbovePoorThreshold()
+    {
+        var summary = new BrowserPerformanceMetricSummary(
+            SampleCount: 4,
+            SupportsLargestContentfulPaint: true,
+            SupportsLayoutShift: true,
+            SupportsEventTiming: true,
+            P50LargestContentfulPaintMs: 3000,
+            P75LargestContentfulPaintMs: 4500,
+            MaxLargestContentfulPaintMs: 6000,
+            P50CumulativeLayoutShift: 0.10,
+            P75CumulativeLayoutShift: 0.20,
+            MaxCumulativeLayoutShift: 0.30,
+            P50ControlledInteractionDurationMs: 300,
+            P75ControlledInteractionDurationMs: 600,
+            MaxControlledInteractionDurationMs: 700,
+            P50ApiRequestCount: 2,
+            P75ApiRequestCount: 3,
+            MaxApiRequestCount: 4,
+            P50ApiTransferBytes: 2048,
+            P75ApiTransferBytes: 3072,
+            MaxApiTransferBytes: 4096,
+            P50ApiDurationMs: 100,
+            P75ApiDurationMs: 125,
+            MaxApiDurationMs: 250);
+
+        var failures = PerformanceMetricsHelper.EvaluatePoorThresholds(
+            "warm-route-navigation",
+            "mobile",
+            summary);
+
+        Assert.Contains(
+            "warm-route-navigation [mobile] LCP p75 4500 ms exceeds local poor threshold 4000 ms",
+            failures);
+        Assert.Contains(
+            "warm-route-navigation [mobile] controlled interaction p75 600 ms exceeds local poor threshold 500 ms",
+            failures);
+        Assert.DoesNotContain(failures, failure => failure.Contains("CLS", StringComparison.Ordinal));
+    }
+}

--- a/tests/Lfm.E2E/Specs/PerformanceSpec.cs
+++ b/tests/Lfm.E2E/Specs/PerformanceSpec.cs
@@ -20,7 +20,7 @@ namespace Lfm.E2E.Specs;
 public class PerformanceSpec(RunsFixture fixture, ITestOutputHelper output)
     : E2ETestBase(output), IAsyncLifetime
 {
-    private const int ReportSchemaVersion = 1;
+    private const int ReportSchemaVersion = 2;
     private const int DefaultSampleCount = 2;
 
     private static readonly PerformanceViewport[] Viewports =
@@ -71,6 +71,18 @@ public class PerformanceSpec(RunsFixture fixture, ITestOutputHelper output)
             diagnosticFailures.Length == 0,
             "Performance journeys emitted unexpected browser/network failures:\n"
             + string.Join("\n", diagnosticFailures));
+
+        var poorThresholdFailures = _results
+            .SelectMany(result => PerformanceMetricsHelper.EvaluatePoorThresholds(
+                result.Name,
+                result.Viewport.Name,
+                result.BrowserMetrics))
+            .ToArray();
+
+        Assert.True(
+            poorThresholdFailures.Length == 0,
+            "Performance journeys exceeded local browser poor-threshold gates:\n"
+            + string.Join("\n", poorThresholdFailures));
     }
 
     private async Task MeasureColdPublicLandingAsync(PerformanceViewport viewport)
@@ -103,7 +115,13 @@ public class PerformanceSpec(RunsFixture fixture, ITestOutputHelper output)
             }
         }
 
-        AddResult("cold-public-landing", TimeSpan.FromSeconds(60), viewport, samples);
+        AddResult(
+            "cold-public-landing",
+            TimeSpan.FromSeconds(60),
+            viewport,
+            "cold-context",
+            "anonymous",
+            samples);
     }
 
     private async Task MeasureAuthenticatedRoutesAsync(PerformanceViewport viewport)
@@ -270,7 +288,13 @@ public class PerformanceSpec(RunsFixture fixture, ITestOutputHelper output)
             }
         }
 
-        AddResult(name, budget, viewport, samples);
+        AddResult(
+            name,
+            budget,
+            viewport,
+            measureRouteTransition ? "warm-spa-route" : "warm-auth-context-new-page",
+            "authenticated",
+            samples);
     }
 
     private static async Task StubCharacterPortraitsAsync(IPage page)
@@ -296,6 +320,7 @@ public class PerformanceSpec(RunsFixture fixture, ITestOutputHelper output)
     {
         var diagnostics = new BrowserDiagnostics(name);
         diagnostics.Attach(page);
+        await PerformanceMetricsHelper.StartCollectionAsync(page);
 
         double? routeTransitionDurationMs = null;
         if (measureRouteTransition)
@@ -315,6 +340,7 @@ public class PerformanceSpec(RunsFixture fixture, ITestOutputHelper output)
         var navigationDurationMs = measureRouteTransition
             ? null
             : await ReadNavigationDurationMsAsync(page);
+        var browserMetrics = await PerformanceMetricsHelper.ReadAsync(page, routeTransitionDurationMs);
 
         return new PerformanceSample(
             sample,
@@ -322,6 +348,7 @@ public class PerformanceSpec(RunsFixture fixture, ITestOutputHelper output)
             (long)budget.TotalMilliseconds,
             navigationDurationMs,
             routeTransitionDurationMs,
+            browserMetrics,
             diagnostics.RequestFailures.ToArray(),
             diagnostics.HttpFailures.ToArray(),
             diagnostics.ConsoleErrors.ToArray());
@@ -331,6 +358,8 @@ public class PerformanceSpec(RunsFixture fixture, ITestOutputHelper output)
         string name,
         TimeSpan budget,
         PerformanceViewport viewport,
+        string cacheState,
+        string userState,
         IReadOnlyList<PerformanceSample> samples)
     {
         var elapsedValues = samples.Select(sample => sample.ElapsedMs).ToArray();
@@ -346,13 +375,22 @@ public class PerformanceSpec(RunsFixture fixture, ITestOutputHelper output)
         _results.Add(new PerformanceJourneyResult(
             name,
             viewport,
+            cacheState,
+            userState,
+            PerformanceMetricsHelper.MetricSource,
+            PerformanceMetricsHelper.GatePolicy,
+            PerformanceMetricsHelper.ThresholdSource,
             (long)budget.TotalMilliseconds,
-            Percentile(elapsedValues, 50),
+            PerformanceMetricsHelper.Percentile(elapsedValues, 50),
+            PerformanceMetricsHelper.Percentile(elapsedValues, 75),
             elapsedValues.Max(),
             PercentileOrNull(navigationValues, 50),
+            PercentileOrNull(navigationValues, 75),
             MaxOrNull(navigationValues),
             PercentileOrNull(routeValues, 50),
+            PercentileOrNull(routeValues, 75),
             MaxOrNull(routeValues),
+            PerformanceMetricsHelper.Summarize(samples.Select(sample => sample.BrowserMetrics).ToArray()),
             samples));
     }
 
@@ -549,6 +587,7 @@ public class PerformanceSpec(RunsFixture fixture, ITestOutputHelper output)
         long BudgetMs,
         double? NavigationDurationMs,
         double? RouteTransitionDurationMs,
+        BrowserPerformanceMetrics BrowserMetrics,
         IReadOnlyCollection<PerformanceDiagnostic> RequestFailures,
         IReadOnlyCollection<PerformanceDiagnostic> HttpFailures,
         IReadOnlyCollection<PerformanceDiagnostic> ConsoleErrors);
@@ -557,6 +596,8 @@ public class PerformanceSpec(RunsFixture fixture, ITestOutputHelper output)
         string StackTarget,
         string BrowserName,
         string BrowserVersion,
+        string Runner,
+        string OperatingSystem,
         string? Commit,
         string? Ref,
         int SampleCount,
@@ -566,19 +607,30 @@ public class PerformanceSpec(RunsFixture fixture, ITestOutputHelper output)
         int SchemaVersion,
         DateTimeOffset GeneratedAt,
         PerformanceRunMetadata Run,
-        string BudgetPolicy,
+        string MetricSource,
+        string GatePolicy,
+        string ThresholdSource,
         IReadOnlyList<PerformanceJourneyResult> Journeys);
 
     private sealed record PerformanceJourneyResult(
         string Name,
         PerformanceViewport Viewport,
+        string CacheState,
+        string UserState,
+        string MetricSource,
+        string GatePolicy,
+        string ThresholdSource,
         long BudgetMs,
         long P50ElapsedMs,
+        long P75ElapsedMs,
         long MaxElapsedMs,
         double? P50NavigationDurationMs,
+        double? P75NavigationDurationMs,
         double? MaxNavigationDurationMs,
         double? P50RouteTransitionDurationMs,
+        double? P75RouteTransitionDurationMs,
         double? MaxRouteTransitionDurationMs,
+        BrowserPerformanceMetricSummary BrowserMetrics,
         IReadOnlyList<PerformanceSample> Samples);
 
     private PerformanceRunMetadata CreateRunMetadata()
@@ -587,6 +639,8 @@ public class PerformanceSpec(RunsFixture fixture, ITestOutputHelper output)
             "local-stack",
             ReadBrowserName(fixture.Stack.Browser),
             ReadBrowserVersion(fixture.Stack.Browser),
+            ReadRunnerName(),
+            Environment.OSVersion.Platform.ToString(),
             ReadFirstEnvironmentValue("GITHUB_SHA", "BUILD_SOURCEVERSION"),
             ReadFirstEnvironmentValue("GITHUB_REF", "GITHUB_HEAD_REF", "BUILD_SOURCEBRANCH"),
             _sampleCount,
@@ -617,6 +671,14 @@ public class PerformanceSpec(RunsFixture fixture, ITestOutputHelper output)
         return null;
     }
 
+    private static string ReadRunnerName()
+    {
+        if (string.Equals(Environment.GetEnvironmentVariable("GITHUB_ACTIONS"), "true", StringComparison.OrdinalIgnoreCase))
+            return "github-actions";
+
+        return "local";
+    }
+
     private void WriteReport()
     {
         var repoRoot = FindRepoRoot();
@@ -627,7 +689,9 @@ public class PerformanceSpec(RunsFixture fixture, ITestOutputHelper output)
             ReportSchemaVersion,
             DateTimeOffset.UtcNow,
             CreateRunMetadata(),
-            "Catastrophic local-stack regression guard; timing drift remains advisory until baseline promotion.",
+            PerformanceMetricsHelper.MetricSource,
+            PerformanceMetricsHelper.GatePolicy,
+            PerformanceMetricsHelper.ThresholdSource,
             _results);
 
         var path = Path.Combine(outputDir, "performance-report.json");


### PR DESCRIPTION
## Summary
- Add Playwright browser performance metrics collection for local E2E journeys, including Web Vitals-style LCP/CLS signals, interaction proxy timings, resource/API timing summaries, and support flags.
- Upgrade local performance and load-smoke reports to schema v2 with p75, metadata, cache/user state, source/gate policy fields, and hybrid hard/advisory gates.
- Expand production synthetic checks to multi-sample status-only probes and add a GitHub Step Summary for scheduled performance evidence.
- Document lab-vs-production interpretation, v2 report artifacts, and out-of-scope authenticated/paid monitoring.

## Env / Artifact Contract Changes
- `artifacts/e2e-results/performance-report.json` is schema v2.
- `artifacts/e2e-results/performance-load-report.json` gains p75/grouping fields.
- `artifacts/production-synthetic/production-synthetic-report.json` gains multi-sample percentile fields.
- Adds `SYNTHETIC_PROBE_SAMPLES`; keeps `LFM_E2E_PERFORMANCE_SAMPLES` and sets scheduled collection to 4 samples.

## Verification
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --filter FullyQualifiedName~PerformanceMetricsHelperSpec`
- `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --filter "Category=Performance"`
- `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --filter "Category=PerformanceLoad"`
- `dotnet build lfm.sln -c Release`
- `bash -n scripts/production-synthetic-check.sh`
- `bash -n scripts/write-performance-summary.sh`
- `bash -n scripts/pre-push`
- `bash ./scripts/check-e2e-drift.sh`
- `jq` validation of generated schema v2 reports

`check-e2e-drift.sh` exited 0 and reported only review-only selector/page-object hints.