### PR TITLE
Add visual route artifacts lane

### DIFF
--- a/app/Components/Runs/SpecIcon.razor.css
+++ b/app/Components/Runs/SpecIcon.razor.css
@@ -1,7 +1,7 @@
 .spec-icon {
     display: inline-grid;
     place-items: center;
-    min-inline-size: 1.5rem;
+    inline-size: 1.5rem;
     block-size: 1.5rem;
     border-radius: 50%;
     border: 1px solid var(--neutral-stroke-rest);

--- a/docs/superpowers/plans/2026-05-06-e2e-visual-route-artifacts.md
+++ b/docs/superpowers/plans/2026-05-06-e2e-visual-route-artifacts.md
@@ -274,7 +274,8 @@ public void Manifest_IncludesProtectedAnonymousAndAuthorizedStates()
 
     Assert.Contains(VisualRouteManifest.States, state =>
         state.Path == "/admin/reference" &&
-        state.AccessMode == VisualAccessMode.SiteAdmin &&
+        state.AccessMode == VisualAccessMode.Public &&
+        state.AnonymousExpectation == VisualAnonymousExpectation.RedirectToLogin &&
         state.ExpectedAnonymousPathAndQuery == "/login?redirect=%2Fadmin%2Freference");
 }
 ```
@@ -447,6 +448,12 @@ git -C /home/souroldgeezer/repos/lfm commit -m "Add visual route manifest"
 
 - [ ] **Step 1: Write failing writer tests**
 
+Ensure `VisualRouteArtifactModelSpec` has this using directive:
+
+```csharp
+using System.Text.Json;
+```
+
 Append these tests to `VisualRouteArtifactModelSpec`:
 
 ```csharp
