### PR TITLE
Cache guild setup status

### DIFF
--- a/app/Lfm.App.Core/Services/GuildClient.cs
+++ b/app/Lfm.App.Core/Services/GuildClient.cs
@@ -6,13 +6,45 @@ using Lfm.Contracts.Guild;
 
 namespace Lfm.App.Services;
 
-public sealed class GuildClient(IHttpClientFactory factory) : IGuildClient
+public sealed class GuildClient(IHttpClientFactory factory) : IGuildClient, IDisposable
 {
+    private static readonly TimeSpan CurrentGuildCacheTtl = TimeSpan.FromMinutes(10);
+    private const int MaxAdminEtags = 32;
+
     private string? _etag;
-    private readonly Dictionary<string, string?> _adminEtags = new(StringComparer.Ordinal);
+    private GuildDto? _currentGuild;
+    private DateTimeOffset _currentGuildExpiresAt;
+    private bool _hasCurrentGuild;
+    private readonly IDataCache? _dataCache;
+    private readonly Dictionary<string, AdminEtagEntry> _adminEtags = new(StringComparer.Ordinal);
+    private TimeProvider _timeProvider = TimeProvider.System;
+    private long _adminEtagSequence;
+
+    public GuildClient(IHttpClientFactory factory, IDataCache dataCache)
+        : this(factory, dataCache, TimeProvider.System)
+    {
+    }
+
+    public GuildClient(IHttpClientFactory factory, TimeProvider timeProvider)
+        : this(factory)
+    {
+        _timeProvider = timeProvider;
+    }
+
+    public GuildClient(IHttpClientFactory factory, IDataCache dataCache, TimeProvider timeProvider)
+        : this(factory, timeProvider)
+    {
+        _dataCache = dataCache;
+        _dataCache.OnInvalidated += HandleCacheInvalidated;
+    }
 
     public async Task<GuildDto?> GetAsync(CancellationToken ct)
     {
+        if (_hasCurrentGuild && _currentGuildExpiresAt > _timeProvider.GetUtcNow())
+            return _currentGuild;
+
+        ClearCurrentGuild();
+
         var http = factory.CreateClient("api");
         try
         {
@@ -22,6 +54,10 @@ public sealed class GuildClient(IHttpClientFactory factory) : IGuildClient
 
             var guild = await response.Content.ReadFromJsonAsync<GuildDto>(ct);
             _etag = guild is null ? null : HttpEtag.Read(response);
+            if (guild is not null)
+            {
+                StoreCurrentGuild(guild);
+            }
             return guild;
         }
         catch (HttpRequestException)
@@ -49,6 +85,10 @@ public sealed class GuildClient(IHttpClientFactory factory) : IGuildClient
 
         var guild = await response.Content.ReadFromJsonAsync<GuildDto>(ct);
         _etag = guild is null ? null : HttpEtag.Read(response);
+        if (guild is null)
+            ClearCurrentGuild();
+        else
+            StoreCurrentGuild(guild);
         return guild;
     }
 
@@ -62,7 +102,7 @@ public sealed class GuildClient(IHttpClientFactory factory) : IGuildClient
                 return null;
 
             var guild = await response.Content.ReadFromJsonAsync<GuildDto>(ct);
-            _adminEtags[guildId] = guild is null ? null : HttpEtag.Read(response);
+            StoreAdminEtag(guildId, guild is null ? null : HttpEtag.Read(response));
             return guild;
         }
         catch (HttpRequestException)
@@ -79,8 +119,8 @@ public sealed class GuildClient(IHttpClientFactory factory) : IGuildClient
         {
             Content = JsonContent.Create(request),
         };
-        if (_adminEtags.TryGetValue(guildId, out var etag) && !string.IsNullOrWhiteSpace(etag))
-            patch.Headers.TryAddWithoutValidation("If-Match", etag);
+        if (_adminEtags.TryGetValue(guildId, out var etag) && !string.IsNullOrWhiteSpace(etag.Value))
+            patch.Headers.TryAddWithoutValidation("If-Match", etag.Value);
 
         var response = await http.SendAsync(patch, ct);
         if (!response.IsSuccessStatusCode)
