### PR TITLE
Remove detail difficulty pill

### DIFF
--- a/app/Pages/RunsPage.razor
+++ b/app/Pages/RunsPage.razor
@@ -172,7 +172,6 @@
                                                     <p class="run-detail-description">@selectedRun.Description</p>
                                                 }
                                             </div>
-                                            <DifficultyPill Difficulty="@selectedRun.Difficulty" />
                                             <FluentButton Appearance="Appearance.Outline"
                                                           OnClick="@(() => Nav.NavigateTo($"/runs/{Uri.EscapeDataString(selectedRun.Id)}/edit"))"
                                                           Disabled="@IsSignupClosed(selectedRun.SignupCloseTime)">

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -1435,6 +1435,26 @@ public class RunsPagesTests : ComponentTestBase
     }
 
     [Fact]
+    public void RunsPage_DetailSummary_DoesNotRenderDifficultyPill()
+    {
+        var client = new Mock<IRunsClient>();
+        client.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<RunSummaryDto> { MakeSummary() with { Difficulty = "MYTHIC" } });
+        client.Setup(c => c.GetAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeDetail() with { Difficulty = "MYTHIC" });
+        Services.AddSingleton(client.Object);
+        WireSignupSupport(client);
+
+        var cut = Render<RunsPage>(p => p.Add(x => x.RunId, "run-1"));
+
+        cut.WaitForAssertion(() =>
+        {
+            var summary = cut.Find("[data-testid='run-detail-summary']");
+            Assert.Empty(summary.QuerySelectorAll(".difficulty-pill"));
+        });
+    }
+
+    [Fact]
     public void RunsPage_RunCards_Render_Mobile_Detail_Toggles()
     {
         var client = new Mock<IRunsClient>();


### PR DESCRIPTION
## Summary
- remove the selected run detail difficulty pill so difficulty is not duplicated beside the run list card
- add a bUnit regression that the detail summary does not render `.difficulty-pill`

## Verification
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release`
- `dotnet build lfm.sln -c Release`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `git diff --check`