### PR TITLE
Cache Blizzard media and show attendee icons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,7 @@ New endpoint → add a new file under `api/Functions/` and register `app.MapXxx(
 
 Static Blizzard reference data (journal-instance, playable-specialization, playable-class, playable-race, hero-talent-tree) lives in blob at `lfmstore/wow/reference/{kind}/`. Dynamic per-user / per-guild / per-run data lives in Cosmos (`lfm-cosmos/lfm/{raiders,runs,guilds}`). Per-entity caches of Blizzard responses (e.g. one user's account profile, one guild's roster) stay **embedded** inside the owning Cosmos document with a `*FetchedAt` timestamp, not in blob.
 
-See [docs/storage-architecture.md](docs/storage-architecture.md) for the full data-kind matrix, rationale, image-caching policy (URL caches only — browser HTTP cache handles bytes), and the decision flow for a new data kind. When adding something new that needs to persist, start there.
+See [docs/storage-architecture.md](docs/storage-architecture.md) for the full data-kind matrix, rationale, Blizzard media image-caching policy, and the decision flow for a new data kind. When adding something new that needs to persist, start there.
 
 **Never hardcode the Cosmos database name.** Read `Cosmos__DatabaseName` from configuration — E2E runs against a different database than production.
 

--- a/api/Functions/BattleNetCharacterPortraitsFunction.cs
+++ b/api/Functions/BattleNetCharacterPortraitsFunction.cs
@@ -18,11 +18,11 @@ namespace Lfm.Api.Functions;
 /// POST /api/battlenet/character-portraits
 ///
 /// Accepts a JSON array of <c>{ region, realm, name }</c> objects and returns a
-/// map of "{region}-{realm}-{name}" → portrait URL for each character that has a
-/// resolvable portrait.
+/// map of "{region}-{realm}-{name}" → media-cache URL for each character that
+/// has a resolvable portrait.
 ///
 /// Portrait URL resolution order (see <see cref="ICharacterPortraitService"/>):
-///   1. Stored character's <c>portraitUrl</c> (Blizzard CDN URL).
+///   1. Stored character's <c>portraitUrl</c> (Blizzard render source URL).
 ///   2. Stored character's <c>mediaSummary.assets[key="avatar"]</c>.
 ///   3. The raider's <c>portraitCache</c> map.
 ///   4. Blizzard character-media API call using the session access token.
@@ -76,7 +76,11 @@ public class BattleNetCharacterPortraitsFunction(
         var accessToken = principal.AccessToken ?? string.Empty;
 
         var response = await portraitService.ResolveAsync(raider, requests, accessToken, cancellationToken);
-        return new OkObjectResult(response);
+        var mapped = response.Portraits.ToDictionary(
+            kvp => kvp.Key,
+            kvp => ApiMediaUrls.ToCachedUrl(req, kvp.Value) ?? kvp.Value,
+            StringComparer.OrdinalIgnoreCase);
+        return new OkObjectResult(new PortraitResponse(mapped));
     }
 
     /// <summary>

--- a/api/Functions/BattleNetCharactersFunction.cs
+++ b/api/Functions/BattleNetCharactersFunction.cs
@@ -54,7 +54,12 @@ public class BattleNetCharactersFunction(
             raider.AccountProfileSummary!,
             region,
             raider.Characters,
-            raider.PortraitCache);
+            raider.PortraitCache)
+            .Select(character => character with
+            {
+                PortraitUrl = ApiMediaUrls.ToCachedUrl(req, character.PortraitUrl),
+            })
+            .ToList();
 
         req.HttpContext.Response.Headers["Cache-Control"] = "private, max-age=300";
         return new OkObjectResult(characters);

--- a/api/Functions/BattleNetCharactersRefreshFunction.cs
+++ b/api/Functions/BattleNetCharactersRefreshFunction.cs
@@ -103,7 +103,12 @@ public class BattleNetCharactersRefreshFunction(
 
         var region = _blizzardOpts.Region.ToLowerInvariant();
         var characters = AccountCharacterMapper.MapToCharacterDtos(
-            freshSummaryStored, region, raider.Characters, raider.PortraitCache);
+            freshSummaryStored, region, raider.Characters, raider.PortraitCache)
+            .Select(character => character with
+            {
+                PortraitUrl = ApiMediaUrls.ToCachedUrl(req, character.PortraitUrl),
+            })
+            .ToList();
 
         return new OkObjectResult(characters);
     }

--- a/api/Functions/MeFunction.cs
+++ b/api/Functions/MeFunction.cs
@@ -31,7 +31,7 @@ public class MeFunction(IRaidersRepository repo, ISiteAdminService siteAdmin)
         var isAdmin = await siteAdmin.IsAdminAsync(principal.BattleNetId, cancellationToken);
 
         var (_, guildName) = GuildResolver.FromRaider(raider);
-        var selectedCharacter = ResolveSelectedCharacter(raider);
+        var selectedCharacter = ResolveSelectedCharacter(req, raider);
 
         // Emit the Cosmos _etag so the SPA can echo it as If-Match on PATCH /me
         // for optimistic concurrency. Cosmos etags are already double-quoted
@@ -48,7 +48,7 @@ public class MeFunction(IRaidersRepository repo, ISiteAdminService siteAdmin)
             Locale: raider.Locale));
     }
 
-    private static SelectedCharacterSummaryDto? ResolveSelectedCharacter(RaiderDocument raider)
+    private static SelectedCharacterSummaryDto? ResolveSelectedCharacter(HttpRequest req, RaiderDocument raider)
     {
         if (string.IsNullOrWhiteSpace(raider.SelectedCharacterId) || raider.Characters is null)
             return null;
@@ -61,7 +61,7 @@ public class MeFunction(IRaidersRepository repo, ISiteAdminService siteAdmin)
             : new SelectedCharacterSummaryDto(
                 selected.Id,
                 ResolveAccountProfileDisplayName(raider.AccountProfileSummary, selected) ?? selected.Name,
-                selected.PortraitUrl);
+                ApiMediaUrls.ToCachedUrl(req, selected.PortraitUrl));
     }
 
     private static string? ResolveAccountProfileDisplayName(

--- a/api/Functions/RaiderCharacterAddFunction.cs
+++ b/api/Functions/RaiderCharacterAddFunction.cs
@@ -174,7 +174,10 @@ public class RaiderCharacterAddFunction(
         await repo.UpsertAsync(updatedRaider, ct);
 
         // 8. Map to CharacterDto and return.
-        var dto = MapToCharacterDto(stored);
+        var dto = MapToCharacterDto(stored) with
+        {
+            PortraitUrl = ApiMediaUrls.ToCachedUrl(req, stored.PortraitUrl),
+        };
         return new OkObjectResult(new AddCharacterResponse(
             SelectedCharacterId: characterId,
             Character: dto));

--- a/api/Functions/RaiderCharacterEnrichFunction.cs
+++ b/api/Functions/RaiderCharacterEnrichFunction.cs
@@ -134,7 +134,11 @@ public sealed class RaiderCharacterEnrichFunction(
         if (persisted is null)
             return Problem.NotFound(req.HttpContext, "raider-not-found", "Raider not found.");
 
-        return new OkObjectResult(RaiderCharacterAddFunction.MapToCharacterDto(stored));
+        var dto = RaiderCharacterAddFunction.MapToCharacterDto(stored) with
+        {
+            PortraitUrl = ApiMediaUrls.ToCachedUrl(req, stored.PortraitUrl),
+        };
+        return new OkObjectResult(dto);
     }
 
     private static RaiderDocument WithStoredCharacter(RaiderDocument raider, StoredSelectedCharacter stored)

--- a/api/Functions/WowMediaCacheFunction.cs
+++ b/api/Functions/WowMediaCacheFunction.cs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Api.Helpers;
+using Lfm.Api.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Primitives;
+
+namespace Lfm.Api.Functions;
+
+public class WowMediaCacheFunction(IWowMediaCache mediaCache)
+{
+    [Function("wow-media-cache")]
+    public Task<IActionResult> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "wow/media/cache")] HttpRequest req,
+        CancellationToken ct)
+        => ServeAsync(req, ct);
+
+    /// <summary>
+    /// <c>/api/v1/wow/media/cache</c> alias for <see cref="Run"/>.
+    /// See <c>docs/api-versioning.md</c>.
+    /// </summary>
+    [Function("wow-media-cache-v1")]
+    public Task<IActionResult> RunV1(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "v1/wow/media/cache")] HttpRequest req,
+        CancellationToken ct)
+        => ServeAsync(req, ct);
+
+    private async Task<IActionResult> ServeAsync(HttpRequest req, CancellationToken ct)
+    {
+        if (!req.Query.TryGetValue("source", out StringValues encodedSource)
+            || StringValues.IsNullOrEmpty(encodedSource))
+        {
+            return Problem.BadRequest(req.HttpContext, "missing-media-source", "Missing media source.");
+        }
+
+        var content = await mediaCache.GetOrFetchAsync(encodedSource.ToString(), ct);
+        if (content is null)
+            return Problem.NotFound(req.HttpContext, "media-not-found", "Media asset not found.");
+
+        req.HttpContext.Response.Headers.CacheControl = "public, max-age=604800";
+        return new FileContentResult(content.Content, content.ContentType);
+    }
+}

--- a/api/Functions/WowReferenceInstancesFunction.cs
+++ b/api/Functions/WowReferenceInstancesFunction.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Lfm.Api.Auth;
+using Lfm.Api.Helpers;
 using Lfm.Api.Repositories;
 
 namespace Lfm.Api.Functions;
@@ -18,7 +19,10 @@ public class WowReferenceInstancesFunction(IInstancesRepository repo)
         CancellationToken ct)
     {
         var items = await repo.ListAsync(ct);
-        return new OkObjectResult(items);
+        var response = items
+            .Select(item => item with { PortraitUrl = ApiMediaUrls.ToCachedUrl(req, item.PortraitUrl) })
+            .ToList();
+        return new OkObjectResult(response);
     }
 
     /// <summary>

--- a/api/Functions/WowReferenceSpecializationsFunction.cs
+++ b/api/Functions/WowReferenceSpecializationsFunction.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Lfm.Api.Auth;
+using Lfm.Api.Helpers;
 using Lfm.Api.Repositories;
 
 namespace Lfm.Api.Functions;
@@ -18,7 +19,10 @@ public class WowReferenceSpecializationsFunction(ISpecializationsRepository repo
         CancellationToken ct)
     {
         var items = await repo.ListAsync(ct);
-        return new OkObjectResult(items);
+        var response = items
+            .Select(item => item with { IconUrl = ApiMediaUrls.ToCachedUrl(req, item.IconUrl) })
+            .ToList();
+        return new OkObjectResult(response);
     }
 
     /// <summary>

--- a/api/Helpers/ApiMediaUrls.cs
+++ b/api/Helpers/ApiMediaUrls.cs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Contracts.Media;
+using Microsoft.AspNetCore.Http;
+
+namespace Lfm.Api.Helpers;
+
+internal static class ApiMediaUrls
+{
+    internal static string? ToCachedUrl(HttpRequest req, string? sourceUrl)
+    {
+        if (string.IsNullOrWhiteSpace(sourceUrl))
+            return null;
+
+        if (!BlizzardMediaCache.IsBlizzardRenderUrl(sourceUrl))
+            return sourceUrl;
+
+        var baseUrl = $"{req.Scheme}://{req.Host}";
+        return $"{baseUrl}/api/v1/wow/media/cache?source={BlizzardMediaCache.EncodeSource(sourceUrl)}";
+    }
+}

--- a/api/Mappers/AccountCharacterMapper.cs
+++ b/api/Mappers/AccountCharacterMapper.cs
@@ -3,6 +3,7 @@
 
 using Lfm.Api.Repositories;
 using Lfm.Contracts.Characters;
+using Lfm.Contracts.Media;
 using Lfm.Contracts.WoW;
 
 namespace Lfm.Api.Mappers;
@@ -91,5 +92,5 @@ internal static class AccountCharacterMapper
     /// <c>functions/src/lib/character-portrait.ts</c>.
     /// </summary>
     private static bool IsBlizzardRenderUrl(string url)
-        => url.StartsWith("https://render.worldofwarcraft.com/", StringComparison.OrdinalIgnoreCase);
+        => BlizzardMediaCache.IsBlizzardRenderUrl(url);
 }

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -170,6 +170,8 @@ builder.Services.AddSingleton<BlobContainerClient>(sp =>
         "Storage:BlobServiceUri or Storage:BlobConnectionString must be configured for reference-data reads.");
 });
 builder.Services.AddSingleton<Lfm.Api.Services.IBlobReferenceClient, Lfm.Api.Services.BlobReferenceClient>();
+builder.Services.AddHttpClient<Lfm.Api.Services.IWowMediaCache, Lfm.Api.Services.WowMediaCache>()
+    .AddHttpMessageHandler<Lfm.Api.Services.BlizzardRateLimitHandler>();
 
 builder.Services.AddScoped<Lfm.Api.Repositories.IInstancesRepository, Lfm.Api.Repositories.InstancesRepository>();
 builder.Services.AddScoped<Lfm.Api.Repositories.IExpansionsRepository, Lfm.Api.Repositories.ExpansionsRepository>();

--- a/api/Services/BlobReferenceClient.cs
+++ b/api/Services/BlobReferenceClient.cs
@@ -56,6 +56,24 @@ public sealed class BlobReferenceClient(BlobContainerClient container) : IBlobRe
         }
     }
 
+    public async Task<ReferenceBlobContent?> GetContentAsync(string blobName, CancellationToken ct)
+    {
+        var blob = container.GetBlobClient(blobName);
+        try
+        {
+            var response = await blob.DownloadContentAsync(ct);
+            var contentType = response.Value.Details.ContentType;
+            if (string.IsNullOrWhiteSpace(contentType))
+                contentType = "application/octet-stream";
+
+            return new ReferenceBlobContent(response.Value.Content.ToArray(), contentType);
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            return null;
+        }
+    }
+
     public async IAsyncEnumerable<T> ListAsync<T>(
         string prefix,
         [EnumeratorCancellation] CancellationToken ct) where T : class
@@ -84,6 +102,23 @@ public sealed class BlobReferenceClient(BlobContainerClient container) : IBlobRe
                 HttpHeaders = new BlobHttpHeaders
                 {
                     ContentType = "application/json",
+                },
+            },
+            ct);
+    }
+
+    public async Task UploadContentAsync(string blobName, byte[] content, string contentType, CancellationToken ct)
+    {
+        await EnsureContainerExistsAsync(ct);
+        var blob = container.GetBlobClient(blobName);
+        using var stream = new MemoryStream(content);
+        await blob.UploadAsync(
+            stream,
+            new BlobUploadOptions
+            {
+                HttpHeaders = new BlobHttpHeaders
+                {
+                    ContentType = contentType,
                 },
             },
             ct);

--- a/api/Services/CharacterPortraitService.cs
+++ b/api/Services/CharacterPortraitService.cs
@@ -7,6 +7,7 @@ using System.Text.Json.Serialization;
 using Lfm.Api.Options;
 using Lfm.Api.Repositories;
 using Lfm.Contracts.Characters;
+using Lfm.Contracts.Media;
 using Microsoft.Extensions.Options;
 
 namespace Lfm.Api.Services;
@@ -252,7 +253,7 @@ public sealed class CharacterPortraitService(
     /// <c>functions/src/lib/character-portrait.ts</c>.
     /// </summary>
     private static bool IsBlizzardRenderUrl(string url)
-        => url.StartsWith("https://render.worldofwarcraft.com/", StringComparison.OrdinalIgnoreCase);
+        => BlizzardMediaCache.IsBlizzardRenderUrl(url);
 
     private sealed record FetchResult(string Id, string Url);
 

--- a/api/Services/IBlobReferenceClient.cs
+++ b/api/Services/IBlobReferenceClient.cs
@@ -21,6 +21,12 @@ public interface IBlobReferenceClient
     Task<T?> GetAsync<T>(string blobName, CancellationToken ct) where T : class;
 
     /// <summary>
+    /// Reads a binary blob from the reference container. Returns null when the
+    /// blob does not exist.
+    /// </summary>
+    Task<ReferenceBlobContent?> GetContentAsync(string blobName, CancellationToken ct);
+
+    /// <summary>
     /// Enumerates every blob under <paramref name="prefix"/>, deserializing each one,
     /// skipping manifest-shaped blobs (<c>index.json</c>, <c>meta.json</c>) so callers
     /// receive only per-id detail documents.
@@ -34,4 +40,13 @@ public interface IBlobReferenceClient
     /// documents and the list-endpoint manifest (<c>reference/{kind}/index.json</c>).
     /// </summary>
     Task UploadAsync<T>(string blobName, T payload, CancellationToken ct);
+
+    /// <summary>
+    /// Uploads binary content to the reference container, overwriting any existing
+    /// blob and preserving the supplied content type for downstream image
+    /// responses.
+    /// </summary>
+    Task UploadContentAsync(string blobName, byte[] content, string contentType, CancellationToken ct);
 }
+
+public sealed record ReferenceBlobContent(byte[] Content, string ContentType);

--- a/api/Services/ICharacterPortraitService.cs
+++ b/api/Services/ICharacterPortraitService.cs
@@ -10,7 +10,7 @@ namespace Lfm.Api.Services;
 /// Resolves portrait URLs for a set of WoW characters.
 ///
 /// Portrait URL resolution order (mirrors battlenet-character-portraits.ts):
-///   1. Stored character's portraitUrl (if it is a Blizzard CDN URL).
+///   1. Stored character's portraitUrl (if it is a Blizzard render source URL).
 ///   2. Stored character's mediaSummary.assets[key="avatar"].
 ///   3. The raider's portraitCache map.
 ///   4. Blizzard character-media API call (requires the user's access token).

--- a/api/Services/IWowMediaCache.cs
+++ b/api/Services/IWowMediaCache.cs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+namespace Lfm.Api.Services;
+
+public interface IWowMediaCache
+{
+    Task<ReferenceBlobContent?> GetOrFetchAsync(string encodedSource, CancellationToken ct);
+}

--- a/api/Services/WowMediaCache.cs
+++ b/api/Services/WowMediaCache.cs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Security.Cryptography;
+using System.Text;
+using Lfm.Contracts.Media;
+using Microsoft.Extensions.Logging;
+
+namespace Lfm.Api.Services;
+
+public sealed class WowMediaCache(
+    IBlobReferenceClient blobs,
+    HttpClient httpClient,
+    ILogger<WowMediaCache> logger) : IWowMediaCache
+{
+    private const int MaxImageBytes = 5 * 1024 * 1024;
+
+    public async Task<ReferenceBlobContent?> GetOrFetchAsync(string encodedSource, CancellationToken ct)
+    {
+        if (!BlizzardMediaCache.TryDecodeSource(encodedSource, out var sourceUri) || sourceUri is null)
+            return null;
+
+        var blobName = BlobNameFor(sourceUri);
+        var cached = await blobs.GetContentAsync(blobName, ct);
+        if (cached is not null)
+            return cached;
+
+        using var response = await httpClient.GetAsync(sourceUri, HttpCompletionOption.ResponseHeadersRead, ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            logger.LogWarning(
+                "Could not fetch Blizzard media asset {Source}: status {StatusCode}",
+                sourceUri,
+                (int)response.StatusCode);
+            return null;
+        }
+
+        var contentType = response.Content.Headers.ContentType?.MediaType;
+        if (string.IsNullOrWhiteSpace(contentType)
+            || !contentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+        {
+            logger.LogWarning(
+                "Rejected Blizzard media asset {Source}: content type {ContentType}",
+                sourceUri,
+                contentType ?? "<missing>");
+            return null;
+        }
+
+        var contentLength = response.Content.Headers.ContentLength;
+        if (contentLength > MaxImageBytes)
+        {
+            logger.LogWarning(
+                "Rejected Blizzard media asset {Source}: content length {ContentLength} exceeds {MaxImageBytes}",
+                sourceUri,
+                contentLength,
+                MaxImageBytes);
+            return null;
+        }
+
+        var content = await response.Content.ReadAsByteArrayAsync(ct);
+        if (content.Length > MaxImageBytes)
+        {
+            logger.LogWarning(
+                "Rejected Blizzard media asset {Source}: content size {ContentLength} exceeds {MaxImageBytes}",
+                sourceUri,
+                content.Length,
+                MaxImageBytes);
+            return null;
+        }
+
+        await blobs.UploadContentAsync(blobName, content, contentType, ct);
+        return new ReferenceBlobContent(content, contentType);
+    }
+
+    internal static string BlobNameFor(Uri sourceUri)
+    {
+        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(sourceUri.AbsoluteUri)))
+            .ToLowerInvariant();
+        var extension = Path.GetExtension(sourceUri.AbsolutePath);
+        if (extension.Length is 0 or > 10)
+            extension = ".img";
+
+        return $"media-cache/render/{hash}{extension}";
+    }
+}

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -531,6 +531,30 @@ paths:
                 $ref: '#/components/schemas/RunSignupOptionsDto'
         default:
           $ref: '#/components/responses/Problem'
+  /api/v1/wow/media/cache:
+    get:
+      tags:
+        - 'WoW Reference'
+      summary: 'GET /api/v1/wow/media/cache'
+      operationId: getWowMediaCache
+      parameters:
+        - name: source
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Base64url-encoded Blizzard render-CDN URL.
+      security: []
+      responses:
+        '200':
+          description: Success.
+          content:
+            image/*:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/Problem'
   /api/v1/wow/reference/expansions:
     get:
       tags:

--- a/app/Components/CharacterRow.razor
+++ b/app/Components/CharacterRow.razor
@@ -1,8 +1,21 @@
 @using Lfm.Contracts.Runs
 @using Lfm.Contracts.WoW
+@using Lfm.App.Components.Runs
+@using Lfm.App.Services
 @inject IStringLocalizer Loc
+@inject IConfiguration Config
 
 <div class="character-row" style="--class-color:@WowClasses.GetColor(Character.CharacterClassId)">
+    <div class="character-row__icons" aria-hidden="true">
+        <SpecIcon SpecName="@Character.CharacterClassName"
+                  IconUrl="@WowMediaUrls.ClassIconUrl(Character.CharacterClassId, Config["ApiBaseUrl"])"
+                  Class="character-row__icon character-row__class-icon"
+                  Decorative="true" />
+        <SpecIcon SpecName="@Character.SpecName"
+                  IconUrl="@SpecIconUrl"
+                  Class="character-row__icon character-row__spec-icon"
+                  Decorative="true" />
+    </div>
     <div class="character-row__main">
         <span class="character-row__name">@Character.CharacterName</span>
         <span class="character-row__sub">@ClassSpec()</span>
@@ -14,6 +27,7 @@
 
 @code {
     [Parameter, EditorRequired] public RunCharacterDto Character { get; set; } = default!;
+    [Parameter] public string? SpecIconUrl { get; set; }
 
     private string ClassSpec()
     {

--- a/app/Components/Runs/SpecIcon.razor
+++ b/app/Components/Runs/SpecIcon.razor
@@ -1,22 +1,39 @@
-@if (!string.IsNullOrWhiteSpace(IconUrl) && !_imageFailed)
+@using Lfm.App.Services
+@inject IConfiguration Config
+
+@if (!string.IsNullOrWhiteSpace(CachedIconUrl) && !_imageFailed)
 {
-    <span class="spec-icon spec-icon--image" role="img" aria-label="@Label">
-        <img class="spec-icon__image" src="@IconUrl" alt="" decoding="async" @onerror="OnImageError" />
+    <span class="@CssClass" role="@IconRole" aria-label="@IconLabel" aria-hidden="@AriaHidden">
+        <img class="spec-icon__image" src="@CachedIconUrl" alt="" decoding="async" @onerror="OnImageError" />
     </span>
 }
 else
 {
-    <span class="spec-icon" role="img" aria-label="@Label">@Abbreviation</span>
+    <span class="@CssClass" role="@IconRole" aria-label="@IconLabel" aria-hidden="@AriaHidden">@Abbreviation</span>
 }
 
 @code {
     [Parameter] public string? SpecName { get; set; }
     [Parameter] public string? IconUrl { get; set; }
+    [Parameter] public string? Class { get; set; }
+    [Parameter] public bool Decorative { get; set; }
 
     private bool _imageFailed;
     private string? _lastIconUrl;
 
     private string Label => string.IsNullOrWhiteSpace(SpecName) ? "Unknown spec" : SpecName;
+    private string? CachedIconUrl => WowMediaUrls.ToCachedUrl(IconUrl, Config["ApiBaseUrl"]);
+    private string CssClass => string.Join(
+        ' ',
+        new[]
+        {
+            "spec-icon",
+            !string.IsNullOrWhiteSpace(CachedIconUrl) && !_imageFailed ? "spec-icon--image" : null,
+            Class,
+        }.Where(value => !string.IsNullOrWhiteSpace(value)));
+    private string? IconRole => Decorative ? null : "img";
+    private string? IconLabel => Decorative ? null : Label;
+    private string? AriaHidden => Decorative ? "true" : null;
 
     protected override void OnParametersSet()
     {

--- a/app/Layout/MainLayout.razor
+++ b/app/Layout/MainLayout.razor
@@ -59,7 +59,7 @@
                                           aria-expanded="@(_showAccountMenu ? "true" : "false")"
                                           OnClick="@ToggleAccountMenu">
                                 <span class="account-menu-trigger__content">
-                                    @if (SelectedCharacterPortraitUrl(accountAuth.User) is { } portraitUrl)
+                                    @if (CachedMediaUrl(SelectedCharacterPortraitUrl(accountAuth.User)) is { } portraitUrl)
                                     {
                                         <img class="account-avatar" src="@portraitUrl" alt="" />
                                     }
@@ -351,6 +351,8 @@
 
     private string? SelectedCharacterPortraitUrl(ClaimsPrincipal user)
         => user.FindFirst(AppAuthenticationStateProvider.SelectedCharacterPortraitUrlClaim)?.Value;
+
+    private string? CachedMediaUrl(string? sourceUrl) => WowMediaUrls.ToCachedUrl(sourceUrl, Config["ApiBaseUrl"]);
 
     private string SelectedCharacterInitial(ClaimsPrincipal user)
     {

--- a/app/Lfm.App.Core/Services/WowMediaUrls.cs
+++ b/app/Lfm.App.Core/Services/WowMediaUrls.cs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.Contracts.Media;
+using Lfm.Contracts.WoW;
+
+namespace Lfm.App.Services;
+
+public static class WowMediaUrls
+{
+    public static string? ToCachedUrl(string? sourceUrl, string? apiBaseUrl)
+    {
+        if (string.IsNullOrWhiteSpace(sourceUrl))
+            return null;
+
+        if (!BlizzardMediaCache.IsBlizzardRenderUrl(sourceUrl))
+            return sourceUrl;
+
+        if (string.IsNullOrWhiteSpace(apiBaseUrl))
+            return null;
+
+        return $"{apiBaseUrl.TrimEnd('/')}/api/v1/wow/media/cache?source={BlizzardMediaCache.EncodeSource(sourceUrl)}";
+    }
+
+    public static string? ClassIconUrl(int classId, string? apiBaseUrl)
+    {
+        var path = WowClasses.GetIconPath(classId);
+        return path is null
+            ? null
+            : ToCachedUrl($"https://{BlizzardMediaCache.RenderHost}/{path}", apiBaseUrl);
+    }
+}

--- a/app/Pages/CharactersPage.razor
+++ b/app/Pages/CharactersPage.razor
@@ -11,6 +11,7 @@
 @inject NavigationManager Nav
 @inject IStringLocalizer Loc
 @inject IJSRuntime JS
+@inject IConfiguration Config
 
 <PageTitle>@Loc["characters.title"] — @Loc["nav.logo"]</PageTitle>
 
@@ -71,7 +72,7 @@
             <div class="characters-grid">
                 @foreach (var c in visibleCharacters)
                 {
-                    var portraitSrc = c.PortraitUrl ?? (portraits.TryGetValue(CharKey(c), out var p) ? p : null);
+                    var portraitSrc = CachedMediaUrl(c.PortraitUrl ?? (portraits.TryGetValue(CharKey(c), out var p) ? p : null));
                     var isSelected = CharKey(c) == selectedCharacterId;
                     var wrapperStyle = isSelected
                         ? "position:relative;cursor:default;outline:2px solid var(--accent-fill-rest);outline-offset:-1px;border-radius:4px"
@@ -222,6 +223,7 @@
     private string deleteConfirmation = "";
     private string? deleteError;
     private bool deleting;
+    private string? CachedMediaUrl(string? sourceUrl) => WowMediaUrls.ToCachedUrl(sourceUrl, Config["ApiBaseUrl"]);
 
     private bool deleteConfirmationValid => deleteConfirmation == "FORGET ME";
     private static int ComponentPageSize => MobilePageSize;

--- a/app/Pages/GuildAdminPage.razor
+++ b/app/Pages/GuildAdminPage.razor
@@ -8,6 +8,7 @@
 @inject ToastHelper Toast
 @inject IStringLocalizer Loc
 @inject UnsavedChangesGuard UnsavedGuard
+@inject IConfiguration Config
 @implements IAsyncDisposable
 
 <PageTitle>@Loc["guildAdmin.title"]</PageTitle>
@@ -63,9 +64,9 @@
                             <FluentLabel>@guildData.Guild.Slogan</FluentLabel>
                         }
                         <FluentLabel>@guildData.Guild.RealmName@(guildData.Guild.FactionName != null ? $" \u00b7 {guildData.Guild.FactionName}" : "")</FluentLabel>
-                        @if (guildData.Guild.CrestEmblemUrl != null)
+                        @if (CachedMediaUrl(guildData.Guild.CrestEmblemUrl) is { } crestEmblemUrl)
                         {
-                            <img src="@guildData.Guild.CrestEmblemUrl"
+                            <img src="@crestEmblemUrl"
                                  alt="@Loc["guild.crestAlt"]"
                                  class="guild-crest"
                                  width="88"
@@ -153,6 +154,7 @@ else if (showLoadConfirmation)
     private string draftLocale = "fi";
     private string draftSlogan = string.Empty;
     private IReadOnlyList<UpdateGuildRankPermission> draftPermissions = [];
+    private string? CachedMediaUrl(string? sourceUrl) => WowMediaUrls.ToCachedUrl(sourceUrl, Config["ApiBaseUrl"]);
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {

--- a/app/Pages/GuildPage.razor
+++ b/app/Pages/GuildPage.razor
@@ -7,6 +7,7 @@
 @inject ToastHelper Toast
 @inject IStringLocalizer Loc
 @inject UnsavedChangesGuard UnsavedGuard
+@inject IConfiguration Config
 @implements IAsyncDisposable
 
 <PageTitle>@Loc["guild.title"]</PageTitle>
@@ -55,6 +56,7 @@
     private string draftLocale = "fi";
     private string draftSlogan = string.Empty;
     private IReadOnlyList<UpdateGuildRankPermission> draftPermissions = [];
+    private string? CachedMediaUrl(string? sourceUrl) => WowMediaUrls.ToCachedUrl(sourceUrl, Config["ApiBaseUrl"]);
 
     [SupplyParameterFromQuery(Name = "setup")]
     public string? Setup { get; set; }
@@ -131,9 +133,9 @@
                             <FluentLabel>@dto.Guild.Slogan</FluentLabel>
                         }
                         <FluentLabel>@dto.Guild.RealmName@(dto.Guild.FactionName != null ? $" \u00b7 {dto.Guild.FactionName}" : "")</FluentLabel>
-                        @if (dto.Guild.CrestEmblemUrl != null)
+                        @if (CachedMediaUrl(dto.Guild.CrestEmblemUrl) is { } crestEmblemUrl)
                         {
-                            <img src="@dto.Guild.CrestEmblemUrl"
+                            <img src="@crestEmblemUrl"
                                  alt="@Loc["guild.crestAlt"]"
                                  class="guild-crest"
                                  width="88"

--- a/app/Pages/RunsPage.razor
+++ b/app/Pages/RunsPage.razor
@@ -221,7 +221,9 @@
                                                         {
                                                             @foreach (var character in roleChars)
                                                             {
-                                                                <CharacterRow @key="@(character.CharacterRealm + "/" + character.CharacterName)" Character="character" />
+                                                                <CharacterRow @key="@(character.CharacterRealm + "/" + character.CharacterName)"
+                                                                              Character="character"
+                                                                              SpecIconUrl="@SpecIconUrlFor(character)" />
                                                             }
                                                         }
                                                     </div>
@@ -237,7 +239,9 @@
                                             <div class="roster-rows">
                                                 @foreach (var character in notAttending)
                                                 {
-                                                    <CharacterRow @key="@(character.CharacterRealm + "/" + character.CharacterName)" Character="character" />
+                                                    <CharacterRow @key="@(character.CharacterRealm + "/" + character.CharacterName)"
+                                                                  Character="character"
+                                                                  SpecIconUrl="@SpecIconUrlFor(character)" />
                                                 }
                                             </div>
                                         }
@@ -303,6 +307,7 @@
     private bool _specIconsLoaded;
     private bool _specIconsLoading;
     private IReadOnlyDictionary<int, string> _specIconUrls = new Dictionary<int, string>();
+    private IReadOnlyDictionary<string, string> _specIconUrlsByClassAndName = new Dictionary<string, string>();
 
     private static readonly (string Key, string LocKey)[] RoleColumnKeys =
     [
@@ -479,11 +484,12 @@
 
             ApplyRunDetail(detail);
             _signupError = null;
-            if (HasCurrentUserSignup(detail))
+            if (NeedsSpecIcons(detail))
             {
                 await EnsureSpecIconsLoaded();
             }
-            else if (!IsSignupClosed(detail.SignupCloseTime))
+
+            if (!HasCurrentUserSignup(detail) && !IsSignupClosed(detail.SignupCloseTime))
             {
                 await EnsureSignupOptionsLoaded();
             }
@@ -636,11 +642,16 @@
                 .Where(spec => !string.IsNullOrWhiteSpace(spec.IconUrl))
                 .GroupBy(spec => spec.Id)
                 .ToDictionary(group => group.Key, group => group.First().IconUrl!);
+            _specIconUrlsByClassAndName = specializations
+                .Where(spec => !string.IsNullOrWhiteSpace(spec.IconUrl) && !string.IsNullOrWhiteSpace(spec.Name))
+                .GroupBy(spec => SpecIconLookupKey(spec.ClassId, spec.Name))
+                .ToDictionary(group => group.Key, group => group.First().IconUrl!);
             _specIconsLoaded = true;
         }
         catch
         {
             _specIconUrls = new Dictionary<int, string>();
+            _specIconUrlsByClassAndName = new Dictionary<string, string>();
         }
         finally
         {
@@ -710,10 +721,25 @@
     private static bool HasCurrentUserSignup(RunDetailDto detail) =>
         detail.RunCharacters.Any(c => c.IsCurrentUser);
 
-    private string? SpecIconUrlFor(RunCharacterDto? signup) =>
-        signup?.SpecId is int specId && _specIconUrls.TryGetValue(specId, out var iconUrl)
-            ? iconUrl
+    private static bool NeedsSpecIcons(RunDetailDto detail) =>
+        detail.RunCharacters.Any(c => c.SpecId is not null || !string.IsNullOrWhiteSpace(c.SpecName));
+
+    private string? SpecIconUrlFor(RunCharacterDto? character)
+    {
+        if (character?.SpecId is int specId && _specIconUrls.TryGetValue(specId, out var iconUrl))
+            return iconUrl;
+
+        return character is not null &&
+               !string.IsNullOrWhiteSpace(character.SpecName) &&
+               _specIconUrlsByClassAndName.TryGetValue(
+                   SpecIconLookupKey(character.CharacterClassId, character.SpecName),
+                   out var iconUrlByName)
+            ? iconUrlByName
             : null;
+    }
+
+    private static string SpecIconLookupKey(int classId, string specName) =>
+        $"{classId}:{specName.Trim().ToUpperInvariant()}";
 
     private void TogglePast() => _showPast = !_showPast;
 

--- a/app/wwwroot/css/app.css
+++ b/app/wwwroot/css/app.css
@@ -369,6 +369,18 @@ fluent-button.footer-language--active::part(control) {
     min-height: 44px;
 }
 
+.character-row__icons {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    flex: none;
+}
+
+.character-row__icon {
+    inline-size: 1.35rem;
+    block-size: 1.35rem;
+}
+
 .character-row__main {
     flex: 1;
     min-width: 0;
@@ -501,7 +513,7 @@ fluent-button.footer-language--active::part(control) {
     background: var(--neutral-fill-rest);
 }
 
-/* Guild crest — fixed dimensions from Blizzard CDN. */
+/* Guild crest — fixed dimensions for cached Blizzard media. */
 .guild-crest {
     inline-size: 88px;
     block-size: 88px;

--- a/app/wwwroot/staticwebapp.config.json.template
+++ b/app/wwwroot/staticwebapp.config.json.template
@@ -40,7 +40,7 @@
     "Referrer-Policy": "strict-origin-when-cross-origin",
     "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
     "Cache-Control": "no-cache",
-    "Content-Security-Policy": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://{{API_HOSTNAME}}; img-src 'self' https://{{API_HOSTNAME}} https://render.worldofwarcraft.com",
+    "Content-Security-Policy": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://{{API_HOSTNAME}}; img-src 'self' https://{{API_HOSTNAME}}",
     "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
   }
 }

--- a/docs/storage-architecture.md
+++ b/docs/storage-architecture.md
@@ -11,7 +11,7 @@ This document is the rule for where any piece of data the app persists should li
 | **Per-entity caches of Blizzard responses** (one user's account profile, one guild's roster) | **Cosmos, embedded** | inside the owning raider/guild document, with a `*FetchedAt` timestamp |
 | **Operational bytes** (ASP.NET Data Protection keys, Functions runtime state, deploy zip artifacts) | **Blob** | `lfmstore/{dataprotection,deployments,azure-webjobs-hosts,azure-webjobs-secrets}` |
 | **Secrets** (OAuth client secret, DP wrapping key) | **Key Vault** | referenced from App Settings via Key Vault references |
-| **Image bytes** | **Not cached by us** | browser HTTP cache + Blizzard render CDN (`render.worldofwarcraft.com`) |
+| **Blizzard media image bytes** | **Blob** | `lfmstore/wow/media-cache/render/{sha256}.{ext}`, served through `/api/v1/wow/media/cache` |
 
 ## Why the split
 
@@ -22,19 +22,26 @@ This document is the rule for where any piece of data the app persists should li
 
 ## Image caching policy
 
-We cache Blizzard CDN **URLs**, not image bytes. Rationale:
+Blizzard media documents may contain `https://render.worldofwarcraft.com/...`
+asset URLs. Store those source URLs next to the owning reference or user cache,
+but do not render them directly in browser image tags.
 
