### PR TITLE
Fix deployment cache refresh policy

### DIFF
--- a/.github/workflows/deploy-app-build.yml
+++ b/.github/workflows/deploy-app-build.yml
@@ -21,6 +21,7 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   NUGET_XMLDOC_MODE: skip
+  APP_ASSET_VERSION: ${{ github.sha }}
 
 jobs:
   build:

--- a/api/Functions/WowReferenceRefreshFunction.cs
+++ b/api/Functions/WowReferenceRefreshFunction.cs
@@ -79,7 +79,7 @@ public class WowReferenceRefreshFunction(
         var response = req.HttpContext.Response;
         response.StatusCode = StatusCodes.Status200OK;
         response.ContentType = "application/x-ndjson";
-        response.Headers["Cache-Control"] = "no-cache, no-transform";
+        response.Headers["Cache-Control"] = "private, no-store, no-transform";
         // Hint to intermediate proxies (incl. nginx-based reverse proxies in
         // front of SWA linked backends) to forward bytes instead of buffering.
         response.Headers["X-Accel-Buffering"] = "no";

--- a/app/Lfm.App.csproj
+++ b/app/Lfm.App.csproj
@@ -57,6 +57,9 @@
       <SecurityPolicyUrl Condition="'$(SecurityPolicyUrl)' == ''">https://example.com/SECURITY.md</SecurityPolicyUrl>
       <ApiHostname Condition="'$(ApiHostname)' == ''">$(API_HOSTNAME)</ApiHostname>
       <ApiHostname Condition="'$(ApiHostname)' == ''">api.localhost</ApiHostname>
+      <AssetVersion Condition="'$(AssetVersion)' == ''">$(APP_ASSET_VERSION)</AssetVersion>
+      <AssetVersion Condition="'$(AssetVersion)' == ''">$(GITHUB_SHA)</AssetVersion>
+      <AssetVersion Condition="'$(AssetVersion)' == ''">dev</AssetVersion>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -85,6 +88,7 @@
 
     <Exec Command="bash -c &quot;sed \
         -e 's|{{API_HOSTNAME}}|$(ApiHostname)|g' \
+        -e 's|{{ASSET_VERSION}}|$(AssetVersion)|g' \
         '$(IndexHtmlSource)' &gt; '$(IndexHtmlDest)'&quot;"
           Condition="Exists('$(IndexHtmlSource)')" />
   </Target>

--- a/app/wwwroot/index.html.template
+++ b/app/wwwroot/index.html.template
@@ -10,9 +10,9 @@
     <title>Lfm.App</title>
     <base href="/" />
     <link rel="preconnect" href="https://{{API_HOSTNAME}}" crossorigin />
-    <link rel="stylesheet" href="css/app.css" />
+    <link rel="stylesheet" href="css/app.css?v={{ASSET_VERSION}}" />
     <link rel="icon" type="image/png" href="favicon.png" />
-    <link href="Lfm.App.styles.css" rel="stylesheet" />
+    <link href="Lfm.App.styles.css?v={{ASSET_VERSION}}" rel="stylesheet" />
 </head>
 
 <body>
@@ -29,8 +29,8 @@
         <a href="." class="reload">Reload</a>
         <button type="button" class="dismiss" aria-label="Dismiss">×</button>
     </div>
-    <script src="js/lfm-interop.js"></script>
-    <script src="_framework/blazor.webassembly.js"></script>
+    <script src="js/lfm-interop.js?v={{ASSET_VERSION}}"></script>
+    <script src="_framework/blazor.webassembly.js?v={{ASSET_VERSION}}"></script>
 </body>
 
 </html>

--- a/app/wwwroot/staticwebapp.config.json.template
+++ b/app/wwwroot/staticwebapp.config.json.template
@@ -4,19 +4,15 @@
   },
   "routes": [
     {
-      "route": "/_framework/*",
+      "route": "/_framework/dotnet.runtime.*",
       "headers": { "Cache-Control": "public, max-age=31536000, immutable" }
     },
     {
-      "route": "/css/*",
+      "route": "/_framework/dotnet.native.*",
       "headers": { "Cache-Control": "public, max-age=31536000, immutable" }
     },
     {
-      "route": "/lib/*",
-      "headers": { "Cache-Control": "public, max-age=31536000, immutable" }
-    },
-    {
-      "route": "/*.{js,wasm,css,woff2,woff,ttf,eot,otf,png,jpg,jpeg,gif,ico,svg,webp}",
+      "route": "/_framework/*.{wasm,dat}",
       "headers": { "Cache-Control": "public, max-age=31536000, immutable" }
     },
     {
@@ -43,6 +39,7 @@
     "X-Frame-Options": "DENY",
     "Referrer-Policy": "strict-origin-when-cross-origin",
     "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
+    "Cache-Control": "no-cache",
     "Content-Security-Policy": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://{{API_HOSTNAME}}; img-src 'self' https://{{API_HOSTNAME}} https://render.worldofwarcraft.com",
     "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
   }

--- a/tests/Lfm.Api.Tests/BattleNetCharactersFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/BattleNetCharactersFunctionTests.cs
@@ -97,12 +97,16 @@ public class BattleNetCharactersFunctionTests
         var ctx = MakeFunctionContext(FakePrincipal());
 
         // Act
-        var result = await fn.Run(new DefaultHttpContext().Request, ctx, CancellationToken.None);
+        var httpContext = new DefaultHttpContext();
+        var result = await fn.Run(httpContext.Request, ctx, CancellationToken.None);
 
         // Assert
         var ok = Assert.IsType<OkObjectResult>(result);
         var characters = Assert.IsAssignableFrom<List<CharacterDto>>(ok.Value);
         Assert.Single(characters);
+        Assert.Equal(
+            "private, max-age=300",
+            httpContext.Response.Headers["Cache-Control"].ToString());
 
         var character = characters[0];
         Assert.Equal("Legolas", character.Name);

--- a/tests/Lfm.Api.Tests/WowReferenceRefreshFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/WowReferenceRefreshFunctionTests.cs
@@ -105,6 +105,7 @@ public class WowReferenceRefreshFunctionTests
 
         Assert.Equal(200, http.Response.StatusCode);
         Assert.Equal("application/x-ndjson", http.Response.ContentType);
+        Assert.Equal("private, no-store, no-transform", http.Response.Headers["Cache-Control"].ToString());
 
         var done = RequireDoneLine(lines);
         var results = done.GetProperty("response").GetProperty("results");

--- a/tests/Lfm.App.Tests/IndexHtmlTemplateContractTests.cs
+++ b/tests/Lfm.App.Tests/IndexHtmlTemplateContractTests.cs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Xunit;
+
+namespace Lfm.App.Tests;
+
+public class IndexHtmlTemplateContractTests
+{
+    private static readonly string TemplatePath = Path.Combine(
+        AppContext.BaseDirectory, "index.html.template");
+    private static readonly string GeneratedPath = Path.Combine(
+        AppContext.BaseDirectory, "index.html");
+
+    [Fact]
+    public void Stable_deployment_entrypoint_assets_include_asset_version_query()
+    {
+        Assert.True(File.Exists(TemplatePath));
+
+        var html = File.ReadAllText(TemplatePath);
+
+        Assert.Contains("href=\"css/app.css?v={{ASSET_VERSION}}\"", html);
+        Assert.Contains("href=\"Lfm.App.styles.css?v={{ASSET_VERSION}}\"", html);
+        Assert.Contains("src=\"js/lfm-interop.js?v={{ASSET_VERSION}}\"", html);
+        Assert.Contains("src=\"_framework/blazor.webassembly.js?v={{ASSET_VERSION}}\"", html);
+    }
+
+    [Fact]
+    public void Generated_index_replaces_asset_version_placeholder()
+    {
+        Assert.True(File.Exists(GeneratedPath));
+
+        var html = File.ReadAllText(GeneratedPath);
+
+        Assert.DoesNotContain("{{ASSET_VERSION}}", html);
+        Assert.Contains("src=\"_framework/blazor.webassembly.js?v=", html);
+    }
+}

--- a/tests/Lfm.App.Tests/Lfm.App.Tests.csproj
+++ b/tests/Lfm.App.Tests/Lfm.App.Tests.csproj
@@ -38,5 +38,13 @@
       <Link>staticwebapp.config.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="..\..\app\wwwroot\index.html.template">
+      <Link>index.html.template</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\app\wwwroot\index.html">
+      <Link>index.html</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/tests/Lfm.App.Tests/StaticWebAppConfigContractTests.cs
+++ b/tests/Lfm.App.Tests/StaticWebAppConfigContractTests.cs
@@ -28,6 +28,17 @@ public class StaticWebAppConfigContractTests
         return headers!;
     }
 
