### PR TITLE
Fix active character race

### DIFF
--- a/api/Functions/RaiderCharacterEnrichFunction.cs
+++ b/api/Functions/RaiderCharacterEnrichFunction.cs
@@ -126,15 +126,25 @@ public sealed class RaiderCharacterEnrichFunction(
                 existing, id, region, realm, originalName, profile, specs, media, nowIso, plan);
         }
 
-        var updatedCharacters = (raider.Characters ?? []).ToList();
-        var idx = updatedCharacters.FindIndex(c => c.Id == id);
-        if (idx >= 0) updatedCharacters[idx] = stored; else updatedCharacters.Add(stored);
-
-        // Preserve SelectedCharacterId — do NOT mutate it.
-        var updated = raider with { Characters = updatedCharacters };
-        await repo.UpsertAsync(updated, ct);
+        var persisted = await RaiderDocumentConcurrency.ReplaceWithRetryAsync(
+            repo,
+            raider,
+            current => WithStoredCharacter(current, stored),
+            ct);
+        if (persisted is null)
+            return Problem.NotFound(req.HttpContext, "raider-not-found", "Raider not found.");
 
         return new OkObjectResult(RaiderCharacterAddFunction.MapToCharacterDto(stored));
+    }
+
+    private static RaiderDocument WithStoredCharacter(RaiderDocument raider, StoredSelectedCharacter stored)
+    {
+        var updatedCharacters = (raider.Characters ?? []).ToList();
+        var idx = updatedCharacters.FindIndex(c => c.Id == stored.Id);
+        if (idx >= 0) updatedCharacters[idx] = stored; else updatedCharacters.Add(stored);
+
+        // Preserve SelectedCharacterId and any fields written by concurrent raider updates.
+        return raider with { Characters = updatedCharacters };
     }
 
     /// <summary>

--- a/api/Repositories/RaiderDocumentConcurrency.cs
+++ b/api/Repositories/RaiderDocumentConcurrency.cs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+namespace Lfm.Api.Repositories;
+
+internal static class RaiderDocumentConcurrency
+{
+    private const int MaxAttempts = 3;
+
+    public static async Task<RaiderDocument?> ReplaceWithRetryAsync(
+        IRaidersRepository repo,
+        RaiderDocument initial,
+        Func<RaiderDocument, RaiderDocument> apply,
+        CancellationToken ct)
+    {
+        var current = initial;
+        for (var attempt = 1; ; attempt++)
+        {
+            var updated = apply(current);
+            if (string.IsNullOrEmpty(current.ETag))
+            {
+                await repo.UpsertAsync(updated, ct);
+                return updated;
+            }
+
+            try
+            {
+                return await repo.ReplaceAsync(updated, current.ETag, ct);
+            }
+            catch (ConcurrencyConflictException) when (attempt < MaxAttempts)
+            {
+                var latest = await repo.GetByBattleNetIdAsync(current.BattleNetId, ct);
+                if (latest is null)
+                    return null;
+
+                current = latest;
+            }
+        }
+    }
+}

