### PR TITLE
Fix local dev stack

### DIFF
--- a/app/wwwroot/appsettings.json
+++ b/app/wwwroot/appsettings.json
@@ -1,5 +1,5 @@
 {
-  "ApiBaseUrl": "http://localhost:7183",
+  "ApiBaseUrl": "http://localhost:7071",
   "SourceRepositoryUrl": "https://github.com/lfm-org/lfm",
   "Logging": {
     "LogLevel": {

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -15,10 +15,17 @@ services:
       - -lc
       - |
         printf '%s' "$COSMOS_KEY_CONTENT" > /tmp/cosmos.key
+        mkdir -p /tmp/cosmos-workspace
+        export HOME=/tmp/cosmos-workspace
         export KEY_FILE=/tmp/cosmos.key
+        export WORKSPACE_ROOT=/tmp/cosmos-workspace
         exec /home/cosmosdev/docker_entrypoint.sh
     tmpfs:
       - /tmp
+      - /logs:rw,mode=1777
+      - /socket:rw,mode=1777
+    volumes:
+      - cosmos-data:/data
     ports:
       - "${COSMOS_PORT:-8081}:8081"
       - "${COSMOS_EXPLORER_PORT:-1234}:1234"
@@ -91,6 +98,7 @@ services:
       - functions-logfiles:/home/LogFiles
 
 volumes:
+  cosmos-data:
   azurite-data:
   functions-data:
   functions-logfiles:

--- a/tests/Lfm.Api.Tests/LocalConfigurationContractTests.cs
+++ b/tests/Lfm.Api.Tests/LocalConfigurationContractTests.cs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
 using System.Text.RegularExpressions;
+using System.Text.Json;
 using Xunit;
 
 namespace Lfm.Api.Tests;
@@ -173,6 +174,34 @@ public sealed class LocalConfigurationContractTests
         Assert.Contains($"    mem_limit: {memLimit}", block);
         Assert.Contains($"    cpus: \"{cpus}\"", block);
         Assert.Contains($"    pids_limit: {pidsLimit}", block);
+    }
+
+    [Fact]
+    public void Docker_compose_cosmosdb_declares_writable_emulator_runtime_paths()
+    {
+        var compose = File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "LocalConfig", "docker-compose.local.yml"));
+        var block = ExtractYamlBlock(compose, "  cosmosdb:");
+
+        Assert.Contains("        mkdir -p /tmp/cosmos-workspace", block);
+        Assert.Contains("        export HOME=/tmp/cosmos-workspace", block);
+        Assert.Contains("        export WORKSPACE_ROOT=/tmp/cosmos-workspace", block);
+        Assert.Contains("    read_only: true", block);
+        Assert.Contains("      - /tmp", block);
+        Assert.Contains("      - /logs:rw,mode=1777", block);
+        Assert.Contains("      - /socket:rw,mode=1777", block);
+        Assert.Contains("    volumes:", block);
+        Assert.Contains("      - cosmos-data:/data", block);
+        Assert.Contains("  cosmos-data:", compose);
+    }
+
+    [Fact]
+    public void Blazor_appsettings_points_at_local_compose_functions_endpoint()
+    {
+        var path = Path.Combine(FindRepositoryRoot(), "app", "wwwroot", "appsettings.json");
+        using var document = JsonDocument.Parse(File.ReadAllText(path));
+        var apiBaseUrl = document.RootElement.GetProperty("ApiBaseUrl").GetString();
+
+        Assert.Equal("http://localhost:7071", apiBaseUrl);
     }
 
     private static string FindRepositoryRoot()


### PR DESCRIPTION
## Summary
- Add writable Cosmos emulator runtime paths while keeping the local container root filesystem read-only.
- Point the Blazor dev app at the documented local Functions endpoint on port 7071.
- Pin both local-dev contracts in `LocalConfigurationContractTests`.

## Verification
- `docker compose -f docker-compose.local.yml config`
- `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release --no-restore --filter LocalConfigurationContractTests`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `dotnet build lfm.sln -c Release --no-restore`
- Cosmos emulator smoke test via separate compose project: PostgreSQL/Gateway/Explorer OK; `GET http://localhost:8081/` returned 200