### PR TITLE
Throttle auth resume probes

### DIFF
--- a/app/Components/AuthSessionMonitor.razor
+++ b/app/Components/AuthSessionMonitor.razor
@@ -3,10 +3,13 @@
 @inject NavigationManager Nav
 @inject IAuthStateRefresher AuthStateRefresher
 @inject ISessionExpiryNotifier SessionExpiryNotifier
+@inject TimeProvider TimeProvider
 
 @code {
+    private static readonly TimeSpan ResumeProbeMinimumInterval = TimeSpan.FromMinutes(5);
     private readonly string _registrationId = $"auth-session-monitor-{Guid.NewGuid():N}";
     private DotNetObjectReference<AuthSessionMonitor>? _dotNetRef;
+    private DateTimeOffset? _lastSessionCheckAt;
     private bool _disposed;
 
     protected override void OnInitialized()
@@ -32,8 +35,15 @@
     [JSInvokable]
     public Task CheckSessionAsync()
     {
-        if (!_disposed && AuthStateRefresher.HasAuthenticatedSession)
-            AuthStateRefresher.RefreshAuthenticationState();
+        if (_disposed || !AuthStateRefresher.HasAuthenticatedSession)
+            return Task.CompletedTask;
+
+        var now = TimeProvider.GetUtcNow();
+        if (_lastSessionCheckAt is not null && now - _lastSessionCheckAt < ResumeProbeMinimumInterval)
+            return Task.CompletedTask;
+
+        _lastSessionCheckAt = now;
+        AuthStateRefresher.RefreshAuthenticationState();
 
         return Task.CompletedTask;
     }

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -57,6 +57,7 @@ builder.Services.AddScoped<IGuildClient, GuildClient>();
 builder.Services.AddScoped<IRunsClient, RunsClient>();
 builder.Services.AddScoped<IBattleNetClient, BattleNetClient>();
 builder.Services.AddScoped<UnsavedChangesGuard>();
+builder.Services.AddSingleton(TimeProvider.System);
 
 builder.Services.AddAuthorizationCore();
 builder.Services.AddScoped<ISessionExpiryNotifier, SessionExpiryNotifier>();

--- a/tests/Lfm.App.Tests/AuthSessionMonitorTests.cs
+++ b/tests/Lfm.App.Tests/AuthSessionMonitorTests.cs
@@ -67,6 +67,27 @@ public class AuthSessionMonitorTests : ComponentTestBase
     }
 
     [Fact]
+    public async Task Resume_probe_rate_limits_repeated_auth_state_refreshes()
+    {
+        var notifier = new SessionExpiryNotifier();
+        var refresher = new RecordingAuthStateRefresher(hasAuthenticatedSession: true);
+        var timeProvider = new ManualTimeProvider(new DateTimeOffset(2026, 5, 21, 12, 0, 0, TimeSpan.Zero));
+        Services.AddSingleton<ISessionExpiryNotifier>(notifier);
+        Services.AddSingleton<IAuthStateRefresher>(refresher);
+        Services.AddSingleton<TimeProvider>(timeProvider);
+        var cut = Render<AuthSessionMonitor>();
+
+        await cut.Instance.CheckSessionAsync();
+        await cut.Instance.CheckSessionAsync();
+        timeProvider.Advance(TimeSpan.FromMinutes(4));
+        await cut.Instance.CheckSessionAsync();
+        timeProvider.Advance(TimeSpan.FromMinutes(1));
+        await cut.Instance.CheckSessionAsync();
+
+        Assert.Equal(2, refresher.RefreshCount);
+    }
+
+    [Fact]
     public async Task CredentialsHandler_notifies_session_expiry_on_401_response()
     {
         var notifier = new SessionExpiryNotifier();
@@ -115,6 +136,15 @@ public class AuthSessionMonitorTests : ComponentTestBase
             MarkExpiredCount++;
             HasAuthenticatedSession = false;
         }
+    }
+
+    private sealed class ManualTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        private DateTimeOffset _utcNow = utcNow;
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+
+        public void Advance(TimeSpan delta) => _utcNow += delta;
     }
 
     private sealed class StaticResponseHandler(HttpStatusCode statusCode) : HttpMessageHandler

--- a/tests/Lfm.App.Tests/RenderWithProviders.cs
+++ b/tests/Lfm.App.Tests/RenderWithProviders.cs
@@ -40,6 +40,7 @@ public abstract class ComponentTestBase : BunitContext
         Services.AddHttpClient("api", c => c.BaseAddress = new Uri("http://localhost:7071"));
 
         Services.AddSingleton<IThemeService, ThemeService>();
+        Services.AddSingleton(TimeProvider.System);
 
         Services.AddSingleton<IDataCache, InMemoryDataCache>();
         Services.AddSingleton<ILocaleService, LocaleService>();


### PR DESCRIPTION
## Summary
- Rate-limit auth resume session probes so repeated focus/resume events do not refresh auth state every time.
- Register `TimeProvider.System` for app and component-test DI.
- Add focused component coverage for the resume-probe throttle.

## Verification
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --filter AuthSessionMonitorTests --no-restore`
- `dotnet build lfm.sln -c Release`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `git diff --check`
- `git ls-files -ci --exclude-standard`