@@ -89,10 +129,62 @@ public sealed class GuildClient(IHttpClientFactory factory) : IGuildClient
         }
 
         var guild = await response.Content.ReadFromJsonAsync<GuildDto>(ct);
-        _adminEtags[guildId] = guild is null ? null : HttpEtag.Read(response);
+        StoreAdminEtag(guildId, guild is null ? null : HttpEtag.Read(response));
         return guild;
     }
 
     private static string AdminPath(string guildId) =>
         $"api/v1/guild/admin?guildId={Uri.EscapeDataString(guildId)}";
+
+    private void StoreCurrentGuild(GuildDto guild)
+    {
+        _currentGuild = guild;
+        _currentGuildExpiresAt = _timeProvider.GetUtcNow().Add(CurrentGuildCacheTtl);
+        _hasCurrentGuild = true;
+    }
+
+    private void ClearCurrentGuild()
+    {
+        _etag = null;
+        _currentGuild = null;
+        _currentGuildExpiresAt = default;
+        _hasCurrentGuild = false;
+    }
+
+    private void StoreAdminEtag(string guildId, string? etag)
+    {
+        if (string.IsNullOrWhiteSpace(etag))
+        {
+            _adminEtags.Remove(guildId);
+            return;
+        }
+
+        _adminEtags[guildId] = new AdminEtagEntry(etag, ++_adminEtagSequence);
+        TrimAdminEtags();
+    }
+
+    private void TrimAdminEtags()
+    {
+        while (_adminEtags.Count > MaxAdminEtags)
+        {
+            var oldest = _adminEtags.MinBy(pair => pair.Value.Sequence).Key;
+            _adminEtags.Remove(oldest);
+        }
+    }
+
+    private void HandleCacheInvalidated(string key)
+    {
+        if (key != DataCacheKeys.Guild)
+            return;
+
+        ClearCurrentGuild();
+    }
+
+    public void Dispose()
+    {
+        if (_dataCache is not null)
+            _dataCache.OnInvalidated -= HandleCacheInvalidated;
+    }
+
+    private sealed record AdminEtagEntry(string Value, long Sequence);
 }

--- a/app/Lfm.App.Core/Services/IDataCache.cs
+++ b/app/Lfm.App.Core/Services/IDataCache.cs
@@ -8,3 +8,8 @@ public interface IDataCache
     void Invalidate(string key);
     event Action<string>? OnInvalidated;
 }
+
+public static class DataCacheKeys
+{
+    public const string Guild = "guild";
+}

--- a/app/Pages/CharactersPage.razor
+++ b/app/Pages/CharactersPage.razor
@@ -7,6 +7,7 @@
 @inject IBattleNetClient BattleNetClient
 @inject IMeClient MeClient
 @inject IAuthStateRefresher AuthStateRefresher
+@inject IDataCache DataCache
 @inject NavigationManager Nav
 @inject IStringLocalizer Loc
 @inject IJSRuntime JS
@@ -481,6 +482,7 @@
         }
         else
         {
+            DataCache.Invalidate(DataCacheKeys.Guild);
             AuthStateRefresher.RefreshAuthenticationState();
             Nav.NavigateTo(SafeRedirectPath(), forceLoad: false);
         }

