### PR TITLE
Fix local reference refresh

### DIFF
--- a/api/Services/BlobReferenceClient.cs
+++ b/api/Services/BlobReferenceClient.cs
@@ -22,6 +22,9 @@ public sealed class BlobReferenceClient(BlobContainerClient container) : IBlobRe
         MissingMemberHandling = MissingMemberHandling.Ignore,
     };
 
+    private readonly SemaphoreSlim _ensureContainerLock = new(1, 1);
+    private bool _containerEnsured;
+
     public async Task<T?> GetAsync<T>(string blobName, CancellationToken ct) where T : class
     {
         var blob = container.GetBlobClient(blobName);
@@ -72,6 +75,7 @@ public sealed class BlobReferenceClient(BlobContainerClient container) : IBlobRe
         var json = JsonConvert.SerializeObject(payload, JsonSettings);
         var bytes = System.Text.Encoding.UTF8.GetBytes(json);
         using var stream = new MemoryStream(bytes);
+        await EnsureContainerExistsAsync(ct);
         var blob = container.GetBlobClient(blobName);
         await blob.UploadAsync(
             stream,
@@ -83,6 +87,24 @@ public sealed class BlobReferenceClient(BlobContainerClient container) : IBlobRe
                 },
             },
             ct);
+    }
+
+    private async Task EnsureContainerExistsAsync(CancellationToken ct)
+    {
+        if (_containerEnsured) return;
+
+        await _ensureContainerLock.WaitAsync(ct);
+        try
+        {
+            if (_containerEnsured) return;
+
+            await container.CreateIfNotExistsAsync(cancellationToken: ct);
+            _containerEnsured = true;
+        }
+        finally
+        {
+            _ensureContainerLock.Release();
+        }
     }
 
     private static bool IsManifestBlob(string blobName)

--- a/docker/local-init/Dockerfile
+++ b/docker/local-init/Dockerfile
@@ -4,7 +4,8 @@
 # Base image pinned to sha256 digest (matching repo Docker pin policy).
 FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:8a90a473da5205a16979de99d2fc20975e922c68304f5c79d564e666dc3982fc
 
-RUN dotnet tool install --tool-path /opt/cosmosdbshell CosmosDBShell --version 1.0.213-preview
+RUN dotnet tool install --tool-path /opt/cosmosdbshell CosmosDBShell --version 1.0.213-preview \
+    && chmod -R a+rX /opt/cosmosdbshell
 
 RUN groupadd --system --gid 10001 localinit \
     && useradd --system --uid 10001 --gid 10001 --home-dir /tmp/local-init-home --shell /usr/sbin/nologin localinit \

--- a/tests/Lfm.Api.Tests/BlobReferenceClientTests.cs
+++ b/tests/Lfm.Api.Tests/BlobReferenceClientTests.cs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Azure;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Lfm.Api.Services;
+using Moq;
+using Xunit;
+
+namespace Lfm.Api.Tests;
+
+public class BlobReferenceClientTests
+{
+    [Fact]
+    public async Task UploadAsync_Creates_Container_Before_Upload()
+    {
+        var ct = new CancellationTokenSource().Token;
+        var container = new Mock<BlobContainerClient>();
+        var blob = new Mock<BlobClient>();
+
+        container
+            .Setup(c => c.GetBlobClient("reference/test.json"))
+            .Returns(blob.Object);
+        container
+            .Setup(c => c.CreateIfNotExistsAsync(
+                PublicAccessType.None,
+                null,
+                null,
+                ct))
+            .ReturnsAsync((Response<BlobContainerInfo>?)null);
+        blob
+            .Setup(b => b.UploadAsync(
+                It.IsAny<Stream>(),
+                It.IsAny<BlobUploadOptions>(),
+                ct))
+            .ReturnsAsync((Response<BlobContentInfo>)null!);
+
+        var client = new BlobReferenceClient(container.Object);
+
+        await client.UploadAsync("reference/test.json", new { ok = true }, ct);
+
+        container.Verify(c => c.CreateIfNotExistsAsync(
+            PublicAccessType.None,
+            null,
+            null,
+            ct), Times.Once);
+        blob.Verify(b => b.UploadAsync(
+            It.IsAny<Stream>(),
+            It.IsAny<BlobUploadOptions>(),
+            ct), Times.Once);
+    }
+
+    [Fact]
+    public async Task UploadAsync_Creates_Container_Only_Once_Per_Client()
+    {
+        var container = new Mock<BlobContainerClient>();
+        var blob = new Mock<BlobClient>();
+        container
+            .Setup(c => c.GetBlobClient(It.IsAny<string>()))
+            .Returns(blob.Object);
+        container
+            .Setup(c => c.CreateIfNotExistsAsync(
+                PublicAccessType.None,
+                null,
+                null,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Response<BlobContainerInfo>?)null);
+        blob
+            .Setup(b => b.UploadAsync(
+                It.IsAny<Stream>(),
+                It.IsAny<BlobUploadOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Response<BlobContentInfo>)null!);
+
+        var client = new BlobReferenceClient(container.Object);
+
+        await client.UploadAsync("reference/one.json", new { ok = true }, CancellationToken.None);
+        await client.UploadAsync("reference/two.json", new { ok = true }, CancellationToken.None);
+
+        container.Verify(c => c.CreateIfNotExistsAsync(
+            PublicAccessType.None,
+            null,
+            null,
+            It.IsAny<CancellationToken>()), Times.Once);
+        blob.Verify(b => b.UploadAsync(
+            It.IsAny<Stream>(),
+            It.IsAny<BlobUploadOptions>(),
+            It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+}

--- a/tests/Lfm.Api.Tests/LocalConfigurationContractTests.cs
+++ b/tests/Lfm.Api.Tests/LocalConfigurationContractTests.cs
@@ -320,6 +320,7 @@ public sealed class LocalConfigurationContractTests
         var dockerfile = File.ReadAllText(Path.Combine(FindRepositoryRoot(), "docker", "local-init", "Dockerfile"));
 
         Assert.Contains("useradd --system --uid 10001 --gid 10001", dockerfile);
+        Assert.Contains("chmod -R a+rX /opt/cosmosdbshell", dockerfile);
         Assert.Contains("chown -R 10001:10001 /home/local-secrets /tmp/local-init-home", dockerfile);
         Assert.Contains("USER 10001:10001", dockerfile);
         Assert.DoesNotContain("USER root", dockerfile);


### PR DESCRIPTION
## Summary
- Create the configured blob container before uploading refreshed WoW reference data.
- Make the local-init CosmosDBShell install readable/executable for the non-root runtime user.
- Add focused API and local configuration contract coverage.

## Verification
- `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release --no-restore`
- `dotnet build lfm.sln -c Release --no-restore`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `git diff --check`
- `git ls-files -ci --exclude-standard`