### PR TITLE
Add run detail artwork header

### DIFF
--- a/app/Pages/RunsPage.razor
+++ b/app/Pages/RunsPage.razor
@@ -6,9 +6,11 @@
 @using Lfm.App.Runs
 @using Lfm.App.Services
 @using Lfm.Contracts.Characters
+@using Lfm.Contracts.Instances
 @using Lfm.Contracts.Runs
 @using Lfm.Contracts.Specializations
 @inject IBattleNetClient BattleNetClient
+@inject IInstancesClient InstancesClient
 @inject IMeClient MeClient
 @inject IRunsClient RunsClient
 @inject ISpecializationsClient SpecializationsClient
@@ -162,8 +164,10 @@
 
                         <div class="run-detail-workbench" data-testid="run-detail-workbench">
                             <div class="run-detail-main" data-testid="run-detail-main">
-                                <FluentCard>
-                                    <section class="run-detail-summary" data-testid="run-detail-summary">
+                                <FluentCard Class="@RunDetailCardClass(selectedRun)">
+                                    <section class="@RunDetailSummaryClass(selectedRun)"
+                                             style="@RunDetailSummaryStyle(selectedRun)"
+                                             data-testid="run-detail-summary">
                                         <div class="run-detail-header">
                                             <div class="run-detail-heading">
                                                 <h2 class="run-detail-title">@RenderTitle(selectedRun.InstanceName)</h2>
@@ -301,6 +305,9 @@
     private bool _specIconsLoading;
     private IReadOnlyDictionary<int, string> _specIconUrls = new Dictionary<int, string>();
     private IReadOnlyDictionary<string, string> _specIconUrlsByClassAndName = new Dictionary<string, string>();
+    private IReadOnlyDictionary<int, string> _instancePortraitUrlsById = new Dictionary<int, string>();
+    private bool _instancePortraitsLoaded;
+    private bool _instancePortraitsLoading;
 
     private static readonly (string Key, string LocKey)[] RoleColumnKeys =
     [
@@ -476,6 +483,11 @@
             }
 
             ApplyRunDetail(detail);
+            if (detail.InstanceId.HasValue)
+            {
+                await EnsureInstancePortraitsLoaded();
+            }
+
             _signupError = null;
             if (NeedsSpecIcons(detail))
             {
@@ -716,6 +728,80 @@
 
     private static bool NeedsSpecIcons(RunDetailDto detail) =>
         detail.RunCharacters.Any(c => c.SpecId is not null || !string.IsNullOrWhiteSpace(c.SpecName));
+
+    private string RunDetailCardClass(RunDetailDto run)
+    {
+        var artworkClass = InstancePortraitUrlFor(run) is null
+            ? null
+            : " run-detail-card--artwork";
+        return $"run-detail-card{artworkClass}";
+    }
+
+    private string RunDetailSummaryClass(RunDetailDto run)
+    {
+        var artworkClass = InstancePortraitUrlFor(run) is null
+            ? null
+            : " run-detail-summary--artwork";
+        return $"run-detail-summary{artworkClass}";
+    }
+
+    private string? RunDetailSummaryStyle(RunDetailDto run)
+    {
+        var portraitUrl = InstancePortraitUrlFor(run);
+        if (portraitUrl is null)
+            return null;
+
+        return "background-image: " +
+            "linear-gradient(90deg, rgba(18, 18, 18, 0.94) 0%, rgba(18, 18, 18, 0.72) 48%, rgba(18, 18, 18, 0.35) 100%), " +
+            $"url('{CssUrlEscape(portraitUrl)}')";
+    }
+
+    private string? InstancePortraitUrlFor(RunDetailDto run)
+    {
+        if (!run.InstanceId.HasValue)
+            return null;
+
+        return _instancePortraitUrlsById.TryGetValue(run.InstanceId.Value, out var portraitUrl)
+            ? portraitUrl
+            : null;
+    }
+
+    private async Task EnsureInstancePortraitsLoaded()
+    {
+        if (_instancePortraitsLoaded || _instancePortraitsLoading)
+            return;
+
+        _instancePortraitsLoading = true;
+        try
+        {
+            var instances = await InstancesClient.ListAsync(CancellationToken.None);
+            _instancePortraitUrlsById = instances
+                .Where(i => i.InstanceNumericId > 0 && IsHttpImageUrl(i.PortraitUrl))
+                .GroupBy(i => i.InstanceNumericId)
+                .ToDictionary(
+                    group => group.Key,
+                    group => group.First().PortraitUrl!);
+        }
+        catch
+        {
+            _instancePortraitUrlsById = new Dictionary<int, string>();
+        }
+        finally
+        {
+            _instancePortraitsLoaded = true;
+            _instancePortraitsLoading = false;
+        }
+    }
+
+    private static string CssUrlEscape(string value) =>
+        value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("'", "\\27 ", StringComparison.Ordinal);
+
+    private static bool IsHttpImageUrl(string? value) =>
+        Uri.TryCreate(value, UriKind.Absolute, out var uri) &&
+        (string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) ||
+         string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase));
 
     private string? SpecIconUrlFor(RunCharacterDto? character)
     {

--- a/app/Pages/RunsPage.razor.css
+++ b/app/Pages/RunsPage.razor.css
@@ -278,6 +278,11 @@
     order: 0;
 }
 
