### PR TITLE
Fix signup spec icon

### DIFF
--- a/app/Components/Runs/RunSignupPanel.razor
+++ b/app/Components/Runs/RunSignupPanel.razor
@@ -20,7 +20,7 @@
             <div class="run-signup-current__summary">
                 <FluentLabel>@Loc["runs.signup.signedUpAs", currentSignup.CharacterName]</FluentLabel>
                 <span class="run-signup-current__spec">
-                    <SpecIcon SpecName="@currentSpecLabel" />
+                    <SpecIcon SpecName="@currentSpecLabel" IconUrl="@CurrentSpecIconUrl" />
                     <span>@currentSpecLabel</span>
                 </span>
             </div>
@@ -156,6 +156,7 @@
     [Parameter] public bool OptionsLoading { get; set; }
     [Parameter] public bool OptionsForbidden { get; set; }
     [Parameter] public string? PreferredCharacterId { get; set; }
+    [Parameter] public string? CurrentSpecIconUrl { get; set; }
     [Parameter] public string? SignupError { get; set; }
     [Parameter] public bool SignupSubmitting { get; set; }
     [Parameter] public bool CancelSubmitting { get; set; }

--- a/app/Components/Runs/SpecIcon.razor
+++ b/app/Components/Runs/SpecIcon.razor
@@ -1,9 +1,31 @@
-<span class="spec-icon" role="img" aria-label="@Label">@Abbreviation</span>
+@if (!string.IsNullOrWhiteSpace(IconUrl) && !_imageFailed)
+{
+    <span class="spec-icon spec-icon--image" role="img" aria-label="@Label">
+        <img class="spec-icon__image" src="@IconUrl" alt="" decoding="async" @onerror="OnImageError" />
+    </span>
+}
+else
+{
+    <span class="spec-icon" role="img" aria-label="@Label">@Abbreviation</span>
+}
 
 @code {
     [Parameter] public string? SpecName { get; set; }
+    [Parameter] public string? IconUrl { get; set; }
+
+    private bool _imageFailed;
+    private string? _lastIconUrl;
 
     private string Label => string.IsNullOrWhiteSpace(SpecName) ? "Unknown spec" : SpecName;
+
+    protected override void OnParametersSet()
+    {
+        if (!StringComparer.Ordinal.Equals(_lastIconUrl, IconUrl))
+        {
+            _imageFailed = false;
+            _lastIconUrl = IconUrl;
+        }
+    }
 
     private string Abbreviation
     {
@@ -18,5 +40,10 @@
 
             return string.Concat(words.Select(word => char.ToUpperInvariant(word[0]))).Substring(0, Math.Min(2, words.Length));
         }
+    }
+
+    private void OnImageError()
+    {
+        _imageFailed = true;
     }
 }

--- a/app/Components/Runs/SpecIcon.razor.css
+++ b/app/Components/Runs/SpecIcon.razor.css
@@ -9,4 +9,17 @@
     background: var(--neutral-fill-rest);
     font-size: 0.7rem;
     font-weight: 700;
+    overflow: hidden;
+    flex: none;
+}
+
+.spec-icon--image {
+    background: transparent;
+}
+
+.spec-icon__image {
+    display: block;
+    inline-size: 100%;
+    block-size: 100%;
+    object-fit: cover;
 }

--- a/app/Lfm.App.Core/Services/ISpecializationsClient.cs
+++ b/app/Lfm.App.Core/Services/ISpecializationsClient.cs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Contracts.Specializations;
+
+namespace Lfm.App.Services;
+
+public interface ISpecializationsClient
+{
+    Task<IReadOnlyList<SpecializationDto>> ListAsync(CancellationToken ct);
+}

--- a/app/Lfm.App.Core/Services/SpecializationsClient.cs
+++ b/app/Lfm.App.Core/Services/SpecializationsClient.cs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Net.Http.Json;
+using Lfm.Contracts.Specializations;
+
+namespace Lfm.App.Services;
+
+public sealed class SpecializationsClient(IHttpClientFactory factory) : ISpecializationsClient
+{
+    public async Task<IReadOnlyList<SpecializationDto>> ListAsync(CancellationToken ct)
+    {
+        var http = factory.CreateClient("api");
+        var items = await http.GetFromJsonAsync<List<SpecializationDto>>("api/v1/wow/reference/specializations", ct);
+        return items ?? [];
+    }
+}

--- a/app/Pages/RunsPage.razor
+++ b/app/Pages/RunsPage.razor
@@ -7,9 +7,11 @@
 @using Lfm.App.Services
 @using Lfm.Contracts.Characters
 @using Lfm.Contracts.Runs
+@using Lfm.Contracts.Specializations
 @inject IBattleNetClient BattleNetClient
 @inject IMeClient MeClient
 @inject IRunsClient RunsClient
