### PR TITLE
Stretch signup attendance toggle

### DIFF
--- a/app/Components/Runs/RunSignupPanel.razor.css
+++ b/app/Components/Runs/RunSignupPanel.razor.css
@@ -82,7 +82,12 @@
 }
 
 ::deep .run-signup-attendance-toggle {
+    inline-size: 100%;
     max-inline-size: 100%;
+}
+
+::deep .run-signup-attendance-toggle .toggle-group__option {
+    flex: 1 1 0;
 }
 
 .run-signup-form__actions {

--- a/tests/Lfm.App.Tests/RunsPageCssContractTests.cs
+++ b/tests/Lfm.App.Tests/RunsPageCssContractTests.cs
@@ -18,6 +18,17 @@ public class RunsPageCssContractTests
     }
 
     [Fact]
+    public void Signup_attendance_toggle_fills_available_panel_width()
+    {
+        var css = File.ReadAllText(FindRepoFile("app", "Components", "Runs", "RunSignupPanel.razor.css"));
+
+        Assert.Contains("::deep .run-signup-attendance-toggle", css);
+        Assert.Contains("inline-size: 100%;", css);
+        Assert.Contains("::deep .run-signup-attendance-toggle .toggle-group__option", css);
+        Assert.Contains("flex: 1 1 0;", css);
+    }
+
+    [Fact]
     public void Wide_roster_uses_matching_three_column_grids_for_attending_and_not_attending()
     {
         var css = File.ReadAllText(FindRepoFile("app", "Pages", "RunsPage.razor.css"));


### PR DESCRIPTION
## Summary
- Stretch the run signup attendance toggle to fill the signup panel width.
- Flex each attendance segment evenly so the panel margins read balanced.
- Add a CSS contract test for the signup toggle width rule.

## Verification
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --no-restore`
- `dotnet build lfm.sln -c Release --no-restore`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `git diff --check`

## Screenshots
- Not captured; this is a narrow CSS alignment change verified by the CSS contract test and compiled Blazor build.