### PR TITLE
Refine runs desktop layout

### DIFF
--- a/app/Pages/RunsPage.razor
+++ b/app/Pages/RunsPage.razor
@@ -160,103 +160,110 @@
                         var attending = selectedRun.RunCharacters.Where(c => RunVisualization.IsAttending(c.ReviewedAttendance)).ToList();
                         var notAttending = selectedRun.RunCharacters.Where(c => c.ReviewedAttendance is "OUT" or "AWAY").ToList();
 
-                        <div class="run-detail-stack">
-                            <FluentCard>
-                                <section class="run-detail-summary" data-testid="run-detail-summary">
-                                    <div class="run-detail-header">
-                                        <div class="run-detail-heading">
-                                            <h2 class="run-detail-title">@RenderTitle(selectedRun.InstanceName)</h2>
-                                            @if (!string.IsNullOrWhiteSpace(selectedRun.Description))
-                                            {
-                                                <p class="run-detail-description">@selectedRun.Description</p>
-                                            }
+                        <div class="run-detail-workbench" data-testid="run-detail-workbench">
+                            <div class="run-detail-main" data-testid="run-detail-main">
+                                <FluentCard>
+                                    <section class="run-detail-summary" data-testid="run-detail-summary">
+                                        <div class="run-detail-header">
+                                            <div class="run-detail-heading">
+                                                <h2 class="run-detail-title">@RenderTitle(selectedRun.InstanceName)</h2>
+                                                @if (!string.IsNullOrWhiteSpace(selectedRun.Description))
+                                                {
+                                                    <p class="run-detail-description">@selectedRun.Description</p>
+                                                }
+                                            </div>
+                                            <DifficultyPill Difficulty="@selectedRun.Difficulty" />
+                                            <FluentButton Appearance="Appearance.Outline"
+                                                          OnClick="@(() => Nav.NavigateTo($"/runs/{Uri.EscapeDataString(selectedRun.Id)}/edit"))"
+                                                          Disabled="@IsSignupClosed(selectedRun.SignupCloseTime)">
+                                                @Loc["runs.edit"]
+                                            </FluentButton>
                                         </div>
-                                        <DifficultyPill Difficulty="@selectedRun.Difficulty" />
-                                        <FluentButton Appearance="Appearance.Outline"
-                                                      OnClick="@(() => Nav.NavigateTo($"/runs/{Uri.EscapeDataString(selectedRun.Id)}/edit"))"
-                                                      Disabled="@IsSignupClosed(selectedRun.SignupCloseTime)">
-                                            @Loc["runs.edit"]
-                                        </FluentButton>
-                                    </div>
 
-                                    <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="16" Wrap="true" Class="run-detail-meta">
-                                        <span><strong>@Loc["runs.start"]</strong> @FormatDate(selectedRun.StartTime)</span>
-                                        <span><strong>@Loc["runs.signupCloses"]</strong> @FormatDate(selectedRun.SignupCloseTime)</span>
-                                        <span><strong>@Loc["runs.guild"]</strong> @selectedRun.CreatorGuild</span>
-                                    </FluentStack>
-                                </section>
-                            </FluentCard>
+                                        <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="16" Wrap="true" Class="run-detail-meta">
+                                            <span><strong>@Loc["runs.start"]</strong> @FormatDate(selectedRun.StartTime)</span>
+                                            <span><strong>@Loc["runs.signupCloses"]</strong> @FormatDate(selectedRun.SignupCloseTime)</span>
+                                            <span><strong>@Loc["runs.guild"]</strong> @selectedRun.CreatorGuild</span>
+                                        </FluentStack>
+                                    </section>
+                                </FluentCard>
 
