### PR TITLE
Fix current season options

### DIFF
--- a/app/Lfm.App.Core/Runs/RunFormState.cs
+++ b/app/Lfm.App.Core/Runs/RunFormState.cs
@@ -82,7 +82,7 @@ public sealed class RunFormState
     {
         AllInstances = instances;
         Expansions = expansions;
-        ExpansionId = ResolveCurrentSeasonId(expansions);
+        ExpansionId = ResolveAvailableExpansionId(instances, ResolveCurrentSeasonId(expansions));
         RefreshDifficultyOptions();
     }
 
@@ -185,5 +185,17 @@ public sealed class RunFormState
         var current = expansions.FirstOrDefault(e => e.Name == CurrentSeasonExpansion);
         if (current is not null) return current.Id;
         return expansions.Count == 0 ? 0 : expansions.MaxBy(e => e.Id)!.Id;
+    }
+
+    private static int ResolveAvailableExpansionId(IReadOnlyList<InstanceOption> instances, int preferredId)
+    {
+        if (instances.Any(i => i.ExpansionId == preferredId)) return preferredId;
+
+        var fallback = instances
+            .Where(i => i.ExpansionId is not null)
+            .Select(i => i.ExpansionId!.Value)
+            .DefaultIfEmpty(preferredId)
+            .Max();
+        return fallback;
     }
 }

--- a/tests/Lfm.App.Core.Tests/Runs/RunFormStateTests.cs
+++ b/tests/Lfm.App.Core.Tests/Runs/RunFormStateTests.cs
@@ -87,6 +87,35 @@ public class RunFormStateTests
     }
 
     [Fact]
+    public void LoadOptions_falls_back_to_instance_expansion_when_current_season_has_no_matches()
+    {
+        var dungeon = new InstanceOption(
+            InstanceId: 1001,
+            Name: "Current Dungeon",
+            Activity: ActivityKind.Dungeon,
+            ExpansionId: 700,
+            Difficulties: [new DifficultyOption("MYTHIC_KEYSTONE", 5, "M+")]);
+        var raid = new InstanceOption(
+            InstanceId: 1002,
+            Name: "Current Raid",
+            Activity: ActivityKind.Raid,
+            ExpansionId: 700,
+            Difficulties: [new DifficultyOption("HEROIC", 25, "Heroic (25)")]);
+        var state = new RunFormState();
+
+        state.LoadOptions(
+            [dungeon, raid],
+            [new ExpansionDto(700, "Midnight"), new ExpansionDto(999, RunFormState.CurrentSeasonExpansion)]);
+
+        Assert.Equal(700, state.ExpansionId);
+        Assert.Equal(new[] { 1001 }, state.FilteredInstances.Select(i => i.InstanceId).ToArray());
+
+        state.OnActivityChanged(ActivityKind.Raid);
+
+        Assert.Equal(new[] { 1002 }, state.FilteredInstances.Select(i => i.InstanceId).ToArray());
+    }
+
+    [Fact]
     public void Visibility_properties_follow_activity_scope_and_instance_selection()
     {
         var state = new RunFormState();

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -1693,6 +1693,46 @@ public class RunsPagesTests : ComponentTestBase
     }
 
     [Fact]
+    public void CreateRunPage_Keeps_Instance_Options_When_CurrentSeason_Id_Has_No_Matches()
+    {
+        WireCreateRunServices(
+            instances:
+            [
+                new("1:MYTHIC_KEYSTONE:5", 1, "Windrunner Spire", "MYTHIC_KEYSTONE:5",
+                    "Midnight", "DUNGEON", 700, "MYTHIC_KEYSTONE", 5),
+                new("2:HEROIC:25", 2, "The Voidspire", "HEROIC:25",
+                    "Midnight", "RAID", 700, "HEROIC", 25),
+            ],
+            expansions:
+            [
+                new ExpansionDto(700, "Midnight"),
+                new ExpansionDto(999, CurrentSeasonExpansion),
+            ]);
+
+        var cut = Render<CreateRunPage>();
+
+        cut.WaitForAssertion(() =>
+            Assert.Contains(Loc("createRun.title"), cut.Markup));
+
+        cut.FindAll("[role='radio']")
+            .Single(b => b.TextContent.Trim() == Loc("createRun.activity.raid"))
+            .Click();
+
+        cut.WaitForAssertion(() =>
+            Assert.Contains("The Voidspire", cut.Markup));
+
+        cut.FindAll("[role='radio']")
+            .Single(b => b.TextContent.Trim() == Loc("createRun.activity.dungeon"))
+            .Click();
+        cut.FindAll("[role='radio']")
+            .Single(b => b.TextContent.Trim() == Loc("createRun.dungeonScope.specific"))
+            .Click();
+
+        cut.WaitForAssertion(() =>
+            Assert.Contains("Windrunner Spire", cut.Markup));
+    }
+
+    [Fact]
     public void CreateRunPage_Wnl_Button_Uses_Visible_Label_As_Accessible_Name()
     {
         WireCreateRunServices(instances: new List<InstanceDto>


### PR DESCRIPTION
## Summary
- fall back to the newest available instance expansion when the Blizzard `Current Season` expansion id has no matching instances
- keep raid and dungeon options visible on the create-run form when the current-season id is only an alias/tier
- add App.Core and bUnit regression coverage using Midnight fixtures

## Testing
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `dotnet build lfm.sln -c Release --no-restore`
- `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release --no-restore --filter FullyQualifiedName~Lfm.App.Core.Tests.Runs`
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --no-restore`
- `git diff --check`