-- Blizzard render URLs are content-addressed (the path includes an asset hash), so the browser's HTTP cache works correctly across visits — a repeat viewer gets the image from their disk, not the network. That's the byte cache.
-- A second byte cache on our side would add egress cost per image load and a staleness window when Blizzard updates art, for zero user-visible win at our scale.
-- The SWA CSP already allows `img-src 'self' https://render.worldofwarcraft.com …`, so the `<img>` tag loads directly from the Blizzard CDN.
+Browser-facing image URLs must go through `/api/v1/wow/media/cache?source=...`:
 
-A URL is a string. It lives next to the other fields of whatever record needs it:
+- The `source` value is base64url-encoded.
+- The API accepts only HTTPS URLs on `render.worldofwarcraft.com`.
+- The API first reads `wow/media-cache/render/{sha256}.{ext}` from blob.
+- On a cache miss, the API fetches the Blizzard image, validates an `image/*`
+  content type and the size cap, stores the bytes in blob, then serves our copy.
+- The SWA CSP allows `img-src 'self' https://{{API_HOSTNAME}}`; it does not
+  allow direct `render.worldofwarcraft.com` image loads.
 
-- Spec icons: `reference/playable-specialization-media/{id}.json` → surfaced as `SpecializationDto.IconUrl` via the spec list endpoint's manifest.
-- Instance portraits: `reference/journal-instance-media/{id}.json` → surfaced as `InstanceDto.PortraitUrl`.
-- Character portraits: `raiders.PortraitCache` (Cosmos map of `{region-realm-name → render URL}` inside the owner's doc — not shared, not reference data, stays per-user).
+The source URL remains a string in the record that discovered it:
 
-If we ever need byte caching (Blizzard CDN reliability changes our mind, offline PWA support, etc.), the escape hatch is a new `lfmstore/media-cache/{kind}/{id}.{ext}` container, populated by the ingester during the weekly refresh. Not done today.
+- Spec icons: `reference/playable-specialization-media/{id}.json` → surfaced as `SpecializationDto.IconUrl` after the API/app maps the source to the media-cache URL.
+- Instance portraits: `reference/journal-instance-media/{id}.json` → surfaced as `InstanceDto.PortraitUrl` after the API/app maps the source to the media-cache URL.
+- Character portraits: `raiders.PortraitCache` (Cosmos map of `{region-realm-name → render URL}` inside the owner's doc — not shared, not reference data, stays per-user) → surfaced as a media-cache URL.
+- Guild crest fields, if populated, use the same media-cache URL mapping before rendering.
 
 ## Decision flow for a new data kind
 
@@ -83,7 +90,7 @@ For every reference kind that has a list endpoint, the ingester emits `reference
 ]
 ```
 
-The per-id detail blobs (`{kind}/{id}.json`, `{kind}-media/{id}.json`) stay for future endpoints (detail pages, hero talents) and as the source of truth the manifest is derived from.
+The per-id detail blobs (`{kind}/{id}.json`, `{kind}-media/{id}.json`) stay for future endpoints (detail pages, hero talents) and as the source of truth the manifest is derived from. Manifest media fields store Blizzard source URLs; HTTP handlers and Blazor image components convert them to `/api/v1/wow/media/cache` before browser rendering.
 
 ## Known exceptions to flag
 
@@ -120,6 +127,8 @@ Blob — lfmstore
 │       ├── playable-class/             (not yet consumed)
 │       ├── playable-race/              (not yet consumed)
 │       └── hero-talent-tree/           (future)
+│   └── media-cache/
+│       └── render/                      cached Blizzard render-CDN image bytes
 ├── dataprotection                      ASP.NET DP keys, KV-wrapped
 ├── deployments                         Functions zip deploy artifacts
 ├── azure-webjobs-hosts                 Functions runtime state (auto-managed)

--- a/shared/Lfm.Contracts/Media/BlizzardMediaCache.cs
+++ b/shared/Lfm.Contracts/Media/BlizzardMediaCache.cs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Text;
+
+namespace Lfm.Contracts.Media;
+
+/// <summary>
+/// Shared helpers for routing Blizzard render-CDN assets through LFM's media
+/// cache instead of linking browser image tags directly to Blizzard.
+/// </summary>
+public static class BlizzardMediaCache
+{
+    public const string RenderHost = "render.worldofwarcraft.com";
+
+    public static bool IsBlizzardRenderUrl(string? url)
+        => Uri.TryCreate(url, UriKind.Absolute, out var uri)
+        && IsAllowedRenderUri(uri);
+
+    public static string EncodeSource(string sourceUrl)
+    {
+        var bytes = Encoding.UTF8.GetBytes(sourceUrl);
+        return Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+
+    public static bool TryDecodeSource(string encodedSource, out Uri? sourceUri)
+    {
+        sourceUri = null;
+        if (string.IsNullOrWhiteSpace(encodedSource))
+            return false;
+
+        var base64 = encodedSource.Replace('-', '+').Replace('_', '/');
+        var padding = base64.Length % 4;
+        if (padding > 0)
+            base64 = base64.PadRight(base64.Length + 4 - padding, '=');
+
+        try
+        {
+            var bytes = Convert.FromBase64String(base64);
+            var source = Encoding.UTF8.GetString(bytes);
+            if (!Uri.TryCreate(source, UriKind.Absolute, out var uri))
+                return false;
+
+            if (!IsAllowedRenderUri(uri))
+                return false;
+
+            sourceUri = uri;
+            return true;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
+
+    private static bool IsAllowedRenderUri(Uri uri)
+        => string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+        && string.Equals(uri.Host, RenderHost, StringComparison.OrdinalIgnoreCase)
+        && string.IsNullOrEmpty(uri.UserInfo);
+}

--- a/shared/Lfm.Contracts/WoW/WowClasses.cs
+++ b/shared/Lfm.Contracts/WoW/WowClasses.cs
@@ -45,9 +45,24 @@ public static class WowClasses
             [13] = "#33937F",  // Evoker
         };
 
-    /// <summary>
-    /// Returns the hex colour for a WoW class ID, or white for unknown IDs.
-    /// </summary>
+    private static readonly IReadOnlyDictionary<int, string> IconNames =
+        new Dictionary<int, string>
+        {
+            [1] = "classicon_warrior",
+            [2] = "classicon_paladin",
+            [3] = "classicon_hunter",
+            [4] = "classicon_rogue",
+            [5] = "classicon_priest",
+            [6] = "spell_deathknight_classicon",
+            [7] = "classicon_shaman",
+            [8] = "classicon_mage",
+            [9] = "classicon_warlock",
+            [10] = "classicon_monk",
+            [11] = "classicon_druid",
+            [12] = "classicon_demonhunter",
+            [13] = "classicon_evoker",
+        };
+
     /// <summary>
     /// Returns the English name for a WoW class ID, or "Unknown" for unknown IDs.
     /// </summary>
@@ -59,4 +74,12 @@ public static class WowClasses
     /// </summary>
     public static string GetColor(int classId) =>
         Colors.TryGetValue(classId, out var color) ? color : "#FFFFFF";
+
+    /// <summary>
+    /// Returns the render asset path for a WoW class ID, or null for unknown IDs.
+    /// Callers that render this as an image must route it through the app media
+    /// cache instead of linking directly to Blizzard.
+    /// </summary>
+    public static string? GetIconPath(int classId) =>
+        IconNames.TryGetValue(classId, out var iconName) ? $"icons/56/{iconName}.jpg" : null;
 }

--- a/tests/Lfm.Api.Tests/BattleNetCharacterPortraitsFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/BattleNetCharacterPortraitsFunctionTests.cs
@@ -10,6 +10,7 @@ using Lfm.Api.Functions;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;
 using Lfm.Contracts.Characters;
+using Lfm.Contracts.Media;
 using Xunit;
 
 namespace Lfm.Api.Tests;
@@ -48,6 +49,20 @@ public class BattleNetCharacterPortraitsFunctionTests
         Mock<IRaidersRepository> repoMock,
         Mock<ICharacterPortraitService> portraitServiceMock)
         => new(repoMock.Object, portraitServiceMock.Object);
+
+    private static HttpRequest JsonRequest(object body)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Scheme = "https";
+        httpContext.Request.Host = new HostString("api.lfm.test");
+        httpContext.Request.ContentType = "application/json";
+        var bodyJson = System.Text.Json.JsonSerializer.Serialize(body);
+        httpContext.Request.Body = new System.IO.MemoryStream(System.Text.Encoding.UTF8.GetBytes(bodyJson));
+        return httpContext.Request;
+    }
+
+    private static string CachedMediaUrl(string sourceUrl) =>
+        $"https://api.lfm.test/api/v1/wow/media/cache?source={BlizzardMediaCache.EncodeSource(sourceUrl)}";
 
     // -------------------------------------------------------------------------
     // Happy path — portrait cached in portraitCache
@@ -90,22 +105,19 @@ public class BattleNetCharacterPortraitsFunctionTests
         var fn = MakeFunction(repo, portraitService);
         var ctx = MakeFunctionContext(FakePrincipal());
 
-        var httpContext = new DefaultHttpContext();
-        httpContext.Request.ContentType = "application/json";
-        var bodyJson = System.Text.Json.JsonSerializer.Serialize(new[]
+        var request = JsonRequest(new[]
         {
             new { region = "eu", realm = "silvermoon", name = "Legolas" },
         });
-        httpContext.Request.Body = new System.IO.MemoryStream(System.Text.Encoding.UTF8.GetBytes(bodyJson));
 
         // Act
-        var result = await fn.Run(httpContext.Request, ctx, CancellationToken.None);
+        var result = await fn.Run(request, ctx, CancellationToken.None);
 
-        // Assert: 200 with the cached portrait URL
+        // Assert: 200 with the cached portrait URL routed through the media cache.
         var ok = Assert.IsType<OkObjectResult>(result);
         var response = Assert.IsAssignableFrom<PortraitResponse>(ok.Value);
         Assert.True(response.Portraits.ContainsKey(CharacterId));
-        Assert.Equal(CachedPortraitUrl, response.Portraits[CharacterId]);
+        Assert.Equal(CachedMediaUrl(CachedPortraitUrl), response.Portraits[CharacterId]);
     }
 
     // -------------------------------------------------------------------------
@@ -145,22 +157,19 @@ public class BattleNetCharacterPortraitsFunctionTests
         var fn = MakeFunction(repo, portraitService);
         var ctx = MakeFunctionContext(FakePrincipal());
 
-        var httpContext = new DefaultHttpContext();
-        httpContext.Request.ContentType = "application/json";
-        var bodyJson = System.Text.Json.JsonSerializer.Serialize(new[]
+        var request = JsonRequest(new[]
         {
             new { region = "eu", realm = "draenor", name = "Thrall" },
         });
-        httpContext.Request.Body = new System.IO.MemoryStream(System.Text.Encoding.UTF8.GetBytes(bodyJson));
 
         // Act
-        var result = await fn.Run(httpContext.Request, ctx, CancellationToken.None);
+        var result = await fn.Run(request, ctx, CancellationToken.None);
 
-        // Assert: 200 with Blizzard-fetched portrait URL
+        // Assert: 200 with Blizzard-fetched portrait URL routed through the media cache.
         var ok = Assert.IsType<OkObjectResult>(result);
         var response = Assert.IsAssignableFrom<PortraitResponse>(ok.Value);
         Assert.True(response.Portraits.ContainsKey(CharacterId));
-        Assert.Equal(BlizzardPortraitUrl, response.Portraits[CharacterId]);
+        Assert.Equal(CachedMediaUrl(BlizzardPortraitUrl), response.Portraits[CharacterId]);
 
         // Verify service was called with the access token
         portraitService.Verify(

--- a/tests/Lfm.Api.Tests/FunctionAuthorizationContractTests.cs
+++ b/tests/Lfm.Api.Tests/FunctionAuthorizationContractTests.cs
@@ -47,6 +47,10 @@ public class FunctionAuthorizationContractTests
         // Public privacy contact — the SPA reveals this only on user click.
         "privacy-email",
         "privacy-email-v1",
+        // Public image cache — source is restricted to Blizzard render-CDN URLs,
+        // and <img> requests must work without an API JSON preflight.
+        "wow-media-cache",
+        "wow-media-cache-v1",
         // Catch-all OPTIONS preflight handler — short-circuited by CorsMiddleware.
         "cors-preflight",
     };

--- a/tests/Lfm.Api.Tests/MeFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/MeFunctionTests.cs
@@ -9,6 +9,7 @@ using Lfm.Api.Auth;
 using Lfm.Api.Functions;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;
+using Lfm.Contracts.Media;
 using Lfm.Contracts.Me;
 using Xunit;
 
@@ -25,6 +26,17 @@ public class MeFunctionTests
         ctx.Setup(c => c.Items).Returns(items);
         return ctx.Object;
     }
+
+    private static HttpRequest Request()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Scheme = "https";
+        context.Request.Host = new HostString("api.lfm.test");
+        return context.Request;
+    }
+
+    private static string CachedMediaUrl(string sourceUrl) =>
+        $"https://api.lfm.test/api/v1/wow/media/cache?source={BlizzardMediaCache.EncodeSource(sourceUrl)}";
 
     [Fact]
     public async Task Returns_me_response_when_raider_exists()
