### PR TITLE
Add local Cosmos bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,20 @@ Edit `.env` and fill in the required values. See the table below for details.
 | `Cosmos__DatabaseName` | Default ok | `lfm` |
 | `Cosmos__ConnectionMode` | Default ok | `Gateway` for the Linux emulator |
 | `Local__AzuriteConnectionString` | Default ok | Azurite connection string; compose maps this to `AzureWebJobsStorage` and `Storage__BlobConnectionString` |
+| `Local__SiteAdminBattleNetIds` | No | Optional comma- or newline-separated local site-admin allowlist. Compose writes it to a Docker secret volume consumed only by the local Functions container |
 | `Auth__CookieName` | Default ok | `battlenet_token` |
 | `Auth__CookieMaxAgeHours` | Default ok | `24` |
-| `Auth__KeyVaultUrl` | No | Leave empty for local dev |
-| `Auth__LocalDevAllAuthenticatedUsersAreSiteAdmins` | No | `false`; set `true` only for local Development to make authenticated local users site admins |
 | `PrivacyContact__Email` | Default ok | Privacy contact returned by the API |
 | `Audit__HashSalt` | No | Empty logs plaintext actor IDs only in Development/E2E; deployed environments fail closed unless this is a resolved secret |
 
 `example.env` lists human-editable local source values. `docker-compose.local.yml`
 maps those sources into platform/app settings such as
 `AZURE_FUNCTIONS_ENVIRONMENT`, `AzureWebJobsStorage`, and
-`Storage__BlobConnectionString`. Deployment and build-time source variables
+`Storage__BlobConnectionString`. The local compose init container uses
+CosmosDBShell inside the container to create the Cosmos emulator
+database/containers and writes the optional local site-admin allowlist to a
+Docker volume mounted into the Functions container as
+`Auth__KeyVaultUrl=file:///home/local-secrets`. Deployment and build-time source variables
 such as `PRIVACY_EMAIL`, `API_HOSTNAME`, and `FRONTEND_HOSTNAME` are documented
 under Deployment and are intentionally not part of the local `.env` template.
 
@@ -64,6 +67,8 @@ This starts:
 
 - Cosmos emulator on `http://127.0.0.1:8081` (explorer on port 1234)
 - Azurite blob storage on `http://127.0.0.1:10000`
+- a one-shot local init container that creates the `lfm` Cosmos database and
+  `raiders`, `guilds`, `runs`, and `idempotency` containers
 - Azure Functions on `http://localhost:7071`
 
 ### 4. Run the Blazor app

--- a/api/Options/AuthOptions.cs
+++ b/api/Options/AuthOptions.cs
@@ -17,10 +17,7 @@ public sealed class AuthOptions
 
     // Key Vault URL for reading the site-admin secret (e.g. https://lfm-kv.vault.azure.net).
     // When null/empty, isSiteAdmin always returns false (no Key Vault configured).
+    // Local compose sets this to file:///home/local-secrets and mounts a
+    // Docker-managed secret directory populated by scripts/local-dev-init.sh.
     public string? KeyVaultUrl { get; init; }