@@ -460,6 +467,19 @@ public async Task ArtifactWriter_WritesDeterministicIndexJson()
     {
         var entries = new[]
         {
+            new VisualRouteArtifactEntry(
+                Route: "/guild/admin",
+                State: "guild admin site admin",
+                AccessMode: "site-admin",
+                AnonymousExpectation: "redirect-to-login",
+                Viewport: "mobile-floor",
+                Width: 320,
+                Height: 568,
+                Variant: "forced-colors",
+                Url: "http://localhost/guild/admin",
+                Screenshot: "visual-routes/forced-colors/mobile-floor/guild-admin-site-admin.png",
+                Status: "captured",
+                SkipReason: "not skipped"),
             new VisualRouteArtifactEntry(
                 Route: "/",
                 State: "landing",
@@ -479,8 +499,20 @@ public async Task ArtifactWriter_WritesDeterministicIndexJson()
 
         var indexPath = Path.Combine(outputRoot, "artifacts", "e2e-results", "visual-routes", "index.json");
         var json = await File.ReadAllTextAsync(indexPath);
-        Assert.Contains("\"route\": \"/\"", json);
-        Assert.Contains("\"status\": \"captured\"", json);
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        Assert.Equal(2, root.GetProperty("count").GetInt32());
+        Assert.False(root.TryGetProperty("generatedAtUtc", out _));
+
+        var entriesJson = root.GetProperty("entries").EnumerateArray().ToArray();
+        Assert.Equal("default", entriesJson[0].GetProperty("variant").GetString());
+        Assert.Equal("desktop", entriesJson[0].GetProperty("viewport").GetString());
+        Assert.Equal("landing", entriesJson[0].GetProperty("state").GetString());
+        Assert.False(entriesJson[0].TryGetProperty("skipReason", out _));
+        Assert.Equal("forced-colors", entriesJson[1].GetProperty("variant").GetString());
+        Assert.Equal("mobile-floor", entriesJson[1].GetProperty("viewport").GetString());
+        Assert.Equal("guild admin site admin", entriesJson[1].GetProperty("state").GetString());
+        Assert.Equal("not skipped", entriesJson[1].GetProperty("skipReason").GetString());
     }
     finally
     {
@@ -555,7 +587,6 @@ internal static class VisualRouteArtifactWriter
             .ToArray();
 
         var index = new VisualRouteArtifactIndex(
-            GeneratedAtUtc: DateTimeOffset.UtcNow,
             Count: ordered.Length,
             Entries: ordered);
 
@@ -563,7 +594,6 @@ internal static class VisualRouteArtifactWriter
     }
 
     private sealed record VisualRouteArtifactIndex(
-        DateTimeOffset GeneratedAtUtc,
         int Count,
         IReadOnlyCollection<VisualRouteArtifactEntry> Entries);
 }
@@ -594,6 +624,7 @@ git -C /home/souroldgeezer/repos/lfm commit -m "Add visual artifact writer"
 - Create: `tests/Lfm.E2E/Specs/VisualRouteArtifactsSpec.cs`
 - Modify: `tests/Lfm.E2E/Helpers/VisualRouteArtifactModel.cs`
 - Modify: `tests/Lfm.E2E/Helpers/VisualRouteManifest.cs`
+- Modify: `tests/Lfm.E2E/Specs/VisualRouteArtifactModelSpec.cs`
 
 - [ ] **Step 1: Add browser-ready delegates to the model**
 
@@ -612,6 +643,7 @@ internal sealed record VisualRouteState(
 ```
 
 Expected compile result before manifest update: FAIL because the existing manifest constructors no longer pass `WaitForReadyAsync`.
+Update any direct `VisualRouteState` construction in `VisualRouteArtifactModelSpec` to pass `_ => Task.CompletedTask` as the ready delegate so those tests stay focused on artifact path/model behavior.
 
 - [ ] **Step 2: Update the manifest with ready checks and setup delegates**
 
@@ -680,7 +712,7 @@ ProtectedRedirect("/runs/new", "runs new anonymous", "runs-new-anonymous", "/log
 Authenticated("/runs/new", "runs new authenticated", "runs-new-authenticated", Heading("Schedule a run", "Uusi runi"), SelectDungeonAsync),
 
 ProtectedRedirect($"/runs/{DefaultSeed.TestRunId}/edit", "runs edit anonymous", "runs-edit-anonymous", "/login?redirect=%2Fruns%2Fe2e-run-001%2Fedit", Heading("Sign In", "Kirjaudu")),
-Authenticated($"/runs/{DefaultSeed.TestRunId}/edit", "runs edit authenticated", "runs-edit-authenticated", Heading("Edit run", "Muokkaa runia")),
+Authenticated($"/runs/{DefaultSeed.TestRunId}/edit", "runs edit authenticated", "runs-edit-authenticated", Heading("Edit Run", "Muokkaa runia")),
 
 ProtectedRedirect("/characters", "characters anonymous", "characters-anonymous", "/login?redirect=%2Fcharacters", Heading("Sign In", "Kirjaudu")),
 Authenticated("/characters", "characters authenticated", "characters-authenticated", Heading("My Characters", "Hahmoni")),
@@ -982,7 +1014,7 @@ Expected output:
 - [ ] **Step 7: Commit Task 4**
 
 ```bash
-git -C /home/souroldgeezer/repos/lfm add tests/Lfm.E2E/Helpers/VisualRouteArtifactModel.cs tests/Lfm.E2E/Helpers/VisualRouteManifest.cs tests/Lfm.E2E/Specs/VisualRouteArtifactsSpec.cs
+git -C /home/souroldgeezer/repos/lfm add tests/Lfm.E2E/Helpers/VisualRouteArtifactModel.cs tests/Lfm.E2E/Helpers/VisualRouteManifest.cs tests/Lfm.E2E/Specs/VisualRouteArtifactModelSpec.cs tests/Lfm.E2E/Specs/VisualRouteArtifactsSpec.cs
 git -C /home/souroldgeezer/repos/lfm commit -m "Capture visual route artifacts"
 ```
 

--- a/tests/Lfm.E2E/Fixtures/VisualArtifactsFixture.cs
+++ b/tests/Lfm.E2E/Fixtures/VisualArtifactsFixture.cs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.E2E.Infrastructure;
+using Xunit;
+
+namespace Lfm.E2E.Fixtures;
+
+[CollectionDefinition("VisualArtifacts")]
+public class VisualArtifactsCollection : ICollectionFixture<VisualArtifactsFixture> { }
+
+public class VisualArtifactsFixture : IAsyncLifetime
+{
+    public StackFixture Stack { get; private set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        Stack = await SharedStack.GetAsync();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+}

--- a/tests/Lfm.E2E/Helpers/VisualRouteArtifactModel.cs
+++ b/tests/Lfm.E2E/Helpers/VisualRouteArtifactModel.cs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Microsoft.Playwright;
+
+namespace Lfm.E2E.Helpers;
+
+internal enum VisualAccessMode
+{
+    Public,
+    Authenticated,
+    SiteAdmin,
+}
+
+internal enum VisualAnonymousExpectation
+{
+    Render,
+    RedirectToLogin,
+}
+
+internal sealed record VisualViewport(string Name, int Width, int Height);
+
+internal sealed record VisualVariant(
+    string Name,
+    string? Locale = null,
+    ColorScheme? ColorScheme = null,
+    ForcedColors? ForcedColors = null)
+{
+    public static readonly VisualVariant Default = new("default");
+    public static readonly VisualVariant Finnish = new("fi", Locale: "fi-FI");
+    public static readonly VisualVariant Dark = new("dark", ColorScheme: Microsoft.Playwright.ColorScheme.Dark);
+    public static readonly VisualVariant ForcedColorsActive = new("forced-colors", ForcedColors: Microsoft.Playwright.ForcedColors.Active);
+}
+
+internal sealed record VisualRouteState(
+    string Name,
+    string Path,
+    VisualAccessMode AccessMode,
+    VisualAnonymousExpectation AnonymousExpectation,
+    string? ExpectedAnonymousPathAndQuery,
+    string Slug);
+
+internal sealed record VisualRouteArtifactEntry(
+    string Route,
+    string State,
+    string AccessMode,
+    string AnonymousExpectation,
+    string Viewport,
+    int Width,
+    int Height,
+    string Variant,
+    string Url,
+    string Screenshot,
+    string Status,
+    string? SkipReason);
+
+internal static class VisualRouteArtifactPaths
+{
+    public const string Root = "artifacts/e2e-results/visual-routes";
+
+    public static string ScreenshotRelativePath(
+        VisualVariant variant,
+        VisualViewport viewport,
+        VisualRouteState state)
+        => Path.Combine(
+            "visual-routes",
+            variant.Name,
+            viewport.Name,
+            state.Slug + ".png")
+            .Replace(Path.DirectorySeparatorChar, '/');
+
+    public static string ScreenshotAbsolutePath(
+        string repoRoot,
+        VisualVariant variant,
+        VisualViewport viewport,
+        VisualRouteState state)
+        => Path.Combine(
+            repoRoot,
+            "artifacts",
+            "e2e-results",
+            "visual-routes",
+            variant.Name,
+            viewport.Name,
+            state.Slug + ".png");
+
+    public static string IndexAbsolutePath(string repoRoot)
+        => Path.Combine(repoRoot, "artifacts", "e2e-results", "visual-routes", "index.json");
+}

--- a/tests/Lfm.E2E/Helpers/VisualRouteArtifactModel.cs
+++ b/tests/Lfm.E2E/Helpers/VisualRouteArtifactModel.cs
@@ -38,7 +38,9 @@ internal sealed record VisualRouteState(
     VisualAccessMode AccessMode,
     VisualAnonymousExpectation AnonymousExpectation,
     string? ExpectedAnonymousPathAndQuery,
-    string Slug);
+    string Slug,
+    Func<IPage, Task> WaitForReadyAsync,
+    Func<IPage, string, string, Task>? PrepareAsync = null);
 
 internal sealed record VisualRouteArtifactEntry(
     string Route,

--- a/tests/Lfm.E2E/Helpers/VisualRouteArtifactWriter.cs
+++ b/tests/Lfm.E2E/Helpers/VisualRouteArtifactWriter.cs
@@ -49,7 +49,6 @@ internal static class VisualRouteArtifactWriter
             .ToArray();
 
         var index = new VisualRouteArtifactIndex(
-            GeneratedAtUtc: DateTimeOffset.UtcNow,
             Count: ordered.Length,
             Entries: ordered);
 
@@ -57,7 +56,6 @@ internal static class VisualRouteArtifactWriter
     }
 
     private sealed record VisualRouteArtifactIndex(
-        DateTimeOffset GeneratedAtUtc,
         int Count,
         IReadOnlyCollection<VisualRouteArtifactEntry> Entries);
 }

--- a/tests/Lfm.E2E/Helpers/VisualRouteArtifactWriter.cs
+++ b/tests/Lfm.E2E/Helpers/VisualRouteArtifactWriter.cs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Playwright;
+
+namespace Lfm.E2E.Helpers;
+
+internal static class VisualRouteArtifactWriter
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    public static async Task<string> CaptureScreenshotAsync(
+        string repoRoot,
+        IPage page,
+        VisualVariant variant,
+        VisualViewport viewport,
+        VisualRouteState state)
+    {
+        var screenshotPath = VisualRouteArtifactPaths.ScreenshotAbsolutePath(repoRoot, variant, viewport, state);
+        Directory.CreateDirectory(Path.GetDirectoryName(screenshotPath)!);
+
+        await page.ScreenshotAsync(new PageScreenshotOptions
+        {
+            Path = screenshotPath,
+            FullPage = true,
+        });
+
+        return VisualRouteArtifactPaths.ScreenshotRelativePath(variant, viewport, state);
+    }
+
+    public static async Task WriteIndexAsync(
+        string repoRoot,
+        IReadOnlyCollection<VisualRouteArtifactEntry> entries)
+    {
+        var indexPath = VisualRouteArtifactPaths.IndexAbsolutePath(repoRoot);
+        Directory.CreateDirectory(Path.GetDirectoryName(indexPath)!);
+
+        var ordered = entries
+            .OrderBy(entry => entry.Variant, StringComparer.Ordinal)
+            .ThenBy(entry => entry.Viewport, StringComparer.Ordinal)
+            .ThenBy(entry => entry.State, StringComparer.Ordinal)
+            .ToArray();
+
+        var index = new VisualRouteArtifactIndex(
+            GeneratedAtUtc: DateTimeOffset.UtcNow,
+            Count: ordered.Length,
+            Entries: ordered);
+
+        await File.WriteAllTextAsync(indexPath, JsonSerializer.Serialize(index, JsonOptions));
+    }
+
+    private sealed record VisualRouteArtifactIndex(
+        DateTimeOffset GeneratedAtUtc,
+        int Count,
+        IReadOnlyCollection<VisualRouteArtifactEntry> Entries);
+}

--- a/tests/Lfm.E2E/Helpers/VisualRouteManifest.cs
+++ b/tests/Lfm.E2E/Helpers/VisualRouteManifest.cs
@@ -54,7 +54,7 @@ internal static class VisualRouteManifest
         SiteAdmin("/guild/admin", "guild admin site admin", "guild-admin-site-admin"),
 
         ProtectedRedirect("/admin/reference", "admin reference anonymous", "admin-reference-anonymous", "/login?redirect=%2Fadmin%2Freference"),
-        SiteAdmin("/admin/reference", "admin reference site admin", "admin-reference-site-admin", "/login?redirect=%2Fadmin%2Freference"),
+        SiteAdmin("/admin/reference", "admin reference site admin", "admin-reference-site-admin"),
 
         ProtectedRedirect("/instances", "instances anonymous", "instances-anonymous", "/login?redirect=%2Finstances"),
         Authenticated("/instances", "instances authenticated", "instances-authenticated"),

--- a/tests/Lfm.E2E/Helpers/VisualRouteManifest.cs
+++ b/tests/Lfm.E2E/Helpers/VisualRouteManifest.cs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.E2E.Seeds;
+
+namespace Lfm.E2E.Helpers;
+
+internal static class VisualRouteManifest
+{
+    public static readonly IReadOnlyList<VisualViewport> Viewports =
+    [
+        new("desktop", 1366, 768),
+        new("phone", 390, 844),
+        new("mobile-floor", 320, 568),
+    ];
+
+    public static readonly IReadOnlyList<VisualVariant> Variants =
+    [
+        VisualVariant.Default,
+        VisualVariant.Finnish,
+        VisualVariant.Dark,
+        VisualVariant.ForcedColorsActive,
+    ];
+
+    public static readonly IReadOnlyList<VisualRouteState> States =
+    [
+        Public("/", "landing", "landing"),
+        Public("/login", "login", "login"),
+        Public("/privacy", "privacy", "privacy"),
+        Public("/login/failed", "login failed", "login-failed"),
+        Public("/auth/failure", "auth failure", "auth-failure"),
+        Public("/not-found", "not found", "not-found"),
+        Public("/goodbye", "goodbye", "goodbye"),
+
+        ProtectedRedirect("/runs", "runs anonymous", "runs-anonymous", "/login?redirect=%2Fruns"),
+        Authenticated("/runs", "runs authenticated", "runs-authenticated"),
+
+        ProtectedRedirect($"/runs/{DefaultSeed.TestRunId}", "runs detail anonymous", "runs-detail-anonymous", "/login?redirect=%2Fruns%2Fe2e-run-001"),
+        Authenticated($"/runs/{DefaultSeed.TestRunId}", "runs detail authenticated", "runs-detail-authenticated"),
+
+        ProtectedRedirect("/runs/new", "runs new anonymous", "runs-new-anonymous", "/login?redirect=%2Fruns%2Fnew"),
+        Authenticated("/runs/new", "runs new authenticated", "runs-new-authenticated"),
+
+        ProtectedRedirect($"/runs/{DefaultSeed.TestRunId}/edit", "runs edit anonymous", "runs-edit-anonymous", "/login?redirect=%2Fruns%2Fe2e-run-001%2Fedit"),
+        Authenticated($"/runs/{DefaultSeed.TestRunId}/edit", "runs edit authenticated", "runs-edit-authenticated"),
+
+        ProtectedRedirect("/characters", "characters anonymous", "characters-anonymous", "/login?redirect=%2Fcharacters"),
+        Authenticated("/characters", "characters authenticated", "characters-authenticated"),
+
+        ProtectedRedirect("/guild", "guild anonymous", "guild-anonymous", "/login?redirect=%2Fguild"),
+        Authenticated("/guild", "guild authenticated", "guild-authenticated"),
+
+        ProtectedRedirect("/guild/admin", "guild admin anonymous", "guild-admin-anonymous", "/login?redirect=%2Fguild%2Fadmin"),
+        SiteAdmin("/guild/admin", "guild admin site admin", "guild-admin-site-admin"),
+
+        ProtectedRedirect("/admin/reference", "admin reference anonymous", "admin-reference-anonymous", "/login?redirect=%2Fadmin%2Freference"),
+        SiteAdmin("/admin/reference", "admin reference site admin", "admin-reference-site-admin", "/login?redirect=%2Fadmin%2Freference"),
+
+        ProtectedRedirect("/instances", "instances anonymous", "instances-anonymous", "/login?redirect=%2Finstances"),
+        Authenticated("/instances", "instances authenticated", "instances-authenticated"),
+    ];
+
+    public static readonly IReadOnlyList<VisualMatrixEntry> Matrix =
+        States
+            .SelectMany(state => Viewports.SelectMany(viewport =>
+                Variants.Select(variant => new VisualMatrixEntry(state, viewport, variant))))
+            .ToArray();
+
+    private static VisualRouteState Public(string path, string name, string slug)
+        => new(name, path, VisualAccessMode.Public, VisualAnonymousExpectation.Render, null, slug);
+
+    private static VisualRouteState ProtectedRedirect(
+        string path,
+        string name,
+        string slug,
+        string expectedAnonymousPathAndQuery)
+        => new(
+            name,
+            path,
+            VisualAccessMode.Public,
+            VisualAnonymousExpectation.RedirectToLogin,
+            expectedAnonymousPathAndQuery,
+            slug);
+
+    private static VisualRouteState Authenticated(string path, string name, string slug)
+        => new(name, path, VisualAccessMode.Authenticated, VisualAnonymousExpectation.RedirectToLogin, null, slug);
+
+    private static VisualRouteState SiteAdmin(
+        string path,
+        string name,
+        string slug,
+        string? expectedAnonymousPathAndQuery = null)
+        => new(name, path, VisualAccessMode.SiteAdmin, VisualAnonymousExpectation.RedirectToLogin, expectedAnonymousPathAndQuery, slug);
+}
+
+internal sealed record VisualMatrixEntry(
+    VisualRouteState State,
+    VisualViewport Viewport,
+    VisualVariant Variant);

--- a/tests/Lfm.E2E/Helpers/VisualRouteManifest.cs
+++ b/tests/Lfm.E2E/Helpers/VisualRouteManifest.cs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
+using System.Text.RegularExpressions;
+using Lfm.E2E.Pages;
 using Lfm.E2E.Seeds;
+using Microsoft.Playwright;
+using Xunit;
 
 namespace Lfm.E2E.Helpers;
 
@@ -24,40 +28,40 @@ internal static class VisualRouteManifest
 
     public static readonly IReadOnlyList<VisualRouteState> States =
     [
-        Public("/", "landing", "landing"),
-        Public("/login", "login", "login"),
-        Public("/privacy", "privacy", "privacy"),
-        Public("/login/failed", "login failed", "login-failed"),
-        Public("/auth/failure", "auth failure", "auth-failure"),
-        Public("/not-found", "not found", "not-found"),
-        Public("/goodbye", "goodbye", "goodbye"),
+        Public("/", "landing", "landing", Heading("Looking For More", "Etsin lisää")),
+        Public("/login", "login", "login", Heading("Sign In", "Kirjaudu")),
+        Public("/privacy", "privacy", "privacy", Heading("Privacy Policy", "Tietosuojaseloste")),
+        Public("/login/failed", "login failed", "login-failed", Heading("Login Failed", "Kirjautuminen epäonnistui")),
+        Public("/auth/failure", "auth failure", "auth-failure", Heading("Login Failed", "Kirjautuminen epäonnistui")),
+        Public("/not-found", "not found", "not-found", Heading("Not Found", "Ei löytynyt")),
+        Public("/goodbye", "goodbye", "goodbye", Heading("Goodbye", "Näkemiin")),
 
-        ProtectedRedirect("/runs", "runs anonymous", "runs-anonymous", "/login?redirect=%2Fruns"),
-        Authenticated("/runs", "runs authenticated", "runs-authenticated"),
+        ProtectedRedirect("/runs", "runs anonymous", "runs-anonymous", "/login?redirect=%2Fruns", Heading("Sign In", "Kirjaudu")),
+        Authenticated("/runs", "runs authenticated", "runs-authenticated", Heading("Runs", "Runit")),
 
-        ProtectedRedirect($"/runs/{DefaultSeed.TestRunId}", "runs detail anonymous", "runs-detail-anonymous", "/login?redirect=%2Fruns%2Fe2e-run-001"),
-        Authenticated($"/runs/{DefaultSeed.TestRunId}", "runs detail authenticated", "runs-detail-authenticated"),
+        ProtectedRedirect($"/runs/{DefaultSeed.TestRunId}", "runs detail anonymous", "runs-detail-anonymous", "/login?redirect=%2Fruns%2Fe2e-run-001", Heading("Sign In", "Kirjaudu")),
+        Authenticated($"/runs/{DefaultSeed.TestRunId}", "runs detail authenticated", "runs-detail-authenticated", Heading("Runs", "Runit"), SelectRunAsync),
 
-        ProtectedRedirect("/runs/new", "runs new anonymous", "runs-new-anonymous", "/login?redirect=%2Fruns%2Fnew"),
-        Authenticated("/runs/new", "runs new authenticated", "runs-new-authenticated"),
+        ProtectedRedirect("/runs/new", "runs new anonymous", "runs-new-anonymous", "/login?redirect=%2Fruns%2Fnew", Heading("Sign In", "Kirjaudu")),
+        Authenticated("/runs/new", "runs new authenticated", "runs-new-authenticated", Heading("Schedule a run", "Uusi runi"), SelectDungeonAsync),
 
-        ProtectedRedirect($"/runs/{DefaultSeed.TestRunId}/edit", "runs edit anonymous", "runs-edit-anonymous", "/login?redirect=%2Fruns%2Fe2e-run-001%2Fedit"),
-        Authenticated($"/runs/{DefaultSeed.TestRunId}/edit", "runs edit authenticated", "runs-edit-authenticated"),
+        ProtectedRedirect($"/runs/{DefaultSeed.TestRunId}/edit", "runs edit anonymous", "runs-edit-anonymous", "/login?redirect=%2Fruns%2Fe2e-run-001%2Fedit", Heading("Sign In", "Kirjaudu")),
+        Authenticated($"/runs/{DefaultSeed.TestRunId}/edit", "runs edit authenticated", "runs-edit-authenticated", Heading("Edit Run", "Muokkaa runia")),
 
-        ProtectedRedirect("/characters", "characters anonymous", "characters-anonymous", "/login?redirect=%2Fcharacters"),
-        Authenticated("/characters", "characters authenticated", "characters-authenticated"),
+        ProtectedRedirect("/characters", "characters anonymous", "characters-anonymous", "/login?redirect=%2Fcharacters", Heading("Sign In", "Kirjaudu")),
+        Authenticated("/characters", "characters authenticated", "characters-authenticated", Heading("My Characters", "Hahmoni")),
 
-        ProtectedRedirect("/guild", "guild anonymous", "guild-anonymous", "/login?redirect=%2Fguild"),
-        Authenticated("/guild", "guild authenticated", "guild-authenticated"),
+        ProtectedRedirect("/guild", "guild anonymous", "guild-anonymous", "/login?redirect=%2Fguild", Heading("Sign In", "Kirjaudu")),
+        Authenticated("/guild", "guild authenticated", "guild-authenticated", Heading("Guild", "Kilta")),
 
-        ProtectedRedirect("/guild/admin", "guild admin anonymous", "guild-admin-anonymous", "/login?redirect=%2Fguild%2Fadmin"),
-        SiteAdmin("/guild/admin", "guild admin site admin", "guild-admin-site-admin"),
+        ProtectedRedirect("/guild/admin", "guild admin anonymous", "guild-admin-anonymous", "/login?redirect=%2Fguild%2Fadmin", Heading("Sign In", "Kirjaudu")),
+        SiteAdmin("/guild/admin", "guild admin site admin", "guild-admin-site-admin", Heading("Guild Admin", "Killan hallinta"), LoadGuildAdminAsync),
 
-        ProtectedRedirect("/admin/reference", "admin reference anonymous", "admin-reference-anonymous", "/login?redirect=%2Fadmin%2Freference"),
-        SiteAdmin("/admin/reference", "admin reference site admin", "admin-reference-site-admin"),
+        ProtectedRedirect("/admin/reference", "admin reference anonymous", "admin-reference-anonymous", "/login?redirect=%2Fadmin%2Freference", Heading("Sign In", "Kirjaudu")),
+        SiteAdmin("/admin/reference", "admin reference site admin", "admin-reference-site-admin", Heading("Reference data", "Referenssitiedot")),
 
-        ProtectedRedirect("/instances", "instances anonymous", "instances-anonymous", "/login?redirect=%2Finstances"),
-        Authenticated("/instances", "instances authenticated", "instances-authenticated"),
+        ProtectedRedirect("/instances", "instances anonymous", "instances-anonymous", "/login?redirect=%2Finstances", Heading("Sign In", "Kirjaudu")),
+        Authenticated("/instances", "instances authenticated", "instances-authenticated", Heading("Instances", "Instanssit")),
     ];
 
     public static readonly IReadOnlyList<VisualMatrixEntry> Matrix =
@@ -66,31 +70,85 @@ internal static class VisualRouteManifest
                 Variants.Select(variant => new VisualMatrixEntry(state, viewport, variant))))
             .ToArray();
 
-    private static VisualRouteState Public(string path, string name, string slug)
-        => new(name, path, VisualAccessMode.Public, VisualAnonymousExpectation.Render, null, slug);
+    private static Func<IPage, Task> Heading(string english, string finnish)
+        => page => Assertions.Expect(page.GetByRole(
+                AriaRole.Heading,
+                new() { NameRegex = new($"^(?:{Regex.Escape(english)}|{Regex.Escape(finnish)})$") }))
+            .ToBeVisibleAsync(new() { Timeout = 15000 });
+
+    private static async Task LoadGuildAdminAsync(IPage page, string apiBaseUrl, string appBaseUrl)
+    {
+        var guildAdminPage = new GuildAdminPage(page);
+        await guildAdminPage.LoadGuildAsync(DefaultSeed.TestGuildId);
+        await Assertions.Expect(guildAdminPage.SloganField).ToBeVisibleAsync(new() { Timeout = 15000 });
+    }
+
+    private static async Task SelectRunAsync(IPage page, string apiBaseUrl, string appBaseUrl)
+    {
+        var runsPage = new RunsPage(page);
+        await runsPage.SelectRunAsync(DefaultSeed.TestRunId);
+        await Assertions.Expect(runsPage.AttendingHeading).ToBeVisibleAsync(new() { Timeout = 15000 });
+    }
+
+    private static async Task SelectDungeonAsync(IPage page, string apiBaseUrl, string appBaseUrl)
+    {
+        await page.GetByRole(AriaRole.Radio, new() { NameRegex = new("Dungeon|Luolasto") })
+            .ClickAsync(new() { Timeout = 15000 });
+    }
+
+    private static VisualRouteState Public(
+        string path,
+        string name,
+        string slug,
+        Func<IPage, Task> waitForReadyAsync)
+        => new(name, path, VisualAccessMode.Public, VisualAnonymousExpectation.Render, null, slug, waitForReadyAsync);
 
     private static VisualRouteState ProtectedRedirect(
         string path,
         string name,
         string slug,
-        string expectedAnonymousPathAndQuery)
+        string expectedAnonymousPathAndQuery,
+        Func<IPage, Task> waitForReadyAsync)
         => new(
             name,
             path,
             VisualAccessMode.Public,
             VisualAnonymousExpectation.RedirectToLogin,
             expectedAnonymousPathAndQuery,
-            slug);
+            slug,
+            waitForReadyAsync);
 
-    private static VisualRouteState Authenticated(string path, string name, string slug)
-        => new(name, path, VisualAccessMode.Authenticated, VisualAnonymousExpectation.RedirectToLogin, null, slug);
+    private static VisualRouteState Authenticated(
+        string path,
+        string name,
+        string slug,
+        Func<IPage, Task> waitForReadyAsync,
+        Func<IPage, string, string, Task>? prepareAsync = null)
+        => new(
+            name,
+            path,
+            VisualAccessMode.Authenticated,
+            VisualAnonymousExpectation.RedirectToLogin,
+            null,
+            slug,
+            waitForReadyAsync,
+            prepareAsync);
 
     private static VisualRouteState SiteAdmin(
         string path,
         string name,
         string slug,
-        string? expectedAnonymousPathAndQuery = null)
-        => new(name, path, VisualAccessMode.SiteAdmin, VisualAnonymousExpectation.RedirectToLogin, expectedAnonymousPathAndQuery, slug);
+        Func<IPage, Task> waitForReadyAsync,
+        Func<IPage, string, string, Task>? prepareAsync = null)
+        => new(
+            name,
+            path,
+            VisualAccessMode.SiteAdmin,
+            VisualAnonymousExpectation.RedirectToLogin,
+            null,
+            slug,
+            waitForReadyAsync,
+            prepareAsync);
 }
 
 internal sealed record VisualMatrixEntry(

--- a/tests/Lfm.E2E/Infrastructure/E2ETestMetadata.cs
+++ b/tests/Lfm.E2E/Infrastructure/E2ETestMetadata.cs
@@ -9,6 +9,7 @@ public static class E2ELanes
     public const string Functional = "Functional";
     public const string Accessibility = "Accessibility";
     public const string LayoutIntegrity = "Layout integrity";
+    public const string VisualArtifacts = "VisualArtifacts";
     public const string Security = "Security";
     public const string AuthFlow = "Auth flow";
     public const string Performance = "Performance";

--- a/tests/Lfm.E2E/Specs/VisualRouteArtifactModelSpec.cs
+++ b/tests/Lfm.E2E/Specs/VisualRouteArtifactModelSpec.cs
@@ -81,7 +81,8 @@ public class VisualRouteArtifactModelSpec
 
         Assert.Contains(VisualRouteManifest.States, state =>
             state.Path == "/admin/reference" &&
-            state.AccessMode == VisualAccessMode.SiteAdmin &&
+            state.AccessMode == VisualAccessMode.Public &&
+            state.AnonymousExpectation == VisualAnonymousExpectation.RedirectToLogin &&
             state.ExpectedAnonymousPathAndQuery == "/login?redirect=%2Fadmin%2Freference");
     }
 }

--- a/tests/Lfm.E2E/Specs/VisualRouteArtifactModelSpec.cs
+++ b/tests/Lfm.E2E/Specs/VisualRouteArtifactModelSpec.cs
@@ -55,4 +55,33 @@ public class VisualRouteArtifactModelSpec
         Assert.Equal("captured", entry.Status);
         Assert.Null(entry.SkipReason);
     }
+
+    [Fact]
+    public void Manifest_CoversEveryApprovedRouteState()
+    {
+        Assert.Equal(25, VisualRouteManifest.States.Count);
+        Assert.Equal(3, VisualRouteManifest.Viewports.Count);
+        Assert.Equal(4, VisualRouteManifest.Variants.Count);
+        Assert.Equal(300, VisualRouteManifest.Matrix.Count);
+    }
+
+    [Fact]
+    public void Manifest_IncludesProtectedAnonymousAndAuthorizedStates()
+    {
+        Assert.Contains(VisualRouteManifest.States, state =>
+            state.Path == "/runs" &&
+            state.AccessMode == VisualAccessMode.Public &&
+            state.AnonymousExpectation == VisualAnonymousExpectation.RedirectToLogin &&
+            state.ExpectedAnonymousPathAndQuery == "/login?redirect=%2Fruns");
+
+        Assert.Contains(VisualRouteManifest.States, state =>
+            state.Path == "/runs" &&
+            state.AccessMode == VisualAccessMode.Authenticated &&
+            state.AnonymousExpectation == VisualAnonymousExpectation.RedirectToLogin);
+
+        Assert.Contains(VisualRouteManifest.States, state =>
+            state.Path == "/admin/reference" &&
+            state.AccessMode == VisualAccessMode.SiteAdmin &&
+            state.ExpectedAnonymousPathAndQuery == "/login?redirect=%2Fadmin%2Freference");
+    }
 }

--- a/tests/Lfm.E2E/Specs/VisualRouteArtifactModelSpec.cs
+++ b/tests/Lfm.E2E/Specs/VisualRouteArtifactModelSpec.cs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.E2E.Helpers;
+using Lfm.E2E.Infrastructure;
+using Xunit;
+
+namespace Lfm.E2E.Specs;
+
+[Trait("Category", E2ELanes.VisualArtifacts)]
+public class VisualRouteArtifactModelSpec
+{
+    [Fact]
+    public void VisualArtifactsLane_IsDeclared()
+    {
+        Assert.Equal("VisualArtifacts", E2ELanes.VisualArtifacts);
+    }
+
+    [Fact]
+    public void ArtifactPath_UsesVariantViewportAndRouteSlug()
+    {
+        var viewport = new VisualViewport("mobile-floor", 320, 568);
+        var variant = VisualVariant.ForcedColorsActive;
+        var state = new VisualRouteState(
+            "runs detail authenticated",
+            "/runs/e2e-run-001",
+            VisualAccessMode.Authenticated,
+            VisualAnonymousExpectation.RedirectToLogin,
+            "/login?redirect=%2Fruns%2Fe2e-run-001",
+            "runs-detail-authenticated");
+
+        var relativePath = VisualRouteArtifactPaths.ScreenshotRelativePath(variant, viewport, state);
+
+        Assert.Equal("visual-routes/forced-colors/mobile-floor/runs-detail-authenticated.png", relativePath);
+    }
+
+    [Fact]
+    public void ArtifactEntry_RecordsInspectableMetadata()
+    {
+        var entry = new VisualRouteArtifactEntry(
+            Route: "/guild/admin",
+            State: "guild admin site admin",
+            AccessMode: "site-admin",
+            AnonymousExpectation: "redirect-to-login",
+            Viewport: "desktop",
+            Width: 1366,
+            Height: 768,
+            Variant: "dark",
+            Url: "http://localhost/guild/admin",
+            Screenshot: "visual-routes/dark/desktop/guild-admin-site-admin.png",
+            Status: "captured",
+            SkipReason: null);
+
+        Assert.Equal("site-admin", entry.AccessMode);
+        Assert.Equal("captured", entry.Status);
+        Assert.Null(entry.SkipReason);
+    }
+}

--- a/tests/Lfm.E2E/Specs/VisualRouteArtifactModelSpec.cs
+++ b/tests/Lfm.E2E/Specs/VisualRouteArtifactModelSpec.cs
@@ -85,4 +85,42 @@ public class VisualRouteArtifactModelSpec
             state.AnonymousExpectation == VisualAnonymousExpectation.RedirectToLogin &&
             state.ExpectedAnonymousPathAndQuery == "/login?redirect=%2Fadmin%2Freference");
     }
+
+    [Fact]
+    public async Task ArtifactWriter_WritesDeterministicIndexJson()
+    {
+        var outputRoot = Path.Combine(Path.GetTempPath(), "lfm-visual-artifact-writer-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outputRoot);
+
+        try
+        {
+            var entries = new[]
+            {
+                new VisualRouteArtifactEntry(
+                    Route: "/",
+                    State: "landing",
+                    AccessMode: "public",
+                    AnonymousExpectation: "render",
+                    Viewport: "desktop",
+                    Width: 1366,
+                    Height: 768,
+                    Variant: "default",
+                    Url: "http://localhost/",
+                    Screenshot: "visual-routes/default/desktop/landing.png",
+                    Status: "captured",
+                    SkipReason: null),
+            };
+
+            await VisualRouteArtifactWriter.WriteIndexAsync(outputRoot, entries);
+
+            var indexPath = Path.Combine(outputRoot, "artifacts", "e2e-results", "visual-routes", "index.json");
+            var json = await File.ReadAllTextAsync(indexPath);
+            Assert.Contains("\"route\": \"/\"", json);
+            Assert.Contains("\"status\": \"captured\"", json);
+        }
+        finally
+        {
+            Directory.Delete(outputRoot, recursive: true);
+        }
+    }
 }

--- a/tests/Lfm.E2E/Specs/VisualRouteArtifactModelSpec.cs
+++ b/tests/Lfm.E2E/Specs/VisualRouteArtifactModelSpec.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
+using System.Text.Json;
 using Lfm.E2E.Helpers;
 using Lfm.E2E.Infrastructure;
 using Xunit;
@@ -109,14 +110,43 @@ public class VisualRouteArtifactModelSpec
                     Screenshot: "visual-routes/default/desktop/landing.png",
                     Status: "captured",
                     SkipReason: null),
+                new VisualRouteArtifactEntry(
+                    Route: "/runs",
+                    State: "runs",
+                    AccessMode: "public",
+                    AnonymousExpectation: "redirect-to-login",
+                    Viewport: "mobile",
+                    Width: 390,
+                    Height: 844,
+                    Variant: "dark",
+                    Url: "http://localhost/runs",
+                    Screenshot: "visual-routes/dark/mobile/runs.png",
+                    Status: "captured",
+                    SkipReason: "not eligible"),
             };
 
             await VisualRouteArtifactWriter.WriteIndexAsync(outputRoot, entries);
 
             var indexPath = Path.Combine(outputRoot, "artifacts", "e2e-results", "visual-routes", "index.json");
             var json = await File.ReadAllTextAsync(indexPath);
-            Assert.Contains("\"route\": \"/\"", json);
-            Assert.Contains("\"status\": \"captured\"", json);
+            using var document = JsonDocument.Parse(json);
+
+            var root = document.RootElement;
+            Assert.Equal(2, root.GetProperty("count").GetInt32());
+            Assert.False(root.TryGetProperty("generatedAtUtc", out _));
+
+            var writtenEntries = root.GetProperty("entries");
+            Assert.Equal(2, writtenEntries.GetArrayLength());
+
+            Assert.Equal("dark", writtenEntries[0].GetProperty("variant").GetString());
+            Assert.Equal("mobile", writtenEntries[0].GetProperty("viewport").GetString());
+            Assert.Equal("runs", writtenEntries[0].GetProperty("state").GetString());
+            Assert.Equal("not eligible", writtenEntries[0].GetProperty("skipReason").GetString());
+
+            Assert.Equal("default", writtenEntries[1].GetProperty("variant").GetString());
+            Assert.Equal("desktop", writtenEntries[1].GetProperty("viewport").GetString());
+            Assert.Equal("landing", writtenEntries[1].GetProperty("state").GetString());
+            Assert.False(writtenEntries[1].TryGetProperty("skipReason", out _));
         }
         finally
         {

--- a/tests/Lfm.E2E/Specs/VisualRouteArtifactModelSpec.cs
+++ b/tests/Lfm.E2E/Specs/VisualRouteArtifactModelSpec.cs
@@ -28,7 +28,8 @@ public class VisualRouteArtifactModelSpec
             VisualAccessMode.Authenticated,
             VisualAnonymousExpectation.RedirectToLogin,
             "/login?redirect=%2Fruns%2Fe2e-run-001",
-            "runs-detail-authenticated");
+            "runs-detail-authenticated",
+            _ => Task.CompletedTask);
 
         var relativePath = VisualRouteArtifactPaths.ScreenshotRelativePath(variant, viewport, state);
 

--- a/tests/Lfm.E2E/Specs/VisualRouteArtifactsSpec.cs
+++ b/tests/Lfm.E2E/Specs/VisualRouteArtifactsSpec.cs
@@ -55,7 +55,7 @@ public class VisualRouteArtifactsSpec(VisualArtifactsFixture fixture, ITestOutpu
             context = await CreateContextAsync(item);
             page = await context.NewPageAsync();
 
-            await StubPortraitsAsync(page);
+            await StubExternalImagesAsync(page);
             await AuthenticateIfNeededAsync(page, item.State);
             AttachDiagnostics(page, diagnostics);
 
@@ -188,7 +188,7 @@ public class VisualRouteArtifactsSpec(VisualArtifactsFixture fixture, ITestOutpu
         await page.EvaluateAsync("() => document.fonts ? document.fonts.ready : Promise.resolve()");
     }
 
-    private static async Task StubPortraitsAsync(IPage page)
+    private static async Task StubExternalImagesAsync(IPage page)
     {
         await page.RouteAsync("**/api/v1/battlenet/character-portraits", async route =>
         {
@@ -197,6 +197,21 @@ public class VisualRouteArtifactsSpec(VisualArtifactsFixture fixture, ITestOutpu
                 Status = 200,
                 ContentType = "application/json",
                 Body = "{\"portraits\":{}}",
+            });
+        });
+
+        await page.RouteAsync("https://render.worldofwarcraft.com/**", async route =>
+        {
+            await route.FulfillAsync(new()
+            {
+                Status = 200,
+                ContentType = "image/svg+xml",
+                Body = """
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                      <rect width="24" height="24" rx="12" fill="#5bc0eb"/>
+                      <path d="M8 16h8M8 12h8M8 8h8" stroke="#111" stroke-width="2" stroke-linecap="round"/>
+                    </svg>
+                    """,
             });
         });
     }

--- a/tests/Lfm.E2E/Specs/VisualRouteArtifactsSpec.cs
+++ b/tests/Lfm.E2E/Specs/VisualRouteArtifactsSpec.cs
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Collections.Concurrent;
+using System.Text.RegularExpressions;
+using Lfm.E2E.Fixtures;
+using Lfm.E2E.Helpers;
+using Lfm.E2E.Infrastructure;
+using Lfm.E2E.Seeds;
+using Microsoft.Playwright;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Lfm.E2E.Specs;
+
+[Collection("VisualArtifacts")]
+[Trait("Category", E2ELanes.VisualArtifacts)]
+public class VisualRouteArtifactsSpec(VisualArtifactsFixture fixture, ITestOutputHelper output)
+{
+    [Fact]
+    public async Task EveryRouteState_EmitsResponsiveVisualArtifacts()
+    {
+        var repoRoot = FindRepoRoot();
+        var entries = new List<VisualRouteArtifactEntry>();
+
+        foreach (var item in VisualRouteManifest.Matrix)
+        {
+            var entry = await CaptureMatrixEntryAsync(repoRoot, item);
+            entries.Add(entry);
+        }
+
+        await VisualRouteArtifactWriter.WriteIndexAsync(repoRoot, entries);
+
+        var failures = entries
+            .Where(entry => entry.Status != "captured")
+            .Select(entry => $"{entry.Variant}/{entry.Viewport}/{entry.State}: {entry.SkipReason}")
+            .ToArray();
+
+        Assert.True(
+            failures.Length == 0,
+            "Visual route artifact capture failed:\n" + string.Join("\n", failures));
+    }
+
+    private async Task<VisualRouteArtifactEntry> CaptureMatrixEntryAsync(
+        string repoRoot,
+        VisualMatrixEntry item)
+    {
+        var diagnostics = new VisualDiagnostics();
+        IBrowserContext? context = null;
+        IPage? page = null;
+
+        try
+        {
+            context = await CreateContextAsync(item);
+            page = await context.NewPageAsync();
+
+            await StubPortraitsAsync(page);
+            await AuthenticateIfNeededAsync(page, item.State);
+            AttachDiagnostics(page, diagnostics);
+
+            var targetUrl = fixture.Stack.AppBaseUrl + item.State.Path;
+            await page.GotoAsync(targetUrl, new() { WaitUntil = WaitUntilState.NetworkIdle });
+
+            if (item.State.ExpectedAnonymousPathAndQuery is not null)
+            {
+                await Assertions.Expect(page).ToHaveURLAsync(
+                    new Regex(Regex.Escape(fixture.Stack.AppBaseUrl + item.State.ExpectedAnonymousPathAndQuery) + "$"),
+                    new() { Timeout = 15000 });
+            }
+
+            await item.State.WaitForReadyAsync(page);
+
+            if (item.State.PrepareAsync is not null)
+            {
+                await item.State.PrepareAsync(page, fixture.Stack.ApiBaseUrl, fixture.Stack.AppBaseUrl);
+                await WaitForVisualReadyAsync(page);
+            }
+
+            diagnostics.ThrowIfAny(item);
+            await LayoutIntegrityHelper.AssertNoOverlapsAsync(
+                page,
+                output,
+                $"{item.State.Name} [{item.Viewport.Name}, {item.Variant.Name}]");
+
+            var screenshot = await VisualRouteArtifactWriter.CaptureScreenshotAsync(
+                repoRoot,
+                page,
+                item.Variant,
+                item.Viewport,
+                item.State);
+
+            return ToEntry(item, page.Url, screenshot, "captured", null);
+        }
+        catch (Exception ex)
+        {
+            var screenshot = VisualRouteArtifactPaths.ScreenshotRelativePath(item.Variant, item.Viewport, item.State);
+            if (page is not null)
+            {
+                screenshot = await TryCaptureFailureScreenshotAsync(repoRoot, page, item, screenshot);
+            }
+
+            return ToEntry(
+                item,
+                page?.Url ?? fixture.Stack.AppBaseUrl + item.State.Path,
+                screenshot,
+                "failed",
+                ex.Message);
+        }
+        finally
+        {
+            if (context is not null)
+                await context.CloseAsync();
+        }
+    }
+
+    private async Task<IBrowserContext> CreateContextAsync(VisualMatrixEntry item)
+    {
+        var options = new BrowserNewContextOptions
+        {
+            Locale = item.Variant.Locale,
+            ColorScheme = item.Variant.ColorScheme,
+            ForcedColors = item.Variant.ForcedColors,
+            ViewportSize = new()
+            {
+                Width = item.Viewport.Width,
+                Height = item.Viewport.Height,
+            },
+        };
+
+        return await fixture.Stack.Browser.NewContextAsync(options);
+    }
+
+    private async Task AuthenticateIfNeededAsync(IPage page, VisualRouteState state)
+    {
+        if (state.AccessMode == VisualAccessMode.Public)
+            return;
+
+        var battleNetId = state.AccessMode == VisualAccessMode.SiteAdmin
+            ? DefaultSeed.SiteAdminBattleNetId
+            : DefaultSeed.PrimaryBattleNetId;
+
+        await AuthHelper.AuthenticatePageAsync(
+            page,
+            fixture.Stack.ApiBaseUrl,
+            fixture.Stack.AppBaseUrl,
+            battleNetId,
+            "/");
+        await WaitForVisualReadyAsync(page);
+    }
+
+    private static void AttachDiagnostics(IPage page, VisualDiagnostics diagnostics)
+    {
+        page.Console += (_, msg) =>
+        {
+            if (msg.Type is "error" or "warning")
+                diagnostics.Messages.Enqueue($"[Browser {msg.Type.ToUpperInvariant()}] {msg.Text}");
+        };
+
+        page.RequestFailed += (_, req) =>
+            diagnostics.Messages.Enqueue($"[Browser REQUESTFAILED] {req.Url} - {req.Failure}");
+    }
+
+    private static async Task<string> TryCaptureFailureScreenshotAsync(
+        string repoRoot,
+        IPage page,
+        VisualMatrixEntry item,
+        string fallbackScreenshot)
+    {
+        try
+        {
+            return await VisualRouteArtifactWriter.CaptureScreenshotAsync(
+                repoRoot,
+                page,
+                item.Variant,
+                item.Viewport,
+                item.State);
+        }
+        catch
+        {
+            return fallbackScreenshot;
+        }
+    }
+
+    private static async Task WaitForVisualReadyAsync(IPage page)
+    {
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await page.EvaluateAsync("() => document.fonts ? document.fonts.ready : Promise.resolve()");
+    }
+
+    private static async Task StubPortraitsAsync(IPage page)
+    {
+        await page.RouteAsync("**/api/v1/battlenet/character-portraits", async route =>
+        {
+            await route.FulfillAsync(new()
+            {
+                Status = 200,
+                ContentType = "application/json",
+                Body = "{\"portraits\":{}}",
+            });
+        });
+    }
+
+    private static VisualRouteArtifactEntry ToEntry(
+        VisualMatrixEntry item,
+        string url,
+        string screenshot,
+        string status,
+        string? skipReason)
+        => new(
+            Route: item.State.Path,
+            State: item.State.Name,
+            AccessMode: ToKebab(item.State.AccessMode.ToString()),
+            AnonymousExpectation: ToKebab(item.State.AnonymousExpectation.ToString()),
+            Viewport: item.Viewport.Name,
+            Width: item.Viewport.Width,
+            Height: item.Viewport.Height,
+            Variant: item.Variant.Name,
+            Url: url,
+            Screenshot: screenshot,
+            Status: status,
+            SkipReason: skipReason);
+
+    private static string ToKebab(string value)
+        => Regex.Replace(value, "([a-z0-9])([A-Z])", "$1-$2").ToLowerInvariant();
+
+    private static string FindRepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir, "lfm.sln")))
+                return dir;
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new InvalidOperationException(
+            "Could not find lfm.sln walking up from " + AppContext.BaseDirectory);
+    }
+
+    private sealed class VisualDiagnostics
+    {
+        public ConcurrentQueue<string> Messages { get; } = new();
+
+        public void ThrowIfAny(VisualMatrixEntry item)
+        {
+            var messages = Messages
+                .Where(message =>
+                    !message.Contains("401", StringComparison.OrdinalIgnoreCase) &&
+                    !message.Contains("/api/v1/me", StringComparison.OrdinalIgnoreCase) &&
+                    !message.Contains("net::ERR_ABORTED", StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+
+            if (messages.Length == 0)
+                return;
+
+            throw new XunitException(
+                $"Unexpected browser diagnostics for {item.State.Name} [{item.Viewport.Name}, {item.Variant.Name}]:\n" +
+                string.Join("\n", messages));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `VisualArtifacts` E2E lane for every approved route state across desktop, phone, mobile-floor, Finnish, dark mode, and forced-colors variants
- emit screenshots and deterministic `index.json` under `artifacts/e2e-results/visual-routes`
- fix `SpecIcon` sizing so intrinsic specialization images cannot widen compact mobile layouts

## Environment / schema changes
- none

## Screenshots
- generated locally by the new lane under `artifacts/e2e-results/visual-routes/`; no image baselines are committed

## Verification
- `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --filter FullyQualifiedName~VisualRouteArtifactModelSpec --no-restore`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `git diff --check main..HEAD`
- earlier full worktree verification before the docs-only rebase included `Category=VisualArtifacts` with 300 captured entries and full `tests/Lfm.E2E` passing