@@ -63,7 +75,7 @@ public class MeFunctionTests
         var fn = new MeFunction(repo.Object, siteAdmin.Object);
         var ctx = MakeFunctionContext(principal);
 
-        var result = await fn.Run(new DefaultHttpContext().Request, ctx, CancellationToken.None);
+        var result = await fn.Run(Request(), ctx, CancellationToken.None);
 
         var ok = Assert.IsType<OkObjectResult>(result);
         var me = Assert.IsType<MeResponse>(ok.Value);
@@ -112,7 +124,7 @@ public class MeFunctionTests
         var fn = new MeFunction(repo.Object, siteAdmin.Object);
         var ctx = MakeFunctionContext(principal);
 
-        var result = await fn.RunV1(new DefaultHttpContext().Request, ctx, CancellationToken.None);
+        var result = await fn.RunV1(Request(), ctx, CancellationToken.None);
 
         var ok = Assert.IsType<OkObjectResult>(result);
         var selected = ok.Value!.GetType().GetProperty("SelectedCharacter")?.GetValue(ok.Value);
@@ -120,7 +132,7 @@ public class MeFunctionTests
         Assert.Equal("char-1", selected.GetType().GetProperty("Id")?.GetValue(selected));
         Assert.Equal("Testchar", selected.GetType().GetProperty("Name")?.GetValue(selected));
         Assert.Equal(
-            "https://render.worldofwarcraft.com/eu/testchar-avatar.jpg",
+            CachedMediaUrl("https://render.worldofwarcraft.com/eu/testchar-avatar.jpg"),
             selected.GetType().GetProperty("PortraitUrl")?.GetValue(selected));
     }
 