+.run-detail-main ::deep fluent-card.run-detail-card--artwork {
+    padding: 0;
+    overflow: hidden;
+}
+
 .run-signup-rail {
     order: 1;
     min-inline-size: 0;
@@ -319,6 +324,17 @@
     gap: 12px;
 }
 
+.run-detail-summary--artwork {
+    min-block-size: 6.5rem;
+    padding-block: 20px;
+    padding-inline: 22px;
+    color: white;
+    background-position: center;
+    background-size: cover;
+    border-radius: calc(var(--layer-corner-radius) * 1px);
+    overflow: hidden;
+}
+
 .run-detail-header {
     display: flex;
     flex-wrap: wrap;
@@ -343,6 +359,26 @@
     font-style: italic;
     color: var(--neutral-foreground-hint-rest);
     margin: 4px 0 0 0;
+}
+
+.run-detail-summary--artwork .run-detail-title {
+    color: white;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.65);
+}
+
+.run-detail-summary--artwork .run-detail-description,
+.run-detail-summary--artwork ::deep .run-detail-meta {
+    color: rgba(255, 255, 255, 0.88);
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.65);
+}
+
+.run-detail-summary--artwork ::deep .run-detail-meta strong {
+    color: white;
+}
+
+.run-detail-summary--artwork fluent-button {
+    --neutral-stroke-rest: rgba(255, 255, 255, 0.58);
+    --neutral-foreground-rest: white;
 }
 
 ::deep .run-detail-meta {

--- a/tests/Lfm.App.Tests/RenderWithProviders.cs
+++ b/tests/Lfm.App.Tests/RenderWithProviders.cs
@@ -8,6 +8,7 @@ using Lfm.App.Auth;
 using Lfm.App.i18n;
 using Lfm.App.Services;
 using Lfm.Contracts.Characters;
+using Lfm.Contracts.Instances;
 using Lfm.Contracts.Me;
 using Lfm.Contracts.Runs;
 using Lfm.Contracts.Specializations;
@@ -47,6 +48,7 @@ public abstract class ComponentTestBase : BunitContext
         Services.AddSingleton<IStringLocalizer>(_localizer);
         Services.AddSingleton<IMeClient, DefaultMeClient>();
         Services.AddSingleton<IBattleNetClient, DefaultBattleNetClient>();
+        Services.AddSingleton<IInstancesClient, DefaultInstancesClient>();
         Services.AddSingleton<ISpecializationsClient, DefaultSpecializationsClient>();
         Services.AddSingleton<ISessionExpiryNotifier, SessionExpiryNotifier>();
         Services.AddSingleton<IAuthStateRefresher, NoopAuthStateRefresher>();
@@ -110,6 +112,12 @@ internal sealed class DefaultSpecializationsClient : ISpecializationsClient
 {
     public Task<IReadOnlyList<SpecializationDto>> ListAsync(CancellationToken ct) =>
         Task.FromResult<IReadOnlyList<SpecializationDto>>([]);
+}
+
+internal sealed class DefaultInstancesClient : IInstancesClient
+{
+    public Task<IReadOnlyList<InstanceDto>> ListAsync(CancellationToken ct) =>
+        Task.FromResult<IReadOnlyList<InstanceDto>>([]);
 }
 
 internal sealed class NoopAuthStateRefresher : IAuthStateRefresher

--- a/tests/Lfm.App.Tests/RunsPageCssContractTests.cs
+++ b/tests/Lfm.App.Tests/RunsPageCssContractTests.cs
@@ -39,6 +39,16 @@ public class RunsPageCssContractTests
     }
 
     [Fact]
