### PR TITLE
Fix signup character display name

### DIFF
--- a/api/Runs/RunSignupService.cs
+++ b/api/Runs/RunSignupService.cs
@@ -57,6 +57,7 @@ public sealed class RunSignupService(
             return new RunOperationResult.BadRequest(
                 "character-not-on-profile",
                 "Character not found on your profile.");
+        var characterDisplayName = ResolveCharacterDisplayName(raider, storedCharacter);
 
         // 2. Resolve spec info — mirrors the specId block in runs-signup.ts.
         int? specId = body.SpecId;
@@ -160,7 +161,7 @@ public sealed class RunSignupService(
             var entry = new RunCharacterEntry(
                 Id: entryId,
                 CharacterId: storedCharacter.Id,
-                CharacterName: storedCharacter.Name,
+                CharacterName: characterDisplayName,
                 CharacterRealm: storedCharacter.Realm,
                 CharacterLevel: storedCharacter.Level ?? 0,
                 CharacterClassId: storedCharacter.ClassId ?? 0,
@@ -204,5 +205,25 @@ public sealed class RunSignupService(
         return new RunOperationResult.ConflictResult(
             "concurrent-modification",
             "Concurrent modification, please retry.");
+    }
+
+    private static string ResolveCharacterDisplayName(
+        RaiderDocument raider,
+        StoredSelectedCharacter storedCharacter)
+    {
+        foreach (var account in raider.AccountProfileSummary?.WowAccounts ?? [])
+        {
+            foreach (var character in account.Characters ?? [])
+            {
+                if (string.Equals(character.Realm.Slug, storedCharacter.Realm, StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(character.Name, storedCharacter.Name, StringComparison.OrdinalIgnoreCase) &&
+                    !string.IsNullOrWhiteSpace(character.Name))
+                {
+                    return character.Name;
+                }
+            }
+        }
+
+        return storedCharacter.Name;
     }
 }

--- a/tests/Lfm.Api.Tests/Runs/RunSignupServiceTests.cs
+++ b/tests/Lfm.Api.Tests/Runs/RunSignupServiceTests.cs
@@ -233,6 +233,55 @@ public class RunSignupServiceTests
     }
 
     [Fact]
+    public async Task SignupAsync_UsesAccountProfileDisplayNameForRunEntry()
+    {
+        var (runsRepo, raidersRepo, _, _, _, sut) = MakeSut();
+        var raider = MakeRaider("bnet-user", characterId: "char-1") with
+        {
+            AccountProfileSummary = new StoredBlizzardAccountProfile(new List<StoredBlizzardWowAccount>
+            {
+                new StoredBlizzardWowAccount(
+                    Id: 1,
+                    Characters: new List<StoredBlizzardAccountCharacter>
+                    {
+                        new StoredBlizzardAccountCharacter(
+                            Name: "Aelrin",
+                            Level: 80,
+                            Realm: new StoredBlizzardRealmRef(Slug: "silvermoon", Name: "Silvermoon"))
+                    })
+            }),
+            Characters = new List<StoredSelectedCharacter>
+            {
+                new StoredSelectedCharacter(
+                    Id: "char-1",
+                    Region: "eu",
+                    Realm: "silvermoon",
+                    Name: "aelrin",
+                    Level: 80,
+                    GuildId: 123,
+                    GuildName: "Test Guild")
+            },
+        };
+
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-user", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(raider);
+        runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeOpenRun());
+        runsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RunDocument doc, string? _, CancellationToken _) => doc);
+
+        var result = await sut.SignupAsync(
+            "run-1",
+            MakeBody(characterId: "char-1", desiredAttendance: "IN"),
+            MakePrincipal("bnet-user"),
+            CancellationToken.None);
+
+        var ok = Assert.IsType<RunOperationResult.Ok>(result);
+        var entry = Assert.Single(ok.Run.RunCharacters);
+        Assert.Equal("Aelrin", entry.CharacterName);
+    }
+
+    [Fact]
     public async Task SignupAsync_GuildRun_SubmittedCharacterNotInRunGuild_ReturnsBadRequest()
     {
         var (runsRepo, raidersRepo, _, signupEligibility, _, sut) = MakeSut();


### PR DESCRIPTION
## Summary
- Resolve run signup display names from the Battle.net account-profile cache when available.
- Keep the stored selected-character name as fallback.
- Add a regression for lowercase stored selected-character names writing properly cased run entries.

## Verification
- `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release --no-restore --filter RunSignup`
- `dotnet restore lfm.sln -m:1`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `dotnet build lfm.sln -c Release --no-restore`
- `./scripts/pre-push`

## Env / Schema
- No environment or schema changes.