+    private static JsonArray LoadRoutes()
+    {
+        Assert.True(File.Exists(ConfigPath));
+
+        var root = JsonNode.Parse(File.ReadAllText(ConfigPath));
+        Assert.NotNull(root);
+        var routes = root!["routes"]?.AsArray();
+        Assert.NotNull(routes);
+        return routes!;
+    }
+
     private static string GetCsp() =>
         LoadGlobalHeaders()["Content-Security-Policy"]!.GetValue<string>();
 
@@ -77,5 +88,41 @@ public class StaticWebAppConfigContractTests
         // the default mirrors the MSBuild default so the test passes without env vars.
         var expected = Environment.GetEnvironmentVariable("API_HOSTNAME") ?? "api.localhost";
         Assert.Contains($"https://{expected}", GetCsp());
+    }
+
+    [Fact]
+    public void Global_cache_control_revalidates_spa_fallback_responses()
+    {
+        // Static Web Apps route rules are not applied to navigationFallback
+        // responses, so the fallback shell for client-routed paths needs the
+        // default response headers to require revalidation after each deploy.
+        var headers = LoadGlobalHeaders();
+
+        Assert.True(
+            headers.TryGetPropertyValue("Cache-Control", out var cacheControl),
+            "globalHeaders must include Cache-Control so navigationFallback responses revalidate.");
+        Assert.Equal("no-cache", cacheControl!.GetValue<string>());
+    }
+
+    [Fact]
+    public void Public_immutable_cache_routes_are_limited_to_content_addressed_framework_assets()
+    {
+        // The Blazor .NET 10 boot configuration lives in _framework/dotnet.js.
+        // Stable URLs such as dotnet.js, blazor.webassembly.js, app CSS, and
+        // local JS must not be caught by broad immutable rules, or an old
+        // browser HTTP cache can keep loading the previous deployment.
+        var immutableRoutePatterns = LoadRoutes()
+            .Where(route =>
+                route!["headers"]?["Cache-Control"]?.GetValue<string>() == "public, max-age=31536000, immutable")
+            .Select(route => route!["route"]!.GetValue<string>())
+            .ToArray();
+
+        Assert.Equal(
+            [
+                "/_framework/dotnet.runtime.*",
+                "/_framework/dotnet.native.*",
+                "/_framework/*.{wasm,dat}",
+            ],
+            immutableRoutePatterns);
     }
 }


### PR DESCRIPTION
## Summary
- version stable Blazor deployment entrypoints with the deploy SHA
- narrow immutable Static Web Apps cache rules to content-addressed framework assets and make SPA fallbacks revalidate
- prevent browser/proxy storage of the admin reference refresh stream while preserving the private character cache contract

## Verification
- dotnet build lfm.sln -c Release
- dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --no-restore
- dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release --no-restore
- dotnet format lfm.sln --verify-no-changes --no-restore --severity error
- jq empty app/wwwroot/staticwebapp.config.json.template
- yq eval '.' .github/workflows/deploy-app-build.yml
- dotnet publish app/Lfm.App.csproj -c Release -o ./.cache/publish-app --no-build -p:AssetVersion=cacheaudit
- ./scripts/check-bundle-size.sh ./.cache/publish-app/wwwroot 5