### PR TITLE
Improve e2e user flow coverage

### DIFF
--- a/api/Program.cs
+++ b/api/Program.cs
@@ -177,7 +177,16 @@ builder.Services.AddScoped<Lfm.Api.Repositories.ISpecializationsRepository, Lfm.
 builder.Services.AddScoped<Lfm.Api.Repositories.IRaidersRepository, Lfm.Api.Repositories.RaidersRepository>();
 builder.Services.AddScoped<Lfm.Api.Repositories.IRunsRepository, Lfm.Api.Repositories.RunsRepository>();
 builder.Services.AddScoped<Lfm.Api.Repositories.IGuildRepository, Lfm.Api.Repositories.GuildRepository>();
-builder.Services.AddSingleton<Lfm.Api.Services.ISecretResolver, Lfm.Api.Services.KeyVaultSecretResolver>();
+#if E2E
+if (string.Equals(builder.Configuration["E2E_TEST_MODE"], "true", StringComparison.OrdinalIgnoreCase))
+{
+    builder.Services.AddSingleton<Lfm.Api.Services.ISecretResolver, Lfm.Api.Services.E2ESecretResolver>();
+}
+else
+#endif
+{
+    builder.Services.AddSingleton<Lfm.Api.Services.ISecretResolver, Lfm.Api.Services.KeyVaultSecretResolver>();
+}
 builder.Services.AddSingleton<Lfm.Api.Services.ISiteAdminService, Lfm.Api.Services.SiteAdminService>();
 builder.Services.AddSingleton<Lfm.Api.Services.IIdempotencyStore, Lfm.Api.Services.IdempotencyStore>();
 builder.Services.AddScoped<Lfm.Api.Services.IGuildPermissions, Lfm.Api.Services.GuildPermissions>();

--- a/api/Services/E2ESecretResolver.cs
+++ b/api/Services/E2ESecretResolver.cs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+#if E2E
+namespace Lfm.Api.Services;
+
+/// <summary>
+/// E2E-only secret resolver used by the containerized test API. It keeps the
+/// site-admin journey local-first while exercising SiteAdminService's allowlist
+/// path instead of bypassing it in the browser test.
+/// </summary>
+public sealed class E2ESecretResolver : ISecretResolver
+{
+    public Task<string?> GetSecretAsync(string vaultUrl, string secretName, CancellationToken ct)
+        => Task.FromResult<string?>(
+            string.Equals(secretName, "site-admin-battle-net-ids", StringComparison.Ordinal)
+                ? "test-bnet-id-admin"
+                : null);
+}
+#endif

--- a/tests/Lfm.E2E/Infrastructure/StackFixture.cs
+++ b/tests/Lfm.E2E/Infrastructure/StackFixture.cs
@@ -405,6 +405,7 @@ public class StackFixture : IAsyncLifetime
             ["E2E_TEST_MODE"] = "true",
             ["Auth__CookieName"] = "battlenet_token",
             ["Auth__CookieMaxAgeHours"] = "24",
+            ["Auth__KeyVaultUrl"] = "https://lfm-e2e-vault.vault.azure.net/",
             ["Blizzard__ClientId"] = "e2e-stub",
             ["Blizzard__ClientSecret"] = "e2e-stub",
             ["Blizzard__Region"] = "eu",

--- a/tests/Lfm.E2E/Pages/RunsPage.cs
+++ b/tests/Lfm.E2E/Pages/RunsPage.cs
@@ -68,6 +68,18 @@ public class RunsPage(IPage page)
     public ILocator SignupButton =>
         _page.GetByRole(AriaRole.Button, new() { Name = "Sign up" });
 
+    /// <summary>"Cancel signup" button shown after the current user has signed up.</summary>
+    public ILocator CancelSignupButton =>
+        _page.GetByRole(AriaRole.Button, new() { Name = "Cancel signup" });
+
+    /// <summary>Current-user signup confirmation label in the run detail signup panel.</summary>
+    public ILocator SignedUpAs(string characterName) =>
+        _page.GetByText($"Signed up as {characterName}.");
+
+    /// <summary>"No signups yet." placeholder in the run detail roster.</summary>
+    public ILocator NoSignupsMessage =>
+        _page.GetByText("No signups yet.");
+
     // ---- Create Run form (/runs/new) ----
 
     /// <summary>Instance dropdown on the create-run form.</summary>