-                            <section class="run-signup-surface" data-testid="run-signup-surface">
-                                <RunSignupPanel RunId="@selectedRun.Id"
-                                                CurrentSignup="@currentSignup"
-                                                Characters="@_signupCharacters"
-                                                SignupClosed="@IsSignupClosed(selectedRun.SignupCloseTime)"
-                                                OptionsLoading="@_signupOptionsLoading"
-                                                OptionsForbidden="@_signupOptionsForbidden"
-                                                PreferredCharacterId="@_preferredSignupCharacterId"
-                                                CurrentSpecIconUrl="@SpecIconUrlFor(currentSignup)"
-                                                SignupError="@_signupError"
-                                                SignupSubmitting="@_signupSubmitting"
-                                                CancelSubmitting="@_cancelSubmitting"
-                                                OnSignup="@SubmitSignup"
-                                                OnCancelConfirmed="@CancelSignup"
-                                                OnOptionsRequested="@EnsureSignupOptionsLoaded" />
-                            </section>
-
-                            <section class="run-roster @(selectedRun.RunCharacters.Count == 0 ? "run-roster--empty" : "")" data-testid="run-roster">
-                                @if (selectedRun.RunCharacters.Count == 0)
-                                {
-                                    <h3 class="roster-section-title" data-testid="roster-attending-title">
-                                        @Loc["runs.attendingSection"] (0)
-                                    </h3>
-                                    <div class="run-roster-empty">
-                                        <FluentLabel>@Loc["runs.noSignups"]</FluentLabel>
-                                    </div>
-                                }
-                                else
-                                {
-                                    @if (attending.Count > 0)
+                                <section class="run-roster @(selectedRun.RunCharacters.Count == 0 ? "run-roster--empty" : "")" data-testid="run-roster">
+                                    @if (selectedRun.RunCharacters.Count == 0)
                                     {
                                         <h3 class="roster-section-title" data-testid="roster-attending-title">
-                                            @Loc["runs.attendingSection"] (@attending.Count)
+                                            @Loc["runs.attendingSection"] (0)
                                         </h3>
-                                        <div class="roster-role-grid">
-                                            @foreach (var (roleKey, roleLabel) in RoleColumns)
-                                            {
-                                                var roleChars = attending.Where(c => RunVisualization.NormalizeRole(c.Role) == roleKey).ToList();
-                                                <div class="roster-role-column">
-                                                    <h4 class="roster-role-column-title">@roleLabel (@roleChars.Count)</h4>
-                                                    @if (roleChars.Count == 0)
-                                                    {
-                                                        <div class="roster-role-empty">@Loc["runs.role.empty"]</div>
-                                                    }
-                                                    else
-                                                    {
-                                                        @foreach (var character in roleChars)
-                                                        {
-                                                            <CharacterRow @key="@(character.CharacterRealm + "/" + character.CharacterName)" Character="character" />
-                                                        }
-                                                    }
-                                                </div>
-                                            }
+                                        <div class="run-roster-empty">
+                                            <FluentLabel>@Loc["runs.noSignups"]</FluentLabel>
                                         </div>
                                     }
-
-                                    @if (notAttending.Count > 0)
+                                    else
                                     {
-                                        <h3 class="roster-section-title" data-testid="roster-not-attending-title">
-                                            @Loc["runs.notAttendingSection"] (@notAttending.Count)
-                                        </h3>
-                                        <div class="roster-rows">
-                                            @foreach (var character in notAttending)
-                                            {
-                                                <CharacterRow @key="@(character.CharacterRealm + "/" + character.CharacterName)" Character="character" />
-                                            }
-                                        </div>
+                                        @if (attending.Count > 0)
+                                        {
+                                            <h3 class="roster-section-title" data-testid="roster-attending-title">
+                                                @Loc["runs.attendingSection"] (@attending.Count)
+                                            </h3>
+                                            <div class="roster-role-grid">
+                                                @foreach (var (roleKey, roleLabel) in RoleColumns)
+                                                {
+                                                    var roleChars = attending.Where(c => RunVisualization.NormalizeRole(c.Role) == roleKey).ToList();
+                                                    <div class="roster-role-column">
+                                                        <h4 class="roster-role-column-title" data-testid="roster-role-title-@RoleTitleTestId(roleKey)">
+                                                            @RoleTitleIcon(roleKey)
+                                                            <span>@roleLabel (@roleChars.Count)</span>
+                                                        </h4>
+                                                        @if (roleChars.Count == 0)
+                                                        {
+                                                            <div class="roster-role-empty">@Loc["runs.role.empty"]</div>
+                                                        }
+                                                        else
+                                                        {
+                                                            @foreach (var character in roleChars)
+                                                            {
+                                                                <CharacterRow @key="@(character.CharacterRealm + "/" + character.CharacterName)" Character="character" />
+                                                            }
+                                                        }
+                                                    </div>
+                                                }
+                                            </div>
+                                        }
+
+                                        @if (notAttending.Count > 0)
+                                        {
+                                            <h3 class="roster-section-title" data-testid="roster-not-attending-title">
+                                                @Loc["runs.notAttendingSection"] (@notAttending.Count)
+                                            </h3>
+                                            <div class="roster-rows">
+                                                @foreach (var character in notAttending)
+                                                {
+                                                    <CharacterRow @key="@(character.CharacterRealm + "/" + character.CharacterName)" Character="character" />
+                                                }
+                                            </div>
+                                        }
                                     }
-                                }
-                            </section>
+                                </section>
+                            </div>
+
+                            <aside class="run-signup-rail" data-testid="run-signup-rail">
+                                <section class="run-signup-surface" data-testid="run-signup-surface">
+                                    <RunSignupPanel RunId="@selectedRun.Id"
+                                                    CurrentSignup="@currentSignup"
+                                                    Characters="@_signupCharacters"
+                                                    SignupClosed="@IsSignupClosed(selectedRun.SignupCloseTime)"
+                                                    OptionsLoading="@_signupOptionsLoading"
+                                                    OptionsForbidden="@_signupOptionsForbidden"
+                                                    PreferredCharacterId="@_preferredSignupCharacterId"
+                                                    CurrentSpecIconUrl="@SpecIconUrlFor(currentSignup)"
+                                                    SignupError="@_signupError"
+                                                    SignupSubmitting="@_signupSubmitting"
+                                                    CancelSubmitting="@_cancelSubmitting"
+                                                    OnSignup="@SubmitSignup"
+                                                    OnCancelConfirmed="@CancelSignup"
+                                                    OnOptionsRequested="@EnsureSignupOptionsLoaded" />
+                                </section>
+                            </aside>
                         </div>
                     }
                     else
