### PR TITLE
Detect expired auth sessions immediately

### DIFF
--- a/app/App.razor
+++ b/app/App.razor
@@ -6,6 +6,7 @@
                    ModeChanged="@OnModeChanged"
                    StorageName="lfm-theme">
     <CascadingAuthenticationState>
+        <AuthSessionMonitor />
         <Router AppAssembly="@typeof(App).Assembly" NotFoundPage="typeof(Pages.NotFound)">
             <Found Context="routeData">
                 @if (RequiresGuildSetupGate(routeData))

--- a/app/Components/AuthSessionMonitor.razor
+++ b/app/Components/AuthSessionMonitor.razor
@@ -1,0 +1,80 @@
+@implements IAsyncDisposable
+@inject IJSRuntime JS
+@inject NavigationManager Nav
+@inject IAuthStateRefresher AuthStateRefresher
+@inject ISessionExpiryNotifier SessionExpiryNotifier
+
+@code {
+    private readonly string _registrationId = $"auth-session-monitor-{Guid.NewGuid():N}";
+    private DotNetObjectReference<AuthSessionMonitor>? _dotNetRef;
+    private bool _disposed;
+
+    protected override void OnInitialized()
+    {
+        SessionExpiryNotifier.SessionExpired += HandleSessionExpired;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+            return;
+
+        _dotNetRef = DotNetObjectReference.Create(this);
+        try
+        {
+            await JS.InvokeVoidAsync("lfmRegisterAuthResumeProbe", _registrationId, _dotNetRef);
+        }
+        catch (JSDisconnectedException)
+        {
+        }
+    }
+
+    [JSInvokable]
+    public Task CheckSessionAsync()
+    {
+        if (!_disposed && AuthStateRefresher.HasAuthenticatedSession)
+            AuthStateRefresher.RefreshAuthenticationState();
+
+        return Task.CompletedTask;
+    }
+
+    private void HandleSessionExpired() => _ = InvokeAsync(ExpireAndRedirect);
+
+    private void ExpireAndRedirect()
+    {
+        if (_disposed || !AuthStateRefresher.HasAuthenticatedSession)
+            return;
+
+        AuthStateRefresher.MarkSessionExpired();
+        var currentPath = new Uri(Nav.Uri).PathAndQuery;
+        if (IsLoginOrAuthFailurePath(currentPath))
+            return;
+
+        Nav.NavigateTo($"/login?redirect={Uri.EscapeDataString(currentPath)}", replace: true);
+    }
+
+    private static bool IsLoginOrAuthFailurePath(string path) =>
+        path.StartsWith("/login", StringComparison.OrdinalIgnoreCase) ||
+        path.StartsWith("/auth/failure", StringComparison.OrdinalIgnoreCase);
+
+    public async ValueTask DisposeAsync()
+    {
+        _disposed = true;
+        SessionExpiryNotifier.SessionExpired -= HandleSessionExpired;
+
+        if (_dotNetRef is null)
+            return;
+
+        try
+        {
+            await JS.InvokeVoidAsync("lfmUnregisterAuthResumeProbe", _registrationId);
+        }
+        catch (JSDisconnectedException)
+        {
+        }
+        finally
+        {
+            _dotNetRef.Dispose();
+        }
+    }
+}