@@ -114,7 +126,8 @@ public class RunsPage(IPage page)
 
     /// <summary>"Cancel" button in the delete confirmation card.</summary>
     public ILocator DeleteCancelButton =>
-        _page.GetByRole(AriaRole.Button, new() { Name = "Cancel" });
+        _page.Locator("dialog.confirm-dialog")
+            .GetByRole(AriaRole.Button, new() { Name = "Cancel" });
 
     /// <summary>"Run saved successfully." success banner.</summary>
     public ILocator SaveSuccessBanner =>

--- a/tests/Lfm.E2E/Seeds/DefaultSeed.cs
+++ b/tests/Lfm.E2E/Seeds/DefaultSeed.cs
@@ -11,6 +11,7 @@ public static class DefaultSeed
     public const string PrimaryBattleNetId = "test-bnet-id";
     public const string SecondaryBattleNetId = "test-bnet-id-2";
     public const string DisposableBattleNetId = "test-bnet-id-delete";
+    public const string SiteAdminBattleNetId = "test-bnet-id-admin";
     // Must match the guildId assigned by E2ELoginFunction for non-admin test users.
     // Must be numeric — RunsRepository.ListForGuildAsync does int.TryParse on it.
     public const string TestGuildId = "12345";
@@ -30,6 +31,7 @@ public static class DefaultSeed
         await SeedPrimaryRaiderAsync(raidersContainer);
         await SeedSecondaryRaiderAsync(raidersContainer);
         await SeedDisposableRaiderAsync(raidersContainer);
+        await SeedSiteAdminRaiderAsync(raidersContainer);
 
         // --- Guilds container (partition key: /id) ---
         var guildsContainer = (await RetryAsync(
@@ -104,6 +106,22 @@ public static class DefaultSeed
 
         await RetryAsync(
             () => container.UpsertItemAsync(raider, new PartitionKey(DisposableBattleNetId)));
+    }
+
+    private static async Task SeedSiteAdminRaiderAsync(Container container)
+    {
+        var raider = new RaiderSeedBuilder(SiteAdminBattleNetId, accountId: 4)
+            .AddCharacter(
+                id: "eu-test-realm-seralyth",
+                name: "Seralyth",
+                classId: 6,
+                className: "Death Knight",
+                specializationId: 250,
+                specializationName: "Blood")
+            .Build();
+
+        await RetryAsync(
+            () => container.UpsertItemAsync(raider, new PartitionKey(SiteAdminBattleNetId)));
     }
 
     private static async Task SeedGuildAsync(Container container)

--- a/tests/Lfm.E2E/Specs/RunsSpec.cs
+++ b/tests/Lfm.E2E/Specs/RunsSpec.cs
@@ -6,6 +6,7 @@ using Lfm.E2E.Helpers;
 using Lfm.E2E.Infrastructure;
 using Lfm.E2E.Pages;
 using Lfm.E2E.Seeds;
+using Microsoft.Azure.Cosmos;
 using Microsoft.Playwright;
 using Xunit;
 using Xunit.Abstractions;
@@ -114,6 +115,10 @@ public class RunsSpec(RunsFixture fixture, ITestOutputHelper output)
         await runsPage.SelectRunAsync(runId);
         await Assertions.Expect(Page.GetByText(uniqueRunName)).ToBeVisibleAsync(
             new() { Timeout = 15000 });
+        await Assertions.Expect(runsPage.EditButton).ToBeVisibleAsync(
+            new() { Timeout = 10000 });
+        await Assertions.Expect(runsPage.NoSignupsMessage).ToBeVisibleAsync(
+            new() { Timeout = 10000 });
     }
 
     // E2E scope: proves list-click navigation renders the seeded run roster and signup count.
@@ -248,17 +253,21 @@ public class RunsSpec(RunsFixture fixture, ITestOutputHelper output)
             new() { Timeout = 15000 });
     }
 