--- a/tests/Lfm.App.Core.Tests/Services/GuildClientTests.cs
+++ b/tests/Lfm.App.Core.Tests/Services/GuildClientTests.cs
@@ -11,12 +11,21 @@ namespace Lfm.App.Core.Tests.Services;
 
 public class GuildClientTests
 {
-    private static (GuildClient client, StubHttpMessageHandler handler) MakeClient(StubHttpMessageHandler handler)
+    private static (GuildClient client, StubHttpMessageHandler handler) MakeClient(
+        StubHttpMessageHandler handler,
+        IDataCache? cache = null,
+        TimeProvider? timeProvider = null)
     {
         var http = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:7071/") };
         var factory = new Mock<IHttpClientFactory>();
         factory.Setup(f => f.CreateClient("api")).Returns(http);
-        return (new GuildClient(factory.Object), handler);
+        return ((cache, timeProvider) switch
+        {
+            (null, null) => new GuildClient(factory.Object),
+            (null, { } clock) => new GuildClient(factory.Object, clock),
+            ({ } dataCache, null) => new GuildClient(factory.Object, dataCache),
+            ({ } dataCache, { } clock) => new GuildClient(factory.Object, dataCache, clock),
+        }, handler);
     }
 
     private static GuildDto MakeGuildDto(string? name = "Stormchasers") =>
@@ -57,6 +66,65 @@ public class GuildClientTests
         Assert.Equal("Stormchasers", result!.Guild!.Name);
         Assert.Equal(HttpMethod.Get, handler.LastRequest!.Method);
         Assert.Equal("/api/v1/guild", handler.LastRequest.RequestUri!.PathAndQuery);
+    }
+
+    [Fact]
+    public async Task GetAsync_returns_cached_guild_on_repeated_successful_call()
+    {
+        var responses = new Queue<HttpResponseMessage>();
+        responses.Enqueue(StubHttpMessageHandler.CreateJsonResponse(HttpStatusCode.OK, MakeGuildDto("Stormchasers")));
+        responses.Enqueue(StubHttpMessageHandler.CreateJsonResponse(HttpStatusCode.OK, MakeGuildDto("Stormchasers Reborn")));
+        var (client, handler) = MakeClient(new StubHttpMessageHandler(_ => responses.Dequeue()));
+
+        var first = await client.GetAsync(CancellationToken.None);
+        var second = await client.GetAsync(CancellationToken.None);
+
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.Equal("Stormchasers", second!.Guild!.Name);
+        Assert.Equal(1, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task GetAsync_refetches_after_guild_cache_invalidation()
+    {
+        var responses = new Queue<HttpResponseMessage>();
+        responses.Enqueue(StubHttpMessageHandler.CreateJsonResponse(HttpStatusCode.OK, MakeGuildDto("Stormchasers")));
+        responses.Enqueue(StubHttpMessageHandler.CreateJsonResponse(HttpStatusCode.OK, MakeGuildDto("Stormchasers Reborn")));
+        var cache = new InMemoryDataCache();
+        var (client, handler) = MakeClient(new StubHttpMessageHandler(_ => responses.Dequeue()), cache);
+
+        var first = await client.GetAsync(CancellationToken.None);
+        cache.Invalidate(DataCacheKeys.Guild);
+        var second = await client.GetAsync(CancellationToken.None);
+
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.Equal("Stormchasers Reborn", second!.Guild!.Name);
+        Assert.Equal(2, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task GetAsync_refetches_only_after_current_guild_cache_ttl_expires()
+    {
+        var responses = new Queue<HttpResponseMessage>();
+        responses.Enqueue(StubHttpMessageHandler.CreateJsonResponse(HttpStatusCode.OK, MakeGuildDto("Stormchasers")));
+        responses.Enqueue(StubHttpMessageHandler.CreateJsonResponse(HttpStatusCode.OK, MakeGuildDto("Stormchasers Reborn")));
+        var timeProvider = new ManualTimeProvider(new DateTimeOffset(2026, 5, 7, 12, 0, 0, TimeSpan.Zero));
+        var (client, handler) = MakeClient(new StubHttpMessageHandler(_ => responses.Dequeue()), timeProvider: timeProvider);
+
+        var first = await client.GetAsync(CancellationToken.None);
+        timeProvider.Advance(TimeSpan.FromMinutes(2).Add(TimeSpan.FromMilliseconds(1)));
+        var stillCached = await client.GetAsync(CancellationToken.None);
+        timeProvider.Advance(TimeSpan.FromMinutes(8));
+        var refreshed = await client.GetAsync(CancellationToken.None);
+
+        Assert.NotNull(first);
+        Assert.NotNull(stillCached);
+        Assert.NotNull(refreshed);
+        Assert.Equal("Stormchasers", stillCached!.Guild!.Name);
+        Assert.Equal("Stormchasers Reborn", refreshed!.Guild!.Name);
+        Assert.Equal(2, handler.CallCount);
     }
 
     [Fact]
@@ -226,5 +294,43 @@ public class GuildClientTests
 
         Assert.True(requests[1].Headers.TryGetValues("If-Match", out var ifMatch));
         Assert.Equal("\"admin-guild-etag-v1\"", ifMatch!.Single());
+    }
+
+    [Fact]
+    public async Task UpdateAdminAsync_does_not_keep_unbounded_admin_etag_cache()
+    {
+        var requests = new List<HttpRequestMessage>();
+        var (client, _) = MakeClient(new StubHttpMessageHandler(request =>
+        {
+            requests.Add(request);
+            if (request.Method == HttpMethod.Get)
+            {
+                var guildId = request.RequestUri!.Query.Split('=', 2)[1];
+                var response = StubHttpMessageHandler.CreateJsonResponse(HttpStatusCode.OK, MakeGuildDto("Stormchasers"));
+                response.Headers.TryAddWithoutValidation("ETag", $"\"admin-guild-etag-{guildId}\"");
+                return response;
+            }
+
+            return StubHttpMessageHandler.CreateJsonResponse(HttpStatusCode.OK, MakeGuildDto("Stormchasers"));
+        }));
+        var request = new UpdateGuildRequest("Europe/Helsinki", "fi", "slogan", null);
+
+        for (var i = 1; i <= 33; i++)
+            await client.GetAdminAsync(i.ToString(), CancellationToken.None);
+        await client.UpdateAdminAsync("1", request, CancellationToken.None);
+        await client.UpdateAdminAsync("33", request, CancellationToken.None);
+
+        Assert.False(requests[^2].Headers.TryGetValues("If-Match", out _));
+        Assert.True(requests[^1].Headers.TryGetValues("If-Match", out var ifMatch));
+        Assert.Equal("\"admin-guild-etag-33\"", ifMatch!.Single());
+    }
+
+    private sealed class ManualTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        private DateTimeOffset _utcNow = utcNow;
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+
+        public void Advance(TimeSpan offset) => _utcNow += offset;
     }
 }

--- a/tests/Lfm.App.Tests/CharactersPagesTests.cs
+++ b/tests/Lfm.App.Tests/CharactersPagesTests.cs
@@ -467,8 +467,10 @@ public class CharactersPagesTests : ComponentTestBase
                     selectedCharacter: new SelectedCharacterSummaryDto("eu-silvermoon-sylvanas", "Sylvanas", null));
                 return true;
             });
