### PR TITLE
Color signup attendance toggle

### DIFF
--- a/app/Components/Runs/RunSignupPanel.razor
+++ b/app/Components/Runs/RunSignupPanel.razor
@@ -1,5 +1,6 @@
 @using Lfm.Contracts.Characters
 @using Lfm.Contracts.Runs
+@using Lfm.App.Runs
 @inject IStringLocalizer Loc
 
 <div class="run-signup-panel" aria-labelledby="@HeadingId">
@@ -46,6 +47,8 @@
                          ValueChanged="@OnAttendanceChangedAsync"
                          AriaLabelledBy="@AttendanceLabelId"
                          Disabled="@_signupControlsDisabled"
+                         OptionClass="@SignupAttendanceOptionClass"
+                         OptionStyle="@SignupAttendanceOptionStyle"
                          Class="run-signup-attendance-toggle" />
         </div>
     }
@@ -117,6 +120,8 @@
                              ValueChanged="@OnAttendanceChangedAsync"
                              AriaLabelledBy="@AttendanceLabelId"
                              Disabled="@_signupControlsDisabled"
+                             OptionClass="@SignupAttendanceOptionClass"
+                             OptionStyle="@SignupAttendanceOptionStyle"
                              Class="run-signup-attendance-toggle" />
             </div>
 
@@ -196,6 +201,12 @@
         SignupAttendanceOptions
             .Select(option => (option.Value, Loc[option.LocKey].Value))
             .ToList();
+
+    private static string SignupAttendanceOptionClass(string value) =>
+        $"run-signup-attendance-toggle__option--{RunVisualization.GetAttendanceClass(value)}";
+
+    private static string SignupAttendanceOptionStyle(string value) =>
+        $"--toggle-group-selected-fill: var(--attendance-{RunVisualization.GetAttendanceClass(value)}-color); --toggle-group-selected-foreground: #fff;";
 
     private string SelectedCharacterValue => _selectedCharacterId ?? string.Empty;
 

--- a/app/Components/ToggleGroup.razor
+++ b/app/Components/ToggleGroup.razor
@@ -49,7 +49,8 @@
                 aria-checked="@(isSelected ? "true" : "false")"
                 tabindex="@(isSelected ? 0 : -1)"
                 disabled="@Disabled"
-                class="toggle-group__option"
+                class="toggle-group__option @OptionClassFor(opt.Value)"
+                style="@OptionStyleFor(opt.Value)"
                 data-selected="@(isSelected ? "true" : "false")"
                 @ref="_buttonRefs[idx]"
                 @onclick="@(() => SelectAsync(idx))">
@@ -80,6 +81,12 @@
     [Parameter] public bool Disabled { get; set; }
 
     [Parameter] public string? Class { get; set; }
+
+    /// <summary>Optional per-option CSS hook for context-specific styling.</summary>
+    [Parameter] public Func<TValue, string?>? OptionClass { get; set; }
+
+    /// <summary>Optional per-option inline CSS custom properties.</summary>
+    [Parameter] public Func<TValue, string?>? OptionStyle { get; set; }
 
     /// <summary>
     /// When true, arrow-key semantics are swapped so that ArrowRight /
@@ -152,6 +159,10 @@
             catch { /* element may not be in the DOM yet on first render */ }
         }
     }
+
+    private string? OptionClassFor(TValue value) => OptionClass?.Invoke(value);
+
+    private string? OptionStyleFor(TValue value) => OptionStyle?.Invoke(value);
 
     private int CurrentIndex()
     {

--- a/app/Components/ToggleGroup.razor.css
+++ b/app/Components/ToggleGroup.razor.css
@@ -84,18 +84,18 @@
 }
 
 .toggle-group__option[data-selected="true"] {
-    background-color: var(--accent-fill-rest);
+    background-color: var(--toggle-group-selected-fill, var(--accent-fill-rest));
     /* --foreground-on-accent-rest is the FluentUI token for text placed ON
        TOP OF accent fill (contrast-paired with --accent-fill-rest).
        --accent-foreground-rest is a different token — accent color used AS
        text (link emphasis, icon tint) — pairing it with --accent-fill-rest
        produces accent-on-accent with no contrast. See
        docs/frontend-style-guide.md §Tokens. */
-    color: var(--foreground-on-accent-rest, #fff);
+    color: var(--toggle-group-selected-foreground, var(--foreground-on-accent-rest, #fff));
     /* Match the selected border to the fill so the boundary with adjacent
        unselected buttons reads as a single coherent shape rather than a
        stripe. Keep the same width to avoid layout shift. */
-    border-color: var(--accent-fill-rest);
+    border-color: var(--toggle-group-selected-fill, var(--accent-fill-rest));
 }
 
 .toggle-group__option:disabled {

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -673,6 +673,12 @@ public class RunsPagesTests : ComponentTestBase
         Assert.Equal(Loc("runs.attendance.away"), radios[3].TextContent.Trim());
         Assert.Equal(Loc("runs.attendance.out"), radios[4].TextContent.Trim());
         Assert.Equal("true", radios[0].GetAttribute("aria-checked"));
+        Assert.Contains("run-signup-attendance-toggle__option--in", radios[0].ClassName ?? "");
+        Assert.Contains("run-signup-attendance-toggle__option--late", radios[1].ClassName ?? "");
+        Assert.Contains("run-signup-attendance-toggle__option--bench", radios[2].ClassName ?? "");
+        Assert.Contains("run-signup-attendance-toggle__option--away", radios[3].ClassName ?? "");
+        Assert.Contains("run-signup-attendance-toggle__option--out", radios[4].ClassName ?? "");
+        Assert.Contains("--toggle-group-selected-fill: var(--attendance-in-color)", radios[0].GetAttribute("style") ?? "");
         Assert.Empty(cut.FindAll("#signup-attendance-select"));
     }
 


### PR DESCRIPTION
## Summary
- Add per-option CSS hooks to the shared ToggleGroup so callers can style individual choices.
- Apply the existing attendance color tokens to selected signup attendance options.
- Pin the signup attendance radiogroup markup with bUnit coverage.

## Verification
- `dotnet build lfm.sln -c Release`
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --no-restore`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `git diff --check`
- `git -C /home/souroldgeezer/repos/lfm/.worktrees/signup-attendance-colors ls-files -ci --exclude-standard`