### PR TITLE
Add local dev site admin opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Edit `.env` and fill in the required values. See the table below for details.
 | `Auth__CookieName` | Default ok | `battlenet_token` |
 | `Auth__CookieMaxAgeHours` | Default ok | `24` |
 | `Auth__KeyVaultUrl` | No | Leave empty for local dev |
+| `Auth__LocalDevAllAuthenticatedUsersAreSiteAdmins` | No | `false`; set `true` only for local Development to make authenticated local users site admins |
 | `PrivacyContact__Email` | Default ok | Privacy contact returned by the API |
 | `Audit__HashSalt` | No | Empty logs plaintext actor IDs only in Development/E2E; deployed environments fail closed unless this is a resolved secret |
 

--- a/api/Options/AuthOptions.cs
+++ b/api/Options/AuthOptions.cs
@@ -18,4 +18,9 @@ public sealed class AuthOptions
     // Key Vault URL for reading the site-admin secret (e.g. https://lfm-kv.vault.azure.net).
     // When null/empty, isSiteAdmin always returns false (no Key Vault configured).
     public string? KeyVaultUrl { get; init; }
+
+    // Local development escape hatch only. When true, authenticated users are
+    // treated as site admins only if the host environment is Development.
+    // Deployed environments ignore this setting even if it is accidentally set.
+    public bool LocalDevAllAuthenticatedUsersAreSiteAdmins { get; init; }
 }

--- a/api/Services/SiteAdminService.cs
+++ b/api/Services/SiteAdminService.cs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Hosting;
 using Lfm.Api.Options;
 
 namespace Lfm.Api.Services;
@@ -12,9 +13,15 @@ namespace Lfm.Api.Services;
 /// window; the ceiling is traded against Key Vault read frequency. Free-tier
 /// Key Vault grants handle the 6× increase over the original 60 s TTL easily
 /// at this project's scale (a handful of admin operations per hour at most).
-/// When KeyVaultUrl is not configured, IsAdminAsync always returns false.
+/// A deliberately loud local-development option can promote every authenticated
+/// local user to site admin, but only when the host environment is Development.
+/// When KeyVaultUrl is not configured and that local-dev option is off,
+/// IsAdminAsync always returns false.
 /// </summary>
