### PR TITLE
Fix guild admin locale save

### DIFF
--- a/app/Components/Guild/GuildSettingsEditor.razor
+++ b/app/Components/Guild/GuildSettingsEditor.razor
@@ -99,8 +99,8 @@
 
     private static readonly (string Value, string Label)[] LocaleOptions =
     [
-        (SupportedLocales.Finnish, "Suomi"),
-        (SupportedLocales.English, "English"),
+        (GuildSettingsLocales.Finnish, "Suomi"),
+        (GuildSettingsLocales.EnglishEditorValue, "English"),
     ];
 
     private static readonly Dictionary<string, object> SloganAttrs = new()

--- a/app/Lfm.App.Core/i18n/GuildSettingsLocales.cs
+++ b/app/Lfm.App.Core/i18n/GuildSettingsLocales.cs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+namespace Lfm.App.i18n;
+
+public static class GuildSettingsLocales
+{
+    public const string Finnish = "fi";
+    public const string EnglishEditorValue = "en";
+    public const string EnglishRequestValue = "en-gb";
+    public const string Default = Finnish;
+
+    private static readonly HashSet<string> RequestValues = new(StringComparer.OrdinalIgnoreCase)
+    {
+        Finnish,
+        EnglishRequestValue,
+        "de",
+        "fr",
+        "es",
+        "sv",
+        "da",
+        "nb",
+    };
+
+    public static string ToEditorValueOrDefault(string? locale)
+    {
+        var normalized = Normalize(locale);
+        if (normalized is null)
+            return Default;
+
+        return normalized is EnglishEditorValue or EnglishRequestValue
+            ? EnglishEditorValue
+            : RequestValues.Contains(normalized) ? normalized : Default;
+    }
+
+    public static string ToRequestValueOrDefault(string? editorValue)
+    {
+        var normalized = Normalize(editorValue);
+        if (normalized is null)
+            return Default;
+
+        return normalized == EnglishEditorValue
+            ? EnglishRequestValue
+            : RequestValues.Contains(normalized) ? normalized : Default;
+    }
+
+    private static string? Normalize(string? locale)
+    {
+        if (string.IsNullOrWhiteSpace(locale))
+            return null;
+
+        return locale.Trim().Replace('_', '-').ToLowerInvariant();
+    }
+}