+@inject ISpecializationsClient SpecializationsClient
 @inject NavigationManager Nav
 @inject IStringLocalizer Loc
 
@@ -170,6 +172,7 @@
                                                 OptionsLoading="@_signupOptionsLoading"
                                                 OptionsForbidden="@_signupOptionsForbidden"
                                                 PreferredCharacterId="@_preferredSignupCharacterId"
+                                                CurrentSpecIconUrl="@SpecIconUrlFor(currentSignup)"
                                                 SignupError="@_signupError"
                                                 SignupSubmitting="@_signupSubmitting"
                                                 CancelSubmitting="@_cancelSubmitting"
@@ -255,6 +258,9 @@
     private string? _signupError;
     private bool _signupSubmitting;
     private bool _cancelSubmitting;
+    private bool _specIconsLoaded;
+    private bool _specIconsLoading;
+    private IReadOnlyDictionary<int, string> _specIconUrls = new Dictionary<int, string>();
 
     private static readonly (string Key, string LocKey)[] RoleColumnKeys =
     [
@@ -414,7 +420,11 @@
 
             ApplyRunDetail(detail);
             _signupError = null;
-            if (!HasCurrentUserSignup(detail) && !IsSignupClosed(detail.SignupCloseTime))
+            if (HasCurrentUserSignup(detail))
+            {
+                await EnsureSpecIconsLoaded();
+            }
+            else if (!IsSignupClosed(detail.SignupCloseTime))
             {
                 await EnsureSignupOptionsLoaded();
             }
@@ -531,6 +541,10 @@
             }
 
             ApplyRunDetail(updated);
+            if (HasCurrentUserSignup(updated))
+            {
+                await EnsureSpecIconsLoaded();
+            }
         }
         catch
         {
@@ -539,6 +553,31 @@
         finally
         {
             _signupSubmitting = false;
+        }
+    }
+
+    private async Task EnsureSpecIconsLoaded()
+    {
+        if (_specIconsLoaded || _specIconsLoading)
+            return;
+
+        _specIconsLoading = true;
+        try
+        {
+            var specializations = await SpecializationsClient.ListAsync(CancellationToken.None);
+            _specIconUrls = specializations
+                .Where(spec => !string.IsNullOrWhiteSpace(spec.IconUrl))
+                .GroupBy(spec => spec.Id)
+                .ToDictionary(group => group.Key, group => group.First().IconUrl!);
+            _specIconsLoaded = true;
+        }
+        catch
+        {
+            _specIconUrls = new Dictionary<int, string>();
+        }
+        finally
+        {
+            _specIconsLoading = false;
         }
     }
 
@@ -603,6 +642,11 @@
 
     private static bool HasCurrentUserSignup(RunDetailDto detail) =>
         detail.RunCharacters.Any(c => c.IsCurrentUser);
+
+    private string? SpecIconUrlFor(RunCharacterDto? signup) =>
+        signup?.SpecId is int specId && _specIconUrls.TryGetValue(specId, out var iconUrl)
+            ? iconUrl
+            : null;
 
     private void TogglePast() => _showPast = !_showPast;
 

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -50,6 +50,7 @@ builder.Services.AddHttpClient("api-admin", client =>
 
 builder.Services.AddScoped<IInstancesClient, InstancesClient>();
 builder.Services.AddScoped<IExpansionsClient, ExpansionsClient>();
+builder.Services.AddScoped<ISpecializationsClient, SpecializationsClient>();
 builder.Services.AddScoped<IWowReferenceAdminClient, WowReferenceAdminClient>();
 builder.Services.AddScoped<IMeClient, MeClient>();
 builder.Services.AddScoped<IGuildClient, GuildClient>();

--- a/tests/Lfm.App.Core.Tests/Services/SpecializationsClientTests.cs
+++ b/tests/Lfm.App.Core.Tests/Services/SpecializationsClientTests.cs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Net;
+using Lfm.App.Services;
+using Lfm.Contracts.Specializations;
+using Moq;
+using Xunit;
+
+namespace Lfm.App.Core.Tests.Services;
+
+public class SpecializationsClientTests
+{
+    private static (SpecializationsClient client, StubHttpMessageHandler handler) MakeClient(
+        StubHttpMessageHandler handler)
+    {
+        var http = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:7071/") };
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient("api")).Returns(http);
+        return (new SpecializationsClient(factory.Object), handler);
+    }
+
+    [Fact]
+    public async Task ListAsync_returns_specializations_on_success()
+    {
+        var specializations = new[]
+        {
+            new SpecializationDto(257, "Holy", 5, "HEALER", "https://render.example/holy.jpg"),
+            new SpecializationDto(258, "Shadow", 5, "DPS", "https://render.example/shadow.jpg"),
+        };
+        var (client, handler) = MakeClient(StubHttpMessageHandler.Json(HttpStatusCode.OK, specializations));
+
+        var result = await client.ListAsync(CancellationToken.None);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(257, result[0].Id);
+        Assert.Equal("https://render.example/shadow.jpg", result[1].IconUrl);
+        Assert.Equal(HttpMethod.Get, handler.LastRequest!.Method);
+        Assert.Equal("/api/v1/wow/reference/specializations", handler.LastRequest.RequestUri!.PathAndQuery);
+    }
+
+    [Fact]
+    public async Task ListAsync_returns_empty_when_body_is_null()
+    {
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("null", System.Text.Encoding.UTF8, "application/json"),
+        });
+        var (client, _) = MakeClient(handler);
+
+        var result = await client.ListAsync(CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task ListAsync_throws_HttpRequestException_on_5xx()
+    {
+        var (client, _) = MakeClient(new StubHttpMessageHandler(HttpStatusCode.ServiceUnavailable));
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => client.ListAsync(CancellationToken.None));
+    }
+}