-public sealed class SiteAdminService(IOptions<AuthOptions> authOpts, ISecretResolver secretResolver) : ISiteAdminService
+public sealed class SiteAdminService(
+    IOptions<AuthOptions> authOpts,
+    ISecretResolver secretResolver,
+    IHostEnvironment environment) : ISiteAdminService
 {
     private const string SecretName = "site-admin-battle-net-ids";
 
@@ -32,6 +39,9 @@ public sealed class SiteAdminService(IOptions<AuthOptions> authOpts, ISecretReso
     public async Task<bool> IsAdminAsync(string battleNetId, CancellationToken ct)
     {
         if (string.IsNullOrEmpty(battleNetId)) return false;
+
+        if (_auth.LocalDevAllAuthenticatedUsersAreSiteAdmins && environment.IsDevelopment())
+            return true;
 
         var ids = await GetAdminIdsAsync(ct);
         return ids.Contains(battleNetId);

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -90,6 +90,7 @@ services:
       Auth__CookieName: ${Auth__CookieName:-battlenet_token}
       Auth__CookieMaxAgeHours: ${Auth__CookieMaxAgeHours:-24}
       Auth__KeyVaultUrl: ${Auth__KeyVaultUrl}
+      Auth__LocalDevAllAuthenticatedUsersAreSiteAdmins: ${Auth__LocalDevAllAuthenticatedUsersAreSiteAdmins:-false}
       PrivacyContact__Email: ${PrivacyContact__Email:-privacy@example.com}
       Audit__HashSalt: ${Audit__HashSalt}
     ports:

--- a/example.env
+++ b/example.env
@@ -14,6 +14,7 @@ Storage__BlobConnectionString=DefaultEndpointsProtocol=http;AccountName=devstore
 Auth__CookieName=battlenet_token
 Auth__CookieMaxAgeHours=24
 Auth__KeyVaultUrl=
+Auth__LocalDevAllAuthenticatedUsersAreSiteAdmins=false
 # Cosmos emulator master key for docker-compose (base64-encoded 256-bit key).
 # Generate with: openssl rand -base64 32
 COSMOS_KEY_CONTENT=

--- a/tests/Lfm.Api.Tests/LocalConfigurationContractTests.cs
+++ b/tests/Lfm.Api.Tests/LocalConfigurationContractTests.cs
@@ -40,6 +40,7 @@ public sealed class LocalConfigurationContractTests
         "Auth__CookieName",
         "Auth__CookieMaxAgeHours",
         "Auth__KeyVaultUrl",
+        "Auth__LocalDevAllAuthenticatedUsersAreSiteAdmins",
         "PrivacyContact__Email",
         "Audit__HashSalt",
     ];

--- a/tests/Lfm.Api.Tests/SiteAdminServiceTests.cs
+++ b/tests/Lfm.Api.Tests/SiteAdminServiceTests.cs
@@ -4,6 +4,7 @@
 using Azure;
 using Lfm.Api.Options;
 using Lfm.Api.Services;
+using Microsoft.Extensions.Hosting;
 using Moq;
 using MsOptions = Microsoft.Extensions.Options.Options;
 using Xunit;
@@ -15,14 +16,25 @@ public class SiteAdminServiceTests
     private const string TestVaultUrl = "https://kv.example.net/";
     private const string SecretName = "site-admin-battle-net-ids";
 
-    private static SiteAdminService MakeSut(string? keyVaultUrl = null, ISecretResolver? secretResolver = null) =>
-        new(
+    private static SiteAdminService MakeSut(
+        string? keyVaultUrl = null,
+        ISecretResolver? secretResolver = null,
+        bool localDevAllAuthenticatedUsersAreSiteAdmins = false,
+        string environmentName = "Production")
+    {
+        var environment = new Mock<IHostEnvironment>();
+        environment.SetupGet(e => e.EnvironmentName).Returns(environmentName);
+
+        return new SiteAdminService(
             MsOptions.Create(new AuthOptions
             {
                 CookieName = "battlenet_token",
                 KeyVaultUrl = keyVaultUrl,
+                LocalDevAllAuthenticatedUsersAreSiteAdmins = localDevAllAuthenticatedUsersAreSiteAdmins,
             }),
-            secretResolver ?? Mock.Of<ISecretResolver>());
+            secretResolver ?? Mock.Of<ISecretResolver>(),
+            environment.Object);
+    }
 
     [Fact]
     public async Task IsAdminAsync_returns_false_when_battle_net_id_is_empty()
@@ -91,6 +103,61 @@ public class SiteAdminServiceTests
         Assert.False(first);
         Assert.False(second);
         Assert.False(third);
+    }
+
+    [Fact]
+    public async Task IsAdminAsync_returns_true_for_authenticated_user_when_local_dev_bypass_enabled_in_development()
+    {
+        var sut = MakeSut(
+            keyVaultUrl: null,
+            localDevAllAuthenticatedUsersAreSiteAdmins: true,
+            environmentName: Environments.Development);
+
+        var result = await sut.IsAdminAsync("player#1234", CancellationToken.None);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task IsAdminAsync_returns_false_for_empty_id_when_local_dev_bypass_enabled_in_development()
+    {
+        var sut = MakeSut(
+            keyVaultUrl: null,
+            localDevAllAuthenticatedUsersAreSiteAdmins: true,
+            environmentName: Environments.Development);
+
+        var result = await sut.IsAdminAsync(string.Empty, CancellationToken.None);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task IsAdminAsync_returns_false_when_local_dev_bypass_enabled_outside_development()
+    {
+        var sut = MakeSut(
+            keyVaultUrl: null,
+            localDevAllAuthenticatedUsersAreSiteAdmins: true,
+            environmentName: Environments.Production);
+
+        var result = await sut.IsAdminAsync("player#1234", CancellationToken.None);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task IsAdminAsync_does_not_read_key_vault_when_local_dev_bypass_is_active()
+    {
+        var resolver = new Mock<ISecretResolver>(MockBehavior.Strict);
+        var sut = MakeSut(
+            keyVaultUrl: TestVaultUrl,
+            secretResolver: resolver.Object,
+            localDevAllAuthenticatedUsersAreSiteAdmins: true,
+            environmentName: Environments.Development);
+
+        var result = await sut.IsAdminAsync("player#1234", CancellationToken.None);
+
+        Assert.True(result);
+        resolver.VerifyNoOtherCalls();
     }
 
     // ── Key Vault fetch path ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add an explicit local-development site-admin opt-in that only activates in Development.
- Pass the local opt-in through example env and local compose configuration.
- Cover Development-only behavior, empty authenticated IDs, and local config contract coverage in API tests.

## Verification
- `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release`
- `dotnet build lfm.sln -c Release`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `git diff --check origin/main...HEAD`
- `git ls-files -ci --exclude-standard`
- `docker compose -f docker-compose.local.yml --env-file example.env config --quiet`

## Env/schema changes
- Adds optional `Auth__LocalDevAllAuthenticatedUsersAreSiteAdmins`, default `false`; ignored unless the API host environment is `Development`.