### PR TITLE
Fix default guild rank permissions

### DIFF
--- a/api/Mappers/GuildMapper.cs
+++ b/api/Mappers/GuildMapper.cs
@@ -70,14 +70,7 @@ internal static class GuildMapper
         GuildSettingsDto? settings = null;
         if (permissions.IsAdmin)
         {
-            var rankPerms = (doc.RankPermissions ?? Array.Empty<GuildRankPermission>())
-                .Select(rp => new GuildRankPermissionDto(
-                    Rank: rp.Rank,
-                    CanCreateGuildRuns: rp.CanCreateGuildRuns,
-                    CanSignupGuildRuns: rp.CanSignupGuildRuns,
-                    CanDeleteGuildRuns: rp.CanDeleteGuildRuns))
-                .ToList();
-            settings = new GuildSettingsDto(RankPermissions: rankPerms);
+            settings = new GuildSettingsDto(RankPermissions: MapRankPermissions(doc));
         }
 
         return new GuildDto(
@@ -93,5 +86,28 @@ internal static class GuildMapper
         if (doc.BlizzardRosterFetchedAt is null) return false;
         if (!DateTimeOffset.TryParse(doc.BlizzardRosterFetchedAt, out var fetchedAt)) return false;
         return DateTimeOffset.UtcNow - fetchedAt < TimeSpan.FromHours(1);
+    }
+
+    private static IReadOnlyList<GuildRankPermissionDto> MapRankPermissions(GuildDocument doc)
+    {
+        var storedPermissions = doc.RankPermissions ?? Array.Empty<GuildRankPermission>();
+        var rosterRanks = doc.BlizzardRosterRaw?.Members?.Select(m => m.Rank) ?? [];
+        var ranks = storedPermissions
+            .Select(p => p.Rank)
+            .Concat(rosterRanks)
+            .Distinct()
+            .Order();
+
+        return ranks
+            .Select(rank =>
+            {
+                var stored = storedPermissions.FirstOrDefault(p => p.Rank == rank);
+                return new GuildRankPermissionDto(
+                    Rank: rank,
+                    CanCreateGuildRuns: stored?.CanCreateGuildRuns ?? rank == 0,
+                    CanSignupGuildRuns: stored?.CanSignupGuildRuns ?? true,
+                    CanDeleteGuildRuns: stored?.CanDeleteGuildRuns ?? rank == 0);
+            })
+            .ToList();
     }
 }

--- a/tests/Lfm.Api.Tests/GuildMapperTests.cs
+++ b/tests/Lfm.Api.Tests/GuildMapperTests.cs
@@ -48,6 +48,53 @@ public class GuildMapperTests
     }
 
     [Fact]