--- a/tests/Lfm.App.Tests/RenderWithProviders.cs
+++ b/tests/Lfm.App.Tests/RenderWithProviders.cs
@@ -10,6 +10,7 @@ using Lfm.App.Services;
 using Lfm.Contracts.Characters;
 using Lfm.Contracts.Me;
 using Lfm.Contracts.Runs;
+using Lfm.Contracts.Specializations;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
@@ -44,6 +45,7 @@ public abstract class ComponentTestBase : BunitContext
         Services.AddSingleton<IStringLocalizer>(_localizer);
         Services.AddSingleton<IMeClient, DefaultMeClient>();
         Services.AddSingleton<IBattleNetClient, DefaultBattleNetClient>();
+        Services.AddSingleton<ISpecializationsClient, DefaultSpecializationsClient>();
         Services.AddSingleton<IAuthStateRefresher, NoopAuthStateRefresher>();
     }
 
@@ -99,6 +101,12 @@ internal sealed class DefaultBattleNetClient : IBattleNetClient
         IEnumerable<CharacterPortraitRequest> requests,
         CancellationToken ct) =>
         Task.FromResult<IDictionary<string, string>?>(new Dictionary<string, string>());
+}
+
+internal sealed class DefaultSpecializationsClient : ISpecializationsClient
+{
+    public Task<IReadOnlyList<SpecializationDto>> ListAsync(CancellationToken ct) =>
+        Task.FromResult<IReadOnlyList<SpecializationDto>>([]);
 }
 
 internal sealed class NoopAuthStateRefresher : IAuthStateRefresher

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -19,6 +19,7 @@ using Lfm.Contracts.Guild;
 using Lfm.Contracts.Instances;
 using Lfm.Contracts.Me;
 using Lfm.Contracts.Runs;
+using Lfm.Contracts.Specializations;
 using Xunit;
 
 namespace Lfm.App.Tests;
@@ -744,6 +745,49 @@ public class RunsPagesTests : ComponentTestBase
                     r.SpecId == 258),
                 It.IsAny<CancellationToken>()),
                 Times.Once));
+    }
+
+    [Fact]
+    public void RunsPage_CurrentSignup_Renders_Spec_Icon_From_Reference_Data()
+    {
+        var currentSignup = MakeCharacter(
+            "Aelrin",
+            classId: 5,
+            className: "Priest",
+            role: "HEALER",
+            attendance: "IN",
+            spec: "Holy",
+            isCurrentUser: true,
+            characterId: "eu-silvermoon-aelrin",
+            specId: 257);
+        var client = new Mock<IRunsClient>();
+        client.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<RunSummaryDto> { MakeSummary() });
+        client.Setup(c => c.GetAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeDetailWithRoster(new List<RunCharacterDto> { currentSignup }));
+        Services.AddSingleton(client.Object);
+
+        var specializations = new Mock<ISpecializationsClient>();
+        specializations.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new SpecializationDto(
+                    Id: 257,
+                    Name: "Holy",
+                    ClassId: 5,
+                    Role: "HEALER",
+                    IconUrl: "https://render.example/holy.jpg"),
+            ]);
+        Services.AddSingleton(specializations.Object);
+
+        var cut = Render<RunsPage>(p => p.Add(x => x.RunId, "run-1"));
+
+        cut.WaitForAssertion(() =>
+        {
+            var icon = cut.Find("img.spec-icon__image");
+            Assert.Equal("https://render.example/holy.jpg", icon.GetAttribute("src"));
+            Assert.Equal("", icon.GetAttribute("alt"));
+        });
+        specializations.Verify(c => c.ListAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- load specialization reference data for current run signup summaries
- render the real spec icon image when an icon URL is available
- keep the existing abbreviation placeholder as the missing/broken-image fallback

## Verification
- `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release --no-restore`
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --no-restore`
- `dotnet build lfm.sln -c Release`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `git diff --check`

## Env / schema changes
- None

## Screenshots
- Not captured; covered by bUnit regression for rendered spec icon markup.