### PR TITLE
Fix message bar overflow

### DIFF
--- a/app/wwwroot/css/app.css
+++ b/app/wwwroot/css/app.css
@@ -43,6 +43,13 @@ a, .btn-link {
     color: var(--accent-fill-rest);
 }
 
+.fluent-messagebar {
+    /* Fluent UI sets width:100% plus inline padding; keep that padding inside the parent. */
+    box-sizing: border-box;
+    inline-size: 100%;
+    max-inline-size: 100%;
+}
+
 #blazor-error-ui {
     background: var(--neutral-layer-3);
     color: var(--neutral-foreground-rest);

--- a/tests/Lfm.App.Tests/Lfm.App.Tests.csproj
+++ b/tests/Lfm.App.Tests/Lfm.App.Tests.csproj
@@ -46,5 +46,9 @@
       <Link>index.html</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="..\..\app\wwwroot\css\app.css">
+      <Link>css\app.css</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/tests/Lfm.App.Tests/MessageBarCssContractTests.cs
+++ b/tests/Lfm.App.Tests/MessageBarCssContractTests.cs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Xunit;
+
+namespace Lfm.App.Tests;
+
+public class MessageBarCssContractTests
+{
+    private static readonly string AppCssPath = Path.Combine(
+        AppContext.BaseDirectory, "css", "app.css");
+
+    [Fact]
+    public void Fluent_message_bars_include_padding_inside_container_width()
+    {
+        Assert.True(File.Exists(AppCssPath));
+
+        var rule = ExtractRule(File.ReadAllText(AppCssPath), ".fluent-messagebar");
+
+        Assert.Contains("box-sizing: border-box;", rule);
+        Assert.Contains("inline-size: 100%;", rule);
+        Assert.Contains("max-inline-size: 100%;", rule);
+    }
+
+    private static string ExtractRule(string css, string selector)
+    {
+        var selectorStart = css.IndexOf(selector, StringComparison.Ordinal);
+        Assert.True(selectorStart >= 0, $"Missing CSS selector {selector}.");
+
+        var blockStart = css.IndexOf('{', selectorStart);
+        Assert.True(blockStart >= 0, $"Missing declaration block for {selector}.");
+
+        var blockEnd = css.IndexOf('}', blockStart);
+        Assert.True(blockEnd >= 0, $"Unclosed declaration block for {selector}.");
+
+        return css[(blockStart + 1)..blockEnd];
+    }
+}

--- a/tests/Lfm.App.Tests/packages.lock.json
+++ b/tests/Lfm.App.Tests/packages.lock.json
@@ -195,8 +195,8 @@
       },
       "Microsoft.DotNet.HotReload.WebAssembly.Browser": {
         "type": "Transitive",
-        "resolved": "10.0.106",
-        "contentHash": "8MzC43QmkOaut7+LL44MrLhtM3rcNeZOmqGtq92m5tbzJ+61bHExfWzE/6SL77ebzq8W+HVD58u+5pov6T1apg=="
+        "resolved": "10.0.107",
+        "contentHash": "PkusSbB46QQD/X4MHjxelrG67Av2TPxlYkkBgW5PJAPR4d9I6zprYAOhOUovO3WkdaFUyVYO7vGtFKdjJGg6MA=="
       },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "Transitive",
@@ -514,7 +514,7 @@
           "Lfm.Contracts": "[1.0.0, )",
           "Microsoft.AspNetCore.Components.WebAssembly": "[10.0.7, )",
           "Microsoft.AspNetCore.Components.WebAssembly.Authentication": "[10.0.7, )",
-          "Microsoft.DotNet.HotReload.WebAssembly.Browser": "[10.0.106, )",
+          "Microsoft.DotNet.HotReload.WebAssembly.Browser": "[10.0.107, )",
           "Microsoft.Extensions.Http": "[10.0.7, )",
           "Microsoft.Extensions.Localization": "[10.0.7, )",
           "Microsoft.Extensions.Logging.Configuration": "[10.0.7, )",


### PR DESCRIPTION
## Summary
- constrain Fluent UI message bars to include padding and borders inside their parent width
- add a CSS contract test for the global message-bar override
- refresh the app test lockfile for the SDK 10.0.107 update already on `main`

## Env/schema changes
- None

## Screenshots
- Not captured locally; this is a shared CSS overflow fix verified by component/static checks and CI.

## Verification
- `git diff --check`
- `rg -n -U "\.fluent-messagebar\s*\{[^}]*box-sizing:\s*border-box" app/wwwroot/css/app.css`
- `env CI=true dotnet restore lfm.sln -m:1`
- `dotnet build lfm.sln -c Release --no-restore`
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --no-restore`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `dotnet tool restore`
- `dotnet list lfm.sln package --vulnerable --include-transitive`
- `dotnet tool run nuget-license --input lfm.sln --include-transitive --allowed-license-types "$ALLOWED" --licenseurl-to-license-mappings .github/license-url-mappings.json`