--- a/app/Pages/GuildAdminPage.razor
+++ b/app/Pages/GuildAdminPage.razor
@@ -241,7 +241,7 @@ else if (showLoadConfirmation)
     private void ApplyGuildData(GuildDto dto)
     {
         draftTimezone = dto.Setup.Timezone;
-        draftLocale = SupportedLocales.NormalizeOrDefault(dto.Setup.Locale);
+        draftLocale = GuildSettingsLocales.ToEditorValueOrDefault(dto.Setup.Locale);
         draftSlogan = dto.Guild?.Slogan ?? string.Empty;
         draftPermissions = dto.Settings?.RankPermissions
             .Select(p => new UpdateGuildRankPermission(p.Rank, p.CanCreateGuildRuns, p.CanSignupGuildRuns, p.CanDeleteGuildRuns))
@@ -275,7 +275,11 @@ else if (showLoadConfirmation)
 
         try
         {
-            var request = new UpdateGuildRequest(draftTimezone, draftLocale, draftSlogan, draftPermissions);
+            var request = new UpdateGuildRequest(
+                draftTimezone,
+                GuildSettingsLocales.ToRequestValueOrDefault(draftLocale),
+                draftSlogan,
+                draftPermissions);
             var updated = await GuildClient.UpdateAdminAsync(loadedGuildId, request, CancellationToken.None);
             if (updated is null)
             {

--- a/app/Pages/GuildPage.razor
+++ b/app/Pages/GuildPage.razor
@@ -100,7 +100,7 @@
     private void ApplyGuildData(GuildDto dto)
     {
         draftTimezone = dto.Setup.Timezone;
-        draftLocale = SupportedLocales.NormalizeOrDefault(dto.Setup.Locale);
+        draftLocale = GuildSettingsLocales.ToEditorValueOrDefault(dto.Setup.Locale);
         draftSlogan = dto.Guild?.Slogan ?? string.Empty;
         draftPermissions = dto.Settings?.RankPermissions
             .Select(p => new UpdateGuildRankPermission(p.Rank, p.CanCreateGuildRuns, p.CanSignupGuildRuns, p.CanDeleteGuildRuns))
@@ -223,7 +223,11 @@
 
         try
         {
-            var request = new UpdateGuildRequest(draftTimezone, draftLocale, draftSlogan, draftPermissions);
+            var request = new UpdateGuildRequest(
+                draftTimezone,
+                GuildSettingsLocales.ToRequestValueOrDefault(draftLocale),
+                draftSlogan,
+                draftPermissions);
             var updated = await GuildClient.UpdateAsync(request, CancellationToken.None);
             if (updated is null)
             {

--- a/tests/Lfm.App.Tests/GuildPagesTests.cs
+++ b/tests/Lfm.App.Tests/GuildPagesTests.cs
@@ -24,11 +24,12 @@ public class GuildPagesTests : ComponentTestBase
         bool rankDataFresh = true,
         bool canEdit = false,
         string slogan = "We ride the storm",
-        string name = "Stormchasers") =>
+        string name = "Stormchasers",
+        string locale = "fi") =>
         new(
             Guild: new GuildInfoDto(1, name, slogan, "Silvermoon", "Alliance",
                 120, 10, null, null),
-            Setup: new GuildSetupDto(isInitialized, requiresSetup, rankDataFresh, "Europe/Helsinki", "fi"),
+            Setup: new GuildSetupDto(isInitialized, requiresSetup, rankDataFresh, "Europe/Helsinki", locale),
             Settings: canEdit
                 ? new GuildSettingsDto(
                 [
@@ -425,6 +426,46 @@ public class GuildPagesTests : ComponentTestBase
         client.Verify(c => c.UpdateAsync(It.IsAny<UpdateGuildRequest>(), It.IsAny<CancellationToken>()), Times.Never);
         Assert.NotNull(captured);
         Assert.Equal("New slogan", captured!.Slogan);
+    }
+
+    [Fact]
+    public void GuildAdminPage_Save_Preserves_Existing_English_Guild_Locale()
+    {
+        this.AddAuthorization().SetAuthorized("admin#1").SetRoles("SiteAdmin");
+        var initial = MakeGuildDto(canEdit: true, slogan: "Old slogan", locale: "en-gb");
+        var updated = MakeGuildDto(canEdit: true, slogan: "New slogan", locale: "en-gb");
+        UpdateGuildRequest? captured = null;
+        var client = new Mock<IGuildClient>();
+        client.Setup(c => c.GetAdminAsync("99", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(initial);
+        client.Setup(c => c.UpdateAdminAsync("99", It.IsAny<UpdateGuildRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<string, UpdateGuildRequest, CancellationToken>((_, request, _) => captured = request)
+            .ReturnsAsync(updated);
+        Services.AddSingleton(client.Object);
+        JSInterop.SetupModule("./js/unsavedChanges.js");
+
+        var cut = Render<GuildAdminPage>();
+
+        cut.Find("#guild-admin-guild-id").Change("99");
+        cut.FindAll("fluent-button")
+            .First(b => b.TextContent.Contains(Loc("guildAdmin.loadButton"), StringComparison.Ordinal))
+            .Click();
+        cut.WaitForAssertion(() =>
+            Assert.Contains(Loc("guildAdmin.settings.save"), cut.Markup));
+        cut.Find("#guild-slogan").Change("New slogan");
+
+        cut.FindAll("fluent-button")
+            .First(b => b.TextContent.Contains(Loc("guildAdmin.settings.save"), StringComparison.Ordinal))
+            .Click();
+
+        cut.WaitForAssertion(() =>
+            client.Verify(c => c.UpdateAdminAsync(
+                "99",
+                It.IsAny<UpdateGuildRequest>(),
+                It.IsAny<CancellationToken>()),
+                Times.Once));
+        Assert.NotNull(captured);
+        Assert.Equal("en-gb", captured!.Locale);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Preserve guild settings locale values separately from UI locale values.
- Map the English editor option back to the guild API value `en-gb` on save.
- Add a site-admin regression test for saving an `en-gb` guild after changing another setting.

## Verification
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --no-restore`
- `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release --no-restore`
- `dotnet build lfm.sln -c Release`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `git diff --check`