### PR TITLE
Adjust attendance card layout

### DIFF
--- a/app/Components/CharacterRow.razor
+++ b/app/Components/CharacterRow.razor
@@ -5,7 +5,11 @@
 @inject IStringLocalizer Loc
 @inject IConfiguration Config
 
-<div class="character-row" style="--class-color:@WowClasses.GetColor(Character.CharacterClassId)">
+<div class="character-row" style="--class-color:@WowClasses.GetColor(Character.CharacterClassId)" aria-label="@RowLabel()">
+    <span class="character-row__name">@Character.CharacterName</span>
+    <span class="attendance-pill attendance-pill--@AttendanceClass(Character.ReviewedAttendance)">
+        @AttendanceLabel(Character.ReviewedAttendance)
+    </span>
     <div class="character-row__icons" aria-hidden="true">
         <SpecIcon SpecName="@Character.CharacterClassName"
                   IconUrl="@WowMediaUrls.ClassIconUrl(Character.CharacterClassId, Config["ApiBaseUrl"])"
@@ -16,13 +20,6 @@
                   Class="character-row__icon character-row__spec-icon"
                   Decorative="true" />
     </div>
-    <div class="character-row__main">
-        <span class="character-row__name">@Character.CharacterName</span>
-        <span class="character-row__sub">@ClassSpec()</span>
-    </div>
-    <span class="attendance-pill attendance-pill--@AttendanceClass(Character.ReviewedAttendance)">
-        @AttendanceLabel(Character.ReviewedAttendance)
-    </span>
 </div>
 
 @code {
@@ -35,6 +32,9 @@
         var spec = Character.SpecName;
         return string.IsNullOrWhiteSpace(spec) ? className : $"{className} \u00B7 {spec}";
     }
+
+    private string RowLabel() =>
+        $"{Character.CharacterName}, {ClassSpec()}, {AttendanceLabel(Character.ReviewedAttendance)}";
 
     private string AttendanceClass(string attendance) => attendance switch
     {

--- a/app/wwwroot/css/app.css
+++ b/app/wwwroot/css/app.css
@@ -359,9 +359,15 @@ fluent-button.footer-language--active::part(control) {
 
 /* Character row */
 .character-row {
-    display: flex;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-areas:
+        "name name"
+        ". attendance"
+        "icons .";
     align-items: center;
-    gap: 12px;
+    column-gap: 12px;
+    row-gap: 4px;
     padding: 10px 12px 10px 9px;
     background: var(--neutral-fill-rest);
     border-radius: calc(var(--control-corner-radius) * 1px);
@@ -370,10 +376,11 @@ fluent-button.footer-language--active::part(control) {
 }
 
 .character-row__icons {
+    grid-area: icons;
     display: inline-flex;
     align-items: center;
     gap: 4px;
-    flex: none;
+    justify-self: start;
 }
 
 .character-row__icon {
@@ -381,27 +388,17 @@ fluent-button.footer-language--active::part(control) {
     block-size: 1.35rem;
 }
 
-.character-row__main {
-    flex: 1;
-    min-width: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-}
-
 .character-row__name {
+    grid-area: name;
     font-weight: 600;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
 }
 
-.character-row__sub {
-    font-size: 0.82em;
-    color: var(--neutral-foreground-hint-rest);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+.character-row .attendance-pill {
+    grid-area: attendance;
+    justify-self: end;
 }
 
 /* Attendance pill */

--- a/tests/Lfm.App.Tests/CharacterRowTests.cs
+++ b/tests/Lfm.App.Tests/CharacterRowTests.cs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Bunit;
+using Lfm.App.Components;
+using Lfm.Contracts.Runs;
+using Xunit;
+
+namespace Lfm.App.Tests;
+
+public class CharacterRowTests : ComponentTestBase
+{
+    [Fact]
+    public void Renders_Name_Attendance_And_Icons_In_Card_Order()
+    {
+        var cut = Render<CharacterRow>(p => p
+            .Add(x => x.Character, MakeCharacter()));
+
+        var row = cut.Find(".character-row");
+        var children = row.Children.ToArray();
+
+        Assert.Contains("Warlock \u00B7 Demonology", row.GetAttribute("aria-label") ?? "");
+        Assert.Equal(3, children.Length);
+        Assert.Contains("character-row__name", children[0].ClassName ?? "");
+        Assert.Contains("Shalena", children[0].TextContent);
+        Assert.Contains("attendance-pill", children[1].ClassName ?? "");
+        Assert.Contains(Loc("runs.attendance.in"), children[1].TextContent);
+        Assert.Contains("character-row__icons", children[2].ClassName ?? "");
+        Assert.Equal(2, children[2].QuerySelectorAll(".spec-icon").Length);
+        Assert.Null(row.QuerySelector(".character-row__main"));
+        Assert.Null(row.QuerySelector(".character-row__sub"));
+    }
+
+    private static RunCharacterDto MakeCharacter() =>
+        new(
+            CharacterId: "eu-silvermoon-shalena",
+            CharacterName: "Shalena",
+            CharacterRealm: "Silvermoon",
+            CharacterClassId: 9,
+            CharacterClassName: "Warlock",
+            DesiredAttendance: "IN",
+            ReviewedAttendance: "IN",
+            SpecId: 266,
+            SpecName: "Demonology",
+            Role: "DPS",
+            IsCurrentUser: false);
+}

--- a/tests/Lfm.App.Tests/RunsPageCssContractTests.cs
+++ b/tests/Lfm.App.Tests/RunsPageCssContractTests.cs
@@ -51,6 +51,20 @@ public class RunsPageCssContractTests
     }
 
     [Fact]
+    public void Character_row_places_name_attendance_and_icons_in_requested_card_rows()
+    {
+        var css = File.ReadAllText(FindRepoFile("app", "wwwroot", "css", "app.css"));
+
+        Assert.Contains("grid-template-areas:", css);
+        Assert.Contains("\"name name\"", css);
+        Assert.Contains("\". attendance\"", css);
+        Assert.Contains("\"icons .\"", css);
+        Assert.Contains("grid-area: name;", css);
+        Assert.Contains("grid-area: attendance;", css);
+        Assert.Contains("grid-area: icons;", css);
+    }
+
+    [Fact]
     public void Run_list_composition_chips_are_muted_indicators_not_alerts()
     {
         var css = File.ReadAllText(FindRepoFile("app", "Components", "RunListItem.razor.css"));

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -959,7 +959,7 @@ public class RunsPagesTests : ComponentTestBase
         cut.WaitForAssertion(() =>
         {
             var row = cut.Find(".character-row");
-            Assert.Contains("Warlock \u00B7 Demonology", row.TextContent);
+            Assert.Contains("Warlock \u00B7 Demonology", row.GetAttribute("aria-label") ?? "");
 
             var classIcon = row.QuerySelector(".character-row__class-icon img");
             Assert.NotNull(classIcon);


### PR DESCRIPTION
## Summary
- Reorder attendance cards so the character name is first, the attendance pill is right-aligned on its own row, and class/spec icons sit below.
- Preserve class/spec detail in the row accessible label after removing the visible subline.
- Add component and CSS contract coverage for the new card layout.

## Verification
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --no-restore`
- `dotnet build lfm.sln -c Release --no-restore`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `git diff --check`