### PR TITLE
Tighten account chip spacing

### DIFF
--- a/app/Layout/MainLayout.razor
+++ b/app/Layout/MainLayout.razor
@@ -36,13 +36,14 @@
                     </div>
                     <div style="margin-inline-start:auto;display:flex;align-items:center;gap:4px">
                         <FluentButton Appearance="Appearance.Stealth"
-                                      Class="mobile-nav-toggle"
+                                      Class="mobile-nav-toggle toolbar-icon-button"
                                       Title="@Loc["nav.toggleMenu"]"
                                       aria-label="@Loc["nav.toggleMenu"]"
                                       OnClick="@ToggleMobileMenu">
                             &#9776;
                         </FluentButton>
                         <FluentButton Appearance="Appearance.Stealth"
+                                      Class="toolbar-icon-button"
                                       Title="@_themeTooltip"
                                       aria-label="@_themeTooltip"
                                       OnClick="@ToggleTheme">
@@ -94,6 +95,7 @@
                 <NotAuthorized>
                     <div style="margin-inline-start:auto;display:flex;align-items:center;gap:4px">
                         <FluentButton Appearance="Appearance.Stealth"
+                                      Class="toolbar-icon-button"
                                       Title="@_themeTooltip"
                                       aria-label="@_themeTooltip"
                                       OnClick="@ToggleTheme">
@@ -165,16 +167,33 @@
         align-items: center;
     }
 
+    .toolbar-icon-button::part(control) {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        inline-size: 32px;
+        block-size: 32px;
+        min-inline-size: 32px;
+        min-block-size: 32px;
+        padding: 0;
+    }
+
     .account-menu-trigger::part(control) {
         display: inline-flex;
         align-items: center;
+        block-size: 32px;
+        min-inline-size: 0;
+        min-block-size: 32px;
         max-inline-size: 192px;
+        padding-block: 2px;
+        padding-inline: 4px 8px;
+        box-sizing: border-box;
     }
 
     .account-menu-trigger__content {
         display: inline-flex;
         align-items: center;
-        gap: 8px;
+        gap: 6px;
         min-inline-size: 0;
         min-block-size: 28px;
         line-height: 1;

--- a/tests/Lfm.App.Tests/LayoutTests.cs
+++ b/tests/Lfm.App.Tests/LayoutTests.cs
@@ -242,6 +242,32 @@ public class LayoutTests : ComponentTestBase
     }
 
     [Fact]
+    public void MainLayout_Account_Toolbar_Controls_Use_Compact_Chrome()
+    {
+        var auth = this.AddAuthorization();
+        auth.SetAuthorized("player#1234");
+        auth.SetClaims(
+            new Claim(AppAuthenticationStateProvider.SelectedCharacterNameClaim, "Aelrin"),
+            new Claim(
+                AppAuthenticationStateProvider.SelectedCharacterPortraitUrlClaim,
+                "https://render.worldofwarcraft.com/eu/aelrin-avatar.jpg"));
+
+        var cut = Render<MainLayout>(p =>
+            p.Add(x => x.Body, builder => builder.AddContent(0, "page content")));
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.NotNull(cut.Find("fluent-button.toolbar-icon-button[aria-label='Switch to light mode']"));
+            Assert.NotNull(cut.Find("fluent-button.account-menu-trigger"));
+            Assert.Contains(".toolbar-icon-button::part(control)", cut.Markup);
+            Assert.Contains("inline-size: 32px;", cut.Markup);
+            Assert.Contains("block-size: 32px;", cut.Markup);
+            Assert.Contains("padding-inline: 4px 8px;", cut.Markup);
+            Assert.Contains("padding-block: 2px;", cut.Markup);
+        });
+    }
+
+    [Fact]
     public void MainLayout_Account_Disclosure_Does_Not_Advertise_Menu_Pattern()
     {
         var auth = this.AddAuthorization();


### PR DESCRIPTION
## Summary
- Gives header icon buttons explicit compact 32px toolbar chrome.
- Tightens the selected-character account chip height and padding so it aligns with the adjacent theme button.
- Adds a bUnit regression for the compact shell-control chrome.

## Screenshots / visual evidence
- Not included. This is a narrow shell CSS follow-up; the spacing contract is covered by bUnit and the PR visual/E2E lane will provide browser evidence.

## Test Plan
- [x] Red regression check failed before the fix: missing `.toolbar-icon-button` compact chrome
- [x] `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --no-restore`
- [x] `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- [x] `dotnet build lfm.sln -c Release --no-restore`