### PR TITLE
Fix mobile run layout

### DIFF
--- a/app/Pages/RunsPage.razor
+++ b/app/Pages/RunsPage.razor
@@ -81,10 +81,22 @@
                                 <h2 class="runs-group__title">@HorizonLabel(group.Horizon)</h2>
                                 @foreach (var run in group.Runs)
                                 {
-                                    <RunListItem @key="run.Id"
-                                                 Run="run"
-                                                 IsSelected="@(run.Id == selectedRunId)"
-                                                 OnSelected="@SelectRun" />
+                                    var isSelected = run.Id == selectedRunId;
+                                    <div @key="run.Id"
+                                         class="run-list-card @(isSelected ? "run-list-card--selected" : null)"
+                                         data-testid="run-card-@run.Id">
+                                        <RunListItem Run="run"
+                                                     IsSelected="@isSelected"
+                                                     OnSelected="@SelectRun" />
+                                        <button type="button"
+                                                class="run-mobile-detail-toggle"
+                                                data-testid="run-mobile-detail-toggle-@run.Id"
+                                                aria-controls="run-detail-panel"
+                                                aria-expanded="@(isSelected ? "true" : "false")"
+                                                @onclick="@(() => ToggleRunDetails(run.Id))">
+                                            @(isSelected ? Loc["runs.hideDetails"] : Loc["runs.showDetails"])
+                                        </button>
+                                    </div>
                                 }
                             </div>
                         }
@@ -99,13 +111,14 @@
                     }
                     @if (!string.IsNullOrWhiteSpace(_loadMoreError))
                     {
-                        <FluentMessageBar Intent="MessageIntent.Error">
+                        <FluentMessageBar Class="runs-load-more-error" Intent="MessageIntent.Error">
                             @_loadMoreError
                         </FluentMessageBar>
                     }
                     @if (!string.IsNullOrEmpty(_continuationToken))
                     {
                         <FluentButton Appearance="Appearance.Outline"
+                                      Class="runs-load-more"
                                       OnClick="@LoadMoreRuns"
                                       Disabled="@_loadingMore">
                             @(_loadingMore ? Loc["common.loading"] : Loc["runs.loadMore"])
@@ -113,7 +126,9 @@
                     }
                 </div>
 
-                <div class="runs-detail">
+                <div id="run-detail-panel"
+                     class="runs-detail @(selectedRun is null ? "runs-detail--empty" : "runs-detail--selected")"
+                     data-testid="run-detail-panel">
                     @if (selectedRun != null)
                     {
                         var currentSignup = selectedRun.RunCharacters.FirstOrDefault(c => c.IsCurrentUser);
@@ -359,6 +374,26 @@
         selectedRunId = id;
         Nav.NavigateTo($"/runs/{Uri.EscapeDataString(id)}", replace: true);
         await LoadRunDetail(id);
+    }
+
+    private async Task ToggleRunDetails(string id)
+    {
+        if (selectedRunId == id)
+        {
+            CollapseRunDetails();
+            return;
+        }
+
+        await SelectRun(id);
+    }
+
+    private void CollapseRunDetails()
+    {
+        selectedRunId = null;
+        selectedRun = null;
+        _signupError = null;
+        ResetSignupOptions();
+        Nav.NavigateTo("/runs", replace: true);
     }
 
     private async Task LoadRunDetail(string id)

--- a/app/Pages/RunsPage.razor.css
+++ b/app/Pages/RunsPage.razor.css
@@ -19,6 +19,14 @@
     overflow: hidden;
 }
 
+.run-list-card {
+    display: block;
+}
+
+.run-mobile-detail-toggle {
+    display: none;
+}
+
 /* Two-column split once the detail pane can still keep a usable roster area.
    The sidebar stays deliberately narrow so mid-width desktop windows do not
    collapse back into a single oversized detail card. */
