### PR TITLE
Keep attendance card height

### DIFF
--- a/app/wwwroot/css/app.css
+++ b/app/wwwroot/css/app.css
@@ -362,9 +362,8 @@ fluent-button.footer-language--active::part(control) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto;
     grid-template-areas:
-        "name name"
-        ". attendance"
-        "icons .";
+        "name attendance"
+        "icons attendance";
     align-items: center;
     column-gap: 12px;
     row-gap: 4px;
@@ -399,6 +398,7 @@ fluent-button.footer-language--active::part(control) {
 .character-row .attendance-pill {
     grid-area: attendance;
     justify-self: end;
+    align-self: center;
 }
 
 /* Attendance pill */

--- a/tests/Lfm.App.Tests/RunsPageCssContractTests.cs
+++ b/tests/Lfm.App.Tests/RunsPageCssContractTests.cs
@@ -51,17 +51,18 @@ public class RunsPageCssContractTests
     }
 
     [Fact]
-    public void Character_row_places_name_attendance_and_icons_in_requested_card_rows()
+    public void Character_row_keeps_two_visual_rows_while_reordering_content()
     {
         var css = File.ReadAllText(FindRepoFile("app", "wwwroot", "css", "app.css"));
 
         Assert.Contains("grid-template-areas:", css);
-        Assert.Contains("\"name name\"", css);
-        Assert.Contains("\". attendance\"", css);
-        Assert.Contains("\"icons .\"", css);
+        Assert.Contains("\"name attendance\"", css);
+        Assert.Contains("\"icons attendance\"", css);
+        Assert.DoesNotContain("\". attendance\"", css);
         Assert.Contains("grid-area: name;", css);
         Assert.Contains("grid-area: attendance;", css);
         Assert.Contains("grid-area: icons;", css);
+        Assert.Contains("align-self: center;", css);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Keep the attendance card character row to two visual rows while preserving the requested content order.
- Center the attendance pill across the two rows instead of adding a dedicated middle row.
- Add CSS contract coverage for the two-row template and centered attendance pill.

## Verification
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --no-restore`
- `dotnet build lfm.sln -c Release`
- `dotnet build lfm.sln -c Release --no-restore`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `git diff --check`