-    // E2E scope: proves the browser signup journey uses run-scoped guild roster
-    // options, persists the signup through the API, and re-renders the run roster.
-    // Cheaper lanes cover the individual filters and service outcomes; only E2E
-    // proves the composed user path from rendered options to persisted roster.
+    // E2E scope: proves the primary raider can manage their own run signup in the browser.
+    // Cheaper lanes cover the individual filters and service outcomes; only E2E proves eligible
+    // option rendering, signup persistence, cancellation, and roster re-rendering compose.
     // Shared data: disposable.
     [Fact]
-    public async Task Signup_GuildRosteredCharacter_AppearsInRoster()
+    public async Task Signup_GuildRosteredCharacter_CanManageOwnSignup()
     {
         var page = Page!;
         var runsPage = new RunsPage(page);
-        var createdRunId = await CreateFreshRunAsync(runsPage);
+        var createdRunId = await SeedDisposableSignupRunAsync();
+
+        await runsPage.GotoAsync(fixture.Stack.AppBaseUrl);
+        await Assertions.Expect(runsPage.RunItem(createdRunId))
+            .ToBeVisibleAsync(new() { Timeout = 15000 });
+        await runsPage.SelectRunAsync(createdRunId);
 
         await Assertions.Expect(runsPage.SignupButton).ToBeVisibleAsync(new() { Timeout = 15000 });
 
@@ -279,6 +288,51 @@ public class RunsSpec(RunsFixture fixture, ITestOutputHelper output)
             runsPage.RosterCharacterRows.GetByText("Aelrin", new() { Exact = true }))
             .ToBeVisibleAsync(new() { Timeout = 10000 });
         await Assertions.Expect(runsPage.RunItem(createdRunId)).ToBeVisibleAsync(new() { Timeout = 10000 });
+
+        await Assertions.Expect(runsPage.CancelSignupButton)
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+        await runsPage.CancelSignupButton.ClickAsync();
+
+        await Assertions.Expect(runsPage.SignupButton)
+            .ToBeVisibleAsync(new() { Timeout = 15000 });
+        await Assertions.Expect(runsPage.SignedUpAs("Aelrin"))
+            .Not.ToBeVisibleAsync(new() { Timeout = 10000 });
+        await Assertions.Expect(runsPage.NoSignupsMessage)
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+        await Assertions.Expect(runsPage.RosterCharacterRows)
+            .ToHaveCountAsync(0, new() { Timeout = 10000 });
+    }
+
+    private async Task<string> SeedDisposableSignupRunAsync()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var startTime = now.AddDays(21);
+        var signupCloseTime = startTime.AddMinutes(-30);
+        var createdAt = now.AddMinutes(-5);
+        var runId = $"e2e-signup-{Guid.NewGuid():N}";
+        const string Format = "yyyy-MM-ddTHH:mm:ss.fffffffZ";
+
+        var run = new Dictionary<string, object?>
+        {
+            ["id"] = runId,
+            ["startTime"] = startTime.ToString(Format),
+            ["signupCloseTime"] = signupCloseTime.ToString(Format),
+            ["description"] = "E2E primary signup management",
+            ["modeKey"] = "NORMAL:25",
+            ["visibility"] = "GUILD",
+            ["creatorGuild"] = "Test Guild",
+            ["creatorGuildId"] = 12345,
+            ["instanceId"] = 67,
+            ["instanceName"] = "Liberation of Undermine",
+            ["creatorBattleNetId"] = DefaultSeed.PrimaryBattleNetId,
+            ["createdAt"] = createdAt.ToString(Format),
+            ["ttl"] = 2592000,
+            ["runCharacters"] = new List<object>(),
+        };
+
+        var container = fixture.Stack.CosmosClient.GetContainer(StackFixture.DatabaseName, "runs");
+        await container.UpsertItemAsync(run, new PartitionKey(runId));
+        return runId;
     }
 
     /// <summary>
@@ -363,6 +417,15 @@ public class RunsSpec(RunsFixture fixture, ITestOutputHelper output)
             await Assertions.Expect(runsPage.DeleteRunButton).ToBeVisibleAsync(new() { Timeout = 15000 });
             await runsPage.DeleteRunButton.ClickAsync();
 