-
-    // Local development escape hatch only. When true, authenticated users are
-    // treated as site admins only if the host environment is Development.
-    // Deployed environments ignore this setting even if it is accidentally set.
-    public bool LocalDevAllAuthenticatedUsersAreSiteAdmins { get; init; }
 }

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -185,7 +185,23 @@ if (string.Equals(builder.Configuration["E2E_TEST_MODE"], "true", StringComparis
 else
 #endif
 {
-    builder.Services.AddSingleton<Lfm.Api.Services.ISecretResolver, Lfm.Api.Services.KeyVaultSecretResolver>();
+    builder.Services.AddSingleton<Lfm.Api.Services.ISecretResolver>(sp =>
+    {
+        var auth = sp.GetRequiredService<IOptions<AuthOptions>>().Value;
+        var environment = sp.GetRequiredService<IHostEnvironment>();
+        if (Lfm.Api.Services.LocalFileSecretResolver.IsLocalFileSecretUrl(auth.KeyVaultUrl))
+        {
+            if (!environment.IsDevelopment())
+            {
+                throw new InvalidOperationException(
+                    "file:// Auth__KeyVaultUrl is only allowed in the local Development environment.");
+            }
+
+            return new Lfm.Api.Services.LocalFileSecretResolver();
+        }
+
+        return new Lfm.Api.Services.KeyVaultSecretResolver();
+    });
 }
 builder.Services.AddSingleton<Lfm.Api.Services.ISiteAdminService, Lfm.Api.Services.SiteAdminService>();
 builder.Services.AddSingleton<Lfm.Api.Services.IIdempotencyStore, Lfm.Api.Services.IdempotencyStore>();

--- a/api/Services/LocalFileSecretResolver.cs
+++ b/api/Services/LocalFileSecretResolver.cs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+namespace Lfm.Api.Services;
+
+/// <summary>
+/// Development-only secret resolver for local compose. The init container
+/// writes allowlist files into a Docker volume; the API reads them through the
+/// same <see cref="ISecretResolver"/> path used by Key Vault in deployed envs.
+/// </summary>
+public sealed class LocalFileSecretResolver : ISecretResolver
+{
+    public async Task<string?> GetSecretAsync(string vaultUrl, string secretName, CancellationToken ct)
+    {
+        if (!IsLocalFileSecretUrl(vaultUrl) || !Uri.TryCreate(vaultUrl, UriKind.Absolute, out var uri))
+        {
+            throw new InvalidOperationException("Local file secrets require a file:// Auth__KeyVaultUrl.");
+        }
+
+        if (secretName.Contains('/') || secretName.Contains('\\') || secretName.Contains("..", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Secret names must be plain file names.");
+        }
+
+        var fullRoot = Path.GetFullPath(uri.LocalPath);
+        var root = fullRoot == Path.DirectorySeparatorChar.ToString()
+            ? fullRoot
+            : fullRoot.TrimEnd(Path.DirectorySeparatorChar);
+        var path = Path.GetFullPath(Path.Combine(root, secretName));
+        if (!path.StartsWith(root + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Secret path escapes the configured local secret directory.");
+        }
+
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        return await File.ReadAllTextAsync(path, ct);
+    }
+
+    internal static bool IsLocalFileSecretUrl(string? vaultUrl) =>
+        Uri.TryCreate(vaultUrl, UriKind.Absolute, out var uri)
+        && string.Equals(uri.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase);
+}

--- a/api/Services/SiteAdminService.cs
+++ b/api/Services/SiteAdminService.cs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
 using Microsoft.Extensions.Options;
-using Microsoft.Extensions.Hosting;
 using Lfm.Api.Options;
 
 namespace Lfm.Api.Services;
@@ -13,15 +12,13 @@ namespace Lfm.Api.Services;
 /// window; the ceiling is traded against Key Vault read frequency. Free-tier
 /// Key Vault grants handle the 6× increase over the original 60 s TTL easily
 /// at this project's scale (a handful of admin operations per hour at most).
-/// A deliberately loud local-development option can promote every authenticated
-/// local user to site admin, but only when the host environment is Development.
-/// When KeyVaultUrl is not configured and that local-dev option is off,
-/// IsAdminAsync always returns false.
+/// Local compose uses the same allowlist contract through a mounted local
+/// secret file populated by scripts/local-dev-init.sh.
+/// When KeyVaultUrl is not configured, IsAdminAsync always returns false.
 /// </summary>
 public sealed class SiteAdminService(
     IOptions<AuthOptions> authOpts,
-    ISecretResolver secretResolver,
-    IHostEnvironment environment) : ISiteAdminService
+    ISecretResolver secretResolver) : ISiteAdminService
 {
     private const string SecretName = "site-admin-battle-net-ids";
 
@@ -39,9 +36,6 @@ public sealed class SiteAdminService(
     public async Task<bool> IsAdminAsync(string battleNetId, CancellationToken ct)
     {
         if (string.IsNullOrEmpty(battleNetId)) return false;
-
-        if (_auth.LocalDevAllAuthenticatedUsersAreSiteAdmins && environment.IsDevelopment())
-            return true;
 
         var ids = await GetAdminIdsAsync(ct);
         return ids.Contains(battleNetId);

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -53,6 +53,32 @@ services:
     volumes:
       - azurite-data:/data
 
+  local-init:
+    build:
+      context: .
+      dockerfile: docker/local-init/Dockerfile
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    mem_limit: 512m
+    cpus: "0.5"
+    pids_limit: 128
+    depends_on:
+      - cosmosdb
+    tmpfs:
+      - /tmp
+    environment:
+      Cosmos__Endpoint: ${Cosmos__Endpoint}
+      Cosmos__AuthKey: ${Cosmos__AuthKey}
+      Cosmos__DatabaseName: ${Cosmos__DatabaseName}
+      Local__SiteAdminBattleNetIds: ${Local__SiteAdminBattleNetIds:-}
+    command: ["bash", "/usr/local/bin/local-dev-init.sh"]
+    volumes:
+      - local-secrets:/home/local-secrets
+      - ./scripts/local-dev-init.sh:/usr/local/bin/local-dev-init.sh:ro
+
   functions:
     build:
       context: .
@@ -68,8 +94,12 @@ services:
     cpus: "1.0"
     pids_limit: 256
     depends_on:
-      - cosmosdb
-      - azurite
+      cosmosdb:
+        condition: service_started
+      azurite:
+        condition: service_started
+      local-init:
+        condition: service_completed_successfully
     tmpfs:
       - /tmp
       - /azure-functions-host/Secrets:rw,mode=1777
@@ -89,8 +119,7 @@ services:
       Storage__BlobConnectionString: ${Local__AzuriteConnectionString}
       Auth__CookieName: ${Auth__CookieName:-battlenet_token}
       Auth__CookieMaxAgeHours: ${Auth__CookieMaxAgeHours:-24}
-      Auth__KeyVaultUrl: ${Auth__KeyVaultUrl}
-      Auth__LocalDevAllAuthenticatedUsersAreSiteAdmins: ${Auth__LocalDevAllAuthenticatedUsersAreSiteAdmins:-false}
+      Auth__KeyVaultUrl: file:///home/local-secrets
       PrivacyContact__Email: ${PrivacyContact__Email:-privacy@example.com}
       Audit__HashSalt: ${Audit__HashSalt}
     ports:
@@ -98,9 +127,11 @@ services:
     volumes:
       - functions-data:/home/data
       - functions-logfiles:/home/LogFiles
+      - local-secrets:/home/local-secrets:ro
 
 volumes:
   cosmos-data:
   azurite-data:
   functions-data:
   functions-logfiles:
+  local-secrets:

--- a/docker/local-init/Dockerfile
+++ b/docker/local-init/Dockerfile
@@ -1,0 +1,8 @@
+# Base image pinned to sha256 digest (matching repo Docker pin policy).
+FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:8a90a473da5205a16979de99d2fc20975e922c68304f5c79d564e666dc3982fc
+
+RUN dotnet tool install --tool-path /opt/cosmosdbshell CosmosDBShell --version 1.0.213-preview
+
+ENV PATH="/opt/cosmosdbshell:${PATH}"
+
+WORKDIR /tmp

--- a/docker/local-init/Dockerfile
+++ b/docker/local-init/Dockerfile
@@ -3,6 +3,13 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:8a90a473da5205a16979de99d2fc20975e
 
 RUN dotnet tool install --tool-path /opt/cosmosdbshell CosmosDBShell --version 1.0.213-preview
 
+RUN groupadd --system --gid 10001 localinit \
+    && useradd --system --uid 10001 --gid 10001 --home-dir /tmp/local-init-home --shell /usr/sbin/nologin localinit \
+    && mkdir -p /home/local-secrets /tmp/local-init-home \
+    && chown -R 10001:10001 /home/local-secrets /tmp/local-init-home
+
 ENV PATH="/opt/cosmosdbshell:${PATH}"
 
 WORKDIR /tmp
+
+USER 10001:10001

--- a/docker/local-init/Dockerfile
+++ b/docker/local-init/Dockerfile
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 LFM contributors
+
 # Base image pinned to sha256 digest (matching repo Docker pin policy).
 FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:8a90a473da5205a16979de99d2fc20975e922c68304f5c79d564e666dc3982fc
 

--- a/example.env
+++ b/example.env
@@ -25,11 +25,14 @@ Cosmos__ConnectionMode=Gateway
 # for the Functions host and Storage__BlobConnectionString for app blob reads.
 Local__AzuriteConnectionString=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;
 
+# Optional local site-admin allowlist. Compose writes this to a local secret
+# volume consumed by the Functions container as file:///home/local-secrets.
+# Use comma-separated or newline-separated Battle.net ids.
+Local__SiteAdminBattleNetIds=
+
 # Local auth/session behavior.
 Auth__CookieName=battlenet_token
 Auth__CookieMaxAgeHours=24
-Auth__KeyVaultUrl=
-Auth__LocalDevAllAuthenticatedUsersAreSiteAdmins=false
 
 # Privacy contact returned by the local API.
 PrivacyContact__Email=privacy@example.com

--- a/scripts/local-dev-init.sh
+++ b/scripts/local-dev-init.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 LFM contributors
+
 set -euo pipefail
 
 : "${Cosmos__Endpoint:?Cosmos__Endpoint is required}"

--- a/scripts/local-dev-init.sh
+++ b/scripts/local-dev-init.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${Cosmos__Endpoint:?Cosmos__Endpoint is required}"
+: "${Cosmos__AuthKey:?Cosmos__AuthKey is required}"
+: "${Cosmos__DatabaseName:?Cosmos__DatabaseName is required}"
+
+mkdir -p /home/local-secrets
+printf '%s' "${Local__SiteAdminBattleNetIds:-}" > /home/local-secrets/site-admin-battle-net-ids
+
+export HOME=/tmp/local-init-home
+export DOTNET_CLI_HOME="$HOME"
+mkdir -p "$HOME"
+cd "$HOME"
+
+endpoint="${Cosmos__Endpoint%/}/"
+connection_string="AccountEndpoint=${endpoint};AccountKey=${Cosmos__AuthKey};"
+
+run_cosmosdbshell() {
+  local command="$1"
+  local output
+
+  if output=$(cosmosdbshell --connect "$connection_string" --connect-mode gateway -c "$command" 2>&1); then
+    return 0
+  fi
+
+  if printf '%s\n' "$output" | grep -Eiq 'already exists|conflict|409'; then
+    return 0
+  fi
+
+  printf '%s\n' "${output//${Cosmos__AuthKey}/[redacted]}" >&2
+  return 1
+}
+
+for attempt in $(seq 1 30); do
+  if run_cosmosdbshell "mkdb \"$Cosmos__DatabaseName\"" &&
+    run_cosmosdbshell "mkcon raiders /battleNetId --database=\"$Cosmos__DatabaseName\"" &&
+    run_cosmosdbshell "mkcon guilds /id --database=\"$Cosmos__DatabaseName\"" &&
+    run_cosmosdbshell "mkcon runs /id --database=\"$Cosmos__DatabaseName\"" &&
+    run_cosmosdbshell "mkcon idempotency /battleNetId --database=\"$Cosmos__DatabaseName\""
+  then
+    echo "Local Cosmos containers and site-admin allowlist are ready."
+    exit 0
+  fi
+
+  echo "Cosmos local init attempt ${attempt} failed; retrying..." >&2
+  sleep 2
+done
+
+echo "Cosmos local init did not complete before the retry limit." >&2
+exit 1

--- a/tests/Lfm.Api.Tests/LocalConfigurationContractTests.cs
+++ b/tests/Lfm.Api.Tests/LocalConfigurationContractTests.cs
@@ -315,6 +315,18 @@ public sealed class LocalConfigurationContractTests
     }
 
     [Fact]
+    public void Local_init_dockerfile_declares_non_root_runtime_user()
+    {
+        var dockerfile = File.ReadAllText(Path.Combine(FindRepositoryRoot(), "docker", "local-init", "Dockerfile"));
+
+        Assert.Contains("useradd --system --uid 10001 --gid 10001", dockerfile);
+        Assert.Contains("chown -R 10001:10001 /home/local-secrets /tmp/local-init-home", dockerfile);
+        Assert.Contains("USER 10001:10001", dockerfile);
+        Assert.DoesNotContain("USER root", dockerfile);
+        Assert.DoesNotContain("USER 0", dockerfile);
+    }
+
+    [Fact]
     public void Local_dev_init_script_runs_setup_tool_from_repo_root()
     {
         var root = FindRepositoryRoot();

--- a/tests/Lfm.Api.Tests/LocalConfigurationContractTests.cs
+++ b/tests/Lfm.Api.Tests/LocalConfigurationContractTests.cs
@@ -24,6 +24,7 @@ public sealed class LocalConfigurationContractTests
         {
             { "cosmosdb", "3g", "2.0", "512" },
             { "azurite", "512m", "0.5", "128" },
+            { "local-init", "512m", "0.5", "128" },
             { "functions", "1g", "1.0", "256" },
         };
 
@@ -40,10 +41,9 @@ public sealed class LocalConfigurationContractTests
         "Cosmos__DatabaseName",
         "Cosmos__ConnectionMode",
         "Local__AzuriteConnectionString",
+        "Local__SiteAdminBattleNetIds",
         "Auth__CookieName",
         "Auth__CookieMaxAgeHours",
-        "Auth__KeyVaultUrl",
-        "Auth__LocalDevAllAuthenticatedUsersAreSiteAdmins",
         "PrivacyContact__Email",
         "Audit__HashSalt",
     ];
@@ -66,7 +66,6 @@ public sealed class LocalConfigurationContractTests
         "Auth__CookieName",
         "Auth__CookieMaxAgeHours",
         "Auth__KeyVaultUrl",
-        "Auth__LocalDevAllAuthenticatedUsersAreSiteAdmins",
         "PrivacyContact__Email",
         "Audit__HashSalt",
     ];
@@ -98,6 +97,8 @@ public sealed class LocalConfigurationContractTests
         "Storage__BlobConnectionString",
         "Cosmos__EmulatorKeyContent",
         "COSMOS_KEY_CONTENT",
+        "Auth__KeyVaultUrl",
+        "Auth__LocalDevAllAuthenticatedUsersAreSiteAdmins",
         "PRIVACY_EMAIL",
         "EXPIRES_SECURITY_TXT",
         "SECURITY_POLICY_URL",
@@ -287,6 +288,60 @@ public sealed class LocalConfigurationContractTests
 
         Assert.Contains("      AzureWebJobsStorage: ${Local__AzuriteConnectionString}", block);
         Assert.Contains("      Storage__BlobConnectionString: ${Local__AzuriteConnectionString}", block);
+    }
+
+    [Fact]
+    public void Docker_compose_runs_local_init_before_functions()
+    {
+        var compose = File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "LocalConfig", "docker-compose.local.yml"));
+        var dockerfile = File.ReadAllText(Path.Combine(FindRepositoryRoot(), "docker", "local-init", "Dockerfile"));
+        var initBlock = ExtractYamlBlock(compose, "  local-init:");
+        var block = ExtractYamlBlock(compose, "  functions:");
+
+        Assert.Contains("      dockerfile: docker/local-init/Dockerfile", initBlock);
+        Assert.Contains("dotnet tool install --tool-path /opt/cosmosdbshell CosmosDBShell --version 1.0.213-preview", dockerfile);
+        Assert.Contains("ENV PATH=\"/opt/cosmosdbshell:${PATH}\"", dockerfile);
+        Assert.Contains("WORKDIR /tmp", dockerfile);
+        Assert.Contains("      - ./scripts/local-dev-init.sh:/usr/local/bin/local-dev-init.sh:ro", initBlock);
+        Assert.Contains("    command: [\"bash\", \"/usr/local/bin/local-dev-init.sh\"]", initBlock);
+        Assert.Contains("      Cosmos__Endpoint: ${Cosmos__Endpoint}", initBlock);
+        Assert.Contains("      Local__SiteAdminBattleNetIds: ${Local__SiteAdminBattleNetIds:-}", initBlock);
+        Assert.Contains("      - local-secrets:/home/local-secrets", initBlock);
+        Assert.Contains("      local-init:", block);
+        Assert.Contains("        condition: service_completed_successfully", block);
+        Assert.Contains("      - local-secrets:/home/local-secrets:ro", block);
+        Assert.Contains("      Auth__KeyVaultUrl: file:///home/local-secrets", block);
+        Assert.DoesNotContain("Auth__LocalDevAllAuthenticatedUsersAreSiteAdmins", compose);
+    }
+
+    [Fact]
+    public void Local_dev_init_script_runs_setup_tool_from_repo_root()
+    {
+        var root = FindRepositoryRoot();
+        var script = File.ReadAllText(Path.Combine(root, "scripts", "local-dev-init.sh"));
+        var toolProject = Path.Combine(root, "tools", "Lfm.LocalDevSetup", "Lfm.LocalDevSetup.csproj");
+
+        Assert.False(File.Exists(toolProject), "Local compose setup should not add another .NET project.");
+        Assert.Contains("cd \"$HOME\"", script);
+        Assert.Contains("cosmosdbshell --connect \"$connection_string\" --connect-mode gateway -c \"$command\"", script);
+        Assert.Contains("already exists|conflict|409", script);
+        Assert.Contains("mkdb \\\"$Cosmos__DatabaseName\\\"", script);
+        Assert.Contains("mkcon raiders /battleNetId --database=\\\"$Cosmos__DatabaseName\\\"", script);
+        Assert.Contains("mkcon guilds /id --database=\\\"$Cosmos__DatabaseName\\\"", script);
+        Assert.Contains("mkcon runs /id --database=\\\"$Cosmos__DatabaseName\\\"", script);
+        Assert.Contains("mkcon idempotency /battleNetId --database=\\\"$Cosmos__DatabaseName\\\"", script);
+        Assert.Contains("site-admin-battle-net-ids", script);
+    }
+
+    [Fact]
+    public void Api_auth_options_do_not_expose_all_local_users_admin_bypass()
+    {
+        var root = FindRepositoryRoot();
+        var authOptions = File.ReadAllText(Path.Combine(root, "api", "Options", "AuthOptions.cs"));
+        var siteAdminService = File.ReadAllText(Path.Combine(root, "api", "Services", "SiteAdminService.cs"));
+
+        Assert.DoesNotContain("LocalDevAllAuthenticatedUsersAreSiteAdmins", authOptions);
+        Assert.DoesNotContain("LocalDevAllAuthenticatedUsersAreSiteAdmins", siteAdminService);
     }
 
     [Fact]

--- a/tests/Lfm.Api.Tests/Services/LocalFileSecretResolverTests.cs
+++ b/tests/Lfm.Api.Tests/Services/LocalFileSecretResolverTests.cs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Services;
+using Xunit;
+
+namespace Lfm.Api.Tests.Services;
+
+public sealed class LocalFileSecretResolverTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), $"lfm-local-secrets-{Guid.NewGuid():N}");
+
+    public LocalFileSecretResolverTests()
+    {
+        Directory.CreateDirectory(_root);
+    }
+
+    [Fact]
+    public async Task GetSecretAsync_reads_secret_from_file_uri_root()
+    {
+        await File.WriteAllTextAsync(Path.Combine(_root, "site-admin-battle-net-ids"), "player-1\nplayer-2");
+        var sut = new LocalFileSecretResolver();
+
+        var value = await sut.GetSecretAsync(new Uri(_root).AbsoluteUri, "site-admin-battle-net-ids", CancellationToken.None);
+
+        Assert.Equal("player-1\nplayer-2", value);
+    }
+
+    [Fact]
+    public async Task GetSecretAsync_accepts_root_uri_with_trailing_separator()
+    {
+        await File.WriteAllTextAsync(Path.Combine(_root, "site-admin-battle-net-ids"), "player-1");
+        var rootUri = new Uri(_root + Path.DirectorySeparatorChar).AbsoluteUri;
+        var sut = new LocalFileSecretResolver();
+
+        var value = await sut.GetSecretAsync(rootUri, "site-admin-battle-net-ids", CancellationToken.None);
+
+        Assert.Equal("player-1", value);
+    }
+
+    [Fact]
+    public async Task GetSecretAsync_returns_null_for_missing_secret()
+    {
+        var sut = new LocalFileSecretResolver();
+
+        var value = await sut.GetSecretAsync(new Uri(_root).AbsoluteUri, "missing", CancellationToken.None);
+
+        Assert.Null(value);
+    }
+
+    [Fact]
+    public async Task GetSecretAsync_rejects_path_traversal_secret_names()
+    {
+        var sut = new LocalFileSecretResolver();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.GetSecretAsync(new Uri(_root).AbsoluteUri, "../outside", CancellationToken.None));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+}

