### PR TITLE
Show Mythic Plus key level in run pills

### DIFF
--- a/app/Components/DifficultyPill.razor
+++ b/app/Components/DifficultyPill.razor
@@ -4,15 +4,16 @@
     populated (see RunModeResolver) so no client-side ModeKey parsing.
 *@
 <span class="difficulty-pill difficulty-pill--@DifficultyClass(Difficulty)" title="@Difficulty">
-    @DifficultyLabel(Difficulty)
+    @DifficultyLabel(Difficulty, KeystoneLevel)
 </span>
 
 @code {
     [Parameter, EditorRequired] public string? Difficulty { get; set; }
+    [Parameter] public int? KeystoneLevel { get; set; }
 
-    private static string DifficultyLabel(string? difficulty) => difficulty switch
+    private static string DifficultyLabel(string? difficulty, int? keystoneLevel) => difficulty switch
     {
-        "MYTHIC_KEYSTONE" => "M+",
+        "MYTHIC_KEYSTONE" => keystoneLevel is > 0 ? $"M+{keystoneLevel}" : "M+",
         "MYTHIC" => "Mythic",
         "HEROIC" => "Heroic",
         "NORMAL" => "Normal",

--- a/app/Components/RunListItem.razor
+++ b/app/Components/RunListItem.razor
@@ -14,7 +14,7 @@
         @onclick="HandleClick">
     <span class="run-list-item__header">
         <span class="run-list-item__title">@_title</span>
-        <DifficultyPill Difficulty="@Run.Difficulty" />
+        <DifficultyPill Difficulty="@Run.Difficulty" KeystoneLevel="@Run.KeystoneLevel" />
     </span>
     <span class="run-list-item__meta">
             <span class="run-list-item__date">@RunDateFormatter.FormatDisplay(Run.StartTime)</span>

--- a/tests/Lfm.App.Tests/DifficultyPillTests.cs
+++ b/tests/Lfm.App.Tests/DifficultyPillTests.cs
@@ -45,6 +45,17 @@ public class DifficultyPillTests : ComponentTestBase
     }
 
     [Fact]
+    public void MythicKeystone_Appends_Key_Level_When_Provided()
+    {
+        var cut = Render<DifficultyPill>(p => p
+            .Add(x => x.Difficulty, "MYTHIC_KEYSTONE")
+            .Add(x => x.KeystoneLevel, 10));
+
+        var pill = cut.Find(".difficulty-pill");
+        Assert.Equal("M+10", pill.TextContent.Trim());
+    }
+
+    [Fact]
     public void Unknown_Difficulty_Falls_Back_To_TitleCased_Label()
     {
         var cut = Render<DifficultyPill>(p => p.Add(x => x.Difficulty, "PVP"));

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -1691,6 +1691,24 @@ public class RunsPagesTests : ComponentTestBase
     }
 
     [Fact]
+    public void RunsPage_RunListItem_ShowsKeystoneLevelInMythicPlusPill()
+    {
+        var client = new Mock<IRunsClient>();
+        var summary = MakeSummary() with { Difficulty = "MYTHIC_KEYSTONE", Size = 5, KeystoneLevel = 12 };
+        client.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<RunSummaryDto> { summary });
+        Services.AddSingleton(client.Object);
+
+        var cut = Render<RunsPage>();
+
+        cut.WaitForAssertion(() =>
+        {
+            var pill = cut.Find(".difficulty-pill--mplus");
+            Assert.Equal("M+12", pill.TextContent.Trim());
+        });
+    }
+
+    [Fact]
     public void RunsPage_RunListItem_ColorsSignupBadgeFromCurrentUserAttendance()
     {
         var client = new Mock<IRunsClient>();


### PR DESCRIPTION
## Summary
- Show the keystone level in Mythic Plus difficulty pills when a run has one, for example `M+12`.
- Pass `RunSummaryDto.KeystoneLevel` from sidebar run list items into the difficulty pill.
- Add bUnit coverage for the pill label and run list rendering.

## Verification
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --no-restore`
- `dotnet build lfm.sln -c Release --no-restore`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `git diff --check`
- `git ls-files -ci --exclude-standard`