### PR TITLE
Consolidate E2E lanes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,9 +4,9 @@
 name: E2E
 
 on:
-  # PRs run the cheap required smoke subset only. The full suite stays manual
-  # because broad WCAG checks against FluentUI shadow DOM have been flaky and
-  # the full stack consumes enough runner minutes to be a poor every-push gate.
+  # PRs run the default normal subset. Fast and full are explicit manual lanes:
+  # fast is a quick smoke probe, while full includes the broad visual artifact,
+  # accessibility, layout, security, and performance categories.
   pull_request:
     paths:
       - ".github/actions/setup-dotnet-cached/**"
@@ -27,12 +27,11 @@ on:
         description: "E2E lane to run"
         required: true
         type: choice
-        default: full
+        default: normal
         options:
+          - fast
+          - normal
           - full
-          - smoke
-          - performance
-          - performance-load
 
 permissions:
   contents: read
@@ -92,13 +91,15 @@ jobs:
       - name: Run E2E
         shell: bash
         run: |
+          lane="${{ github.event_name == 'pull_request' && 'normal' || inputs.lane }}"
           filter_args=()
-          if [ "${{ github.event_name }}" = "pull_request" ] || [ "${{ inputs.lane }}" = "smoke" ]; then
+          if [ "$lane" = "fast" ]; then
             filter_args+=(--filter "Category=Smoke")
-          elif [ "${{ inputs.lane }}" = "performance" ]; then
-            filter_args+=(--filter "Category=Performance")
-          elif [ "${{ inputs.lane }}" = "performance-load" ]; then
-            filter_args+=(--filter "Category=PerformanceLoad")
+          elif [ "$lane" = "normal" ]; then
+            filter_args+=(--filter "Category=Smoke|Category=Functional|Category=Auth flow")
+          elif [ "$lane" != "full" ]; then
+            echo "Unsupported E2E lane: $lane" >&2
+            exit 1
           fi
 
           dotnet test tests/Lfm.E2E/Lfm.E2E.csproj \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,7 +5,7 @@ name: E2E
 
 on:
   # PRs run the default normal subset. Fast and full are explicit manual lanes:
-  # fast is a quick smoke probe, while full includes the broad visual artifact,
+  # fast is a minimal probe, while full includes the broad visual artifact,
   # accessibility, layout, security, and performance categories.
   pull_request:
     paths:
@@ -94,9 +94,9 @@ jobs:
           lane="${{ github.event_name == 'pull_request' && 'normal' || inputs.lane }}"
           filter_args=()
           if [ "$lane" = "fast" ]; then
-            filter_args+=(--filter "Category=Smoke")
+            filter_args+=(--filter "Category=Fast")
           elif [ "$lane" = "normal" ]; then
-            filter_args+=(--filter "Category=Smoke|Category=Functional|Category=Auth flow")
+            filter_args+=(--filter "Category=Smoke")
           elif [ "$lane" != "full" ]; then
             echo "Unsupported E2E lane: $lane" >&2
             exit 1

--- a/docs/superpowers/specs/2026-05-06-e2e-visual-route-artifacts-design.md
+++ b/docs/superpowers/specs/2026-05-06-e2e-visual-route-artifacts-design.md
@@ -17,8 +17,8 @@ machine-readable index while still failing on browser-observable defects:
 wrong redirects, missing route content, console errors, failed requests,
 layout overflow, layout overlap, or artifact write failures.
 
-This is an artifact and health-check lane, not a pixel-diff visual regression
-system.
+This is a full-E2E artifact category and health check, not a pixel-diff visual
+regression system or a separate workflow level.
 
 ## Approved Decisions
 
@@ -77,16 +77,18 @@ Each viewport runs through four variants:
 | `dark` | dark color scheme |
 | `forced-colors` | forced-colors active |
 
-The matrix deliberately overlaps with the existing layout-integrity E2E lane,
-but serves a different purpose: this lane emits inspectable screenshots for
+The matrix deliberately overlaps with the existing layout-integrity E2E
+category, but serves a different purpose: it emits inspectable screenshots for
 every route state while layout-integrity remains the deeper geometry-focused
-assertion lane.
+assertion category.
 
 ## Implementation Shape
 
 Add a dedicated E2E spec, tentatively `VisualRouteArtifactsSpec`, instead of
 expanding the existing accessibility, navigation, performance, or
-layout-integrity specs.
+layout-integrity specs. Tag it as `VisualArtifacts` so targeted local runs can
+request only screenshots, while the GitHub Actions workflow folds it into the
+explicit `full` level.
 
 Use a typed route manifest. Each entry declares:
 
@@ -163,10 +165,10 @@ review this file and run `git diff --check`.
 
 ## Risks And Mitigations
 