--- a/app/Lfm.App.Core/Auth/AppAuthenticationStateProvider.cs
+++ b/app/Lfm.App.Core/Auth/AppAuthenticationStateProvider.cs
@@ -21,6 +21,11 @@ public sealed class AppAuthenticationStateProvider(IMeClient meClient, ILocaleSe
     public const string SelectedCharacterPortraitUrlClaim = "selected_character_portrait_url";
 
     private AuthenticationState? _cached;
+    private static readonly AuthenticationState AnonymousState =
+        new(new ClaimsPrincipal(new ClaimsIdentity()));
+
+    public bool HasAuthenticatedSession =>
+        _cached?.User.Identity?.IsAuthenticated == true;
 
     public override async Task<AuthenticationState> GetAuthenticationStateAsync()
     {
@@ -33,7 +38,7 @@ public sealed class AppAuthenticationStateProvider(IMeClient meClient, ILocaleSe
             // Do not cache the anonymous result — a transient network failure
             // or cold-start race must not cement the user as anonymous for the
             // rest of the session. Let the next call retry MeClient.
-            return new AuthenticationState(new ClaimsPrincipal(new ClaimsIdentity()));
+            return AnonymousState;
         }
 
         // Apply the user's persisted locale preference (overrides browser detection).
@@ -72,5 +77,11 @@ public sealed class AppAuthenticationStateProvider(IMeClient meClient, ILocaleSe
     {
         _cached = null;
         NotifyAuthenticationStateChanged(GetAuthenticationStateAsync());
+    }
+
+    public void MarkSessionExpired()
+    {
+        _cached = AnonymousState;
+        NotifyAuthenticationStateChanged(Task.FromResult(_cached));
     }
 }

--- a/app/Lfm.App.Core/Auth/IAuthStateRefresher.cs
+++ b/app/Lfm.App.Core/Auth/IAuthStateRefresher.cs
@@ -8,5 +8,7 @@ namespace Lfm.App.Auth;
 /// </summary>
 public interface IAuthStateRefresher
 {
+    bool HasAuthenticatedSession { get; }
     void RefreshAuthenticationState();
+    void MarkSessionExpired();
 }

--- a/app/Lfm.App.Core/Auth/ISessionExpiryNotifier.cs
+++ b/app/Lfm.App.Core/Auth/ISessionExpiryNotifier.cs
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+namespace Lfm.App.Auth;
+
+public interface ISessionExpiryNotifier
+{
+    event Action? SessionExpired;
+    void NotifySessionExpired();
+}

--- a/app/Lfm.App.Core/Auth/SessionExpiryNotifier.cs
+++ b/app/Lfm.App.Core/Auth/SessionExpiryNotifier.cs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+namespace Lfm.App.Auth;
+
+public sealed class SessionExpiryNotifier : ISessionExpiryNotifier
+{
+    public event Action? SessionExpired;
+
+    public void NotifySessionExpired() => SessionExpired?.Invoke();
+}

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -59,6 +59,7 @@ builder.Services.AddScoped<IBattleNetClient, BattleNetClient>();
 builder.Services.AddScoped<UnsavedChangesGuard>();
 
 builder.Services.AddAuthorizationCore();
+builder.Services.AddScoped<ISessionExpiryNotifier, SessionExpiryNotifier>();
 builder.Services.AddScoped<AppAuthenticationStateProvider>();
 builder.Services.AddScoped<AuthenticationStateProvider>(sp => sp.GetRequiredService<AppAuthenticationStateProvider>());
 builder.Services.AddScoped<IAuthStateRefresher>(sp => sp.GetRequiredService<AppAuthenticationStateProvider>());

--- a/app/Services/CredentialsHandler.cs
+++ b/app/Services/CredentialsHandler.cs
@@ -3,16 +3,21 @@
 
 using System.Net.Http;
 using Microsoft.AspNetCore.Components.WebAssembly.Http;
+using Lfm.App.Auth;
 
 namespace Lfm.App.Services;
 
-public sealed class CredentialsHandler : DelegatingHandler
+public sealed class CredentialsHandler(ISessionExpiryNotifier sessionExpiryNotifier) : DelegatingHandler
 {
-    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
     {
         // Include cookies on all requests — required when the API is on a different
         // origin (different port) from the Blazor WASM app.
         request.SetBrowserRequestCredentials(BrowserRequestCredentials.Include);
-        return base.SendAsync(request, ct);
+        var response = await base.SendAsync(request, ct);
+        if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+            sessionExpiryNotifier.NotifySessionExpired();
+
+        return response;
     }
 }

--- a/app/wwwroot/js/lfm-interop.js
+++ b/app/wwwroot/js/lfm-interop.js
@@ -28,3 +28,51 @@ window.lfmGetStoredTheme = function () {
         return null;
     }
 };
+
+window.lfmRegisterAuthResumeProbe = function (id, dotNetRef) {
+    window.__lfmAuthResumeProbes = window.__lfmAuthResumeProbes || new Map();
+    window.lfmUnregisterAuthResumeProbe(id);
+
+    let pending = false;
+    const trigger = function () {
+        if (pending) {
+            return;
+        }
+
+        pending = true;
+        Promise.resolve(dotNetRef.invokeMethodAsync('CheckSessionAsync'))
+            .catch(function () { })
+            .finally(function () {
+                pending = false;
+            });
+    };
+    const triggerWhenVisible = function () {
+        if (document.visibilityState === 'visible') {
+            trigger();
+        }
+    };
+
+    window.addEventListener('focus', trigger);
+    window.addEventListener('pageshow', trigger);
+    window.addEventListener('online', trigger);
+    document.addEventListener('visibilitychange', triggerWhenVisible);
+
+    window.__lfmAuthResumeProbes.set(id, {
+        trigger,
+        triggerWhenVisible
+    });
+};
+
+window.lfmUnregisterAuthResumeProbe = function (id) {
+    const probes = window.__lfmAuthResumeProbes;
+    if (!probes || !probes.has(id)) {
+        return;
+    }
+
+    const registration = probes.get(id);
+    window.removeEventListener('focus', registration.trigger);
+    window.removeEventListener('pageshow', registration.trigger);
+    window.removeEventListener('online', registration.trigger);
+    document.removeEventListener('visibilitychange', registration.triggerWhenVisible);
+    probes.delete(id);
+};

--- a/tests/Lfm.App.Core.Tests/Auth/AppAuthenticationStateProviderTests.cs
+++ b/tests/Lfm.App.Core.Tests/Auth/AppAuthenticationStateProviderTests.cs
@@ -6,6 +6,7 @@ using Lfm.App.Auth;
 using Lfm.App.i18n;
 using Lfm.App.Services;
 using Lfm.Contracts.Me;
+using Microsoft.AspNetCore.Components.Authorization;
 using Moq;
 using Xunit;
 
@@ -215,5 +216,38 @@ public class AppAuthenticationStateProviderTests
         sut.NotifyStateChanged();
 
         Assert.True(eventFired);
+    }
+
+    [Fact]
+    public async Task HasAuthenticatedSession_tracks_only_cached_authenticated_state()
+    {
+        var meClient = new Mock<IMeClient>();
+        meClient.Setup(c => c.GetAsync(It.IsAny<CancellationToken>())).ReturnsAsync(MakeMe());
+        var sut = new AppAuthenticationStateProvider(meClient.Object, Mock.Of<ILocaleService>());
+
+        Assert.False(sut.HasAuthenticatedSession);
+
+        await sut.GetAuthenticationStateAsync();
+
+        Assert.True(sut.HasAuthenticatedSession);
+    }
+
+    [Fact]
+    public async Task MarkSessionExpired_clears_cached_state_and_notifies_anonymous_without_refetch()
+    {
+        var meClient = new Mock<IMeClient>();
+        meClient.Setup(c => c.GetAsync(It.IsAny<CancellationToken>())).ReturnsAsync(MakeMe());
+        var sut = new AppAuthenticationStateProvider(meClient.Object, Mock.Of<ILocaleService>());
+        await sut.GetAuthenticationStateAsync();
+        Task<AuthenticationState>? notifiedState = null;
+        sut.AuthenticationStateChanged += state => notifiedState = state;
+
+        sut.MarkSessionExpired();
+
+        Assert.False(sut.HasAuthenticatedSession);
+        Assert.NotNull(notifiedState);
+        var state = await notifiedState!;
+        Assert.False(state.User.Identity!.IsAuthenticated);
+        meClient.Verify(c => c.GetAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/tests/Lfm.App.Tests/AuthSessionMonitorTests.cs
+++ b/tests/Lfm.App.Tests/AuthSessionMonitorTests.cs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Net;
+using Bunit;
+using Bunit.TestDoubles;
+using Lfm.App.Auth;
+using Lfm.App.Components;
+using Lfm.App.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Lfm.App.Tests;
+
+public class AuthSessionMonitorTests : ComponentTestBase
+{
+    [Fact]
+    public void SessionExpired_with_cached_authenticated_session_redirects_to_login_and_clears_auth_state()
+    {
+        var notifier = new SessionExpiryNotifier();
+        var refresher = new RecordingAuthStateRefresher(hasAuthenticatedSession: true);
+        Services.AddSingleton<ISessionExpiryNotifier>(notifier);
+        Services.AddSingleton<IAuthStateRefresher>(refresher);
+        var nav = Services.GetRequiredService<BunitNavigationManager>();
+        nav.NavigateTo("/runs/abc?tab=signups");
+        Render<AuthSessionMonitor>();
+
+        notifier.NotifySessionExpired();
+
+        Assert.False(refresher.HasAuthenticatedSession);
+        Assert.Equal(1, refresher.MarkExpiredCount);
+        Assert.EndsWith("/login?redirect=%2Fruns%2Fabc%3Ftab%3Dsignups", nav.Uri);
+        Assert.True(nav.History.First().Options.ReplaceHistoryEntry);
+    }
+
+    [Fact]
+    public void SessionExpired_without_cached_authenticated_session_does_not_redirect()
+    {
+        var notifier = new SessionExpiryNotifier();
+        var refresher = new RecordingAuthStateRefresher(hasAuthenticatedSession: false);
+        Services.AddSingleton<ISessionExpiryNotifier>(notifier);
+        Services.AddSingleton<IAuthStateRefresher>(refresher);
+        var nav = Services.GetRequiredService<BunitNavigationManager>();
+        nav.NavigateTo("/");
+        Render<AuthSessionMonitor>();
+
+        notifier.NotifySessionExpired();
+
+        Assert.Equal("http://localhost/", nav.Uri);
+        Assert.Equal(0, refresher.MarkExpiredCount);
+    }
+
+    [Fact]
+    public async Task Resume_probe_refreshes_auth_state_only_when_cached_session_exists()
+    {
+        var notifier = new SessionExpiryNotifier();
+        var refresher = new RecordingAuthStateRefresher(hasAuthenticatedSession: true);
+        Services.AddSingleton<ISessionExpiryNotifier>(notifier);
+        Services.AddSingleton<IAuthStateRefresher>(refresher);
+        var cut = Render<AuthSessionMonitor>();
+
+        await cut.Instance.CheckSessionAsync();
+        refresher.HasAuthenticatedSession = false;
+        await cut.Instance.CheckSessionAsync();
+
+        Assert.Equal(1, refresher.RefreshCount);
+    }
+
+    [Fact]
+    public async Task CredentialsHandler_notifies_session_expiry_on_401_response()
+    {
+        var notifier = new SessionExpiryNotifier();
+        var notified = 0;
+        notifier.SessionExpired += () => notified++;
+        using var handler = new CredentialsHandler(notifier)
+        {
+            InnerHandler = new StaticResponseHandler(HttpStatusCode.Unauthorized),
+        };
+        using var client = new HttpClient(handler);
+
+        using var response = await client.GetAsync("http://localhost/api/v1/runs");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Equal(1, notified);
+    }
+
+    [Fact]
+    public async Task CredentialsHandler_does_not_notify_session_expiry_on_403_response()
+    {
+        var notifier = new SessionExpiryNotifier();
+        var notified = 0;
+        notifier.SessionExpired += () => notified++;
+        using var handler = new CredentialsHandler(notifier)
+        {
+            InnerHandler = new StaticResponseHandler(HttpStatusCode.Forbidden),
+        };
+        using var client = new HttpClient(handler);
+
+        using var response = await client.GetAsync("http://localhost/api/v1/guild/admin");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.Equal(0, notified);
+    }
+
+    private sealed class RecordingAuthStateRefresher(bool hasAuthenticatedSession) : IAuthStateRefresher
+    {
+        public bool HasAuthenticatedSession { get; set; } = hasAuthenticatedSession;
+        public int RefreshCount { get; private set; }
+        public int MarkExpiredCount { get; private set; }
+
+        public void RefreshAuthenticationState() => RefreshCount++;
+
+        public void MarkSessionExpired()
+        {
+            MarkExpiredCount++;
+            HasAuthenticatedSession = false;
+        }
+    }
+
+    private sealed class StaticResponseHandler(HttpStatusCode statusCode) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(statusCode));
+    }
+}

