### PR TITLE
Use muted role composition chips

### DIFF
--- a/app/Components/RoleIcon.razor
+++ b/app/Components/RoleIcon.razor
@@ -1,0 +1,47 @@
+<svg class="@IconClass" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+    @switch (NormalizedRole)
+    {
+        case "TANK":
+            <path d="M12 3.5 19 6v5.3c0 4.3-2.6 7.5-7 9.2-4.4-1.7-7-4.9-7-9.2V6l7-2.5Z" />
+            break;
+        case "HEALER":
+            <circle cx="12" cy="12" r="8.2" />
+            <path d="M12 7.4v9.2" />
+            <path d="M7.4 12h9.2" />
+            break;
+        default:
+            <g class="@ElementClass("dagger")" transform="rotate(45 12 12)">
+                <path class="@ElementClass("blade")" d="M12 3.2 13.7 13.1 12 15.1 10.3 13.1 12 3.2Z" />
+                <path class="@ElementClass("edge")" d="M12 5.8v7.4" />
+                <path class="@ElementClass("guard")" d="M8.1 13.9h7.8" />
+                <path class="@ElementClass("grip")" d="M12 14.7v4.8" />
+                <circle class="@ElementClass("pommel")" cx="12" cy="20.5" r="0.9" />
+            </g>
+            break;
+    }
+</svg>
+
+@code {
+    [Parameter] public string? Role { get; set; }
+    [Parameter] public string ClassPrefix { get; set; } = "role-icon";
+    [Parameter] public string? Class { get; set; }
+
+    private string NormalizedRole => (Role ?? "").ToUpperInvariant() switch
+    {
+        "TANK" => "TANK",
+        "HEALER" or "HEAL" => "HEALER",
+        _ => "DPS",
+    };
+
+    private string RoleClass => NormalizedRole.ToLowerInvariant();
+
+    private string IconClass =>
+        string.Join(" ", new[]
+        {
+            ClassPrefix,
+            $"{ClassPrefix}--{RoleClass}",
+            Class,
+        }.Where(c => !string.IsNullOrWhiteSpace(c)));
+
+    private string ElementClass(string name) => $"{ClassPrefix}-{name}";
+}

--- a/app/Components/RunListItem.razor
+++ b/app/Components/RunListItem.razor
@@ -26,16 +26,16 @@
         }
     </span>
     <span class="run-list-item__composition" aria-label="@_compositionAria">
-        <span class="run-list-item__roleslot @(_counts.Tank.IsShortage ? "run-list-item__roleslot--short" : "")">
-            <span class="run-list-item__rolekey">@Loc["runs.role.tank"]</span>
+        <span class="run-list-item__roleslot run-list-item__roleslot--tank" aria-label='@RoleSlotLabel("runs.role.tank", _counts.Tank)'>
+            <RoleIcon Role="TANK" ClassPrefix="run-list-item__roleicon" />
             @RenderCount(_counts.Tank)
         </span>
-        <span class="run-list-item__roleslot @(_counts.Healer.IsShortage ? "run-list-item__roleslot--short" : "")">
-            <span class="run-list-item__rolekey">@Loc["runs.role.healer"]</span>
+        <span class="run-list-item__roleslot run-list-item__roleslot--healer" aria-label='@RoleSlotLabel("runs.role.healer", _counts.Healer)'>
+            <RoleIcon Role="HEALER" ClassPrefix="run-list-item__roleicon" />
             @RenderCount(_counts.Healer)
         </span>
-        <span class="run-list-item__roleslot @(_counts.Dps.IsShortage ? "run-list-item__roleslot--short" : "")">
-            <span class="run-list-item__rolekey">@Loc["runs.role.dps"]</span>
+        <span class="run-list-item__roleslot run-list-item__roleslot--dps" aria-label='@RoleSlotLabel("runs.role.dps", _counts.Dps)'>
+            <RoleIcon Role="DPS" ClassPrefix="run-list-item__roleicon" />
             @RenderCount(_counts.Dps)
         </span>
     </span>
@@ -79,5 +79,8 @@
 
     private static string RenderCount(RoleCount slot) =>
         slot.Target > 0 ? $"{slot.Attending}/{slot.Target}" : slot.Attending.ToString();
+
+    private string RoleSlotLabel(string locKey, RoleCount slot) =>
+        $"{Loc[locKey].Value} {RenderCount(slot)}";
 
 }