-The full matrix can produce roughly hundreds of screenshots. Tag the new spec
-with a dedicated category such as `VisualArtifacts` so it can be run directly
-when reviewing responsive UI without making every local E2E run harder to
-triage.
+The full matrix can produce roughly hundreds of screenshots. Keep it in a
+dedicated category such as `VisualArtifacts` so it can be run directly when
+reviewing responsive UI, and keep it out of the workflow's `fast` and `normal`
+levels so routine CI does not become harder to triage.
 
 Forced-colors support can be browser-version sensitive. Treat unsupported
 browser context options as an explicit skipped variant with a reason in the

--- a/docs/superpowers/specs/2026-05-06-e2e-visual-route-artifacts-design.md
+++ b/docs/superpowers/specs/2026-05-06-e2e-visual-route-artifacts-design.md
@@ -168,7 +168,8 @@ review this file and run `git diff --check`.
 The full matrix can produce roughly hundreds of screenshots. Keep it in a
 dedicated category such as `VisualArtifacts` so it can be run directly when
 reviewing responsive UI, and keep it out of the workflow's `fast` and `normal`
-levels so routine CI does not become harder to triage.
+levels so routine CI stays focused on the smoke subset and does not become
+harder to triage.
 
 Forced-colors support can be browser-version sensitive. Treat unsupported
 browser context options as an explicit skipped variant with a reason in the

--- a/docs/testing/e2e-maintenance.md
+++ b/docs/testing/e2e-maintenance.md
@@ -17,7 +17,22 @@ Runtime publish output lives under `.cache/e2e-runtime/`, and normal fixture
 disposal removes its own run directory. Diagnostics are written under
 `artifacts/e2e-results/` so failed runs do not leave tracked-file pollution.
 
-## Lanes
+## Workflow Levels
+
+The GitHub Actions workflow exposes three E2E levels:
+
+| Level | When to use | Test filter |
+|-------|-------------|-------------|
+| Fast | Explicit manual quick probe | `Category=Smoke` |
+| Normal | Pull requests and default manual dispatch | `Category=Smoke\|Category=Functional\|Category=Auth flow` |
+| Full | Explicit manual review only | no filter |
+
+Full includes the broad accessibility, layout-integrity, security,
+performance, and visual-artifact categories. The visual-artifact category writes
+screenshots under `artifacts/e2e-results/visual-routes/`; it is not a separate
+workflow level.
+
+## Coverage Categories
 
 | Lane | Use E2E for | Move down when |
 |------|-------------|----------------|
@@ -26,6 +41,7 @@ disposal removes its own run directory. Diagnostics are written under
 | Security | Browser-enforced CORS, CSP, iframe, cookie, and redirect behavior | Server-only status/header logic can be tested in API tests |
 | Auth flow | Real redirect/callback/session behavior | `/api/e2e/login` is enough and the browser adds no signal |
 | Performance | Browser Web Vitals-style lab metrics, route interaction timing, resource/API counts, and local request-health probes | A bundle check, API operation-count assertion, or production telemetry query proves the same regression |
+| Visual artifacts | Every-route responsive screenshots for local/CI artifact review | A route-specific assertion already proves the behavior and no screenshot evidence is needed |
 
 Auth-sensitive E2E tests should use the Testcontainers-managed OAuth provider
 and drive the app's real sign-in button, provider authorize page, callback,

--- a/docs/testing/e2e-maintenance.md
+++ b/docs/testing/e2e-maintenance.md
@@ -23,14 +23,15 @@ The GitHub Actions workflow exposes three E2E levels:
 
 | Level | When to use | Test filter |
 |-------|-------------|-------------|
-| Fast | Explicit manual quick probe | `Category=Smoke` |
-| Normal | Pull requests and default manual dispatch | `Category=Smoke\|Category=Functional\|Category=Auth flow` |
+| Fast | Explicit manual minimal probe | `Category=Fast` |
+| Normal | Pull requests and default manual dispatch | `Category=Smoke` |
 | Full | Explicit manual review only | no filter |
 
-Full includes the broad accessibility, layout-integrity, security,
-performance, and visual-artifact categories. The visual-artifact category writes
-screenshots under `artifacts/e2e-results/visual-routes/`; it is not a separate
-workflow level.
+Fast is a strict subset of normal. Normal is the CI-focused browser subset.
+Full includes the broader functional, auth-flow, accessibility,
+layout-integrity, security, performance, and visual-artifact categories. The
+visual-artifact category writes screenshots under
+`artifacts/e2e-results/visual-routes/`; it is not a separate workflow level.
 
 ## Coverage Categories
 

