### PR TITLE
Match signup badge attendance color

### DIFF
--- a/app/Components/RunListItem.razor
+++ b/app/Components/RunListItem.razor
@@ -20,7 +20,7 @@
             <span class="run-list-item__date">@RunDateFormatter.FormatDisplay(Run.StartTime)</span>
         @if (_isMe)
         {
-            <span class="run-list-item__badge"
+            <span class="run-list-item__badge run-list-item__badge--@_currentUserAttendanceClass"
                   aria-label="@Loc["runs.signedUpAria"]"
                   title="@Loc["runs.signedUpAria"]">&#9733;</span>
         }
@@ -49,6 +49,7 @@
     private string _difficultyClass = "unknown";
     private string _kindClass = "unknown";
     private string _isCurrentUserClass = "false";
+    private string _currentUserAttendanceClass = "unknown";
     private bool _isMe;
     private RunRoleCounts _counts;
     private string _title = "";
@@ -59,8 +60,10 @@
     {
         _difficultyClass = RunVisualization.GetDifficultyClass(Run.Difficulty);
         _kindClass = RunVisualization.GetKindClass(RunVisualization.GetKind(Run.Size));
-        _isMe = RunVisualization.IsCurrentUserSignedUp(Run.RunCharacters);
+        var currentUserSignup = Run.RunCharacters.FirstOrDefault(c => c.IsCurrentUser);
+        _isMe = currentUserSignup is not null;
         _isCurrentUserClass = _isMe ? "true" : "false";
+        _currentUserAttendanceClass = RunVisualization.GetAttendanceClass(currentUserSignup?.ReviewedAttendance);
         _counts = RunVisualization.CountRoles(Run.RunCharacters, Run.Size);
         // Mythic+ "any dungeon" runs carry no InstanceName; fall back to a
         // localized label so the list entry isn't missing a heading.

--- a/app/Components/RunListItem.razor.css
+++ b/app/Components/RunListItem.razor.css
@@ -115,10 +115,30 @@
 }
 
 .run-list-item__badge {
-    color: #2ecc71;
+    color: var(--neutral-foreground-hint-rest);
     font-size: 1.05em;
     line-height: 1;
     flex-shrink: 0;
+}
+
+.run-list-item__badge--in {
+    color: var(--attendance-in-color);
+}
+
+.run-list-item__badge--late {
+    color: var(--attendance-late-color);
+}
+
+.run-list-item__badge--bench {
+    color: var(--attendance-bench-color);
+}
+
+.run-list-item__badge--out {
+    color: var(--attendance-out-color);
+}
+
+.run-list-item__badge--away {
+    color: var(--attendance-away-color);
 }
 
 .run-list-item__composition {

--- a/app/Lfm.App.Core/Runs/RunVisualization.cs
+++ b/app/Lfm.App.Core/Runs/RunVisualization.cs
@@ -67,6 +67,16 @@ public static class RunVisualization
     public static bool IsAttending(string? reviewedAttendance) =>
         reviewedAttendance is "IN" or "LATE" or "BENCH";
 
+    public static string GetAttendanceClass(string? attendance) => attendance switch
+    {
+        "IN" => "in",
+        "LATE" => "late",
+        "BENCH" => "bench",
+        "OUT" => "out",
+        "AWAY" => "away",
+        _ => "unknown",
+    };
+
     public static string NormalizeRole(string? role) => (role ?? "").ToUpperInvariant() switch
     {
         "TANK" => "TANK",

--- a/app/wwwroot/css/app.css
+++ b/app/wwwroot/css/app.css
@@ -4,6 +4,14 @@ html, body {
     color: var(--neutral-foreground-rest);
 }
 
+:root {
+    --attendance-in-color: #1d8049;
+    --attendance-late-color: #a05900;
+    --attendance-bench-color: #6c757d;
+    --attendance-out-color: #c0392b;
+    --attendance-away-color: #ad4400;
+}
+
 /* Scrollbar theming */
 ::-webkit-scrollbar {
     width: 10px;
@@ -398,23 +406,23 @@ fluent-button.footer-language--active::part(control) {
  * out (5.44) already passed and are left alone. See issue #44.
  */
 .attendance-pill--in {
-    background: #1d8049;
+    background: var(--attendance-in-color);
 }
 
 .attendance-pill--late {
-    background: #a05900;
+    background: var(--attendance-late-color);
 }
 
 .attendance-pill--bench {
-    background: #6c757d;
+    background: var(--attendance-bench-color);
 }
 
 .attendance-pill--out {
-    background: #c0392b;
+    background: var(--attendance-out-color);
 }
 
 .attendance-pill--away {
-    background: #ad4400;
+    background: var(--attendance-away-color);
 }
 
 .attendance-pill--unknown {

--- a/tests/Lfm.App.Core.Tests/Runs/RunVisualizationTests.cs
+++ b/tests/Lfm.App.Core.Tests/Runs/RunVisualizationTests.cs
@@ -107,6 +107,19 @@ public class RunVisualizationTests
     }
 
     [Theory]
+    [InlineData("IN", "in")]
+    [InlineData("LATE", "late")]
+    [InlineData("BENCH", "bench")]
+    [InlineData("OUT", "out")]
+    [InlineData("AWAY", "away")]
+    [InlineData("", "unknown")]
+    [InlineData(null, "unknown")]
+    public void GetAttendanceClass_maps_attendance_tokens(string? attendance, string expected)
+    {
+        Assert.Equal(expected, RunVisualization.GetAttendanceClass(attendance));
+    }
+
+    [Theory]
     [InlineData("TANK", "TANK")]
     [InlineData("tank", "TANK")]
     [InlineData("HEALER", "HEALER")]

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -1529,6 +1529,30 @@ public class RunsPagesTests : ComponentTestBase
     }
 
     [Fact]
+    public void RunsPage_RunListItem_ColorsSignupBadgeFromCurrentUserAttendance()
+    {
+        var client = new Mock<IRunsClient>();
+        var summary = MakeSummary() with
+        {
+            RunCharacters = new List<RunCharacterDto>
+            {
+                MakeCharacter("Aelrin", attendance: "BENCH", isCurrentUser: true),
+            },
+        };
+        client.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<RunSummaryDto> { summary });
+        Services.AddSingleton(client.Object);
+
+        var cut = Render<RunsPage>();
+
+        cut.WaitForAssertion(() =>
+        {
+            var badge = cut.Find(".run-list-item__badge");
+            Assert.Contains("run-list-item__badge--bench", badge.ClassName ?? "");
+        });
+    }
+
+    [Fact]
     public void RunsPage_RunListItem_FallsBackToAnyDungeonLabel_WhenInstanceNameIsNull()
     {
         // Mythic+ "any dungeon" runs persist InstanceName as null per the


### PR DESCRIPTION
## Summary
- Color the run-list signup star from the current user's reviewed attendance.
- Share attendance color tokens between roster pills and the signup star.
- Add regression coverage for attendance class mapping and the BENCH signup badge modifier.

## Test Plan
- dotnet build lfm.sln -c Release
- dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release --no-build
- dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --no-build
- dotnet format lfm.sln --verify-no-changes --no-restore --severity error

## Screenshots
- Not captured locally; this change is a narrow CSS color-token mapping for the existing signup star.