### PR TITLE
Fix signup attendance roster mismatch

### DIFF
--- a/api/Runs/RunSignupService.cs
+++ b/api/Runs/RunSignupService.cs
@@ -146,15 +146,21 @@ public sealed class RunSignupService(
                 : Guid.NewGuid().ToString();
 
             // ReviewedAttendance follows the signup's desired attendance until a
-            // separate review decision exists. For a re-signup *after* a previous
+            // rejection-list guard applies. For a re-signup *after* a previous
             // rejection (entry was removed by cancel, but the raider sits in the
             // run's rejection list), the default flips to "OUT" to close the
-            // cancel-then-resignup bypass.
+            // cancel-then-resignup bypass. Existing non-rejected mismatches are
+            // repaired because older signup writes stored DesiredAttendance
+            // correctly but left ReviewedAttendance stuck at "IN".
             var rejected = run.RejectedRaiderBattleNetIds ?? [];
             var desiredAttendance = body.DesiredAttendance!;
+            var rejectedRaider = rejected.Contains(principal.BattleNetId, StringComparer.Ordinal);
             var reviewedAttendance = existingIndex >= 0
-                ? ResolveReviewedAttendanceForExistingSignup(run.RunCharacters[existingIndex], desiredAttendance)
-                : rejected.Contains(principal.BattleNetId, StringComparer.Ordinal)
+                ? ResolveReviewedAttendanceForExistingSignup(
+                    run.RunCharacters[existingIndex],
+                    desiredAttendance,
+                    rejectedRaider)
+                : rejectedRaider
                     ? "OUT"
                     : desiredAttendance;
 
@@ -229,7 +235,9 @@ public sealed class RunSignupService(
 
     private static string ResolveReviewedAttendanceForExistingSignup(
         RunCharacterEntry existing,
-        string desiredAttendance) =>
+        string desiredAttendance,
+        bool rejectedRaider) =>
+        !rejectedRaider ||
         string.Equals(existing.ReviewedAttendance, existing.DesiredAttendance, StringComparison.Ordinal)
             ? desiredAttendance
             : existing.ReviewedAttendance;

--- a/tests/Lfm.Api.Tests/Runs/RunSignupServiceTests.cs
+++ b/tests/Lfm.Api.Tests/Runs/RunSignupServiceTests.cs
@@ -296,6 +296,45 @@ public class RunSignupServiceTests
     }
 
     [Fact]
+    public async Task SignupAsync_ExistingLegacyMismatchedSignup_RepairsReviewedAttendance()
+    {
+        var (runsRepo, raidersRepo, _, _, _, sut) = MakeSut();
+        var existingEntry = new RunCharacterEntry(
+            Id: "entry-1",
+            CharacterId: "char-1",
+            CharacterName: "Testchar",
+            CharacterRealm: "silvermoon",
+            CharacterLevel: 80,
+            CharacterClassId: 1,
+            CharacterClassName: "Warrior",
+            CharacterRaceId: 0,
+            CharacterRaceName: "",
+            RaiderBattleNetId: "bnet-user",
+            DesiredAttendance: "AWAY",
+            ReviewedAttendance: "IN",
+            SpecId: null,
+            SpecName: null,
+            Role: null);
+        raidersRepo.Setup(r => r.GetByBattleNetIdAsync("bnet-user", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeRaider("bnet-user", characterId: "char-1"));
+        runsRepo.Setup(r => r.GetByIdAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeOpenRun(runCharacters: [existingEntry]));
+        runsRepo.Setup(r => r.UpdateAsync(It.IsAny<RunDocument>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RunDocument doc, string? _, CancellationToken _) => doc);
+
+        var result = await sut.SignupAsync(
+            "run-1",
+            MakeBody(characterId: "char-1", desiredAttendance: "BENCH"),
+            MakePrincipal("bnet-user"),
+            CancellationToken.None);
+
+        var ok = Assert.IsType<RunOperationResult.Ok>(result);
+        var entry = Assert.Single(ok.Run.RunCharacters);
+        Assert.Equal("BENCH", entry.DesiredAttendance);
+        Assert.Equal("BENCH", entry.ReviewedAttendance);
+    }
+
+    [Fact]
     public async Task SignupAsync_UsesAccountProfileDisplayNameForRunEntry()
     {
         var (runsRepo, raidersRepo, _, _, _, sut) = MakeSut();


### PR DESCRIPTION
## Summary
- repair non-rejected legacy signup rows whose reviewed attendance stayed stuck at `IN`
- keep the rejection-list reviewed-attendance guard for previously rejected raiders
- add a regression test for mismatched desired/reviewed attendance on self-edit

## Verification
- `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release --no-restore`
- `dotnet build lfm.sln -c Release --no-restore`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `git diff --check origin/main...HEAD`
- `git -C /home/souroldgeezer/repos/lfm/.worktrees/fix-signup-attendance-mismatch ls-files -ci --exclude-standard`