+        var dataCache = new Mock<IDataCache>();
         Services.AddSingleton(battleNet.Object);
         Services.AddSingleton(me.Object);
+        Services.AddSingleton(dataCache.Object);
         Services.AddSingleton<IAuthStateRefresher>(new ActionAuthStateRefresher(() =>
             auth.SetClaims(MakeAuthClaims(currentMe))));
 
@@ -487,6 +489,7 @@ public class CharactersPagesTests : ComponentTestBase
         cut.WaitForAssertion(() =>
         {
             me.Verify(m => m.SelectCharacterAsync("eu-silvermoon-sylvanas", It.IsAny<CancellationToken>()), Times.Once);
+            dataCache.Verify(c => c.Invalidate(DataCacheKeys.Guild), Times.Once);
             Assert.Contains("Sylvanas", cut.Find(".account-menu-trigger").TextContent);
         });
     }

--- a/tests/Lfm.App.Tests/RenderWithProviders.cs
+++ b/tests/Lfm.App.Tests/RenderWithProviders.cs
@@ -41,6 +41,7 @@ public abstract class ComponentTestBase : BunitContext
 
         Services.AddSingleton<IThemeService, ThemeService>();
 
+        Services.AddSingleton<IDataCache, InMemoryDataCache>();
         Services.AddSingleton<ILocaleService, LocaleService>();
         Services.AddSingleton<IStringLocalizer>(_localizer);
         Services.AddSingleton<IMeClient, DefaultMeClient>();


### PR DESCRIPTION
## Summary
- cache current guild lookups in the Blazor client with a bounded 10 minute TTL
- invalidate the current-guild cache when the active character changes and refresh it after guild settings saves
- cap admin guild ETag cache entries to prevent unbounded runtime growth

## Verification
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release --no-restore --filter FullyQualifiedName~GuildClientTests`
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~GuildSetupGate|FullyQualifiedName~CharactersPagesTests.CharactersPage_Selecting_Character_Refreshes_Layout_Account_Menu"`
- `dotnet build lfm.sln -c Release --no-restore`