+    public void MapToDto_AdminWithNoStoredRankPermissions_PopulatesDefaultSettingsFromRosterRanks()
+    {
+        var perms = new GuildEffectivePermissions(
+            IsAdmin: true,
+            CanCreateGuildRuns: true,
+            CanSignupGuildRuns: true,
+            CanDeleteGuildRuns: true);
+        var doc = SampleDoc() with
+        {
+            RankPermissions = null,
+            BlizzardRosterRaw = new StoredGuildRoster(
+            [
+                new StoredGuildRosterMember(
+                    Character: new StoredGuildRosterMemberCharacter(
+                        Name: "Aelrin",
+                        Realm: new StoredGuildRosterRealm("ravencrest")),
+                    Rank: 0),
+                new StoredGuildRosterMember(
+                    Character: new StoredGuildRosterMemberCharacter(
+                        Name: "Kaldris",
+                        Realm: new StoredGuildRosterRealm("ravencrest")),
+                    Rank: 5),
+            ]),
+        };
+
+        var dto = GuildMapper.MapToDto(doc, perms);
+
+        Assert.NotNull(dto.Settings);
+        Assert.Collection(
+            dto.Settings.RankPermissions,
+            rank0 =>
+            {
+                Assert.Equal(0, rank0.Rank);
+                Assert.True(rank0.CanCreateGuildRuns);
+                Assert.True(rank0.CanSignupGuildRuns);
+                Assert.True(rank0.CanDeleteGuildRuns);
+            },
+            rank5 =>
+            {
+                Assert.Equal(5, rank5.Rank);
+                Assert.False(rank5.CanCreateGuildRuns);
+                Assert.True(rank5.CanSignupGuildRuns);
+                Assert.False(rank5.CanDeleteGuildRuns);
+            });
+    }
+
+    [Fact]
     public void MapToDto_NonAdmin_OmitsSettings_PopulatesMemberPermissions()
     {
         var perms = new GuildEffectivePermissions(

--- a/tests/Lfm.E2E/Pages/GuildAdminPage.cs
+++ b/tests/Lfm.E2E/Pages/GuildAdminPage.cs
@@ -17,6 +17,12 @@ public class GuildAdminPage(IPage page)
     public ILocator OverrideSettingsHeading =>
         _page.GetByText("Override Settings");
 
+    public ILocator RankPermissionsHeading =>
+        _page.GetByText("Rank Permissions");
+
+    public ILocator RankLabel(int rank) =>
+        _page.GetByText($"Rank {rank}", new() { Exact = true });
+
     // FluentTextArea — target inner textarea for FillAsync to work.
     public ILocator SloganField =>
         _page.Locator("#guild-slogan textarea");

--- a/tests/Lfm.E2E/Seeds/DefaultSeed.cs
+++ b/tests/Lfm.E2E/Seeds/DefaultSeed.cs
@@ -12,9 +12,11 @@ public static class DefaultSeed
     public const string SecondaryBattleNetId = "test-bnet-id-2";
     public const string DisposableBattleNetId = "test-bnet-id-delete";
     public const string SiteAdminBattleNetId = "test-bnet-id-admin";
+    public const string UnconfiguredGuildAdminBattleNetId = "test-bnet-id-unconfigured-guild-admin";
     // Must match the guildId assigned by E2ELoginFunction for non-admin test users.
     // Must be numeric — RunsRepository.ListForGuildAsync does int.TryParse on it.
     public const string TestGuildId = "12345";
+    private const string UnconfiguredGuildId = "67890";
     public const string TestRunId = "e2e-run-001";
 
     public static async Task SeedAsync(CosmosClient client, string databaseName)
@@ -32,6 +34,7 @@ public static class DefaultSeed
         await SeedSecondaryRaiderAsync(raidersContainer);
         await SeedDisposableRaiderAsync(raidersContainer);
         await SeedSiteAdminRaiderAsync(raidersContainer);
+        await SeedUnconfiguredGuildAdminRaiderAsync(raidersContainer);
 
         // --- Guilds container (partition key: /id) ---
         var guildsContainer = (await RetryAsync(
@@ -39,6 +42,7 @@ public static class DefaultSeed
                 new ContainerProperties("guilds", "/id")))).Container;
 
         await SeedGuildAsync(guildsContainer);
+        await SeedUnconfiguredGuildAsync(guildsContainer);
 
         // --- Runs container (partition key: /id) ---
         var runsContainer = (await RetryAsync(
@@ -124,6 +128,23 @@ public static class DefaultSeed
             () => container.UpsertItemAsync(raider, new PartitionKey(SiteAdminBattleNetId)));
     }
 
+    private static async Task SeedUnconfiguredGuildAdminRaiderAsync(Container container)
+    {
+        var raider = new RaiderSeedBuilder(UnconfiguredGuildAdminBattleNetId, accountId: 5)
+            .WithGuild(id: 67890, name: "Unconfigured Guild")
+            .AddCharacter(
+                id: "eu-test-realm-veyra",
+                name: "Veyra",
+                classId: 11,
+                className: "Druid",
+                specializationId: 105,
+                specializationName: "Restoration")
+            .Build();
+
+        await RetryAsync(
+            () => container.UpsertItemAsync(raider, new PartitionKey(UnconfiguredGuildAdminBattleNetId)));
+    }
+
     private static async Task SeedGuildAsync(Container container)
     {
         var guild = new Dictionary<string, object?>
@@ -202,6 +223,66 @@ public static class DefaultSeed
 
         await RetryAsync(
             () => container.UpsertItemAsync(guild, new PartitionKey(TestGuildId)));
+    }
+
+    private static async Task SeedUnconfiguredGuildAsync(Container container)
+    {
+        var guild = new Dictionary<string, object?>
+        {
+            ["id"] = UnconfiguredGuildId,
+            ["guildId"] = 67890,
+            ["realmSlug"] = "test-realm",
+            ["slogan"] = "Unconfigured permissions",
+            ["setup"] = new Dictionary<string, object?>
+            {
+                ["initializedAt"] = "2026-03-01T00:00:00.0000000Z",
+                ["timezone"] = "Europe/London",
+                ["locale"] = "en_GB",
+            },
+            ["blizzardProfileRaw"] = new Dictionary<string, object?>
+            {
+                ["name"] = "Unconfigured Guild",
+                ["realm"] = new Dictionary<string, object?>
+                {
+                    ["slug"] = "test-realm",
+                    ["name"] = "Test Realm",
+                },
+                ["faction"] = new Dictionary<string, object?>
+                {
+                    ["name"] = "Alliance",
+                },
+                ["memberCount"] = 12,
+                ["achievementPoints"] = 900,
+            },
+            ["blizzardRosterFetchedAt"] = DateTimeOffset.UtcNow.ToString("O"),
+            ["blizzardRosterRaw"] = new Dictionary<string, object?>
+            {
+                ["members"] = new List<object>
+                {
+                    new Dictionary<string, object?>
+                    {
+                        ["rank"] = 0,
+                        ["character"] = new Dictionary<string, object?>
+                        {
+                            ["name"] = "Veyra",
+                            ["realm"] = new Dictionary<string, object?> { ["slug"] = "test-realm" },
+                        },
+                    },
+                    new Dictionary<string, object?>
+                    {
+                        ["rank"] = 5,
+                        ["character"] = new Dictionary<string, object?>
+                        {
+                            ["name"] = "Guildmate",
+                            ["realm"] = new Dictionary<string, object?> { ["slug"] = "test-realm" },
+                        },
+                    },
+                },
+            },
+        };
+
+        await RetryAsync(
+            () => container.UpsertItemAsync(guild, new PartitionKey(UnconfiguredGuildId)));
     }
 
     private static async Task SeedRunAsync(Container container)

--- a/tests/Lfm.E2E/Seeds/RaiderSeedBuilder.cs
+++ b/tests/Lfm.E2E/Seeds/RaiderSeedBuilder.cs
@@ -32,18 +32,25 @@ internal sealed class RaiderSeedBuilder
     private const string RealmSlug = "test-realm";
     private const string RealmName = "Test Realm";
     private const int Level = 80;
-    private const int GuildId = 12345;
-    private const string GuildName = "Test Guild";
     private const string LastSeenAt = "2026-03-18T12:00:00.0000000Z";
 
     private readonly string battleNetId;
     private readonly int accountId;
     private readonly List<CharacterSeed> characters = [];
+    private int guildId = 12345;
+    private string guildName = "Test Guild";
 
     public RaiderSeedBuilder(string battleNetId, int accountId)
     {
         this.battleNetId = battleNetId;
         this.accountId = accountId;
+    }
+
+    public RaiderSeedBuilder WithGuild(int id, string name)
+    {
+        guildId = id;
+        guildName = name;
+        return this;
     }
 
     public RaiderSeedBuilder AddCharacter(
@@ -99,7 +106,7 @@ internal sealed class RaiderSeedBuilder
         };
     }
 