@@ -170,14 +182,14 @@ public class MeFunctionTests
         var fn = new MeFunction(repo.Object, siteAdmin.Object);
         var ctx = MakeFunctionContext(principal);
 
-        var result = await fn.RunV1(new DefaultHttpContext().Request, ctx, CancellationToken.None);
+        var result = await fn.RunV1(Request(), ctx, CancellationToken.None);
 
         var ok = Assert.IsType<OkObjectResult>(result);
         var me = Assert.IsType<MeResponse>(ok.Value);
         Assert.NotNull(me.SelectedCharacter);
         Assert.Equal("eu-doomhammer-shalena", me.SelectedCharacter.Id);
         Assert.Equal("Shalena", me.SelectedCharacter.Name);
-        Assert.Equal("https://render.worldofwarcraft.com/eu/shalena-avatar.jpg", me.SelectedCharacter.PortraitUrl);
+        Assert.Equal(CachedMediaUrl("https://render.worldofwarcraft.com/eu/shalena-avatar.jpg"), me.SelectedCharacter.PortraitUrl);
     }
 
     [Fact]
@@ -200,7 +212,7 @@ public class MeFunctionTests
         var fn = new MeFunction(repo.Object, siteAdmin.Object);
         var ctx = MakeFunctionContext(principal);
 
