### PR TITLE
Fix account chip alignment

### DIFF
--- a/app/Layout/MainLayout.razor
+++ b/app/Layout/MainLayout.razor
@@ -55,17 +55,19 @@
                                           aria-label="@Loc["nav.accountMenu", SelectedCharacterName(accountAuth.User)]"
                                           aria-expanded="@(_showAccountMenu ? "true" : "false")"
                                           OnClick="@ToggleAccountMenu">
-                                @if (SelectedCharacterPortraitUrl(accountAuth.User) is { } portraitUrl)
-                                {
-                                    <img class="account-avatar" src="@portraitUrl" alt="" />
-                                }
-                                else
-                                {
-                                    <span class="account-avatar account-avatar-initial" aria-hidden="true">
-                                        @SelectedCharacterInitial(accountAuth.User)
-                                    </span>
-                                }
-                                <span class="account-character-name">@SelectedCharacterName(accountAuth.User)</span>
+                                <span class="account-menu-trigger__content">
+                                    @if (SelectedCharacterPortraitUrl(accountAuth.User) is { } portraitUrl)
+                                    {
+                                        <img class="account-avatar" src="@portraitUrl" alt="" />
+                                    }
+                                    else
+                                    {
+                                        <span class="account-avatar account-avatar-initial" aria-hidden="true">
+                                            @SelectedCharacterInitial(accountAuth.User)
+                                        </span>
+                                    }
+                                    <span class="account-character-name">@SelectedCharacterName(accountAuth.User)</span>
+                                </span>
                             </FluentButton>
                             <div class="account-menu @(_showAccountMenu ? "open" : "")"
                                  aria-hidden="@(!_showAccountMenu)">
@@ -166,8 +168,16 @@
     .account-menu-trigger::part(control) {
         display: inline-flex;
         align-items: center;
-        gap: 8px;
         max-inline-size: 192px;
+    }
+
+    .account-menu-trigger__content {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        min-inline-size: 0;
+        min-block-size: 28px;
+        line-height: 1;
     }
 
     .account-avatar {
@@ -194,6 +204,7 @@
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+        line-height: 1;
     }
 
     .account-menu {

--- a/tests/Lfm.App.Tests/LayoutTests.cs
+++ b/tests/Lfm.App.Tests/LayoutTests.cs
@@ -217,6 +217,31 @@ public class LayoutTests : ComponentTestBase
     }
 
     [Fact]
+    public void MainLayout_Account_Menu_Button_Groups_Avatar_And_Name_For_Alignment()
+    {
+        var auth = this.AddAuthorization();
+        auth.SetAuthorized("player#1234");
+        auth.SetClaims(
+            new Claim(AppAuthenticationStateProvider.SelectedCharacterNameClaim, "Aelrin"),
+            new Claim(
+                AppAuthenticationStateProvider.SelectedCharacterPortraitUrlClaim,
+                "https://render.worldofwarcraft.com/eu/aelrin-avatar.jpg"));
+
+        var cut = Render<MainLayout>(p =>
+            p.Add(x => x.Body, builder => builder.AddContent(0, "page content")));
+
+        cut.WaitForAssertion(() =>
+        {
+            var trigger = cut.Find("fluent-button.account-menu-trigger");
+            var content = trigger.QuerySelector(".account-menu-trigger__content");
+
+            Assert.NotNull(content);
+            Assert.NotNull(content.QuerySelector("img.account-avatar"));
+            Assert.NotNull(content.QuerySelector(".account-character-name"));
+        });
+    }
+
+    [Fact]
     public void MainLayout_Account_Disclosure_Does_Not_Advertise_Menu_Pattern()
     {
         var auth = this.AddAuthorization();


### PR DESCRIPTION
## Summary
- Wraps the account menu avatar and selected-character name in a centered content row inside the Fluent button.
- Keeps the existing trigger behavior and accessible name while avoiding baseline alignment between the avatar image and text.
- Adds a bUnit regression that proves the avatar/name grouping exists.

## Screenshots / visual evidence
- Not included. This is a narrow shell markup/CSS alignment fix; the structural regression is covered by bUnit and visual confirmation will come from the normal PR visual/E2E lane.

## Test Plan
- [x] Red regression check failed before the fix: missing `.account-menu-trigger__content`
- [x] `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --filter FullyQualifiedName~LayoutTests.MainLayout_Account_Menu_Button_Groups_Avatar_And_Name_For_Alignment`
- [x] `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --filter FullyQualifiedName~LayoutTests`
- [x] `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release`
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- [x] `dotnet build lfm.sln -c Release`