-    private static Dictionary<string, object?> BuildRaiderCharacter(CharacterSeed character, string fetchedAt)
+    private Dictionary<string, object?> BuildRaiderCharacter(CharacterSeed character, string fetchedAt)
     {
         return new Dictionary<string, object?>
         {
@@ -122,8 +129,8 @@ internal sealed class RaiderSeedBuilder
                     },
                 },
             },
-            [GuildIdKey] = GuildId,
-            [GuildNameKey] = GuildName,
+            [GuildIdKey] = guildId,
+            [GuildNameKey] = guildName,
             [FetchedAtKey] = fetchedAt,
             [ProfileFetchedAtKey] = fetchedAt,
             [SpecsFetchedAtKey] = fetchedAt,

--- a/tests/Lfm.E2E/Specs/ProfileSpec.cs
+++ b/tests/Lfm.E2E/Specs/ProfileSpec.cs
@@ -135,6 +135,34 @@ public class ProfileSpec(ProfileFixture fixture, ITestOutputHelper output)
         Log("Guild admin settings form is visible");
     }
 
+    // E2E scope: proves a production-like guild with a fresh roster but no
+    // stored rankPermissions still renders permission configuration controls.
+    // Cheaper lanes prove the default permission values; the browser journey
+    // proves the admin route receives usable controls instead of hiding the
+    // whole Rank Permissions section.
+    // Shared data: read-only.
+    [Fact]
+    public async Task GuildAdmin_UnconfiguredRankPermissions_DisplaysDefaultPermissionControls()
+    {
+        await using var authContext = await AuthHelper.AuthenticatedContextAsync(
+            fixture.Stack.Browser,
+            fixture.Stack.ApiBaseUrl,
+            fixture.Stack.AppBaseUrl,
+            battleNetId: DefaultSeed.UnconfiguredGuildAdminBattleNetId,
+            redirect: "/guild/admin");
+        var page = await authContext.NewPageAsync();
+
+        var guildAdminPage = new GuildAdminPage(page);
+
+        await guildAdminPage.GotoAsync(fixture.Stack.AppBaseUrl);
+
+        await Assertions.Expect(guildAdminPage.Heading).ToBeVisibleAsync(new() { Timeout = 15000 });
+        await Assertions.Expect(guildAdminPage.RankPermissionsHeading)
+            .ToBeVisibleAsync(new() { Timeout = 10000 });
+        await Assertions.Expect(guildAdminPage.RankLabel(0)).ToBeVisibleAsync(new() { Timeout = 10000 });
+        await Assertions.Expect(guildAdminPage.RankLabel(5)).ToBeVisibleAsync(new() { Timeout = 10000 });
+    }
+
     // E2E scope: proves guild admin browser edits persist and reload into the form.
     // Cheaper lanes cannot prove this because form binding, API patch, storage, and page reload must round-trip.
     // Shared data: restored.


### PR DESCRIPTION
## Summary
- synthesize default guild rank permission rows from fresh roster ranks when stored rankPermissions are missing
- add a mapper regression test for unconfigured guild permission settings
- add an E2E browser guard for a guild admin viewing permission controls before rankPermissions are configured

## Verification
- `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release --no-restore --filter FullyQualifiedName~GuildMapperTests`
- `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --no-restore --filter FullyQualifiedName~ProfileSpec.GuildAdmin_UnconfiguredRankPermissions_DisplaysDefaultPermissionControls`
- `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --no-restore --filter FullyQualifiedName~Lfm.E2E.Specs.ProfileSpec`
- `bash scripts/check-e2e-drift.sh`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `dotnet build lfm.sln -c Release --no-restore`
- `git diff --check`