@@ -307,6 +314,31 @@
 
     private IEnumerable<(string Key, string Label)> RoleColumns =>
         RoleColumnKeys.Select(x => (x.Key, Loc[x.LocKey].Value));
+
+    private static string RoleTitleTestId(string roleKey) =>
+        roleKey.ToLowerInvariant();
+
+    private static RenderFragment RoleTitleIcon(string roleKey) => roleKey switch
+    {
+        "TANK" => @<svg class="roster-role-title__icon roster-role-title__icon--tank" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M12 3.5 19 6v5.3c0 4.3-2.6 7.5-7 9.2-4.4-1.7-7-4.9-7-9.2V6l7-2.5Z" />
+        </svg>,
+        "HEALER" => @<svg class="roster-role-title__icon roster-role-title__icon--healer" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <circle cx="12" cy="12" r="8.2" />
+            <path d="M12 7.4v9.2" />
+            <path d="M7.4 12h9.2" />
+        </svg>,
+        "DPS" => @<svg class="roster-role-title__icon roster-role-title__icon--dps" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <g class="roster-role-title__icon-dagger" transform="rotate(45 12 12)">
+                <path class="roster-role-title__icon-blade" d="M12 3.2 13.7 13.1 12 15.1 10.3 13.1 12 3.2Z" />
+                <path class="roster-role-title__icon-edge" d="M12 5.8v7.4" />
+                <path class="roster-role-title__icon-guard" d="M8.1 13.9h7.8" />
+                <path class="roster-role-title__icon-grip" d="M12 14.7v4.8" />
+                <circle class="roster-role-title__icon-pommel" cx="12" cy="20.5" r="0.9" />
+            </g>
+        </svg>,
+        _ => builder => { },
+    };
 
     protected override async Task OnInitializedAsync()
     {

--- a/app/Pages/RunsPage.razor.css
+++ b/app/Pages/RunsPage.razor.css
@@ -27,16 +27,17 @@
     display: none;
 }
 