--- a/tests/Lfm.Api.Tests/SiteAdminServiceTests.cs
+++ b/tests/Lfm.Api.Tests/SiteAdminServiceTests.cs
@@ -4,7 +4,6 @@
 using Azure;
 using Lfm.Api.Options;
 using Lfm.Api.Services;
-using Microsoft.Extensions.Hosting;
 using Moq;
 using MsOptions = Microsoft.Extensions.Options.Options;
 using Xunit;
@@ -18,22 +17,15 @@ public class SiteAdminServiceTests
 
     private static SiteAdminService MakeSut(
         string? keyVaultUrl = null,
-        ISecretResolver? secretResolver = null,
-        bool localDevAllAuthenticatedUsersAreSiteAdmins = false,
-        string environmentName = "Production")
+        ISecretResolver? secretResolver = null)
     {
-        var environment = new Mock<IHostEnvironment>();
-        environment.SetupGet(e => e.EnvironmentName).Returns(environmentName);
-
         return new SiteAdminService(
             MsOptions.Create(new AuthOptions
             {
                 CookieName = "battlenet_token",
                 KeyVaultUrl = keyVaultUrl,
-                LocalDevAllAuthenticatedUsersAreSiteAdmins = localDevAllAuthenticatedUsersAreSiteAdmins,
             }),
-            secretResolver ?? Mock.Of<ISecretResolver>(),
-            environment.Object);
+            secretResolver ?? Mock.Of<ISecretResolver>());
     }
 
     [Fact]