--- a/api/Services/CharacterPortraitService.cs
+++ b/api/Services/CharacterPortraitService.cs
@@ -47,6 +47,8 @@ public sealed class CharacterPortraitService(
             : new List<StoredSelectedCharacter>();
         var result = new Dictionary<string, string>();
         var toFetch = new List<(string Region, string Realm, string Name, string Id)>();
+        var characterUpdates = new Dictionary<string, StoredSelectedCharacter>(StringComparer.OrdinalIgnoreCase);
+        var portraitUpdates = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         var cacheUpdated = false;
 
         foreach (var req in requests)
@@ -67,12 +69,15 @@ public sealed class CharacterPortraitService(
                 result[characterId] = storedPortraitUrl;
                 if (stored is not null && stored.PortraitUrl != storedPortraitUrl)
                 {
-                    characters[storedIndex] = stored with { PortraitUrl = storedPortraitUrl };
+                    var updatedStored = stored with { PortraitUrl = storedPortraitUrl };
+                    characters[storedIndex] = updatedStored;
+                    characterUpdates[characterId] = updatedStored;
                     cacheUpdated = true;
                 }
                 if (!portraitCache.TryGetValue(characterId, out var existingCached) || existingCached != storedPortraitUrl)
                 {
                     portraitCache[characterId] = storedPortraitUrl;
+                    portraitUpdates[characterId] = storedPortraitUrl;
                     cacheUpdated = true;
                 }
                 continue;
@@ -84,7 +89,9 @@ public sealed class CharacterPortraitService(
                 result[characterId] = cachedUrl;
                 if (stored is not null && stored.PortraitUrl != cachedUrl)
                 {
-                    characters[storedIndex] = stored with { PortraitUrl = cachedUrl };
+                    var updatedStored = stored with { PortraitUrl = cachedUrl };
+                    characters[storedIndex] = updatedStored;
+                    characterUpdates[characterId] = updatedStored;
                     cacheUpdated = true;
                 }
                 continue;
@@ -118,6 +125,7 @@ public sealed class CharacterPortraitService(
                 {
                     result[outcome.Id] = outcome.Url;
                     portraitCache[outcome.Id] = outcome.Url;
+                    portraitUpdates[outcome.Id] = outcome.Url;
                     cacheUpdated = true;
                 }
             }
@@ -126,16 +134,47 @@ public sealed class CharacterPortraitService(
         // Persist raider if cache was updated.
         if (cacheUpdated)
         {
-            var updated = raider with
-            {
-                Characters = characters,
-                PortraitCache = portraitCache,
-                Ttl = 180 * 86400,
-            };
-            await repo.UpsertAsync(updated, ct);
+            await RaiderDocumentConcurrency.ReplaceWithRetryAsync(
+                repo,
+                raider,
+                current => WithPortraitUpdates(current, characterUpdates.Values, portraitUpdates),
+                ct);
         }
 
         return new PortraitResponse(result);
+    }
+
+    private static RaiderDocument WithPortraitUpdates(
+        RaiderDocument raider,
+        IEnumerable<StoredSelectedCharacter> characterUpdates,
+        IReadOnlyDictionary<string, string> portraitUpdates)
+    {
+        IReadOnlyList<StoredSelectedCharacter>? mergedCharacters = raider.Characters;
+        var updates = characterUpdates.ToList();
+        if (updates.Count > 0)
+        {
+            var characters = (raider.Characters ?? []).ToList();
+            foreach (var updatedCharacter in updates)
+            {
+                var idx = characters.FindIndex(c => c.Id == updatedCharacter.Id);
+                if (idx >= 0) characters[idx] = updatedCharacter; else characters.Add(updatedCharacter);
+            }
+
+            mergedCharacters = characters;
+        }
+
+        var mergedPortraitCache = raider.PortraitCache is not null
+            ? new Dictionary<string, string>(raider.PortraitCache)
+            : new Dictionary<string, string>();
+        foreach (var kvp in portraitUpdates)
+            mergedPortraitCache[kvp.Key] = kvp.Value;
+
+        return raider with
+        {
+            Characters = mergedCharacters,
+            PortraitCache = mergedPortraitCache,
+            Ttl = 180 * 86400,
+        };
     }
 
     // ---------------------------------------------------------------------------

--- a/tests/Lfm.Api.Tests/RaiderCharacterEnrichFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RaiderCharacterEnrichFunctionTests.cs
@@ -81,6 +81,53 @@ public class RaiderCharacterEnrichFunctionTests
     }
 
     [Fact]
+    public async Task Retries_conflicting_character_write_and_preserves_latest_characters()
+    {
+        var initial = MakeRaider(
+            accountChars: [("stormreaver", "Shalena")],
+            etag: "\"etag-1\"");
+        var latest = MakeRaider(
+            characters: [StoredCharacter("eu-stormreaver-valoneito", "Valoneito")],
+            accountChars: [("stormreaver", "Shalena")],
+            etag: "\"etag-2\"");
+        var readCall = 0;
+        var replaceCall = 0;
+        RaiderDocument? retriedWrite = null;
+
+        var repo = new Mock<IRaidersRepository>(MockBehavior.Strict);
+        repo.Setup(r => r.GetByBattleNetIdAsync("bnet-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => ++readCall == 1 ? initial : latest);
+        repo.Setup(r => r.ReplaceAsync(
+                It.IsAny<RaiderDocument>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<RaiderDocument, string, CancellationToken>((doc, _, _) =>
+            {
+                replaceCall++;
+                if (replaceCall == 1)
+                    throw new ConcurrencyConflictException();
+
+                retriedWrite = doc;
+                return Task.FromResult(doc with { ETag = "\"etag-3\"" });
+            });
+
+        var fn = MakeFunction(repo.Object, MakeProfileClient().Object);
+        var result = await fn.Run(MakeRequest(), CharId, MakeCtx(), CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Equal(2, replaceCall);
+        Assert.NotNull(retriedWrite);
+        Assert.Contains(retriedWrite.Characters!, c => c.Id == CharId);
+        Assert.Contains(retriedWrite.Characters!, c => c.Id == "eu-stormreaver-valoneito");
+        repo.Verify(r => r.ReplaceAsync(
+            It.Is<RaiderDocument>(d => d.Characters != null
+                && d.Characters.Any(c => c.Id == CharId)
+                && d.Characters.Any(c => c.Id == "eu-stormreaver-valoneito")),
+            "\"etag-2\"",
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public async Task Calls_Blizzard_with_dashed_realm_slug_intact()
     {
         const string dashedId = "eu-the-maelstrom-kalmatar";
@@ -207,7 +254,8 @@ public class RaiderCharacterEnrichFunctionTests
     private static RaiderDocument MakeRaider(
         string? selected = null,
         IReadOnlyList<StoredSelectedCharacter>? characters = null,
-        IEnumerable<(string Realm, string Name)>? accountChars = null)
+        IEnumerable<(string Realm, string Name)>? accountChars = null,
+        string? etag = null)
         => new(
             Id: "bnet-1", BattleNetId: "bnet-1",
             SelectedCharacterId: selected, Locale: null,
@@ -218,7 +266,15 @@ public class RaiderCharacterEnrichFunctionTests
                     Characters: accountChars.Select(c =>
                         new StoredBlizzardAccountCharacter(
                             Name: c.Name, Level: 80,
-                            Realm: new StoredBlizzardRealmRef(Slug: c.Realm))).ToList())]));
+                            Realm: new StoredBlizzardRealmRef(Slug: c.Realm))).ToList())]),
+            ETag: etag);
+
+    private static StoredSelectedCharacter StoredCharacter(string id, string name) =>
+        new(
+            Id: id,
+            Region: "eu",
+            Realm: "stormreaver",
+            Name: name);
 
     private static Mock<IBlizzardProfileClient> MakeProfileClient()
     {

--- a/tests/Lfm.Api.Tests/Services/CharacterPortraitServiceTests.cs
+++ b/tests/Lfm.Api.Tests/Services/CharacterPortraitServiceTests.cs
@@ -24,10 +24,9 @@ public class CharacterPortraitServiceTests
             => Task.FromResult(response);
     }
 
-    private static CharacterPortraitService MakeService(HttpMessageHandler handler)
+    private static CharacterPortraitService MakeService(HttpMessageHandler handler, IRaidersRepository? repo = null)
     {
         var httpClient = new HttpClient(handler);
-        var repo = new Mock<IRaidersRepository>().Object;
         var opts = Microsoft.Extensions.Options.Options.Create(new BlizzardOptions
         {
             ClientId = "id",
@@ -36,7 +35,7 @@ public class CharacterPortraitServiceTests
             RedirectUri = "https://example.com/callback",
             AppBaseUrl = "https://example.com",
         });
-        return new CharacterPortraitService(repo, httpClient, opts);
+        return new CharacterPortraitService(repo ?? new Mock<IRaidersRepository>().Object, httpClient, opts);
     }
 
     // -------------------------------------------------------------------------
@@ -98,5 +97,78 @@ public class CharacterPortraitServiceTests
         // The portrait is unresolved but the call succeeds.
         Assert.NotNull(result);
         Assert.False(result.Portraits.ContainsKey("eu-silvermoon-legolas"));
+    }
+
+    [Fact]
+    public async Task ResolveAsync_retries_conflicting_cache_write_and_preserves_latest_characters()
+    {
+        var initial = new RaiderDocument(
+            Id: "bnet-1",
+            BattleNetId: "bnet-1",
+            SelectedCharacterId: null,
+            Locale: null,
+            ETag: "\"etag-1\"");
+        var latest = initial with
+        {
+            Characters =
+            [
+                new StoredSelectedCharacter(
+                    Id: "eu-stormreaver-valoneito",
+                    Region: "eu",
+                    Realm: "stormreaver",
+                    Name: "Valoneito")
+            ],
+            ETag = "\"etag-2\"",
+        };
+        var repo = new Mock<IRaidersRepository>(MockBehavior.Strict);
+        repo.Setup(r => r.GetByBattleNetIdAsync("bnet-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(latest);
+
+        var replaceCall = 0;
+        RaiderDocument? retriedWrite = null;
+        repo.Setup(r => r.ReplaceAsync(
+                It.IsAny<RaiderDocument>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<RaiderDocument, string, CancellationToken>((doc, _, _) =>
+            {
+                replaceCall++;
+                if (replaceCall == 1)
+                    throw new ConcurrencyConflictException();
+
+                retriedWrite = doc;
+                return Task.FromResult(doc with { ETag = "\"etag-3\"" });
+            });
+
+        var payload = """
+            {"assets":[{"key":"avatar","value":"https://render.worldofwarcraft.com/eu/avatar.jpg"}]}
+            """;
+        var service = MakeService(
+            new StubHandler(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(payload),
+            }),
+            repo.Object);
+
+        var result = await service.ResolveAsync(
+            initial,
+            [new CharacterPortraitRequest(Region: "eu", Realm: "stormreaver", Name: "Shalena")],
+            "fake-token",
+            CancellationToken.None);
+
+        Assert.Equal("https://render.worldofwarcraft.com/eu/avatar.jpg", result.Portraits["eu-stormreaver-shalena"]);
+        Assert.Equal(2, replaceCall);
+        Assert.NotNull(retriedWrite);
+        Assert.Contains(retriedWrite.Characters!, c => c.Id == "eu-stormreaver-valoneito");
+        Assert.Equal(
+            "https://render.worldofwarcraft.com/eu/avatar.jpg",
+            retriedWrite.PortraitCache!["eu-stormreaver-shalena"]);
+        repo.Verify(r => r.ReplaceAsync(
+            It.Is<RaiderDocument>(d => d.Characters != null
+                && d.Characters.Any(c => c.Id == "eu-stormreaver-valoneito")
+                && d.PortraitCache != null
+                && d.PortraitCache.ContainsKey("eu-stormreaver-shalena")),
+            "\"etag-2\"",
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 }


### PR DESCRIPTION
## Summary
- use ETag-based replace/retry when enriching raider characters
- merge portrait cache updates onto the latest raider document instead of overwriting concurrent character changes
- cover both conflict paths with API unit tests

## Verification
- `env CI=true dotnet restore lfm.sln -m:1`
- `dotnet build lfm.sln -c Release --no-restore`
- `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release --no-restore`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `git diff --check main...HEAD`
- `git ls-files -ci --exclude-standard`
- `git rev-list --merges --count main..HEAD`