-/* Two-column split once the detail pane can still keep a usable roster area.
-   The sidebar stays deliberately narrow so mid-width desktop windows do not
-   collapse back into a single oversized detail card. */
+/* Two-column shell once the detail pane can still keep a usable roster area.
+   Wider screens split the selected run again into center detail + signup rail. */
 @media (min-width: 56em) {
     .runs-layout {
-        flex-direction: row;
+        display: grid;
+        grid-template-columns: clamp(15.5rem, 24vw, 18rem) minmax(0, 1fr);
+        align-items: start;
     }
 
     .runs-sidebar {
-        inline-size: clamp(15.5rem, 26vw, 19rem);
+        inline-size: 100%;
     }
 }
 
@@ -262,11 +263,54 @@
     align-items: center;
 }
 
-.run-detail-stack {
+.run-detail-workbench {
     display: flex;
     flex-direction: column;
     gap: 16px;
     inline-size: 100%;
+}
+
+.run-detail-main {
+    display: contents;
+}
+
+.run-detail-main > fluent-card {
+    order: 0;
+}
+
+.run-signup-rail {
+    order: 1;
+    min-inline-size: 0;
+}
+
+.run-roster {
+    order: 2;
+}
+
+@media (min-width: 72em) {
+    .run-detail-workbench {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) clamp(23.5rem, 27vw, 25rem);
+        align-items: start;
+    }
+
+    .run-detail-main {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        min-inline-size: 0;
+    }
+
+    .run-detail-main > fluent-card,
+    .run-signup-rail,
+    .run-roster {
+        order: initial;
+    }
+
+    .run-signup-rail {
+        position: sticky;
+        inset-block-start: 16px;
+    }
 }
 
 .run-detail-summary {
@@ -342,19 +386,39 @@
     gap: 16px;
 }
 