@@ -103,61 +95,6 @@ public class SiteAdminServiceTests
         Assert.False(first);
         Assert.False(second);
         Assert.False(third);
-    }
-
-    [Fact]
-    public async Task IsAdminAsync_returns_true_for_authenticated_user_when_local_dev_bypass_enabled_in_development()
-    {
-        var sut = MakeSut(
-            keyVaultUrl: null,
-            localDevAllAuthenticatedUsersAreSiteAdmins: true,
-            environmentName: Environments.Development);
-
-        var result = await sut.IsAdminAsync("player#1234", CancellationToken.None);
-
-        Assert.True(result);
-    }
-
-    [Fact]
-    public async Task IsAdminAsync_returns_false_for_empty_id_when_local_dev_bypass_enabled_in_development()
-    {
-        var sut = MakeSut(
-            keyVaultUrl: null,
-            localDevAllAuthenticatedUsersAreSiteAdmins: true,
-            environmentName: Environments.Development);
-
-        var result = await sut.IsAdminAsync(string.Empty, CancellationToken.None);
-
-        Assert.False(result);
-    }
-
-    [Fact]
-    public async Task IsAdminAsync_returns_false_when_local_dev_bypass_enabled_outside_development()
-    {
-        var sut = MakeSut(
-            keyVaultUrl: null,
-            localDevAllAuthenticatedUsersAreSiteAdmins: true,
-            environmentName: Environments.Production);
-
-        var result = await sut.IsAdminAsync("player#1234", CancellationToken.None);
-
-        Assert.False(result);
-    }
-
-    [Fact]
-    public async Task IsAdminAsync_does_not_read_key_vault_when_local_dev_bypass_is_active()
-    {
-        var resolver = new Mock<ISecretResolver>(MockBehavior.Strict);
-        var sut = MakeSut(
-            keyVaultUrl: TestVaultUrl,
-            secretResolver: resolver.Object,
-            localDevAllAuthenticatedUsersAreSiteAdmins: true,
-            environmentName: Environments.Development);
-
-        var result = await sut.IsAdminAsync("player#1234", CancellationToken.None);
-
-        Assert.True(result);
-        resolver.VerifyNoOtherCalls();
     }
 
     // ── Key Vault fetch path ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add a local-init compose service that installs and runs CosmosDBShell inside the container
- create the local Cosmos emulator database and required containers before Functions starts
- replace the local all-users-admin bypass with a local file-backed secret resolver mounted only in local compose

## Env and config changes
- removes local `.env` use of `Auth__KeyVaultUrl` and `Auth__LocalDevAllAuthenticatedUsersAreSiteAdmins`
- adds optional `Local__SiteAdminBattleNetIds` for local site-admin allowlist setup
- local compose maps the generated secret volume to `Auth__KeyVaultUrl=file:///home/local-secrets`

## Verification
- `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release --no-restore`
- `dotnet build lfm.sln -c Release --no-restore`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `docker compose --env-file example.env -f docker-compose.local.yml config --quiet`
- `bash -n scripts/local-dev-init.sh`
- local-init Docker smoke test passed twice, including repeat run against existing temporary volumes

No screenshots: non-UI local development setup change.