### PR TITLE
Remove open slot placeholders

### DIFF
--- a/app/Pages/RunsPage.razor
+++ b/app/Pages/RunsPage.razor
@@ -213,18 +213,11 @@
                                                             <RoleIcon Role="@roleKey" ClassPrefix="roster-role-title__icon" />
                                                             <span>@roleLabel (@roleChars.Count)</span>
                                                         </h4>
-                                                        @if (roleChars.Count == 0)
+                                                        @foreach (var character in roleChars)
                                                         {
-                                                            <div class="roster-role-empty">@Loc["runs.role.empty"]</div>
-                                                        }
-                                                        else
-                                                        {
-                                                            @foreach (var character in roleChars)
-                                                            {
-                                                                <CharacterRow @key="@(character.CharacterRealm + "/" + character.CharacterName)"
-                                                                              Character="character"
-                                                                              SpecIconUrl="@SpecIconUrlFor(character)" />
-                                                            }
+                                                            <CharacterRow @key="@(character.CharacterRealm + "/" + character.CharacterName)"
+                                                                          Character="character"
+                                                                          SpecIconUrl="@SpecIconUrlFor(character)" />
                                                         }
                                                     </div>
                                                 }

--- a/app/Pages/RunsPage.razor.css
+++ b/app/Pages/RunsPage.razor.css
@@ -427,16 +427,6 @@
     gap: 8px;
 }
 
-.roster-role-empty {
-    min-block-size: 44px;
-    padding-block: 10px;
-    padding-inline: 12px;
-    color: var(--neutral-foreground-hint-rest);
-    background: var(--neutral-fill-rest);
-    border: 1px dashed var(--neutral-stroke-rest);
-    border-radius: calc(var(--control-corner-radius) * 1px);
-}
-
 .roster-rows {
     display: grid;
     grid-template-columns: 1fr;

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -1416,7 +1416,7 @@ public class RunsPagesTests : ComponentTestBase
     }
 
     [Fact]
-    public void RunsPage_RoleColumns_Show_Muted_Empty_State_For_Open_Roles()
+    public void RunsPage_RoleColumns_Omit_Open_Role_Placeholders()
     {
         var client = new Mock<IRunsClient>();
         client.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
@@ -1432,9 +1432,9 @@ public class RunsPagesTests : ComponentTestBase
 
         cut.WaitForAssertion(() =>
         {
-            var emptySlots = cut.FindAll(".roster-role-empty");
-            Assert.Equal(2, emptySlots.Count);
-            Assert.All(emptySlots, slot => Assert.Contains(Loc("runs.role.empty"), slot.TextContent));
+            Assert.Equal(3, cut.FindAll(".roster-role-column").Count);
+            Assert.Empty(cut.FindAll(".roster-role-empty"));
+            Assert.DoesNotContain(Loc("runs.role.empty"), cut.Markup);
         });
     }
 


### PR DESCRIPTION
## Summary
- Remove redundant `Open slot` placeholder cards from empty attendance role columns.
- Keep role headings and zero-count labels visible for Tank/Healer/DPS.
- Update the Runs page component test to lock the no-placeholder behavior.

## Visual evidence
- Before screenshot captured from `main`: `artifacts/e2e-results/screenshots/Lfm.E2E.Specs.RunsSpec.RunDetail_DeepLink_DisplaysSeededRoster.png`
- After screenshot captured from this branch: `.worktrees/attendance-open-slots/artifacts/e2e-results/screenshots/Lfm.E2E.Specs.RunsSpec.RunDetail_DeepLink_DisplaysSeededRoster.png`

## Verification
- `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --filter "FullyQualifiedName~RunDetail_DeepLink_DisplaysSeededRoster"` on `main` for before screenshot
- `dotnet test tests/Lfm.E2E/Lfm.E2E.csproj -c Release --filter "FullyQualifiedName~RunDetail_DeepLink_DisplaysSeededRoster"` on this branch for after screenshot
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --no-restore`
- `dotnet build lfm.sln -c Release --no-restore`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `git diff --check`
- `git ls-files -ci --exclude-standard`