--- a/tests/Lfm.E2E/Infrastructure/E2ETestMetadata.cs
+++ b/tests/Lfm.E2E/Infrastructure/E2ETestMetadata.cs
@@ -5,6 +5,7 @@ namespace Lfm.E2E.Infrastructure;
 
 public static class E2ELanes
 {
+    public const string Fast = "Fast";
     public const string Smoke = "Smoke";
     public const string Functional = "Functional";
     public const string Accessibility = "Accessibility";

--- a/tests/Lfm.E2E/Specs/E2EWorkflowLaneSpec.cs
+++ b/tests/Lfm.E2E/Specs/E2EWorkflowLaneSpec.cs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.E2E.Infrastructure;
+using Xunit;
+
+namespace Lfm.E2E.Specs;
+
+[Trait("Category", E2ELanes.Smoke)]
+public class E2EWorkflowLaneSpec
+{
+    [Fact]
+    public void Workflow_ExposesFastNormalAndFullLanes()
+    {
+        var workflow = ReadE2EWorkflow();
+
+        Assert.Contains("default: normal", workflow);
+        Assert.Contains("- fast", workflow);
+        Assert.Contains("- normal", workflow);
+        Assert.Contains("- full", workflow);
+        Assert.DoesNotContain("- smoke", workflow);
+        Assert.DoesNotContain("- performance", workflow);
+        Assert.DoesNotContain("- performance-load", workflow);
+    }
+
+    [Fact]
+    public void Workflow_UsesNormalLaneForPullRequestsAndManualDefault()
+    {
+        var workflow = ReadE2EWorkflow();
+
+        Assert.Contains("github.event_name == 'pull_request' && 'normal' || inputs.lane", workflow);
+        Assert.Contains("--filter \"Category=Smoke\"", workflow);
+        Assert.Contains("--filter \"Category=Smoke|Category=Functional|Category=Auth flow\"", workflow);
+    }
+
+    private static string ReadE2EWorkflow()
+    {
+        var repoRoot = FindRepoRoot();
+        var workflowPath = Path.Combine(repoRoot, ".github", "workflows", "e2e.yml");
+
+        Assert.True(File.Exists(workflowPath), $"Expected E2E workflow at {workflowPath}");
+        return File.ReadAllText(workflowPath);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir, "lfm.sln")))
+                return dir;
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new InvalidOperationException(
+            "Could not find lfm.sln walking up from " + AppContext.BaseDirectory);
+    }
+}

--- a/tests/Lfm.E2E/Specs/E2EWorkflowLaneSpec.cs
+++ b/tests/Lfm.E2E/Specs/E2EWorkflowLaneSpec.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace Lfm.E2E.Specs;
 
+[Trait("Category", E2ELanes.Fast)]
 [Trait("Category", E2ELanes.Smoke)]
 public class E2EWorkflowLaneSpec
 {
@@ -29,8 +30,9 @@ public class E2EWorkflowLaneSpec
         var workflow = ReadE2EWorkflow();
 
         Assert.Contains("github.event_name == 'pull_request' && 'normal' || inputs.lane", workflow);
+        Assert.Contains("--filter \"Category=Fast\"", workflow);
         Assert.Contains("--filter \"Category=Smoke\"", workflow);
-        Assert.Contains("--filter \"Category=Smoke|Category=Functional|Category=Auth flow\"", workflow);
+        Assert.DoesNotContain("--filter \"Category=Smoke|Category=Functional|Category=Auth flow\"", workflow);
     }
 
     private static string ReadE2EWorkflow()

--- a/tests/Lfm.E2E/Specs/RunsSpec.cs
+++ b/tests/Lfm.E2E/Specs/RunsSpec.cs
@@ -45,6 +45,7 @@ public class RunsSpec(RunsFixture fixture, ITestOutputHelper output)
     // Cheaper lanes cannot prove this because the browser observes auth, API, storage, and UI composition together.
     // Shared data: read-only.
     [Fact]
+    [Trait("Category", E2ELanes.Fast)]
     [Trait("Category", E2ELanes.Smoke)]
     public async Task RunsPage_Loads_DisplaysRunList()
     {

--- a/tests/Lfm.E2E/Specs/SmokeLaneMetadataSpec.cs
+++ b/tests/Lfm.E2E/Specs/SmokeLaneMetadataSpec.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace Lfm.E2E.Specs;
 
+[Trait("Category", E2ELanes.Fast)]
 [Trait("Category", E2ELanes.Smoke)]
 public class SmokeLaneMetadataSpec
 {


### PR DESCRIPTION
## Summary
- replace the E2E workflow choices with `fast`, `normal`, and `full`
- run `normal` for PRs/default manual dispatch as the focused smoke subset and keep visual route screenshots in explicit `full`
- add a workflow contract spec, add a smaller `Fast` subset marker, and update E2E maintenance docs/spec wording

## Verification
- `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --filter FullyQualifiedName~E2EWorkflowLaneSpec`
- `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --no-build --list-tests --filter "Category=Fast"`
- `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --no-build --list-tests --filter "Category=Smoke"`
- `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --no-build --filter "Category=Smoke" --logger "console;verbosity=normal" --results-directory ./artifacts/e2e-results`
- `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --no-build --filter "Category=Smoke|Category=Functional|Category=Auth flow" --logger "console;verbosity=normal" --results-directory ./artifacts/e2e-results` (diagnostic run before narrowing normal; passed locally)
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `dotnet build lfm.sln -c Release`
- `git diff --check`
- `yq eval '.on.workflow_dispatch.inputs.lane.default, .on.workflow_dispatch.inputs.lane.options' .github/workflows/e2e.yml`