+            await Assertions.Expect(runsPage.ConfirmDeleteButton).ToBeVisibleAsync(new() { Timeout = 10000 });
+            await Assertions.Expect(runsPage.DeleteCancelButton).ToBeVisibleAsync(new() { Timeout = 10000 });
+            await runsPage.DeleteCancelButton.ClickAsync();
+
+            await Assertions.Expect(runsPage.ConfirmDeleteButton).Not.ToBeVisibleAsync(
+                new() { Timeout = 10000 });
+            await Assertions.Expect(runsPage.DeleteRunButton).ToBeVisibleAsync(new() { Timeout = 10000 });
+
+            await runsPage.DeleteRunButton.ClickAsync();
             await Assertions.Expect(runsPage.ConfirmDeleteButton).ToBeVisibleAsync(new() { Timeout = 10000 });
             await runsPage.ConfirmDeleteButton.ClickAsync();
 

--- a/tests/Lfm.E2E/Specs/SiteAdminSpec.cs
+++ b/tests/Lfm.E2E/Specs/SiteAdminSpec.cs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Text.RegularExpressions;
+using Lfm.E2E.Fixtures;
+using Lfm.E2E.Helpers;
+using Lfm.E2E.Infrastructure;
+using Lfm.E2E.Seeds;
+using Microsoft.Playwright;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Lfm.E2E.Specs;
+
+[Collection("Navigation")]
+[Trait("Category", E2ELanes.Functional)]
+public class SiteAdminSpec(NavigationFixture fixture, ITestOutputHelper output)
+    : E2ETestBase(output), IAsyncLifetime
+{
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+        Context = await AuthHelper.AuthenticatedContextAsync(
+            fixture.Stack.Browser,
+            fixture.Stack.ApiBaseUrl,
+            fixture.Stack.AppBaseUrl,
+            battleNetId: DefaultSeed.SiteAdminBattleNetId,
+            redirect: "/runs");
+        Page = await Context.NewPageAsync();
+        AttachDiagnosticListeners();
+        await StartTracingAsync();
+    }
+
+    public override async Task DisposeAsync()
+    {
+        await base.DisposeAsync();
+        if (Context is not null)
+            await Context.CloseAsync();
+    }
+
+    // E2E scope: proves a real browser session receives the SiteAdmin role from
+    // /api/v1/me, renders the admin nav affordance, and reaches the protected
+    // reference-data page. Cheaper lanes already cover component markup and the
+    // POST refresh contract, so this test intentionally does not click Refresh.
+    // Shared data: read-only.
+    [Fact]
+    public async Task SiteAdmin_NavLink_ReachesReferenceDataPage()
+    {
+        await Page!.GotoAsync(
+            $"{fixture.Stack.AppBaseUrl}/runs",
+            new() { WaitUntil = WaitUntilState.NetworkIdle });
+
+        var adminLink = Page.GetByRole(AriaRole.Link, new() { Name = "Admin", Exact = true });
+        await Assertions.Expect(adminLink).ToBeVisibleAsync(new() { Timeout = 15000 });
+
+        await adminLink.ClickAsync();
+
+        await Assertions.Expect(Page).ToHaveURLAsync(
+            new Regex(@"/admin/reference$"),
+            new() { Timeout = 10000 });
+        await Assertions.Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Reference data" }))
+            .ToBeVisibleAsync(new() { Timeout = 15000 });
+        await Assertions.Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Refresh now" }))
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+    }
+}


### PR DESCRIPTION
## Summary
- expand the primary run signup journey to cover eligible options, signup persistence, cancellation, and empty-roster recovery
- add organizer-flow assertions for created-run detail affordances and delete-dialog cancellation
- add an E2E site-admin journey through the real /api/v1/me role path to the protected reference-data page

## Verification
- `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --no-restore --filter FullyQualifiedName~SiteAdminSpec`
- `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --no-restore --filter "FullyQualifiedName~Lfm.E2E.Specs.RunsSpec|FullyQualifiedName~Lfm.E2E.Specs.SiteAdminSpec"`
- `bash scripts/check-e2e-drift.sh`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `dotnet build lfm.sln -c Release --no-restore`
- `git diff --check`