### PR TITLE
Sanitize audit log values

### DIFF
--- a/api/Audit/AuditLog.cs
+++ b/api/Audit/AuditLog.cs
@@ -37,13 +37,22 @@ public static class AuditLog
 
     public static void Emit(ILogger logger, AuditEvent evt)
     {
-        var actor = _hasher.Hash(evt.ActorId);
+        var actor = ToLogSafeValue(_hasher.Hash(evt.ActorId));
         logger.LogInformation(
             "Audit: {AuditAction} actor={AuditActorId} target={AuditTargetId} result={AuditResult} detail={AuditDetail}",
-            evt.Action,
+            ToLogSafeValue(evt.Action),
             actor,
-            evt.TargetId ?? "-",
-            evt.Result,
-            evt.Detail ?? "-");
+            ToLogSafeOptionalValue(evt.TargetId),
+            ToLogSafeValue(evt.Result),
+            ToLogSafeOptionalValue(evt.Detail));
     }
+
+    private static string ToLogSafeOptionalValue(string? value) =>
+        value is null ? "-" : ToLogSafeValue(value);
+
+    private static string ToLogSafeValue(string value) =>
+        value
+            .Replace("\r\n", " ", StringComparison.Ordinal)
+            .Replace('\r', ' ')
+            .Replace('\n', ' ');
 }

--- a/tests/Lfm.Api.Tests/AuditLogTests.cs
+++ b/tests/Lfm.Api.Tests/AuditLogTests.cs
@@ -68,4 +68,26 @@ public class AuditLogTests
         Assert.Equal("failure", entry.Properties[AuditProperties.Result]);
         Assert.Equal("missing login_state cookie", entry.Properties[AuditProperties.Detail]);
     }
+
+    [Fact]
+    public void Emit_removes_line_breaks_from_user_controlled_audit_fields()
+    {
+        var logger = new TestLogger<AuditLogTests>();
+        var evt = new AuditEvent(
+            Action: "run.update",
+            ActorId: "111222333",
+            TargetId: "run-42\r\nforged=true",
+            Result: "failure",
+            Detail: "invalid\rsecond\nthird");
+
+        AuditLog.Emit(logger, evt);
+
+        var entry = Assert.Single(logger.Entries);
+        var targetId = Assert.IsType<string>(entry.Properties[AuditProperties.TargetId]);
+        var detail = Assert.IsType<string>(entry.Properties[AuditProperties.Detail]);
+        Assert.Equal("run-42 forged=true", targetId);
+        Assert.Equal("invalid second third", detail);
+        Assert.DoesNotContain('\r', entry.Message);
+        Assert.DoesNotContain('\n', entry.Message);
+    }
 }


### PR DESCRIPTION
## Summary
- Normalize CR/LF characters in audit log values before they reach structured logging.
- Keep nullable audit target/detail fields as `-` while preventing forged line breaks in rendered logs.
- Add a regression test for the CodeQL `cs/log-forging` alert at https://github.com/lfm-org/lfm/security/code-scanning/2.

## Test Plan
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release --filter FullyQualifiedName~Lfm.Api.Tests.AuditLogTests` red before the fix
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release --filter FullyQualifiedName~Lfm.Api.Tests.AuditLogTests`
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release`
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- [x] `dotnet build lfm.sln -c Release`