-@media (min-width: 48em) {
-    .roster-role-grid {
-        grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
-    }
-}
-
 .roster-role-column-title {
+    display: flex;
+    align-items: center;
+    gap: 6px;
     text-transform: uppercase;
     letter-spacing: 0.05em;
     font-weight: 600;
     color: var(--neutral-foreground-hint-rest);
     font-size: 0.95em;
     margin: 0 0 8px 0;
+}
+
+.roster-role-title__icon {
+    flex: 0 0 auto;
+    inline-size: 1.15rem;
+    block-size: 1.15rem;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.8;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+.roster-role-title__icon--tank {
+    color: #7db7ff;
+}
+
+.roster-role-title__icon--healer {
+    color: #69d37d;
+}
+
+.roster-role-title__icon--dps {
+    color: #f06f64;
 }
 
 .roster-role-column {
@@ -374,9 +438,16 @@
 }
 
 .roster-rows {
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: 1fr;
     gap: 8px;
+}
+
+@media (min-width: 88em) {
+    .roster-role-grid,
+    .roster-rows {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
 }
 
 .run-roster-empty {

--- a/tests/Lfm.App.Tests/RunsPageCssContractTests.cs
+++ b/tests/Lfm.App.Tests/RunsPageCssContractTests.cs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Xunit;
+
+namespace Lfm.App.Tests;
+
+public class RunsPageCssContractTests
+{
+    [Fact]
+    public void Desktop_workbench_gives_signup_rail_room_for_one_row_attendance_toggle()
+    {
+        var css = File.ReadAllText(FindRepoFile("app", "Pages", "RunsPage.razor.css"));
+
+        Assert.Contains(
+            "grid-template-columns: minmax(0, 1fr) clamp(23.5rem, 27vw, 25rem);",
+            css);
+    }
+
+    [Fact]
+    public void Wide_roster_uses_matching_three_column_grids_for_attending_and_not_attending()
+    {
+        var css = File.ReadAllText(FindRepoFile("app", "Pages", "RunsPage.razor.css"));
+
+        Assert.Contains("@media (min-width: 88em)", css);
+        Assert.Contains(".roster-role-grid,\n    .roster-rows", css);
+        Assert.Contains("grid-template-columns: repeat(3, minmax(0, 1fr));", css);
+    }
+
+    [Fact]
+    public void Roster_role_icons_use_single_color_outline_styling()
+    {
+        var css = File.ReadAllText(FindRepoFile("app", "Pages", "RunsPage.razor.css"));
+
+        Assert.Contains("stroke: currentColor;", css);
+        Assert.Contains("fill: none;", css);
+        Assert.DoesNotContain(".roster-role-title__icon--dps .roster-role-title__icon-blade", css);
+        Assert.DoesNotContain(".roster-role-title__icon--dps .roster-role-title__icon-edge", css);
+        Assert.DoesNotContain("rgb(255 255 255", css);
+    }
+
+    private static string FindRepoFile(params string[] segments)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory != null)
+        {
+            var candidate = Path.Combine(new[] { directory.FullName }.Concat(segments).ToArray());
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new FileNotFoundException($"Could not find repository file {Path.Combine(segments)}.");
+    }
+}

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -1296,10 +1296,54 @@ public class RunsPagesTests : ComponentTestBase
         var roleColumns = cut.FindAll(".roster-role-column");
         Assert.Equal(3, roleColumns.Count);
 
+        var tankTitle = cut.Find("[data-testid='roster-role-title-tank']");
+        var healerTitle = cut.Find("[data-testid='roster-role-title-healer']");
+        var dpsTitle = cut.Find("[data-testid='roster-role-title-dps']");
+
+        Assert.Equal($"{Loc("runs.role.tank")} (1)", tankTitle.TextContent.Trim());
+        Assert.Equal($"{Loc("runs.role.healer")} (1)", healerTitle.TextContent.Trim());
+        Assert.Equal($"{Loc("runs.role.dps")} (1)", dpsTitle.TextContent.Trim());
+        AssertRoleIconIsInlineSvg(tankTitle, "tank");
+        AssertRoleIconIsInlineSvg(healerTitle, "healer");
+        var dpsIcon = AssertRoleIconIsInlineSvg(dpsTitle, "dps");
+        Assert.Single(tankTitle.QuerySelectorAll(".roster-role-title__icon--tank path"));
+        Assert.Null(dpsIcon.QuerySelector("polygon"));
+        var dpsDagger = dpsIcon.QuerySelector(".roster-role-title__icon-dagger");
+        Assert.NotNull(dpsDagger);
+        Assert.Equal("rotate(45 12 12)", dpsDagger.GetAttribute("transform"));
+        Assert.NotNull(dpsIcon.QuerySelector(".roster-role-title__icon-blade"));
+        Assert.NotNull(dpsIcon.QuerySelector(".roster-role-title__icon-edge"));
+        Assert.NotNull(dpsIcon.QuerySelector(".roster-role-title__icon-guard"));
+        Assert.NotNull(dpsIcon.QuerySelector(".roster-role-title__icon-grip"));
+        Assert.NotNull(dpsIcon.QuerySelector(".roster-role-title__icon-pommel"));
+
         var markup = cut.Markup;
+        Assert.DoesNotContain("images/wow/role-", markup);
+        Assert.DoesNotContain("render.worldofwarcraft.com/eu/icons/56/ability_warrior_defensivestance.jpg", markup);
+        Assert.DoesNotContain("render.worldofwarcraft.com/eu/icons/56/spell_holy_holybolt.jpg", markup);
+        Assert.DoesNotContain("render.worldofwarcraft.com/eu/icons/56/inv_weapon_shortblade_01.jpg", markup);
+        Assert.DoesNotContain("14.8 3.8 17.2 6.2", markup);
+        Assert.DoesNotContain("M16.9 3.4 20.6 7.1", markup);
+        Assert.DoesNotContain("M21 2.8", markup);
+        Assert.DoesNotContain("M12 2.6 15.6 12.7", markup);
+        Assert.Contains("M12 3.2 13.7 13.1", markup);
+        Assert.DoesNotContain("M16.2 3.8 20.2 7.8", markup);
+        Assert.DoesNotContain("M8.5 5.4 5.6 18.6", markup);
         Assert.Contains("Tankington", markup);
         Assert.Contains("Healsworth", markup);
         Assert.Contains("Dpsalot", markup);
+
+        static IElement AssertRoleIconIsInlineSvg(IElement title, string role)
+        {
+            Assert.Null(title.QuerySelector("img"));
+
+            var icon = title.QuerySelector($"svg.roster-role-title__icon--{role}")!;
+            Assert.NotNull(icon);
+            Assert.Equal("true", icon.GetAttribute("aria-hidden"));
+            Assert.Equal("false", icon.GetAttribute("focusable"));
+            Assert.Equal("0 0 24 24", icon.GetAttribute("viewBox"));
+            return icon;
+        }
     }
 
     [Fact]
@@ -1326,7 +1370,7 @@ public class RunsPagesTests : ComponentTestBase
     }
 
     [Fact]