-        var result = await fn.Run(new DefaultHttpContext().Request, ctx, CancellationToken.None);
+        var result = await fn.Run(Request(), ctx, CancellationToken.None);
 
         var notFound = Assert.IsType<ObjectResult>(result);
         Assert.Equal(404, notFound.StatusCode);

--- a/tests/Lfm.Api.Tests/Openapi/OpenApiContractTests.cs
+++ b/tests/Lfm.Api.Tests/Openapi/OpenApiContractTests.cs
@@ -147,6 +147,7 @@ public class OpenApiContractTests
     [InlineData("/api/v1/wow/reference/expansions")]
     [InlineData("/api/v1/wow/reference/instances")]
     [InlineData("/api/v1/wow/reference/specializations")]
+    [InlineData("/api/v1/wow/media/cache")]
     [InlineData("/api/v1/wow/reference/refresh")]
     [InlineData("/api/v1/admin/runs/migrate-schema")]
     [InlineData("/api/v1/privacy-contact/email")]

--- a/tests/Lfm.Api.Tests/RaiderCharacterAddFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/RaiderCharacterAddFunctionTests.cs
@@ -11,6 +11,7 @@ using Lfm.Api.Functions;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;
 using Lfm.Api.Services.Blizzard.Models;
+using Lfm.Contracts.Media;
 using Lfm.Contracts.Raiders;
 using System.Text;
 using System.Text.Json;
