### PR TITLE
Restore run layout hierarchy

### DIFF
--- a/app/Components/Runs/RunSignupPanel.razor
+++ b/app/Components/Runs/RunSignupPanel.razor
@@ -10,14 +10,18 @@
         <FluentMessageBar Intent="MessageIntent.Error">@SignupError</FluentMessageBar>
     }
 
-    @if (CurrentSignup is not null && !_editorOpen)
+    @if (CurrentSignup is { } currentSignup && !_editorOpen)
     {
+        var currentSpecLabel = string.IsNullOrWhiteSpace(currentSignup.SpecName)
+            ? Loc["runs.signup.unknownSpec"].Value
+            : currentSignup.SpecName;
+
         <div class="run-signup-current">
             <div class="run-signup-current__summary">
-                <FluentLabel>@Loc["runs.signup.signedUpAs", CurrentSignup.CharacterName]</FluentLabel>
+                <FluentLabel>@Loc["runs.signup.signedUpAs", currentSignup.CharacterName]</FluentLabel>
                 <span class="run-signup-current__spec">
-                    <SpecIcon SpecName="@CurrentSpecLabel" />
-                    <span>@CurrentSpecLabel</span>
+                    <SpecIcon SpecName="@currentSpecLabel" />
+                    <span>@currentSpecLabel</span>
                 </span>
             </div>
             <div class="run-signup-current__actions">
@@ -67,41 +71,45 @@
     else
     {
         <div class="run-signup-form">
-            <FluentSelect Id="@CharacterSelectId"
-                          Label="@Loc["runs.signup.character"]"
-                          TOption="string"
-                          Value="@SelectedCharacterValue"
-                          ValueChanged="@OnCharacterChangedAsync"
-                          Disabled="@_signupControlsDisabled">
-                @foreach (var character in Characters)
-                {
-                    var characterId = CharacterId(character);
-                    <FluentOption TOption="string" Value="@characterId">@CharacterLabel(character)</FluentOption>
-                }
-            </FluentSelect>
-
-            <FluentSelect Id="@SpecSelectId"
-                          Label="@Loc["runs.signup.spec"]"
-                          TOption="string"
-                          Value="@SelectedSpecValue"
-                          ValueChanged="@OnSpecChangedAsync"
-                          Disabled="@_signupControlsDisabled">
-                @if (SelectedSpecOptions.Count == 0)
-                {
-                    <FluentOption TOption="string" Value="">@Loc["runs.signup.unknownSpec"]</FluentOption>
-                }
-                else
-                {
-                    @foreach (var spec in SelectedSpecOptions)
+            <div class="run-signup-field run-signup-field--character">
+                <FluentSelect Id="@CharacterSelectId"
+                              Label="@Loc["runs.signup.character"]"
+                              TOption="string"
+                              Value="@SelectedCharacterValue"
+                              ValueChanged="@OnCharacterChangedAsync"
+                              Disabled="@_signupControlsDisabled">
+                    @foreach (var character in Characters)
                     {
-                        <FluentOption TOption="string" Value="@spec.Id.ToString(System.Globalization.CultureInfo.InvariantCulture)">
-                            @spec.Name
-                        </FluentOption>
+                        var characterId = CharacterId(character);
+                        <FluentOption TOption="string" Value="@characterId">@CharacterLabel(character)</FluentOption>
                     }
-                }
-            </FluentSelect>
+                </FluentSelect>
+            </div>
 
-            <div class="run-signup-attendance-field">
+            <div class="run-signup-field run-signup-field--spec">
+                <FluentSelect Id="@SpecSelectId"
+                              Label="@Loc["runs.signup.spec"]"
+                              TOption="string"
+                              Value="@SelectedSpecValue"
+                              ValueChanged="@OnSpecChangedAsync"
+                              Disabled="@_signupControlsDisabled">
+                    @if (SelectedSpecOptions.Count == 0)
+                    {
+                        <FluentOption TOption="string" Value="">@Loc["runs.signup.unknownSpec"]</FluentOption>
+                    }
+                    else
+                    {
+                        @foreach (var spec in SelectedSpecOptions)
+                        {
+                            <FluentOption TOption="string" Value="@spec.Id.ToString(System.Globalization.CultureInfo.InvariantCulture)">
+                                @spec.Name
+                            </FluentOption>
+                        }
+                    }
+                </FluentSelect>
+            </div>
+
+            <div class="run-signup-field run-signup-field--attendance run-signup-attendance-field">
                 <span id="@AttendanceLabelId" class="field__label">@Loc["runs.signup.attendance"]</span>
                 <ToggleGroup TValue="string"
                              Options="@SignupAttendanceToggleOptions"
@@ -112,7 +120,7 @@
                              Class="run-signup-attendance-toggle" />
             </div>
 
-            <div class="run-signup-form__actions">
+            <div class="run-signup-field run-signup-field--actions run-signup-form__actions">
                 @if (CurrentSignup is not null)
                 {
                     <FluentButton Appearance="Appearance.Outline"
@@ -187,11 +195,6 @@
         SignupAttendanceOptions
             .Select(option => (option.Value, Loc[option.LocKey].Value))
             .ToList();
-
-    private string CurrentSpecLabel =>
-        string.IsNullOrWhiteSpace(CurrentSignup?.SpecName)
-            ? Loc["runs.signup.unknownSpec"].Value
-            : CurrentSignup.SpecName;
 
     private string SelectedCharacterValue => _selectedCharacterId ?? string.Empty;
 

--- a/app/Components/Runs/RunSignupPanel.razor.css
+++ b/app/Components/Runs/RunSignupPanel.razor.css
@@ -1,9 +1,8 @@
 .run-signup-panel {
     display: flex;
     flex-direction: column;
-    gap: 0.625rem;
-    padding-block: 0.75rem;
-    border-block: 1px solid var(--neutral-stroke-rest);
+    container-type: inline-size;
+    gap: 0.75rem;
 }
 
 .run-signup-title {
@@ -39,12 +38,38 @@
 
 .run-signup-form {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(min(100%, 14rem), 1fr));
-    gap: 0.625rem;
+    grid-template-areas:
+        "character"
+        "spec"
+        "attendance"
+        "actions";
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.75rem;
     align-items: end;
 }
 
-::deep .run-signup-form fluent-select {
+.run-signup-field {
+    min-inline-size: 0;
+}
+
+.run-signup-field--character {
+    grid-area: character;
+}
+
+.run-signup-field--spec {
+    grid-area: spec;
+}
+
+.run-signup-field--attendance {
+    grid-area: attendance;
+}
+
+.run-signup-field--actions {
+    grid-area: actions;
+}
+
+::deep .run-signup-field fluent-select {
+    inline-size: 100%;
     min-inline-size: 0;
 }
 
@@ -65,6 +90,7 @@
     flex-wrap: wrap;
     gap: 0.5rem;
     align-items: center;
+    justify-content: flex-start;
     min-inline-size: min(100%, 12rem);
 }
 
@@ -72,4 +98,28 @@
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
+}
+
+@container (min-width: 40rem) {
+    .run-signup-form {
+        grid-template-areas:
+            "character spec"
+            "attendance actions";
+        grid-template-columns: minmax(0, 1fr) minmax(9rem, 0.7fr);
+    }
+
+    .run-signup-form__actions {
+        justify-content: flex-end;
+    }
+}
+
+@container (min-width: 58rem) {
+    .run-signup-form {
+        grid-template-areas: "character spec attendance actions";
+        grid-template-columns:
+            minmax(13rem, 1fr)
+            minmax(9rem, 0.65fr)
+            minmax(18rem, max-content)
+            auto;
+    }
 }

--- a/app/Pages/RunsPage.razor
+++ b/app/Pages/RunsPage.razor
@@ -116,36 +116,38 @@
                 <div class="runs-detail">
                     @if (selectedRun != null)
                     {
-                        <FluentCard>
-                            <FluentStack Orientation="Orientation.Vertical" VerticalGap="12">
-                                <div class="run-detail-header">
-                                    <div class="run-detail-heading">
-                                        <h2 class="run-detail-title">@RenderTitle(selectedRun.InstanceName)</h2>
-                                        @if (!string.IsNullOrWhiteSpace(selectedRun.Description))
-                                        {
-                                            <p class="run-detail-description">@selectedRun.Description</p>
-                                        }
+                        var currentSignup = selectedRun.RunCharacters.FirstOrDefault(c => c.IsCurrentUser);
+                        var attending = selectedRun.RunCharacters.Where(c => RunVisualization.IsAttending(c.ReviewedAttendance)).ToList();
+                        var notAttending = selectedRun.RunCharacters.Where(c => c.ReviewedAttendance is "OUT" or "AWAY").ToList();
+
+                        <div class="run-detail-stack">
+                            <FluentCard>
+                                <section class="run-detail-summary" data-testid="run-detail-summary">
+                                    <div class="run-detail-header">
+                                        <div class="run-detail-heading">
+                                            <h2 class="run-detail-title">@RenderTitle(selectedRun.InstanceName)</h2>
+                                            @if (!string.IsNullOrWhiteSpace(selectedRun.Description))
+                                            {
+                                                <p class="run-detail-description">@selectedRun.Description</p>
+                                            }
+                                        </div>
+                                        <DifficultyPill Difficulty="@selectedRun.Difficulty" />
+                                        <FluentButton Appearance="Appearance.Outline"
+                                                      OnClick="@(() => Nav.NavigateTo($"/runs/{Uri.EscapeDataString(selectedRun.Id)}/edit"))"
+                                                      Disabled="@IsSignupClosed(selectedRun.SignupCloseTime)">
+                                            @Loc["runs.edit"]
+                                        </FluentButton>
                                     </div>
-                                    <DifficultyPill Difficulty="@selectedRun.Difficulty" />
-                                    <FluentButton Appearance="Appearance.Outline"
-                                                  OnClick="@(() => Nav.NavigateTo($"/runs/{Uri.EscapeDataString(selectedRun.Id)}/edit"))"
-                                                  Disabled="@IsSignupClosed(selectedRun.SignupCloseTime)">
-                                        @Loc["runs.edit"]
-                                    </FluentButton>
-                                </div>
 
-                                <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="16" Wrap="true" Class="run-detail-meta">
-                                    <span><strong>@Loc["runs.start"]</strong> @FormatDate(selectedRun.StartTime)</span>
-                                    <span><strong>@Loc["runs.signupCloses"]</strong> @FormatDate(selectedRun.SignupCloseTime)</span>
-                                    <span><strong>@Loc["runs.guild"]</strong> @selectedRun.CreatorGuild</span>
-                                </FluentStack>
+                                    <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="16" Wrap="true" Class="run-detail-meta">
+                                        <span><strong>@Loc["runs.start"]</strong> @FormatDate(selectedRun.StartTime)</span>
+                                        <span><strong>@Loc["runs.signupCloses"]</strong> @FormatDate(selectedRun.SignupCloseTime)</span>
+                                        <span><strong>@Loc["runs.guild"]</strong> @selectedRun.CreatorGuild</span>
+                                    </FluentStack>
+                                </section>
+                            </FluentCard>
 
-                                @{
-                                    var currentSignup = selectedRun.RunCharacters.FirstOrDefault(c => c.IsCurrentUser);
-                                    var attending = selectedRun.RunCharacters.Where(c => RunVisualization.IsAttending(c.ReviewedAttendance)).ToList();
-                                    var notAttending = selectedRun.RunCharacters.Where(c => c.ReviewedAttendance is "OUT" or "AWAY").ToList();
-                                }
-
+                            <section class="run-signup-surface" data-testid="run-signup-surface">
                                 <RunSignupPanel RunId="@selectedRun.Id"
                                                 CurrentSignup="@currentSignup"
                                                 Characters="@_signupCharacters"
@@ -159,10 +161,17 @@
                                                 OnSignup="@SubmitSignup"
                                                 OnCancelConfirmed="@CancelSignup"
                                                 OnOptionsRequested="@EnsureSignupOptionsLoaded" />
+                            </section>
 
+                            <section class="run-roster @(selectedRun.RunCharacters.Count == 0 ? "run-roster--empty" : "")" data-testid="run-roster">
                                 @if (selectedRun.RunCharacters.Count == 0)
                                 {
-                                    <FluentLabel>@Loc["runs.noSignups"]</FluentLabel>
+                                    <h3 class="roster-section-title" data-testid="roster-attending-title">
+                                        @Loc["runs.attendingSection"] (0)
+                                    </h3>
+                                    <div class="run-roster-empty">
+                                        <FluentLabel>@Loc["runs.noSignups"]</FluentLabel>
+                                    </div>
                                 }
                                 else
                                 {
@@ -199,8 +208,8 @@
                                         </div>
                                     }
                                 }
-                            </FluentStack>
-                        </FluentCard>
+                            </section>
+                        </div>
                     }
                     else
                     {

--- a/app/Pages/RunsPage.razor.css
+++ b/app/Pages/RunsPage.razor.css
@@ -19,23 +19,23 @@
     overflow: hidden;
 }
 
-/* Two-column split only on genuine desktop widths.
-   At 48em the sidebar + gap + page padding left the detail pane around 420px,
-   which cramped the roster grid and edit form. 64em gives the detail pane
-   ~640px+ and keeps the whole tablet range on a single-column layout. */
-@media (min-width: 64em) {
+/* Two-column split once the detail pane can still keep a usable roster area.
+   The sidebar stays deliberately narrow so mid-width desktop windows do not
+   collapse back into a single oversized detail card. */
+@media (min-width: 56em) {
     .runs-layout {
         flex-direction: row;
     }
 
     .runs-sidebar {
-        inline-size: clamp(18rem, 28vw, 22rem);
+        inline-size: clamp(15.5rem, 26vw, 19rem);
     }
 }
 
 .runs-detail {
     flex: 1;
     min-inline-size: 0;
+    inline-size: 100%;
 }
 
 /* Group heading — compact divider between time-horizon buckets. */
@@ -125,7 +125,19 @@
     align-items: center;
 }
 
-/* Run detail card */
+.run-detail-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    inline-size: 100%;
+}
+
+.run-detail-summary {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
 .run-detail-header {
     display: flex;
     flex-wrap: wrap;
@@ -162,53 +174,22 @@
     font-weight: 600;
 }
 
-/* Signup controls */
-.run-signup-panel {
-    display: flex;
-    flex-direction: column;
-    gap: 0.625rem;
-    padding-block: 0.75rem;
-    border-block: 1px solid var(--neutral-stroke-rest);
-}
-
-.run-signup-title {
-    margin: 0;
-    font-size: 1rem;
-    font-weight: 700;
+.run-signup-surface {
+    background: var(--neutral-fill-rest);
     color: var(--neutral-foreground-rest);
-}
-
-.run-signup-form {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 0.625rem;
-    align-items: end;
-}
-
-@media (min-width: 48em) {
-    .run-signup-form {
-        grid-template-columns: minmax(12rem, 1fr) minmax(18rem, max-content) auto;
-    }
-}
-
-.run-signup-attendance-field {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-    min-inline-size: 0;
-}
-
-::deep .run-signup-attendance-toggle {
-    max-inline-size: 100%;
-}
-
-.run-signup-status {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
+    border: 1px solid var(--neutral-stroke-rest);
+    border-radius: calc(var(--layer-corner-radius) * 1px);
+    padding-block: 12px;
+    padding-inline: 14px;
 }
 
 /* Roster sections */
+.run-roster {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
 .roster-section-title {
     text-transform: uppercase;
     letter-spacing: 0.08em;
@@ -249,4 +230,13 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
+}
+
+.run-roster-empty {
+    background: var(--neutral-fill-rest);
+    border: 1px solid var(--neutral-stroke-rest);
+    border-radius: calc(var(--layer-corner-radius) * 1px);
+    padding-block: 18px;
+    padding-inline: 14px;
+    color: var(--neutral-foreground-hint-rest);
 }

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -1144,6 +1144,44 @@ public class RunsPagesTests : ComponentTestBase
     }
 
     [Fact]
+    public void RunsPage_Detail_Separates_Summary_Signup_And_Roster_Regions()
+    {
+        var client = new Mock<IRunsClient>();
+        client.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<RunSummaryDto> { MakeSummary() });
+        client.Setup(c => c.GetAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeDetailWithRoster(new List<RunCharacterDto>
+            {
+                MakeCharacter("Tankington", classId: 1, className: "Warrior", role: "TANK", spec: "Protection"),
+                MakeCharacter("Healsworth", classId: 2, className: "Paladin", role: "HEALER", spec: "Holy"),
+                MakeCharacter("Dpsalot", classId: 8, className: "Mage", role: "DPS", spec: "Frost"),
+            }));
+        Services.AddSingleton(client.Object);
+        WireSignupSupport(client);
+
+        var cut = Render<RunsPage>(p => p.Add(x => x.RunId, "run-1"));
+
+        cut.WaitForAssertion(() =>
+            Assert.NotNull(cut.Find("[data-testid='run-roster']")));
+
+        var summary = cut.Find("[data-testid='run-detail-summary']");
+        var signup = cut.Find("[data-testid='run-signup-surface']");
+        var roster = cut.Find("[data-testid='run-roster']");
+
+        Assert.NotNull(summary.Closest("fluent-card"));
+        Assert.Null(roster.Closest("fluent-card"));
+
+        var markup = cut.Markup;
+        Assert.True(
+            markup.IndexOf("data-testid=\"run-detail-summary\"", StringComparison.Ordinal) <
+            markup.IndexOf("data-testid=\"run-signup-surface\"", StringComparison.Ordinal));
+        Assert.True(
+            markup.IndexOf("data-testid=\"run-signup-surface\"", StringComparison.Ordinal) <
+            markup.IndexOf("data-testid=\"run-roster\"", StringComparison.Ordinal));
+        Assert.Contains(Loc("runs.attendingSection"), roster.TextContent);
+    }
+
+    [Fact]
     public void RunsPage_NotAttendingSection_RendersOutAndAwayCharacters()
     {
         var client = new Mock<IRunsClient>();


### PR DESCRIPTION
## Summary
- split the run detail view back into distinct summary, signup, and roster regions
- move signup form layout into `RunSignupPanel` with container-aware grid areas
- add bUnit coverage for the summary/signup/roster region hierarchy

## Verification
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release` (247 passed)
- `dotnet build lfm.sln -c Release` (0 warnings, 0 errors)
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --filter FullyQualifiedName~RunsSpec` (8 passed)
- `git diff --check`

## Screenshots
- Not captured in this local run; the targeted Runs E2E browser lane passed against the changed UI.