### PR TITLE
Fix selected character display name

### DIFF
--- a/api/Functions/MeFunction.cs
+++ b/api/Functions/MeFunction.cs
@@ -58,7 +58,27 @@ public class MeFunction(IRaidersRepository repo, ISiteAdminService siteAdmin)
 
         return selected is null
             ? null
-            : new SelectedCharacterSummaryDto(selected.Id, selected.Name, selected.PortraitUrl);
+            : new SelectedCharacterSummaryDto(
+                selected.Id,
+                ResolveAccountProfileDisplayName(raider.AccountProfileSummary, selected) ?? selected.Name,
+                selected.PortraitUrl);
+    }
+
+    private static string? ResolveAccountProfileDisplayName(
+        StoredBlizzardAccountProfile? accountProfile,
+        StoredSelectedCharacter selected)
+    {
+        foreach (var account in accountProfile?.WowAccounts ?? [])
+        {
+            foreach (var character in account.Characters ?? [])
+            {
+                var characterId = $"{selected.Region.ToLowerInvariant()}-{character.Realm.Slug.ToLowerInvariant()}-{character.Name.ToLowerInvariant()}";
+                if (string.Equals(characterId, selected.Id, StringComparison.OrdinalIgnoreCase))
+                    return character.Name;
+            }
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/tests/Lfm.Api.Tests/MeFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/MeFunctionTests.cs
@@ -125,6 +125,62 @@ public class MeFunctionTests
     }
 
     [Fact]
+    public async Task Returns_selected_character_summary_with_account_profile_display_name()
+    {
+        var principal = new SessionPrincipal(
+            BattleNetId: "bnet-1",
+            BattleTag: "Player#1234",
+            GuildId: null,
+            GuildName: null,
+            IssuedAt: DateTimeOffset.UtcNow,
+            ExpiresAt: DateTimeOffset.UtcNow.AddHours(1));
+
+        var raider = new RaiderDocument(
+            Id: "bnet-1",
+            BattleNetId: "bnet-1",
+            SelectedCharacterId: "eu-doomhammer-shalena",
+            Locale: "en",
+            AccountProfileSummary: new StoredBlizzardAccountProfile([
+                new StoredBlizzardWowAccount(
+                    Id: 1,
+                    Characters: [
+                        new StoredBlizzardAccountCharacter(
+                            Name: "Shalena",
+                            Level: 80,
+                            Realm: new StoredBlizzardRealmRef(Slug: "doomhammer", Name: "Doomhammer"))
+                    ])
+            ]),
+            Characters: [
+                new StoredSelectedCharacter(
+                    Id: "eu-doomhammer-shalena",
+                    Region: "eu",
+                    Realm: "doomhammer",
+                    Name: "shalena",
+                    PortraitUrl: "https://render.worldofwarcraft.com/eu/shalena-avatar.jpg")
+            ]);
+
+        var repo = new Mock<IRaidersRepository>();
+        repo.Setup(r => r.GetByBattleNetIdAsync("bnet-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(raider);
+
+        var siteAdmin = new Mock<ISiteAdminService>();
+        siteAdmin.Setup(s => s.IsAdminAsync("bnet-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var fn = new MeFunction(repo.Object, siteAdmin.Object);
+        var ctx = MakeFunctionContext(principal);
+
+        var result = await fn.RunV1(new DefaultHttpContext().Request, ctx, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var me = Assert.IsType<MeResponse>(ok.Value);
+        Assert.NotNull(me.SelectedCharacter);
+        Assert.Equal("eu-doomhammer-shalena", me.SelectedCharacter.Id);
+        Assert.Equal("Shalena", me.SelectedCharacter.Name);
+        Assert.Equal("https://render.worldofwarcraft.com/eu/shalena-avatar.jpg", me.SelectedCharacter.PortraitUrl);
+    }
+
+    [Fact]
     public async Task Returns_not_found_when_raider_document_missing()
     {
         var principal = new SessionPrincipal(


### PR DESCRIPTION
## Summary
- Makes `/api/v1/me` prefer the canonical account-profile display name for the selected character when it matches the selected character id.
- Preserves the selected character id and portrait source while preventing legacy lowercased stored names from surfacing in the account chip.
- Adds an API regression test for a stored `shalena` row with account-profile `Shalena`.

## Screenshots / visual evidence
- Not included. This is a backend projection fix for the existing account chip; the regression is covered at the `/me` API boundary.

## Test Plan
- [x] Red regression check failed before the fix: expected `Shalena`, actual `shalena`
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release --filter FullyQualifiedName~MeFunctionTests.Returns_selected_character_summary_with_account_profile_display_name`
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release --filter FullyQualifiedName~MeFunctionTests`
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- [x] `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release`
- [x] `dotnet build lfm.sln -c Release`