@@ -29,6 +37,111 @@
 
     .runs-sidebar {
         inline-size: clamp(15.5rem, 26vw, 19rem);
+    }
+}
+
+@media (max-width: 55.999em) {
+    .runs-layout {
+        gap: 16px;
+    }
+
+    .runs-sidebar,
+    .runs-group {
+        display: contents;
+    }
+
+    .runs-group__title {
+        display: none;
+    }
+
+    .run-list-card {
+        order: 2;
+        inline-size: 100%;
+        background: var(--fill-color);
+        color: var(--neutral-foreground-rest);
+        border: calc(var(--stroke-width) * 1px) solid var(--neutral-stroke-layer-rest);
+        border-radius: calc(var(--layer-corner-radius) * 1px);
+        box-shadow: var(--elevation-shadow-card-rest);
+        overflow: hidden;
+    }
+
+    .run-list-card--selected {
+        order: 0;
+        border-block-end: 0;
+        border-end-start-radius: 0;
+        border-end-end-radius: 0;
+    }
+
+    .run-list-card ::deep .run-list-item {
+        border-block-end: 0;
+        padding-block: 16px 10px;
+        padding-inline: 18px;
+    }
+
+    .run-list-card ::deep .run-list-item__title {
+        font-size: 1.15rem;
+    }
+
+    .run-list-card ::deep .run-list-item__meta {
+        font-size: 0.95rem;
+    }
+
+    .run-mobile-detail-toggle {
+        all: unset;
+        box-sizing: border-box;
+        display: block;
+        inline-size: calc(100% - 36px);
+        margin-block: 0 16px;
+        margin-inline: 18px;
+        padding-block: 10px;
+        padding-inline: 12px;
+        text-align: center;
+        color: var(--neutral-foreground-hint-rest);
+        border: 1px solid var(--neutral-stroke-rest);
+        border-radius: calc(var(--control-corner-radius) * 1px);
+        cursor: pointer;
+    }
+
+    .run-mobile-detail-toggle:focus-visible {
+        outline: 2px solid var(--accent-fill-rest);
+        outline-offset: 2px;
+    }
+
+    .runs-detail {
+        order: 1;
+        box-sizing: border-box;
+        background: var(--fill-color);
+        color: var(--neutral-foreground-rest);
+        border: calc(var(--stroke-width) * 1px) solid var(--neutral-stroke-layer-rest);
+        border-block-start: 0;
+        border-radius: calc(var(--layer-corner-radius) * 1px);
+        border-start-start-radius: 0;
+        border-start-end-radius: 0;
+        box-shadow: var(--elevation-shadow-card-rest);
+        margin-block-start: -16px;
+        padding-block: 0 18px;
+        padding-inline: 18px;
+    }
+
+    .runs-detail--empty {
+        display: none;
+    }
+
+    .runs-detail fluent-card {
+        display: none;
+    }
+
+    .runs-detail .run-signup-surface {
+        background: transparent;
+        border: 0;
+        border-radius: 0;
+        padding: 0;
+    }
+
+    .runs-past-toggle,
+    ::deep .runs-load-more,
+    ::deep .runs-load-more-error {
+        order: 3;
     }
 }
 

--- a/app/wwwroot/locales/en.json
+++ b/app/wwwroot/locales/en.json
@@ -77,6 +77,8 @@
     "runs.empty": "No upcoming runs found.",
     "runs.emptyCta": "Create the first one.",
     "runs.selectPrompt": "Select a run to see details.",
+    "runs.showDetails": "Show details",
+    "runs.hideDetails": "Hide details",
     "runs.signedUp": "{0} signed up",
     "runs.edit": "Edit",
     "runs.mode": "Mode:",

--- a/app/wwwroot/locales/fi.json
+++ b/app/wwwroot/locales/fi.json
@@ -65,6 +65,8 @@
     "runs.empty": "Ei tulevia runeja.",
     "runs.emptyCta": "Kasaa ensimm\u00e4inen.",
     "runs.selectPrompt": "Valitse runi listalta \u2014 tiedot aukeavat t\u00e4h\u00e4n.",
+    "runs.showDetails": "N\u00e4yt\u00e4 tiedot",
+    "runs.hideDetails": "Piilota tiedot",
     "runs.signedUp": "{0} ilmoittautunut",
     "runs.edit": "Muokkaa",
     "runs.mode": "Tila:",

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -1182,6 +1182,71 @@ public class RunsPagesTests : ComponentTestBase
     }
 
     [Fact]