--- a/tests/Lfm.App.Tests/CharactersPagesTests.cs
+++ b/tests/Lfm.App.Tests/CharactersPagesTests.cs
@@ -496,8 +496,14 @@ public class CharactersPagesTests : ComponentTestBase
 
     private sealed class ActionAuthStateRefresher(Action refresh) : IAuthStateRefresher
     {
+        public bool HasAuthenticatedSession => true;
+
         public void RefreshAuthenticationState() =>
             refresh();
+
+        public void MarkSessionExpired()
+        {
+        }
     }
 
     [Theory]

--- a/tests/Lfm.App.Tests/RenderWithProviders.cs
+++ b/tests/Lfm.App.Tests/RenderWithProviders.cs
@@ -47,6 +47,7 @@ public abstract class ComponentTestBase : BunitContext
         Services.AddSingleton<IMeClient, DefaultMeClient>();
         Services.AddSingleton<IBattleNetClient, DefaultBattleNetClient>();
         Services.AddSingleton<ISpecializationsClient, DefaultSpecializationsClient>();
+        Services.AddSingleton<ISessionExpiryNotifier, SessionExpiryNotifier>();
         Services.AddSingleton<IAuthStateRefresher, NoopAuthStateRefresher>();
     }
 
@@ -112,7 +113,13 @@ internal sealed class DefaultSpecializationsClient : ISpecializationsClient
 
 internal sealed class NoopAuthStateRefresher : IAuthStateRefresher
 {
+    public bool HasAuthenticatedSession => false;
+
     public void RefreshAuthenticationState()
+    {
+    }
+
+    public void MarkSessionExpired()
     {
     }
 }


### PR DESCRIPTION
## Summary
- add a central session-expiry notifier for API `401` responses
- probe the cached auth state when the browser returns to the app
- redirect expired authenticated sessions to login while preserving the current route

## Verification
- `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release --no-restore`
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --no-restore`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `dotnet build lfm.sln -c Release`
- `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --no-restore --filter "FullyQualifiedName~ExpiredSessionCookie_AccessingProtectedRoute_RedirectsToLogin"`

No screenshots: this change is auth-state behavior rather than a layout change.