### PR TITLE
Fix run instance options

### DIFF
--- a/app/Lfm.App.Core/Runs/InstanceOptions.cs
+++ b/app/Lfm.App.Core/Runs/InstanceOptions.cs
@@ -36,9 +36,10 @@ public static class InstanceOptions
             .GroupBy(i => i.InstanceNumericId)
             .Select(g =>
             {
+                var rows = g.ToList();
                 var first = g.First();
-                var activity = ActivityKindExtensions.FromCategory(first.Category);
-                var difficulties = g
+                var activity = ResolveActivity(rows);
+                var difficulties = rows
                     .Where(i => !string.IsNullOrEmpty(i.Difficulty))
                     .Select(i => new DifficultyOption(
                         DifficultyId: i.Difficulty,
@@ -59,6 +60,19 @@ public static class InstanceOptions
             .ToList();
     }
 
+    private static ActivityKind ResolveActivity(IReadOnlyList<InstanceDto> rows)
+    {
+        var explicitActivity = ActivityKindExtensions.FromCategory(rows[0].Category);
+        if (explicitActivity != ActivityKind.Other) return explicitActivity;
+
+        if (rows.Any(r => r.Difficulty == "MYTHIC_KEYSTONE")) return ActivityKind.Dungeon;
+        if (rows.Any(r => r.Difficulty == "LFR" || r.Size > 5)) return ActivityKind.Raid;
+
+        return rows.Any(r => r.Size == 5 && IsDungeonDifficulty(r.Difficulty))
+            ? ActivityKind.Dungeon
+            : ActivityKind.Other;
+    }
+
     private static int CanonicalOrder(string difficulty) => difficulty switch
     {
         "LFR" => 0,
@@ -67,5 +81,11 @@ public static class InstanceOptions
         "MYTHIC" => 3,
         "MYTHIC_KEYSTONE" => 4,
         _ => 99,
+    };
+
+    private static bool IsDungeonDifficulty(string difficulty) => difficulty switch
+    {
+        "NORMAL" or "HEROIC" or "MYTHIC" => true,
+        _ => false,
     };
 }

--- a/tests/Lfm.App.Core.Tests/Runs/InstanceOptionsTests.cs
+++ b/tests/Lfm.App.Core.Tests/Runs/InstanceOptionsTests.cs
@@ -75,6 +75,20 @@ public class InstanceOptionsTests
     }
 
     [Fact]
+    public void Classifies_activity_from_mode_when_category_is_missing()
+    {
+        var raid = Row(1, "R", "MYTHIC", 20, category: null);
+        var dungeon = Row(2, "D", "MYTHIC_KEYSTONE", 5, category: null);
+        var other = Row(3, "O", "UNKNOWN", 0, category: null);
+
+        var opts = InstanceOptions.Build([raid, dungeon, other]);
+
+        Assert.Equal(ActivityKind.Raid, opts.Single(o => o.InstanceId == 1).Activity);
+        Assert.Equal(ActivityKind.Dungeon, opts.Single(o => o.InstanceId == 2).Activity);
+        Assert.Equal(ActivityKind.Other, opts.Single(o => o.InstanceId == 3).Activity);
+    }
+
+    [Fact]
     public void Orders_instances_alphabetically_case_insensitively()
     {
         var flat = new List<InstanceDto>


### PR DESCRIPTION
## Summary
- Preserve explicit WoW instance category when present.
- Infer Raid/Dungeon from mode data when legacy reference rows have no category.
- Add regression coverage for legacy rows so the create-run instance list does not go empty.

## Test Plan
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `dotnet build lfm.sln -c Release --no-restore`
- `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release --no-restore --filter FullyQualifiedName~Lfm.App.Core.Tests.Runs`
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --no-restore`
- `git diff --check`