-    public void RunsPage_Detail_Separates_Summary_Signup_And_Roster_Regions()
+    public void RunsPage_Detail_Uses_Workbench_Main_And_Signup_Rail()
     {
         var client = new Mock<IRunsClient>();
         client.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
@@ -1349,17 +1393,24 @@ public class RunsPagesTests : ComponentTestBase
         var summary = cut.Find("[data-testid='run-detail-summary']");
         var signup = cut.Find("[data-testid='run-signup-surface']");
         var roster = cut.Find("[data-testid='run-roster']");
+        var main = cut.Find("[data-testid='run-detail-main']");
+        var rail = cut.Find("[data-testid='run-signup-rail']");
 
         Assert.NotNull(summary.Closest("fluent-card"));
         Assert.Null(roster.Closest("fluent-card"));
+        Assert.NotNull(main);
+        Assert.NotNull(rail);
+        Assert.Equal("run-detail-main", summary.Closest("[data-testid='run-detail-main']")?.GetAttribute("data-testid"));
+        Assert.Equal("run-detail-main", roster.Closest("[data-testid='run-detail-main']")?.GetAttribute("data-testid"));
+        Assert.Equal("run-signup-rail", signup.Closest("[data-testid='run-signup-rail']")?.GetAttribute("data-testid"));
 
         var markup = cut.Markup;
         Assert.True(
             markup.IndexOf("data-testid=\"run-detail-summary\"", StringComparison.Ordinal) <
-            markup.IndexOf("data-testid=\"run-signup-surface\"", StringComparison.Ordinal));
-        Assert.True(
-            markup.IndexOf("data-testid=\"run-signup-surface\"", StringComparison.Ordinal) <
             markup.IndexOf("data-testid=\"run-roster\"", StringComparison.Ordinal));
+        Assert.True(
+            markup.IndexOf("data-testid=\"run-roster\"", StringComparison.Ordinal) <
+            markup.IndexOf("data-testid=\"run-signup-surface\"", StringComparison.Ordinal));
         Assert.Contains(Loc("runs.attendingSection"), roster.TextContent);
     }
 


### PR DESCRIPTION
## Summary
- Split the runs detail area into a main summary/roster column plus a signup rail for wider screens.
- Align attending and not-attending roster grids at the wide breakpoint.
- Add single-color inline role icons for roster role titles.

## Verification
- `dotnet format lfm.sln`
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release` (298 passed)
- `dotnet build lfm.sln -c Release` (0 warnings, 0 errors)
- `git diff --check`

## Notes
- Local preview artifacts under `output/` are not part of this PR.