@@ -60,6 +61,8 @@ public class RaiderCharacterAddFunctionTests
     private static HttpRequest MakePostRequest(object body)
     {
         var httpContext = new DefaultHttpContext();
+        httpContext.Request.Scheme = "https";
+        httpContext.Request.Host = new HostString("api.lfm.test");
         httpContext.Request.Method = "POST";
         httpContext.Request.ContentType = "application/json";
         var json = JsonSerializer.Serialize(body);
@@ -67,6 +70,9 @@ public class RaiderCharacterAddFunctionTests
         httpContext.Request.ContentLength = httpContext.Request.Body.Length;
         return httpContext.Request;
     }
+
+    private static string CachedMediaUrl(string sourceUrl) =>
+        $"https://api.lfm.test/api/v1/wow/media/cache?source={BlizzardMediaCache.EncodeSource(sourceUrl)}";
 
     private static RaiderCharacterAddFunction MakeFunction(
         Mock<IRaidersRepository> repoMock,
@@ -169,7 +175,7 @@ public class RaiderCharacterAddFunctionTests
         Assert.Equal(80, response.Character.Level);
         Assert.Equal(65, response.Character.ActiveSpecId);
         Assert.Equal("Holy", response.Character.SpecName);
-        Assert.Equal("https://render.worldofwarcraft.com/avatar.jpg", response.Character.PortraitUrl);
+        Assert.Equal(CachedMediaUrl("https://render.worldofwarcraft.com/avatar.jpg"), response.Character.PortraitUrl);
 
         // Upsert called once with selected character updated, the stored character present,
         // and the portrait cache populated.
@@ -232,7 +238,7 @@ public class RaiderCharacterAddFunctionTests
         var ok = Assert.IsType<OkObjectResult>(result);
         var response = Assert.IsType<AddCharacterResponse>(ok.Value);
         Assert.Equal("eu-silvermoon-aelrin", response.SelectedCharacterId);
-        Assert.Equal("https://render.worldofwarcraft.com/cached.jpg", response.Character.PortraitUrl);
+        Assert.Equal(CachedMediaUrl("https://render.worldofwarcraft.com/cached.jpg"), response.Character.PortraitUrl);
 
         // Blizzard calls were skipped.
         profileClient.Verify(p => p.GetCharacterProfileAsync(

--- a/tests/Lfm.Api.Tests/Services/WowMediaCacheTests.cs
+++ b/tests/Lfm.Api.Tests/Services/WowMediaCacheTests.cs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Net;
+using Lfm.Api.Services;
+using Lfm.Contracts.Media;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Lfm.Api.Tests.Services;
+
+public class WowMediaCacheTests
+{
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> send) : HttpMessageHandler
+    {
+        public int Calls { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Calls++;
+            return Task.FromResult(send(request));
+        }
+    }
+
+    [Fact]
+    public async Task GetOrFetchAsync_returns_cached_blob_without_fetching_render_cdn()
+    {
+        var source = new Uri("https://render.worldofwarcraft.com/icons/56/classicon_warlock.jpg");
+        var encoded = BlizzardMediaCache.EncodeSource(source.AbsoluteUri);
+        var cached = new ReferenceBlobContent([1, 2, 3], "image/jpeg");
+        var blobs = new Mock<IBlobReferenceClient>(MockBehavior.Strict);
+        blobs.Setup(b => b.GetContentAsync(WowMediaCache.BlobNameFor(source), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(cached);
+        var handler = new StubHandler(_ => throw new InvalidOperationException("should not fetch"));
+        var sut = new WowMediaCache(blobs.Object, new HttpClient(handler), NullLogger<WowMediaCache>.Instance);
+
+        var result = await sut.GetOrFetchAsync(encoded, CancellationToken.None);
+
+        Assert.Same(cached, result);
+        Assert.Equal(0, handler.Calls);
+        blobs.Verify(b => b.UploadContentAsync(
+            It.IsAny<string>(),
+            It.IsAny<byte[]>(),
+            It.IsAny<string>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetOrFetchAsync_fetches_and_stores_blizzard_render_image_on_cache_miss()
+    {
+        var source = new Uri("https://render.worldofwarcraft.com/icons/56/classicon_warlock.jpg");
+        var encoded = BlizzardMediaCache.EncodeSource(source.AbsoluteUri);
+        var image = new byte[] { 9, 8, 7 };
+        var blobs = new Mock<IBlobReferenceClient>(MockBehavior.Strict);
+        blobs.Setup(b => b.GetContentAsync(WowMediaCache.BlobNameFor(source), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ReferenceBlobContent?)null);
+        blobs.Setup(b => b.UploadContentAsync(
+                WowMediaCache.BlobNameFor(source),
+                It.Is<byte[]>(bytes => bytes.SequenceEqual(image)),
+                "image/jpeg",
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var handler = new StubHandler(request =>
+        {
+            Assert.Equal(source, request.RequestUri);
+            var content = new ByteArrayContent(image);
+            content.Headers.ContentType = new("image/jpeg");
+            return new HttpResponseMessage(HttpStatusCode.OK) { Content = content };
+        });
+        var sut = new WowMediaCache(blobs.Object, new HttpClient(handler), NullLogger<WowMediaCache>.Instance);
+
+        var result = await sut.GetOrFetchAsync(encoded, CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal("image/jpeg", result!.ContentType);
+        Assert.Equal(image, result.Content);
+        Assert.Equal(1, handler.Calls);
+        blobs.VerifyAll();
+    }
+
+    [Fact]
+    public async Task GetOrFetchAsync_rejects_non_blizzard_render_sources()
+    {
+        var encoded = BlizzardMediaCache.EncodeSource("https://example.com/icons/56/classicon_warlock.jpg");
+        var blobs = new Mock<IBlobReferenceClient>(MockBehavior.Strict);
+        var handler = new StubHandler(_ => throw new InvalidOperationException("should not fetch"));
+        var sut = new WowMediaCache(blobs.Object, new HttpClient(handler), NullLogger<WowMediaCache>.Instance);
+
+        var result = await sut.GetOrFetchAsync(encoded, CancellationToken.None);
+
+        Assert.Null(result);
+        Assert.Equal(0, handler.Calls);
+    }
+}

--- a/tests/Lfm.Api.Tests/WowClassesTests.cs
+++ b/tests/Lfm.Api.Tests/WowClassesTests.cs
@@ -80,6 +80,25 @@ public class WowClassesTests
     }
 
     [Theory]
+    [InlineData(6, "icons/56/spell_deathknight_classicon.jpg")]
+    [InlineData(9, "icons/56/classicon_warlock.jpg")]
+    [InlineData(13, "icons/56/classicon_evoker.jpg")]
+    public void GetIconPath_returns_render_asset_path_for_known_classId(int classId, string expected)
+    {
+        Assert.Equal(expected, WowClasses.GetIconPath(classId));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(99)]
+    [InlineData(14)]
+    public void GetIconPath_returns_null_for_invalid_classId(int classId)
+    {
+        Assert.Null(WowClasses.GetIconPath(classId));
+    }
+
+    [Theory]
     [InlineData(1)]
     [InlineData(13)]
     public void GetName_returns_non_unknown_for_valid_ids(int classId)

--- a/tests/Lfm.Api.Tests/WowReferenceSpecializationsFunctionTests.cs
+++ b/tests/Lfm.Api.Tests/WowReferenceSpecializationsFunctionTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Azure.Functions.Worker;
 using Moq;
 using Lfm.Api.Functions;
 using Lfm.Api.Repositories;
+using Lfm.Contracts.Media;
 using Lfm.Contracts.Specializations;
 using Xunit;
 
@@ -21,18 +22,27 @@ public class WowReferenceSpecializationsFunctionTests
     };
 
     [Fact]
-    public async Task Returns_specializations_from_repository_unchanged()
+    public async Task Returns_specializations_with_media_urls_routed_through_cache()
     {
         var fixture = RepositoryFixture();
         var repo = new Mock<ISpecializationsRepository>();
         repo.Setup(r => r.ListAsync(It.IsAny<CancellationToken>())).ReturnsAsync(fixture);
         var fn = new WowReferenceSpecializationsFunction(repo.Object);
 
-        var result = await fn.Run(new DefaultHttpContext().Request, CancellationToken.None);
+        var context = new DefaultHttpContext();
+        context.Request.Scheme = "https";
+        context.Request.Host = new HostString("api.lfm.test");
+
+        var result = await fn.Run(context.Request, CancellationToken.None);
 
         var ok = Assert.IsType<OkObjectResult>(result);
-        Assert.Equal(fixture, Assert.IsType<List<SpecializationDto>>(ok.Value));
+        var response = Assert.IsType<List<SpecializationDto>>(ok.Value);
+        Assert.Equal(CachedMediaUrl(fixture[0].IconUrl!), response[0].IconUrl);
+        Assert.Null(response[1].IconUrl);
     }
+
+    private static string CachedMediaUrl(string sourceUrl) =>
+        $"https://api.lfm.test/api/v1/wow/media/cache?source={BlizzardMediaCache.EncodeSource(sourceUrl)}";
 
     [Fact]
     public void Function_has_correct_function_attribute()

--- a/tests/Lfm.App.Tests/CharactersPagesTests.cs
+++ b/tests/Lfm.App.Tests/CharactersPagesTests.cs
@@ -11,6 +11,7 @@ using Moq;
 using Lfm.App.Pages;
 using Lfm.App.Services;
 using Lfm.Contracts.Characters;
+using Lfm.Contracts.Media;
 using Lfm.Contracts.Me;
 using Xunit;
 
@@ -19,6 +20,9 @@ namespace Lfm.App.Tests;
 public class CharactersPagesTests : ComponentTestBase
 {
     // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static string CachedMediaUrl(string sourceUrl) =>
+        $"http://localhost:7071/api/v1/wow/media/cache?source={BlizzardMediaCache.EncodeSource(sourceUrl)}";
 
     private static MeResponse MakeMeResponse(
         string? selectedCharacterId = null,
@@ -382,6 +386,31 @@ public class CharactersPagesTests : ComponentTestBase
         await Task.Delay(TimeSpan.FromMilliseconds(100));
 
         Assert.Equal("page-2-char4.png", cut.Find("[data-char-id='eu-silvermoon-char4'] img").GetAttribute("src"));
+    }
+
+    [Fact]
+    public void CharactersPage_Routes_Blizzard_Portraits_Through_Media_Cache()
+    {
+        this.AddAuthorization().SetAuthorized("player#1234");
+        const string SourceUrl = "https://render.worldofwarcraft.com/eu/character/silvermoon/1/aelrin-avatar.jpg";
+        var battleNet = new Mock<IBattleNetClient>();
+        battleNet.Setup(c => c.GetCharactersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CharactersFetchResult.Cached([MakeChar("Aelrin")]));
+        battleNet.Setup(c => c.GetPortraitsAsync(It.IsAny<IEnumerable<CharacterPortraitRequest>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, string>
+            {
+                ["eu-silvermoon-aelrin"] = SourceUrl,
+            });
+        Services.AddSingleton(battleNet.Object);
+
+        var cut = Render<CharactersPage>();
+
+        cut.WaitForAssertion(() =>
+        {
+            var img = cut.Find("[data-char-id='eu-silvermoon-aelrin'] img");
+            Assert.Equal(CachedMediaUrl(SourceUrl), img.GetAttribute("src"));
+            Assert.DoesNotContain(SourceUrl, cut.Markup);
+        });
     }
 
     [Fact]

--- a/tests/Lfm.App.Tests/LayoutTests.cs
+++ b/tests/Lfm.App.Tests/LayoutTests.cs
@@ -7,6 +7,7 @@ using Lfm.App.Auth;
 using Lfm.App.Layout;
 using Lfm.App.Services;
 using Lfm.App.i18n;
+using Lfm.Contracts.Media;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
@@ -18,6 +19,9 @@ namespace Lfm.App.Tests;
 
 public class LayoutTests : ComponentTestBase
 {
+    private static string CachedMediaUrl(string sourceUrl) =>
+        $"http://localhost:7071/api/v1/wow/media/cache?source={BlizzardMediaCache.EncodeSource(sourceUrl)}";
+
     [Fact]
     public void MainLayout_Renders_App_Name()
     {
@@ -255,7 +259,8 @@ public class LayoutTests : ComponentTestBase
             var trigger = cut.Find("fluent-button.account-menu-trigger");
             Assert.Contains("Aelrin", trigger.TextContent);
             Assert.Equal("Account menu for Aelrin", trigger.GetAttribute("aria-label"));
-            Assert.Contains("https://render.worldofwarcraft.com/eu/aelrin-avatar.jpg", cut.Markup);
+            Assert.Contains(CachedMediaUrl("https://render.worldofwarcraft.com/eu/aelrin-avatar.jpg"), cut.Markup);
+            Assert.DoesNotContain("https://render.worldofwarcraft.com/eu/aelrin-avatar.jpg", cut.Markup);
         });
     }
 

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -18,6 +18,7 @@ using Lfm.Contracts.Characters;
 using Lfm.Contracts.Expansions;
 using Lfm.Contracts.Guild;
 using Lfm.Contracts.Instances;
+using Lfm.Contracts.Media;
 using Lfm.Contracts.Me;
 using Lfm.Contracts.Runs;
 using Lfm.Contracts.Specializations;
@@ -40,6 +41,9 @@ public class RunsPagesTests : ComponentTestBase
         DateTimeOffset.UtcNow.AddDays(30).ToString("o");
     private static readonly string FutureSignupCloseTime =
         DateTimeOffset.UtcNow.AddDays(30).AddHours(-2).ToString("o");
+
+    private static string CachedMediaUrl(string sourceUrl) =>
+        $"http://localhost:7071/api/v1/wow/media/cache?source={BlizzardMediaCache.EncodeSource(sourceUrl)}";
 
     private static RunSummaryDto MakeSummary(string id = "run-1") =>
         new(
@@ -910,7 +914,7 @@ public class RunsPagesTests : ComponentTestBase
                     Name: "Holy",
                     ClassId: 5,
                     Role: "HEALER",
-                    IconUrl: "https://render.example/holy.jpg"),
+                    IconUrl: "https://render.worldofwarcraft.com/eu/icons/56/spell_holy_holybolt.jpg"),
             ]);
         Services.AddSingleton(specializations.Object);
 
@@ -918,9 +922,54 @@ public class RunsPagesTests : ComponentTestBase
 
         cut.WaitForAssertion(() =>
         {
-            var icon = cut.Find("img.spec-icon__image");
-            Assert.Equal("https://render.example/holy.jpg", icon.GetAttribute("src"));
+            var icon = cut.Find("[data-testid='run-signup-surface'] img.spec-icon__image");
+            Assert.Equal(CachedMediaUrl("https://render.worldofwarcraft.com/eu/icons/56/spell_holy_holybolt.jpg"), icon.GetAttribute("src"));
             Assert.Equal("", icon.GetAttribute("alt"));
+        });
+        specializations.Verify(c => c.ListAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public void RunsPage_AttendingRows_Render_Class_And_Spec_Media_Icons()
+    {
+        var client = new Mock<IRunsClient>();
+        client.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<RunSummaryDto> { MakeSummary() });
+        client.Setup(c => c.GetAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeDetailWithRoster(new List<RunCharacterDto>
+            {
+                MakeCharacter("Shalena", classId: 9, className: "Warlock", role: "DPS", spec: "Demonology"),
+            }));
+        Services.AddSingleton(client.Object);
+
+        var specializations = new Mock<ISpecializationsClient>();
+        specializations.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new SpecializationDto(
+                    Id: 266,
+                    Name: "Demonology",
+                    ClassId: 9,
+                    Role: "DPS",
+                    IconUrl: "https://render.worldofwarcraft.com/eu/icons/56/spell_warlock_demonology.jpg"),
+            ]);
+        Services.AddSingleton(specializations.Object);
+
+        var cut = Render<RunsPage>(p => p.Add(x => x.RunId, "run-1"));
+
+        cut.WaitForAssertion(() =>
+        {
+            var row = cut.Find(".character-row");
+            Assert.Contains("Warlock \u00B7 Demonology", row.TextContent);
+
+            var classIcon = row.QuerySelector(".character-row__class-icon img");
+            Assert.NotNull(classIcon);
+            Assert.Equal(CachedMediaUrl("https://render.worldofwarcraft.com/icons/56/classicon_warlock.jpg"), classIcon.GetAttribute("src"));
+            Assert.Equal("", classIcon.GetAttribute("alt"));
+
+            var specIcon = row.QuerySelector(".character-row__spec-icon img");
+            Assert.NotNull(specIcon);
+            Assert.Equal(CachedMediaUrl("https://render.worldofwarcraft.com/eu/icons/56/spell_warlock_demonology.jpg"), specIcon.GetAttribute("src"));
+            Assert.Equal("", specIcon.GetAttribute("alt"));
         });
         specializations.Verify(c => c.ListAsync(It.IsAny<CancellationToken>()), Times.Once);
     }

--- a/tools/Lfm.OpenApiGenerator/OpenApiSnapshotGenerator.cs
+++ b/tools/Lfm.OpenApiGenerator/OpenApiSnapshotGenerator.cs
@@ -69,6 +69,12 @@ public static class OpenApiSnapshotGenerator
             [("post", "/api/v1/wow/reference/refresh")] = SchemaRef.Object<WowReferenceRefreshProgress>(),
         };
 
+    private static readonly IReadOnlySet<(string Method, string Path)> BinaryResponseEndpoints =
+        new HashSet<(string, string)>(StringTupleComparer.OrdinalIgnoreCase)
+        {
+            ("get", "/api/v1/wow/media/cache"),
+        };
+
     private static readonly string[] Tags =
     [
         "Health",
@@ -210,7 +216,8 @@ public static class OpenApiSnapshotGenerator
         builder.AppendLine($"      operationId: {OperationId(endpoint.Method, endpoint.Path)}");
 
         var pathParameters = ExtractPathParameters(endpoint.Path);
-        if (pathParameters.Count > 0)
+        var hasMediaSourceQuery = string.Equals(endpoint.Path, "/api/v1/wow/media/cache", StringComparison.OrdinalIgnoreCase);
+        if (pathParameters.Count > 0 || hasMediaSourceQuery)
         {
             builder.AppendLine("      parameters:");
             foreach (var parameter in pathParameters)
@@ -220,6 +227,15 @@ public static class OpenApiSnapshotGenerator
                 builder.AppendLine("          required: true");
                 builder.AppendLine("          schema:");
                 builder.AppendLine("            type: string");
+            }
+            if (hasMediaSourceQuery)
+            {
+                builder.AppendLine("        - name: source");
+                builder.AppendLine("          in: query");
+                builder.AppendLine("          required: true");
+                builder.AppendLine("          schema:");
+                builder.AppendLine("            type: string");
+                builder.AppendLine("          description: Base64url-encoded Blizzard render-CDN URL.");
             }
         }
 
@@ -247,6 +263,16 @@ public static class OpenApiSnapshotGenerator
             builder.AppendLine("            application/json:");
             builder.AppendLine("              schema:");
             AppendSchemaRef(builder, responseSchema, 16);
+        }
+        else if (BinaryResponseEndpoints.Contains((endpoint.Method, endpoint.Path)))
+        {
+            builder.AppendLine("        '200':");
+            builder.AppendLine("          description: Success.");
+            builder.AppendLine("          content:");
+            builder.AppendLine("            image/*:");
+            builder.AppendLine("              schema:");
+            builder.AppendLine("                type: string");
+            builder.AppendLine("                format: binary");
         }
         else
         {


### PR DESCRIPTION
## Summary
- Add an API-backed Blizzard render media cache that stores fetched image bytes in blob storage and serves browser-facing URLs from `/api/v1/wow/media/cache`.
- Route class/spec icons, portraits, instance media, guild crests, and selected-character avatars through the cache instead of linking directly to Blizzard render URLs.
- Show WoW class and specialization icons on attendee cards, with fallback-safe image handling.
- Update CSP, OpenAPI, storage guidance, repo guidance, and tests for the project-wide media policy.

## Env / Schema Changes
- No new environment variables or Cosmos schema migration.
- New lazy blob cache path: `wow/media-cache/render/{sha256}.{ext}`.
- Static Web App CSP no longer allows direct `https://render.worldofwarcraft.com` image loads.

## Screenshots
- Not captured. The changed UI state requires authenticated/seeded run data; rendering is covered by bUnit/component tests for attendee cards, character portraits, and layout avatars.

## Verification
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `dotnet build lfm.sln -c Release --no-restore` — 0 warnings, 0 errors
- `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release --no-restore` — 895 passed
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --no-restore` — 312 passed
- `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release --no-restore` — 286 passed
- `git diff --check`
- `git diff --cached --check`