### PR TITLE
Hash Cosmos log partition keys

### DIFF
--- a/api/Repositories/CosmosRequestChargeLogger.cs
+++ b/api/Repositories/CosmosRequestChargeLogger.cs
@@ -3,6 +3,8 @@
 
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Logging;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace Lfm.Api.Repositories;
 
@@ -21,14 +23,14 @@ internal static class CosmosRequestChargeLogger
     {
         logger.LogInformation(
             "Cosmos op={CosmosOp} container={CosmosContainer} pk={CosmosPartitionKey} ru={CosmosRequestCharge}",
-            op, container, partitionKey, response.RequestCharge);
+            op, container, HashPartitionKey(partitionKey), response.RequestCharge);
     }
 
     public static void LogRequestCharge<T>(this ILogger logger, FeedResponse<T> response, string op, string container, string partitionKey)
     {
         logger.LogInformation(
             "Cosmos op={CosmosOp} container={CosmosContainer} pk={CosmosPartitionKey} ru={CosmosRequestCharge}",
-            op, container, partitionKey, response.RequestCharge);
+            op, container, HashPartitionKey(partitionKey), response.RequestCharge);
     }
 
     /// <summary>
@@ -42,5 +44,11 @@ internal static class CosmosRequestChargeLogger
         logger.LogInformation(
             "Cosmos op={CosmosOp} container={CosmosContainer} pk={CosmosPartitionKey} ru={CosmosRequestCharge}",
             op, container, "*cross-partition*", requestCharge);
+    }
+
+    private static string HashPartitionKey(string partitionKey)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(partitionKey));
+        return Convert.ToHexString(bytes)[..16];
     }
 }

--- a/tests/Lfm.Api.Tests/CosmosRequestChargeLoggerTests.cs
+++ b/tests/Lfm.Api.Tests/CosmosRequestChargeLoggerTests.cs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Repositories;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging;
+using System.Net;
+using System.Reflection;
+using Xunit;
+
+namespace Lfm.Api.Tests;
+
+public class CosmosRequestChargeLoggerTests
+{
+    [Fact]
+    public void LogRequestCharge_does_not_emit_raw_partition_key()
+    {
+        var logger = new TestLogger<CosmosRequestChargeLoggerTests>();
+        var response = CreateItemResponse();
+        const string rawPartitionKey = "run-42\r\nforged=true";
+
+        logger.LogRequestCharge(response, "read", "runs", rawPartitionKey);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Information, entry.Level);
+        var loggedPartitionKey = Assert.IsType<string>(entry.Properties["CosmosPartitionKey"]);
+        Assert.DoesNotContain(rawPartitionKey, entry.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(rawPartitionKey, loggedPartitionKey, StringComparison.Ordinal);
+        Assert.Matches("^[0-9A-F]{16}$", loggedPartitionKey);
+    }
+
+    private static ItemResponse<object> CreateItemResponse()
+    {
+        var headers = new Headers();
+        headers.Set("x-ms-request-charge", "1.25");
+
+        return (ItemResponse<object>)Activator.CreateInstance(
+            typeof(ItemResponse<object>),
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            args: [HttpStatusCode.OK, headers, new object(), null, null],
+            culture: null)!;
+    }
+}

--- a/tests/Lfm.Api.Tests/RunsRepositoryConcurrencyTests.cs
+++ b/tests/Lfm.Api.Tests/RunsRepositoryConcurrencyTests.cs
@@ -112,12 +112,14 @@ public class RunsRepositoryConcurrencyTests
             Times.Once);
 
         // Every Cosmos op must emit the four structured log fields so App
-        // Insights can aggregate RU-per-endpoint; regression guard for
-        // Slice 6.1.
-        Assert.Contains(logger.Entries, e =>
+        // Insights can aggregate RU-per-endpoint without exposing raw
+        // partition keys.
+        var chargeEntry = Assert.Single(logger.Entries, e =>
             e.Properties.TryGetValue("CosmosOp", out var op) && (op?.ToString() == "replace")
             && e.Properties.TryGetValue("CosmosContainer", out var container) && (container?.ToString() == "runs")
-            && e.Properties.TryGetValue("CosmosPartitionKey", out var pk) && (pk?.ToString() == "run-1")
             && e.Properties.TryGetValue("CosmosRequestCharge", out var ru) && ((double)ru! == 3.14));
+        var partitionKey = Assert.IsType<string>(chargeEntry.Properties["CosmosPartitionKey"]);
+        Assert.NotEqual("run-1", partitionKey);
+        Assert.Matches("^[0-9A-F]{16}$", partitionKey);
     }
 }


### PR DESCRIPTION
## Summary
- Hash Cosmos partition keys before structured RU logging so raw user-controlled IDs do not enter logs.
- Add a regression test for newline/control-bearing partition keys.
- Update the existing RU logging assertion to preserve grouping without raw partition-key exposure.

## Test Plan
- `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release`
- `dotnet build lfm.sln -c Release`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`