### PR TITLE
Fix local Battle.net callback secrets path

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -72,6 +72,7 @@ services:
       - azurite
     tmpfs:
       - /tmp
+      - /azure-functions-host/Secrets:rw,mode=1777
     environment:
       AZURE_FUNCTIONS_ENVIRONMENT: Development
       AzureWebJobsStorage: ${AzureWebJobsStorage}

--- a/tests/Lfm.Api.Tests/LocalConfigurationContractTests.cs
+++ b/tests/Lfm.Api.Tests/LocalConfigurationContractTests.cs
@@ -195,6 +195,17 @@ public sealed class LocalConfigurationContractTests
     }
 
     [Fact]
+    public void Docker_compose_functions_declares_writable_host_secrets_path()
+    {
+        var compose = File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "LocalConfig", "docker-compose.local.yml"));
+        var block = ExtractYamlBlock(compose, "  functions:");
+
+        Assert.Contains("    read_only: true", block);
+        Assert.Contains("      - /tmp", block);
+        Assert.Contains("      - /azure-functions-host/Secrets:rw,mode=1777", block);
+    }
+
+    [Fact]
     public void Blazor_appsettings_points_at_local_compose_functions_endpoint()
     {
         var path = Path.Combine(FindRepositoryRoot(), "app", "wwwroot", "appsettings.json");


### PR DESCRIPTION
## Summary
- Add a writable tmpfs mount for the Azure Functions host secrets path in the local compose stack.
- Add a local configuration contract test so the read-only Functions container keeps that writable host path.

## Why
Battle.net redirects back with a `code` query parameter. Azure Functions also treats `code` as a possible host/function key query parameter, which initializes the host secret manager even for anonymous callbacks. With the local container root filesystem read-only, that path crashed before the callback handler ran.

## Verification
- `dotnet build lfm.sln -c Release`
- `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `git diff --check`
- `docker compose ... config --quiet`
- local stack: `GET /api/v1/health/ready` returned 200 ready
- local stack: dummy `/api/battlenet/callback?code=dummy&state=dummy` returned 302 to `/auth/failure` instead of host-level 500