### PR TITLE
Center app content rail

### DIFF
--- a/app/Layout/MainLayout.razor
+++ b/app/Layout/MainLayout.razor
@@ -129,7 +129,7 @@
     </AuthorizeView>
 
     <!-- Page content -->
-    <main id="main-content" tabindex="-1" @ref="_mainRef" style="flex:1;padding-block:24px;padding-inline:16px">
+    <main id="main-content" class="app-main" tabindex="-1" @ref="_mainRef">
         @Body
     </main>
 
@@ -164,6 +164,15 @@
 </div>
 
 <style>
+    .app-main {
+        flex: 1;
+        box-sizing: border-box;
+        inline-size: min(100%, 90rem);
+        margin-inline: auto;
+        padding-block: 24px;
+        padding-inline: 16px;
+    }
+
     .account-menu-container {
         position: relative;
         display: inline-flex;

--- a/app/Pages/EditRunPage.razor
+++ b/app/Pages/EditRunPage.razor
@@ -39,6 +39,10 @@
             break;
 
         case LoadingState<RunDetailDto>.Success s:
+            <FluentButton Appearance="Appearance.Outline" OnClick="@NavigateBackToRuns" Disabled="@(_saving || _deleting)">
+                @Loc["editRun.backToRuns"]
+            </FluentButton>
+
             <FluentCard Class="run-form-card">
                 <FluentStack Orientation="Orientation.Vertical" VerticalGap="12">
                     <FluentLabel Typo="Typography.H4">@Loc["editRun.runDetails"]</FluentLabel>
@@ -522,6 +526,8 @@
                 await UnsavedGuard.RefreshAsync();
                 Toast.ShowSuccess(Loc["editRun.saveSuccess"]);
                 _state = new LoadingState<RunDetailDto>.Success(updatedEnvelope.Run);
+                await DisposeUnsavedChangesGuardAsync();
+                Nav.NavigateTo("/runs");
             }
         }
         catch (StaleEtagException)
@@ -541,6 +547,8 @@
             _saving = false;
         }
     }
+
+    private void NavigateBackToRuns() => Nav.NavigateTo("/runs");
 
     private void HandleCancel() => Nav.NavigateTo($"/runs/{Uri.EscapeDataString(RunId!)}");
 

--- a/tests/Lfm.App.Tests/LayoutTests.cs
+++ b/tests/Lfm.App.Tests/LayoutTests.cs
@@ -362,6 +362,23 @@ public class LayoutTests : ComponentTestBase
     }
 
     [Fact]
+    public void MainLayout_Main_Content_Uses_Centered_Readable_Rail()
+    {
+        this.AddAuthorization();
+        var cut = Render<MainLayout>(p =>
+            p.Add(x => x.Body, builder => builder.AddContent(0, "page content")));
+
+        var main = cut.Find("main#main-content.app-main");
+
+        Assert.Contains("page content", main.TextContent);
+        Assert.Contains(".app-main", cut.Markup);
+        Assert.Contains("inline-size: min(100%, 90rem);", cut.Markup);
+        Assert.Contains("margin-inline: auto;", cut.Markup);
+        Assert.Contains("box-sizing: border-box;", cut.Markup);
+        Assert.Contains("padding-inline: 16px;", cut.Markup);
+    }
+
+    [Fact]
     public void MainLayout_Locale_Change_Survives_JSDisconnectedException()
     {
         // Regression: HandleLocaleChanged is `async void` and crosses JS interop.

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -2003,6 +2003,28 @@ public class RunsPagesTests : ComponentTestBase
     }
 
     [Fact]
+    public void EditRunPage_Back_To_Runs_Action_Navigates_To_List()
+    {
+        var runsClient = new Mock<IRunsClient>();
+        runsClient.Setup(c => c.GetWithEtagAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunDetailWithEtag(MakeDetail(), "\"etag-v1\""));
+        WireEditRunServices(runsClient);
+        var nav = Services.GetRequiredService<BunitNavigationManager>();
+
+        var cut = Render<EditRunPage>(p => p.Add(x => x.RunId, "run-1"));
+
+        cut.WaitForAssertion(() =>
+            Assert.Contains(Loc("editRun.backToRuns"), cut.Markup));
+
+        var backButton = cut.FindAll("fluent-button")
+            .First(b => b.TextContent.Contains(Loc("editRun.backToRuns"), StringComparison.Ordinal));
+        backButton.Click();
+
+        cut.WaitForAssertion(() =>
+            Assert.Equal("/runs", new Uri(nav.Uri).AbsolutePath));
+    }
+
+    [Fact]
     public void EditRunPage_Wnl_Button_Uses_Visible_Label_As_Accessible_Name()
     {
         var mplusInstance = new InstanceDto(
@@ -2205,6 +2227,32 @@ public class RunsPagesTests : ComponentTestBase
         cut.WaitForAssertion(() => Assert.Equal(2, ifMatches.Count));
 
         Assert.Equal(["\"etag-v1\"", "\"etag-v2\""], ifMatches);
+    }
+
+    [Fact]
+    public void EditRunPage_Save_Navigates_To_Runs_List_On_Success()
+    {
+        var runsClient = new Mock<IRunsClient>();
+        runsClient.Setup(c => c.GetWithEtagAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunDetailWithEtag(MakeDetail(), "\"etag-v1\""));
+        runsClient.Setup(c => c.UpdateAsync("run-1", It.IsAny<UpdateRunRequest>(), "\"etag-v1\"", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunDetailWithEtag(MakeDetail() with { Description = "Updated notes" }, "\"etag-v2\""));
+        WireEditRunServices(runsClient);
+        var nav = Services.GetRequiredService<BunitNavigationManager>();
+
+        var cut = Render<EditRunPage>(p => p.Add(x => x.RunId, "run-1"));
+
+        cut.WaitForAssertion(() =>
+            Assert.Contains(Loc("editRun.saveChanges"), cut.Markup));
+        cut.Find("#description-input").Change("Updated notes");
+
+        var saveButton = cut.FindAll("fluent-button")
+            .First(b => b.TextContent.Contains(Loc("editRun.saveChanges"), StringComparison.Ordinal));
+        saveButton.Click();
+
+        cut.WaitForAssertion(() =>
+            Assert.Equal("/runs", new Uri(nav.Uri).AbsolutePath));
+        Assert.Equal(NavigationState.Succeeded, nav.History.First().State);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- center the main app content in a capped readable rail for wide screens
- move the main content spacing from inline styles to an `.app-main` rule
- keep the edit-run flow returning to the runs list after back/save actions

## Env and config changes
- none

## Verification
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --filter "FullyQualifiedName~LayoutTests|FullyQualifiedName~RunsPagesTests"`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --no-restore`
- `dotnet build lfm.sln -c Release --no-restore`
- `git diff --check`

No screenshots captured in this run; layout change is covered by component contract tests.