+    public void Artwork_run_detail_card_removes_default_card_padding()
+    {
+        var css = File.ReadAllText(FindRepoFile("app", "Pages", "RunsPage.razor.css"));
+
+        Assert.Contains(".run-detail-main ::deep fluent-card.run-detail-card--artwork", css);
+        Assert.Contains("padding: 0;", css);
+        Assert.Contains("overflow: hidden;", css);
+    }
+
+    [Fact]
     public void Roster_role_icons_use_single_color_outline_styling()
     {
         var css = File.ReadAllText(FindRepoFile("app", "Pages", "RunsPage.razor.css"));

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -1504,6 +1504,60 @@ public class RunsPagesTests : ComponentTestBase
     }
 
     [Fact]
+    public void RunsPage_DetailSummary_Uses_Instance_Portrait_As_Artwork_Background()
+    {
+        const string SourceUrl = "https://render.worldofwarcraft.com/eu/dungeon/maisara-caverns.jpg";
+        var artworkUrl = CachedMediaUrl(SourceUrl);
+        var summary = MakeSummary() with
+        {
+            InstanceName = "Maisara Caverns",
+            Difficulty = "MYTHIC_KEYSTONE",
+            Size = 5,
+        };
+        var detail = MakeDetail() with
+        {
+            InstanceName = "Maisara Caverns",
+            Difficulty = "MYTHIC_KEYSTONE",
+            Size = 5,
+        };
+        var client = new Mock<IRunsClient>();
+        client.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<RunSummaryDto> { summary });
+        client.Setup(c => c.GetAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(detail);
+        Services.AddSingleton(client.Object);
+
+        var instances = new Mock<IInstancesClient>();
+        instances.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<InstanceDto>
+            {
+                MakeInstanceFixture() with
+                {
+                    Name = "Maisara Caverns",
+                    Category = "DUNGEON",
+                    Difficulty = "MYTHIC_KEYSTONE",
+                    Size = 5,
+                    PortraitUrl = artworkUrl,
+                },
+            });
+        Services.AddSingleton(instances.Object);
+        WireSignupSupport(client);
+
+        var cut = Render<RunsPage>(p => p.Add(x => x.RunId, "run-1"));
+
+        cut.WaitForAssertion(() =>
+        {
+            var detailSummary = cut.Find("[data-testid='run-detail-summary']");
+            Assert.Contains("run-detail-summary--artwork", detailSummary.ClassName ?? "");
+            Assert.Contains("run-detail-card--artwork", detailSummary.Closest("fluent-card")?.ClassName ?? "");
+            var style = detailSummary.GetAttribute("style") ?? "";
+            Assert.Contains("background-image:", style);
+            Assert.Contains(BlizzardMediaCache.EncodeSource(SourceUrl), style);
+        });
+        instances.Verify(c => c.ListAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public void RunsPage_RunCards_Render_Mobile_Detail_Toggles()
     {
         var client = new Mock<IRunsClient>();


### PR DESCRIPTION
## Summary
- Load cached WoW instance portrait media for the selected run detail.
- Render the run detail header with dungeon artwork and edge-to-edge card styling.
- Add component/CSS coverage plus the default test provider wiring.

## Environment / schema
- None.

## Screenshots
- Captured locally with mock media and shared in the Codex session.
- Local captures were generated under `output/playwright/runs-detail-maisara-artwork-desktop.png` and `output/playwright/runs-detail-maisara-artwork-header.png`; they are not committed artifacts.

## Verification
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release`
- `dotnet build lfm.sln -c Release`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `git diff --check`