--- a/app/Components/RunListItem.razor.css
+++ b/app/Components/RunListItem.razor.css
@@ -153,29 +153,37 @@
 
 .run-list-item__roleslot {
     display: inline-flex;
-    align-items: baseline;
-    gap: 4px;
-    padding-block: 1px;
-    padding-inline: 7px;
+    align-items: center;
+    gap: 5px;
+    padding-block: 2px;
+    padding-inline: 6px 7px;
     border-radius: 999px;
     background: var(--neutral-fill-rest);
+    border: 1px solid var(--neutral-stroke-rest);
+    color: var(--neutral-foreground-rest);
+    line-height: 1;
 }
 
-.run-list-item__roleslot--short {
-    /*
-     * #c0392b on white clears 5.44:1 (WCAG 2.2 AA); matches the existing
-     * attendance-pill--out shade so the "shortage" signal feels consistent.
-     */
-    color: #fff;
-    background: #c0392b;
+.run-list-item__roleslot--tank {
+    --run-list-role-color: #7db7ff;
 }
 
-.run-list-item__rolekey {
-    font-weight: 700;
-    font-size: 0.9em;
-    opacity: 0.75;
+.run-list-item__roleslot--healer {
+    --run-list-role-color: #69d37d;
 }
 
-.run-list-item__roleslot--short .run-list-item__rolekey {
-    opacity: 1;
+.run-list-item__roleslot--dps {
+    --run-list-role-color: #f06f64;
+}
+
+.run-list-item__roleslot ::deep .run-list-item__roleicon {
+    flex: 0 0 auto;
+    inline-size: 0.95rem;
+    block-size: 0.95rem;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.9;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    color: var(--run-list-role-color, currentColor);
 }

--- a/app/Pages/RunsPage.razor
+++ b/app/Pages/RunsPage.razor
@@ -211,7 +211,7 @@
                                                     var roleChars = attending.Where(c => RunVisualization.NormalizeRole(c.Role) == roleKey).ToList();
                                                     <div class="roster-role-column">
                                                         <h4 class="roster-role-column-title" data-testid="roster-role-title-@RoleTitleTestId(roleKey)">
-                                                            @RoleTitleIcon(roleKey)
+                                                            <RoleIcon Role="@roleKey" ClassPrefix="roster-role-title__icon" />
                                                             <span>@roleLabel (@roleChars.Count)</span>
                                                         </h4>
                                                         @if (roleChars.Count == 0)
@@ -317,28 +317,6 @@
 
     private static string RoleTitleTestId(string roleKey) =>
         roleKey.ToLowerInvariant();
-
-    private static RenderFragment RoleTitleIcon(string roleKey) => roleKey switch
-    {
-        "TANK" => @<svg class="roster-role-title__icon roster-role-title__icon--tank" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-            <path d="M12 3.5 19 6v5.3c0 4.3-2.6 7.5-7 9.2-4.4-1.7-7-4.9-7-9.2V6l7-2.5Z" />
-        </svg>,
-        "HEALER" => @<svg class="roster-role-title__icon roster-role-title__icon--healer" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-            <circle cx="12" cy="12" r="8.2" />
-            <path d="M12 7.4v9.2" />
-            <path d="M7.4 12h9.2" />
-        </svg>,
-        "DPS" => @<svg class="roster-role-title__icon roster-role-title__icon--dps" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-            <g class="roster-role-title__icon-dagger" transform="rotate(45 12 12)">
-                <path class="roster-role-title__icon-blade" d="M12 3.2 13.7 13.1 12 15.1 10.3 13.1 12 3.2Z" />
-                <path class="roster-role-title__icon-edge" d="M12 5.8v7.4" />
-                <path class="roster-role-title__icon-guard" d="M8.1 13.9h7.8" />
-                <path class="roster-role-title__icon-grip" d="M12 14.7v4.8" />
-                <circle class="roster-role-title__icon-pommel" cx="12" cy="20.5" r="0.9" />
-            </g>
-        </svg>,
-        _ => builder => { },
-    };
 
     protected override async Task OnInitializedAsync()
     {

--- a/app/Pages/RunsPage.razor.css
+++ b/app/Pages/RunsPage.razor.css
@@ -398,7 +398,7 @@
     margin: 0 0 8px 0;
 }
 
-.roster-role-title__icon {
+.roster-role-column-title ::deep .roster-role-title__icon {
     flex: 0 0 auto;
     inline-size: 1.15rem;
     block-size: 1.15rem;
@@ -409,15 +409,15 @@
     stroke-linejoin: round;
 }
 
-.roster-role-title__icon--tank {
+.roster-role-column-title ::deep .roster-role-title__icon--tank {
     color: #7db7ff;
 }
 
-.roster-role-title__icon--healer {
+.roster-role-column-title ::deep .roster-role-title__icon--healer {
     color: #69d37d;
 }
 
-.roster-role-title__icon--dps {
+.roster-role-column-title ::deep .roster-role-title__icon--dps {
     color: #f06f64;
 }
 

--- a/tests/Lfm.App.Tests/RunsPageCssContractTests.cs
+++ b/tests/Lfm.App.Tests/RunsPageCssContractTests.cs
@@ -39,6 +39,19 @@ public class RunsPageCssContractTests
         Assert.DoesNotContain("rgb(255 255 255", css);
     }
 
+    [Fact]
+    public void Run_list_composition_chips_are_muted_indicators_not_alerts()
+    {
+        var css = File.ReadAllText(FindRepoFile("app", "Components", "RunListItem.razor.css"));
+
+        Assert.Contains(".run-list-item__roleicon", css);
+        Assert.Contains(".run-list-item__roleslot--tank", css);
+        Assert.Contains(".run-list-item__roleslot--healer", css);
+        Assert.Contains(".run-list-item__roleslot--dps", css);
+        Assert.DoesNotContain(".run-list-item__roleslot--short", css);
+        Assert.DoesNotContain("#c0392b", css);
+    }
+
     private static string FindRepoFile(params string[] segments)
     {
         var directory = new DirectoryInfo(AppContext.BaseDirectory);

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -331,7 +331,7 @@ public class RunsPagesTests : ComponentTestBase
     }
 
     [Fact]
-    public void RunsPage_RunListItem_Uses_Readable_Composition_Labels()
+    public void RunsPage_RunListItem_Uses_Muted_Role_Icon_Composition_Chips()
     {
         var client = new Mock<IRunsClient>();
         client.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
@@ -342,12 +342,32 @@ public class RunsPagesTests : ComponentTestBase
 
         cut.WaitForAssertion(() =>
         {
-            var roleKeys = cut.FindAll(".run-list-item__rolekey").Select(e => e.TextContent.Trim()).ToArray();
-            Assert.Contains(Loc("runs.role.tank"), roleKeys);
-            Assert.Contains(Loc("runs.role.healer"), roleKeys);
-            Assert.Contains(Loc("runs.role.dps"), roleKeys);
-            Assert.DoesNotContain(Loc("runs.roleShort.tank"), roleKeys);
+            var roleSlots = cut.FindAll(".run-list-item__roleslot");
+            Assert.Equal(3, roleSlots.Count);
+            Assert.Empty(cut.FindAll(".run-list-item__rolekey"));
+
+            AssertRunListRoleChip(cut, "tank", Loc("runs.role.tank"), "0/2");
+            AssertRunListRoleChip(cut, "healer", Loc("runs.role.healer"), "0/5");
+            AssertRunListRoleChip(cut, "dps", Loc("runs.role.dps"), "0/18");
         });
+
+        static void AssertRunListRoleChip(
+            IRenderedComponent<RunsPage> cut,
+            string role,
+            string label,
+            string count)
+        {
+            var chip = cut.Find($".run-list-item__roleslot--{role}");
+            Assert.Contains(count, chip.TextContent);
+            Assert.Contains(label, chip.GetAttribute("aria-label") ?? "");
+            Assert.Contains(count, chip.GetAttribute("aria-label") ?? "");
+
+            var icon = chip.QuerySelector($"svg.run-list-item__roleicon--{role}")!;
+            Assert.NotNull(icon);
+            Assert.Equal("true", icon.GetAttribute("aria-hidden"));
+            Assert.Equal("false", icon.GetAttribute("focusable"));
+            Assert.Equal("0 0 24 24", icon.GetAttribute("viewBox"));
+        }
     }
 
     [Fact]
@@ -1537,9 +1557,8 @@ public class RunsPagesTests : ComponentTestBase
     {
         var client = new Mock<IRunsClient>();
         // Seed 2 DPS attending (IN) and 1 DPS OUT in a MYTHIC 25-man raid.
-        // Standard composition target for 25-man is 2T / 5H / 18D, so the
-        // rendered composition summary is "Tank 0/2 · Healer 0/5 · DPS 2/18" with the
-        // tank + healer slots carrying the shortage modifier class.
+        // Standard composition target for 25-man is 2T / 5H / 18D, but the
+        // run-list chips are indicative, muted counts rather than red quota warnings.
         var summary = MakeSummary() with { Difficulty = "MYTHIC", Size = 25 };
         client.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<RunSummaryDto>
@@ -1568,11 +1587,9 @@ public class RunsPagesTests : ComponentTestBase
         Assert.Contains("0/5", composition.TextContent);
         Assert.Contains("2/18", composition.TextContent);
 
-        // All three role slots are under-target for this partially-filled
-        // 25-man so each carries the shortage modifier.
         var slots = cut.FindAll(".run-list-item__roleslot");
         Assert.Equal(3, slots.Count);
-        Assert.All(slots, s => Assert.Contains("run-list-item__roleslot--short", s.ClassName ?? ""));
+        Assert.All(slots, s => Assert.DoesNotContain("run-list-item__roleslot--short", s.ClassName ?? ""));
 
         // Difficulty + kind drive data-attributes on the item so CSS can
         // stripe the left edge from `data-kind` without inline style

--- a/tests/Lfm.E2E/Pages/RunsPage.cs
+++ b/tests/Lfm.E2E/Pages/RunsPage.cs
@@ -66,6 +66,9 @@ public class RunsPage(IPage page)
     public ILocator RoleLabel(string label) =>
         _page.GetByText(label, new() { Exact = true });
 
+    public ILocator RunCompositionRoleChip(string runId, string role) =>
+        RunItem(runId).Locator($".run-list-item__roleslot--{role}");
+
     public ILocator OpenRoleSlots =>
         _page.GetByText("Open slot", new() { Exact = true });
 

--- a/tests/Lfm.E2E/Specs/RunsSpec.cs
+++ b/tests/Lfm.E2E/Specs/RunsSpec.cs
@@ -9,6 +9,7 @@ using Lfm.E2E.Seeds;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Playwright;
 using System.Globalization;
+using System.Text.RegularExpressions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -58,12 +59,15 @@ public class RunsSpec(RunsFixture fixture, ITestOutputHelper output)
 
         await Assertions.Expect(runsPage.EmptyDetailTitle).ToBeVisibleAsync(new() { Timeout = 10000 });
         await Assertions.Expect(runsPage.SelectRunPlaceholder).ToBeVisibleAsync(new() { Timeout = 10000 });
-        await Assertions.Expect(runsPage.RoleLabel("Tank").First).ToBeVisibleAsync(new() { Timeout = 10000 });
-        await Assertions.Expect(runsPage.RoleLabel("Healer").First).ToBeVisibleAsync(new() { Timeout = 10000 });
-        await Assertions.Expect(runsPage.RoleLabel("DPS").First).ToBeVisibleAsync(new() { Timeout = 10000 });
 
         // Seed data has at least one run
         await Assertions.Expect(runsPage.RunItem(DefaultSeed.TestRunId)).ToBeVisibleAsync(new() { Timeout = 15000 });
+        await Assertions.Expect(runsPage.RunCompositionRoleChip(DefaultSeed.TestRunId, "tank"))
+            .ToHaveAttributeAsync("aria-label", new Regex(@"^Tank \d+/\d+$"), new() { Timeout = 10000 });
+        await Assertions.Expect(runsPage.RunCompositionRoleChip(DefaultSeed.TestRunId, "healer"))
+            .ToHaveAttributeAsync("aria-label", new Regex(@"^Healer \d+/\d+$"), new() { Timeout = 10000 });
+        await Assertions.Expect(runsPage.RunCompositionRoleChip(DefaultSeed.TestRunId, "dps"))
+            .ToHaveAttributeAsync("aria-label", new Regex(@"^DPS \d+/\d+$"), new() { Timeout = 10000 });
     }
 
     // E2E scope: proves creating a run through the browser appears in list and detail views.


### PR DESCRIPTION
## Summary
- replace red under-target run-list composition pills with muted role icon chips
- extract the role SVGs into a reusable `RoleIcon` component shared by the roster and run list
- add bUnit/CSS/E2E contracts covering icon chips and no shortage alert styling

## Verification
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release` (299 passed)
- `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --filter "FullyQualifiedName~RunsPage_Loads_DisplaysRunList"` (1 passed)
- `dotnet build lfm.sln -c Release`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `git diff --check`

## Notes
- Full local E2E is currently blocked by `RunsSpec.EditRun_ModifyFields_ChangesReflected`; the same isolated spec fails on clean `main`, so it is not introduced by this PR.