+    public void RunsPage_RunCards_Render_Mobile_Detail_Toggles()
+    {
+        var client = new Mock<IRunsClient>();
+        client.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<RunSummaryDto>
+            {
+                MakeSummary("run-1"),
+                MakeSummary("run-2") with { InstanceName = "Nerub-ar Palace", Difficulty = "MYTHIC" },
+            });
+        client.Setup(c => c.GetAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeDetailWithRoster(new List<RunCharacterDto>
+            {
+                MakeCharacter("Tankington", classId: 1, className: "Warrior", role: "TANK", spec: "Protection"),
+            }));
+        Services.AddSingleton(client.Object);
+        WireSignupSupport(client);
+
+        var cut = Render<RunsPage>(p => p.Add(x => x.RunId, "run-1"));
+
+        cut.WaitForAssertion(() =>
+            Assert.NotNull(cut.Find("[data-testid='run-card-run-1']")));
+
+        var selectedToggle = cut.Find("[data-testid='run-mobile-detail-toggle-run-1']");
+        var collapsedToggle = cut.Find("[data-testid='run-mobile-detail-toggle-run-2']");
+
+        Assert.Equal("true", selectedToggle.GetAttribute("aria-expanded"));
+        Assert.Contains(Loc("runs.hideDetails"), selectedToggle.TextContent);
+        Assert.Equal("false", collapsedToggle.GetAttribute("aria-expanded"));
+        Assert.Contains(Loc("runs.showDetails"), collapsedToggle.TextContent);
+    }
+
+    [Fact]
+    public void RunsPage_Mobile_Detail_Toggle_Collapses_Selected_Run()
+    {
+        var client = new Mock<IRunsClient>();
+        client.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<RunSummaryDto> { MakeSummary("run-1") });
+        client.Setup(c => c.GetAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeDetailWithRoster(new List<RunCharacterDto>
+            {
+                MakeCharacter("Tankington", classId: 1, className: "Warrior", role: "TANK", spec: "Protection"),
+            }));
+        Services.AddSingleton(client.Object);
+        WireSignupSupport(client);
+        var nav = Services.GetRequiredService<BunitNavigationManager>();
+
+        var cut = Render<RunsPage>(p => p.Add(x => x.RunId, "run-1"));
+
+        cut.WaitForAssertion(() =>
+            Assert.Contains(Loc("runs.hideDetails"), cut.Find("[data-testid='run-mobile-detail-toggle-run-1']").TextContent));
+
+        cut.Find("[data-testid='run-mobile-detail-toggle-run-1']").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            var toggle = cut.Find("[data-testid='run-mobile-detail-toggle-run-1']");
+            Assert.Equal("false", toggle.GetAttribute("aria-expanded"));
+            Assert.Contains(Loc("runs.showDetails"), toggle.TextContent);
+            Assert.Contains(Loc("runs.selectPrompt"), cut.Find("[data-testid='run-detail-panel']").TextContent);
+        });
+        Assert.Equal("/runs", new Uri(nav.Uri).AbsolutePath);
+        client.Verify(c => c.GetAsync("run-1", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public void RunsPage_NotAttendingSection_RendersOutAndAwayCharacters()
     {
         var client = new Mock<IRunsClient>();


### PR DESCRIPTION
## Summary
- restore mobile run list cards with explicit Show/Hide details controls
- place the selected run detail panel directly after the selected card on narrow screens
- add EN/FI labels and bUnit coverage for mobile detail toggle behavior

## Verification
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --no-restore`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `dotnet build lfm.sln -c Release --no-restore`
- `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --no-restore --filter "FullyQualifiedName~LayoutIntegritySpec.AuthenticatedDenseRoutes_HaveNoLayoutOverlaps"`
- `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --no-restore --filter "FullyQualifiedName~LayoutIntegritySpec.FinnishDenseStates_HaveNoMobileLayoutOverlaps"`

## Screenshots
- Not attached from this terminal session; browser layout-integrity checks covered the affected mobile and breakpoint states.

## Env / schema
- No env or schema changes.