### PR TITLE
Fix role quota pills

### DIFF
--- a/app/Components/RunListItem.razor
+++ b/app/Components/RunListItem.razor
@@ -59,12 +59,13 @@
     protected override void OnParametersSet()
     {
         _difficultyClass = RunVisualization.GetDifficultyClass(Run.Difficulty);
-        _kindClass = RunVisualization.GetKindClass(RunVisualization.GetKind(Run.Size));
+        var kind = RunVisualization.GetKind(Run.Size);
+        _kindClass = RunVisualization.GetKindClass(kind);
         var currentUserSignup = Run.RunCharacters.FirstOrDefault(c => c.IsCurrentUser);
         _isMe = currentUserSignup is not null;
         _isCurrentUserClass = _isMe ? "true" : "false";
         _currentUserAttendanceClass = RunVisualization.GetAttendanceClass(currentUserSignup?.ReviewedAttendance);
-        _counts = RunVisualization.CountRoles(Run.RunCharacters, Run.Size);
+        _counts = RunVisualization.CountRoles(Run.RunCharacters, kind, Run.Difficulty, Run.Size);
         // Mythic+ "any dungeon" runs carry no InstanceName; fall back to a
         // localized label so the list entry isn't missing a heading.
         _title = string.IsNullOrEmpty(Run.InstanceName)

--- a/app/Lfm.App.Core/Runs/RunVisualization.cs
+++ b/app/Lfm.App.Core/Runs/RunVisualization.cs
@@ -31,6 +31,11 @@ public readonly record struct RunRoleCounts(RoleCount Tank, RoleCount Healer, Ro
 
 public static class RunVisualization
 {
+    private const int MinimumRaidSize = 10;
+    private const int MaximumRaidSize = 30;
+    private const int MythicRaidSize = 20;
+    private const int RaidTankTarget = 2;
+
     public static RunKind GetKind(int size) => size switch
     {
         <= 0 => RunKind.Unknown,
@@ -54,15 +59,40 @@ public static class RunVisualization
         _ => "unknown",
     };
 
-    public static (int Tank, int Healer, int Dps) GetRoleTargets(int size) => size switch
+    public static (int Tank, int Healer, int Dps) GetRoleTargets(int size) =>
+        GetRoleTargets(GetKind(size), difficulty: null, size);
+
+    public static (int Tank, int Healer, int Dps) GetRoleTargets(
+        RunKind kind,
+        string? difficulty,
+        int size)
     {
-        5 => (1, 1, 3),
-        10 => (2, 2, 6),
-        20 => (2, 4, 14),
-        25 => (2, 5, 18),
-        30 => (2, 6, 22),
-        _ => (0, 0, 0),
-    };
+        if (kind == RunKind.Dungeon)
+        {
+            return (1, 1, 3);
+        }
+
+        if (kind != RunKind.Raid)
+        {
+            return (0, 0, 0);
+        }
+
+        var targetSize = difficulty == "MYTHIC" ? MythicRaidSize : size;
+        return GetRaidRoleTargets(targetSize);
+    }
+
+    private static (int Tank, int Healer, int Dps) GetRaidRoleTargets(int size)
+    {
+        return size switch
+        {
+            < MinimumRaidSize or > MaximumRaidSize => (0, 0, 0),
+            <= 10 => (RaidTankTarget, 2, 6),
+            <= 14 => (RaidTankTarget, 3, 9),
+            <= 20 => (RaidTankTarget, 4, 14),
+            <= 25 => (RaidTankTarget, 5, 18),
+            _ => (RaidTankTarget, 6, 22),
+        };
+    }
 
     public static bool IsAttending(string? reviewedAttendance) =>
         reviewedAttendance is "IN" or "LATE" or "BENCH";
@@ -85,10 +115,15 @@ public static class RunVisualization
         _ => "DPS",
     };
 
-    public static RunRoleCounts CountRoles(IEnumerable<RunCharacterDto> characters, int size)
-    {
-        var (tTarget, hTarget, dTarget) = GetRoleTargets(size);
+    public static RunRoleCounts CountRoles(IEnumerable<RunCharacterDto> characters, int size) =>
+        CountRoles(characters, GetKind(size), difficulty: null, size);
 
+    public static RunRoleCounts CountRoles(
+        IEnumerable<RunCharacterDto> characters,
+        RunKind kind,
+        string? difficulty,
+        int size)
+    {
         int tAttend = 0, hAttend = 0, dAttend = 0;
         foreach (var c in characters)
         {
@@ -103,6 +138,11 @@ public static class RunVisualization
                 default: dAttend++; break;
             }
         }
+
+        var targetSize = difficulty == "MYTHIC"
+            ? MythicRaidSize
+            : Math.Clamp(tAttend + hAttend + dAttend, MinimumRaidSize, MaximumRaidSize);
+        var (tTarget, hTarget, dTarget) = GetRoleTargets(kind, difficulty, targetSize);
 
         return new RunRoleCounts(
             new RoleCount(tAttend, tTarget),

--- a/tests/Lfm.App.Core.Tests/Runs/RunVisualizationTests.cs
+++ b/tests/Lfm.App.Core.Tests/Runs/RunVisualizationTests.cs
@@ -25,18 +25,29 @@ public class RunVisualizationTests
     [Theory]
     [InlineData(5, 1, 1, 3)]
     [InlineData(10, 2, 2, 6)]
+    [InlineData(11, 2, 3, 9)]
+    [InlineData(14, 2, 3, 9)]
+    [InlineData(15, 2, 4, 14)]
     [InlineData(20, 2, 4, 14)]
+    [InlineData(21, 2, 5, 18)]
     [InlineData(25, 2, 5, 18)]
+    [InlineData(26, 2, 6, 22)]
     [InlineData(30, 2, 6, 22)]
     [InlineData(0, 0, 0, 0)]
     [InlineData(40, 0, 0, 0)]
-    public void GetRoleTargets_returns_standard_comp(int size, int tanks, int healers, int dps)
+    public void GetRoleTargets_returns_role_quota_targets(int size, int tanks, int healers, int dps)
     {
         Assert.Equal((tanks, healers, dps), RunVisualization.GetRoleTargets(size));
     }
 
     [Fact]
-    public void CountRoles_counts_attending_per_role_and_fills_targets()
+    public void GetRoleTargets_uses_twenty_player_targets_for_mythic_raids()
+    {
+        Assert.Equal((2, 4, 14), RunVisualization.GetRoleTargets(RunKind.Raid, "MYTHIC", size: 25));
+    }
+
+    [Fact]
+    public void CountRoles_counts_attending_per_role_and_fills_mythic_targets()
     {
         var chars = new List<RunCharacterDto>
         {
@@ -50,7 +61,7 @@ public class RunVisualizationTests
             MakeChar(null, "IN"),
         };
 
-        var counts = RunVisualization.CountRoles(chars, size: 20);
+        var counts = RunVisualization.CountRoles(chars, RunKind.Raid, "MYTHIC", size: 20);
 
         Assert.Equal(1, counts.Tank.Attending);
         Assert.Equal(2, counts.Tank.Target);
@@ -58,6 +69,66 @@ public class RunVisualizationTests
         Assert.Equal(4, counts.Healer.Target);
         Assert.Equal(2, counts.Dps.Attending);
         Assert.Equal(14, counts.Dps.Target);
+    }
+
+    [Fact]
+    public void CountRoles_uses_current_flexible_raid_signup_count_for_targets()
+    {
+        var chars = new List<RunCharacterDto>
+        {
+            MakeChar("TANK", "IN"),
+            MakeChar("TANK", "IN"),
+            MakeChar("HEALER", "IN"),
+            MakeChar("HEALER", "IN"),
+            MakeChar("HEALER", "IN"),
+        };
+        chars.AddRange(Enumerable.Range(0, 9).Select(_ => MakeChar("DPS", "IN")));
+
+        var counts = RunVisualization.CountRoles(chars, RunKind.Raid, "HEROIC", size: 25);
+
+        Assert.Equal(2, counts.Tank.Target);
+        Assert.Equal(3, counts.Healer.Target);
+        Assert.Equal(9, counts.Dps.Target);
+    }
+
+    [Fact]
+    public void CountRoles_moves_flexible_raid_to_next_recommended_preset()
+    {
+        var chars = new List<RunCharacterDto>
+        {
+            MakeChar("TANK", "IN"),
+            MakeChar("TANK", "IN"),
+            MakeChar("HEALER", "IN"),
+            MakeChar("HEALER", "IN"),
+            MakeChar("HEALER", "IN"),
+        };
+        chars.AddRange(Enumerable.Range(0, 10).Select(_ => MakeChar("DPS", "IN")));
+
+        var counts = RunVisualization.CountRoles(chars, RunKind.Raid, "HEROIC", size: 25);
+
+        Assert.Equal(2, counts.Tank.Target);
+        Assert.Equal(4, counts.Healer.Target);
+        Assert.Equal(14, counts.Dps.Target);
+    }
+
+    [Fact]
+    public void CountRoles_counts_dungeon_roles_with_dungeon_targets()
+    {
+        var chars = new List<RunCharacterDto>
+        {
+            MakeChar("TANK", "IN"),
+            MakeChar("HEALER", "IN"),
+            MakeChar("DPS", "IN"),
+        };
+
+        var counts = RunVisualization.CountRoles(chars, RunKind.Dungeon, "MYTHIC_KEYSTONE", size: 5);
+
+        Assert.Equal(1, counts.Tank.Attending);
+        Assert.Equal(1, counts.Tank.Target);
+        Assert.Equal(1, counts.Healer.Attending);
+        Assert.Equal(1, counts.Healer.Target);
+        Assert.Equal(1, counts.Dps.Attending);
+        Assert.Equal(3, counts.Dps.Target);
     }
 
     [Fact]

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -347,8 +347,8 @@ public class RunsPagesTests : ComponentTestBase
             Assert.Empty(cut.FindAll(".run-list-item__rolekey"));
 
             AssertRunListRoleChip(cut, "tank", Loc("runs.role.tank"), "0/2");
-            AssertRunListRoleChip(cut, "healer", Loc("runs.role.healer"), "0/5");
-            AssertRunListRoleChip(cut, "dps", Loc("runs.role.dps"), "0/18");
+            AssertRunListRoleChip(cut, "healer", Loc("runs.role.healer"), "0/2");
+            AssertRunListRoleChip(cut, "dps", Loc("runs.role.dps"), "0/6");
         });
 
         static void AssertRunListRoleChip(
@@ -1576,9 +1576,9 @@ public class RunsPagesTests : ComponentTestBase
     public void RunsPage_RunListItem_RendersDifficultyPillAndCompositionSummary()
     {
         var client = new Mock<IRunsClient>();
-        // Seed 2 DPS attending (IN) and 1 DPS OUT in a MYTHIC 25-man raid.
-        // Standard composition target for 25-man is 2T / 5H / 18D, but the
-        // run-list chips are indicative, muted counts rather than red quota warnings.
+        // Seed 2 DPS attending (IN) and 1 DPS OUT in a MYTHIC raid. Mythic
+        // raids are fixed at 20 players, even when stale data carries a
+        // different size.
         var summary = MakeSummary() with { Difficulty = "MYTHIC", Size = 25 };
         client.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<RunSummaryDto>
@@ -1604,8 +1604,8 @@ public class RunsPagesTests : ComponentTestBase
 
         var composition = cut.Find(".run-list-item__composition");
         Assert.Contains("0/2", composition.TextContent);
-        Assert.Contains("0/5", composition.TextContent);
-        Assert.Contains("2/18", composition.TextContent);
+        Assert.Contains("0/4", composition.TextContent);
+        Assert.Contains("2/14", composition.TextContent);
 
         var slots = cut.FindAll(".run-list-item__roleslot");
         Assert.Equal(3, slots.Count);
@@ -1620,6 +1620,74 @@ public class RunsPagesTests : ComponentTestBase
         Assert.Equal("mythic", item.GetAttribute("data-difficulty"));
         Assert.Equal("raid", item.GetAttribute("data-kind"));
         Assert.False(item.HasAttribute("style"));
+    }
+
+    [Fact]
+    public void RunsPage_RunListItem_UsesFlexibleRaidRoleTargets()
+    {
+        var client = new Mock<IRunsClient>();
+        var signups = new List<RunCharacterDto>
+        {
+            MakeCharacter("Shielda", role: "TANK"),
+            MakeCharacter("Guardia", role: "TANK"),
+            MakeCharacter("Mendor", role: "HEALER"),
+            MakeCharacter("Bloom", role: "HEALER"),
+            MakeCharacter("Serene", role: "HEALER"),
+        };
+        signups.AddRange(Enumerable.Range(1, 10).Select(i => MakeCharacter($"Bolt{i}", role: "DPS")));
+
+        var summary = MakeSummary() with { Difficulty = "HEROIC", Size = 25 };
+        client.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<RunSummaryDto>
+            {
+                summary with
+                {
+                    RunCharacters = signups,
+                },
+            });
+        Services.AddSingleton(client.Object);
+
+        var cut = Render<RunsPage>();
+
+        cut.WaitForAssertion(() =>
+        {
+            var composition = cut.Find(".run-list-item__composition");
+            Assert.Contains("2/2", composition.TextContent);
+            Assert.Contains("3/4", composition.TextContent);
+            Assert.Contains("10/14", composition.TextContent);
+        });
+    }
+
+    [Fact]
+    public void RunsPage_RunListItem_ShowsDungeonRoleCountsWithDungeonTargets()
+    {
+        var client = new Mock<IRunsClient>();
+        var summary = MakeSummary() with { Difficulty = "MYTHIC_KEYSTONE", Size = 5 };
+        client.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<RunSummaryDto>
+            {
+                summary with
+                {
+                    InstanceName = null,
+                    RunCharacters = new List<RunCharacterDto>
+                    {
+                        MakeCharacter("Shielda", role: "TANK"),
+                        MakeCharacter("Mendor", role: "HEALER"),
+                        MakeCharacter("Bolt", role: "DPS"),
+                    },
+                },
+            });
+        Services.AddSingleton(client.Object);
+
+        var cut = Render<RunsPage>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("1/1", cut.Find(".run-list-item__roleslot--tank").TextContent);
+            Assert.Contains("1/1", cut.Find(".run-list-item__roleslot--healer").TextContent);
+            Assert.Contains("1/3", cut.Find(".run-list-item__roleslot--dps").TextContent);
+            Assert.Equal("dungeon", cut.Find("button.run-list-item").GetAttribute("data-kind"));
+        });
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- compare run-list role pills against explicit role target presets
- keep dungeon targets at 1/1/3 and Mythic raids at 2/4/14
- snap flexible raid targets to recommended preset buckets based on current attending signups

## Verification
- dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release
- dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release
- dotnet format lfm.sln --verify-no-changes --no-restore --severity error
- dotnet build lfm.sln -c Release

## Screenshots
- Not captured; behavior is covered by component and core tests.