### PR TITLE
Rotate any dungeon artwork

### DIFF
--- a/app/Pages/RunsPage.razor
+++ b/app/Pages/RunsPage.razor
@@ -1,6 +1,7 @@
 @page "/runs"
 @page "/runs/{RunId}"
 @attribute [Authorize]
+@implements IDisposable
 @using Lfm.App.Components
 @using Lfm.App.Components.Runs
 @using Lfm.App.Runs
@@ -16,6 +17,7 @@
 @inject ISpecializationsClient SpecializationsClient
 @inject NavigationManager Nav
 @inject IStringLocalizer Loc
+@inject TimeProvider TimeProvider
 
 <PageTitle>@Loc["runs.title"]</PageTitle>
 
@@ -306,8 +308,12 @@
     private IReadOnlyDictionary<int, string> _specIconUrls = new Dictionary<int, string>();
     private IReadOnlyDictionary<string, string> _specIconUrlsByClassAndName = new Dictionary<string, string>();
     private IReadOnlyDictionary<int, string> _instancePortraitUrlsById = new Dictionary<int, string>();
+    private IReadOnlyList<string> _dungeonPortraitUrls = [];
+    private int _rotatingInstancePortraitIndex;
+    private ITimer? _instancePortraitRotationTimer;
     private bool _instancePortraitsLoaded;
     private bool _instancePortraitsLoading;
+    private static readonly TimeSpan InstancePortraitRotationInterval = TimeSpan.FromSeconds(5);
 
     private static readonly (string Key, string LocKey)[] RoleColumnKeys =
     [
@@ -342,6 +348,7 @@
                 selectedRun = null;
                 _runDetailError = null;
                 _runDetailLoading = false;
+                StopInstancePortraitRotation();
             }
         }
     }
@@ -458,6 +465,7 @@
         _runDetailLoading = false;
         _signupError = null;
         ResetSignupOptions();
+        StopInstancePortraitRotation();
         Nav.NavigateTo("/runs", replace: true);
     }
 
@@ -465,6 +473,7 @@
     {
         _runDetailLoading = true;
         _runDetailError = null;
+        StopInstancePortraitRotation();
 
         try
         {
@@ -474,6 +483,7 @@
                 selectedRun = null;
                 _runDetailError = Loc["runs.detailUnavailable.notFound"];
                 ResetSignupOptions();
+                StopInstancePortraitRotation();
                 return;
             }
 
@@ -483,10 +493,11 @@
             }
 
             ApplyRunDetail(detail);
-            if (detail.InstanceId.HasValue)
+            if (UsesInstanceArtwork(detail))
             {
                 await EnsureInstancePortraitsLoaded();
             }
+            ConfigureInstancePortraitRotation(detail);
 
             _signupError = null;
             if (NeedsSpecIcons(detail))
@@ -506,6 +517,7 @@
                 ? Loc["runs.detailUnavailable.failed"]
                 : ex.Message;
             ResetSignupOptions();
+            StopInstancePortraitRotation();
         }
         finally
         {
@@ -759,11 +771,59 @@
     private string? InstancePortraitUrlFor(RunDetailDto run)
     {
         if (!run.InstanceId.HasValue)
-            return null;
+        {
+            if (!UsesRotatingDungeonPortrait(run) || _dungeonPortraitUrls.Count == 0)
+                return null;
+
+            return _dungeonPortraitUrls[_rotatingInstancePortraitIndex % _dungeonPortraitUrls.Count];
+        }
 
         return _instancePortraitUrlsById.TryGetValue(run.InstanceId.Value, out var portraitUrl)
             ? portraitUrl
             : null;
+    }
+
+    private static bool UsesInstanceArtwork(RunDetailDto run) =>
+        run.InstanceId.HasValue || UsesRotatingDungeonPortrait(run);
+
+    private static bool UsesRotatingDungeonPortrait(RunDetailDto run) =>
+        !run.InstanceId.HasValue &&
+        string.Equals(run.Difficulty, "MYTHIC_KEYSTONE", StringComparison.OrdinalIgnoreCase) &&
+        run.Size == 5;
+
+    private void ConfigureInstancePortraitRotation(RunDetailDto run)
+    {
+        _rotatingInstancePortraitIndex = 0;
+        StopInstancePortraitRotation();
+
+        if (!UsesRotatingDungeonPortrait(run) || _dungeonPortraitUrls.Count <= 1)
+            return;
+
+        _instancePortraitRotationTimer = TimeProvider.CreateTimer(
+            _ => _ = InvokeAsync(AdvanceInstancePortraitRotation),
+            null,
+            InstancePortraitRotationInterval,
+            InstancePortraitRotationInterval);
+    }
+
+    private void AdvanceInstancePortraitRotation()
+    {
+        if (selectedRun is null ||
+            !UsesRotatingDungeonPortrait(selectedRun) ||
+            _dungeonPortraitUrls.Count <= 1)
+        {
+            StopInstancePortraitRotation();
+            return;
+        }
+
+        _rotatingInstancePortraitIndex = (_rotatingInstancePortraitIndex + 1) % _dungeonPortraitUrls.Count;
+        StateHasChanged();
+    }
+
+    private void StopInstancePortraitRotation()
+    {
+        _instancePortraitRotationTimer?.Dispose();
+        _instancePortraitRotationTimer = null;
     }
 
     private async Task EnsureInstancePortraitsLoaded()
@@ -781,10 +841,18 @@
                 .ToDictionary(
                     group => group.Key,
                     group => group.First().PortraitUrl!);
+            _dungeonPortraitUrls = instances
+                .Where(i => string.Equals(i.Category, "DUNGEON", StringComparison.OrdinalIgnoreCase) &&
+                            IsHttpImageUrl(i.PortraitUrl))
+                .OrderBy(i => i.Name, StringComparer.OrdinalIgnoreCase)
+                .Select(i => i.PortraitUrl!)
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
         }
         catch
         {
             _instancePortraitUrlsById = new Dictionary<int, string>();
+            _dungeonPortraitUrls = [];
         }
         finally
         {
@@ -802,6 +870,8 @@
         Uri.TryCreate(value, UriKind.Absolute, out var uri) &&
         (string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) ||
          string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase));
+
+    public void Dispose() => StopInstancePortraitRotation();
 
     private string? SpecIconUrlFor(RunCharacterDto? character)
     {

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -1558,6 +1558,91 @@ public class RunsPagesTests : ComponentTestBase
     }
 
     [Fact]
+    public void RunsPage_AnyDungeonDetail_Rotates_Dungeon_Portrait_Backgrounds()
+    {
+        const string FirstDungeonSource = "https://render.worldofwarcraft.com/eu/dungeon/cinderbrew-meadery.jpg";
+        const string SecondDungeonSource = "https://render.worldofwarcraft.com/eu/dungeon/rookery.jpg";
+        const string RaidSource = "https://render.worldofwarcraft.com/eu/raid/liberation-of-undermine.jpg";
+        var timeProvider = new ManualTimerTimeProvider();
+        Services.AddSingleton<TimeProvider>(timeProvider);
+        var summary = MakeSummary() with
+        {
+            InstanceId = null,
+            InstanceName = null,
+            Difficulty = "MYTHIC_KEYSTONE",
+            Size = 5,
+        };
+        var detail = MakeDetail() with
+        {
+            InstanceId = null,
+            InstanceName = null,
+            Difficulty = "MYTHIC_KEYSTONE",
+            Size = 5,
+        };
+        var client = new Mock<IRunsClient>();
+        client.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<RunSummaryDto> { summary });
+        client.Setup(c => c.GetAsync("run-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(detail);
+        Services.AddSingleton(client.Object);
+
+        var instances = new Mock<IInstancesClient>();
+        instances.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<InstanceDto>
+            {
+                MakeInstanceFixture() with
+                {
+                    InstanceNumericId = 2,
+                    Name = "Cinderbrew Meadery",
+                    Category = "DUNGEON",
+                    Difficulty = "MYTHIC_KEYSTONE",
+                    Size = 5,
+                    PortraitUrl = CachedMediaUrl(FirstDungeonSource),
+                },
+                MakeInstanceFixture() with
+                {
+                    InstanceNumericId = 3,
+                    Name = "The Rookery",
+                    Category = "DUNGEON",
+                    Difficulty = "MYTHIC_KEYSTONE",
+                    Size = 5,
+                    PortraitUrl = CachedMediaUrl(SecondDungeonSource),
+                },
+                MakeInstanceFixture() with
+                {
+                    InstanceNumericId = 4,
+                    Name = "Liberation of Undermine",
+                    Category = "RAID",
+                    Difficulty = "HEROIC",
+                    Size = 25,
+                    PortraitUrl = CachedMediaUrl(RaidSource),
+                },
+            });
+        Services.AddSingleton(instances.Object);
+        WireSignupSupport(client);
+
+        var cut = Render<RunsPage>(p => p.Add(x => x.RunId, "run-1"));
+
+        cut.WaitForAssertion(() =>
+        {
+            var style = cut.Find("[data-testid='run-detail-summary']").GetAttribute("style") ?? "";
+            Assert.Contains(BlizzardMediaCache.EncodeSource(FirstDungeonSource), style);
+            Assert.DoesNotContain(BlizzardMediaCache.EncodeSource(RaidSource), style);
+            Assert.Equal(TimeSpan.FromSeconds(5), timeProvider.CreatedTimer?.DueTime);
+            Assert.Equal(TimeSpan.FromSeconds(5), timeProvider.CreatedTimer?.Period);
+        });
+
+        timeProvider.CreatedTimer!.Fire();
+
+        cut.WaitForAssertion(() =>
+        {
+            var style = cut.Find("[data-testid='run-detail-summary']").GetAttribute("style") ?? "";
+            Assert.Contains(BlizzardMediaCache.EncodeSource(SecondDungeonSource), style);
+            Assert.DoesNotContain(BlizzardMediaCache.EncodeSource(RaidSource), style);
+        });
+    }
+
+    [Fact]
     public void RunsPage_RunCards_Render_Mobile_Detail_Toggles()
     {
         var client = new Mock<IRunsClient>();
@@ -2189,6 +2274,57 @@ public class RunsPagesTests : ComponentTestBase
         Assert.NotNull(field);
         cut.WaitForAssertion(() =>
             Assert.False((bool)field!.GetValue(instance)!));
+    }
+
+    private sealed class ManualTimerTimeProvider : TimeProvider
+    {
+        public ManualTimer? CreatedTimer { get; private set; }
+
+        public override ITimer CreateTimer(
+            TimerCallback callback,
+            object? state,
+            TimeSpan dueTime,
+            TimeSpan period)
+        {
+            CreatedTimer = new ManualTimer(callback, state, dueTime, period);
+            return CreatedTimer;
+        }
+    }
+
+    private sealed class ManualTimer(
+        TimerCallback callback,
+        object? state,
+        TimeSpan dueTime,
+        TimeSpan period) : ITimer
+    {
+        public TimeSpan DueTime { get; private set; } = dueTime;
+
+        public TimeSpan Period { get; private set; } = period;
+
+        public bool Disposed { get; private set; }
+
+        public bool Change(TimeSpan dueTime, TimeSpan period)
+        {
+            DueTime = dueTime;
+            Period = period;
+            return true;
+        }
+
+        public void Fire()
+        {
+            if (!Disposed)
+            {
+                callback(state);
+            }
+        }
+
+        public void Dispose() => Disposed = true;
+
+        public ValueTask DisposeAsync()
+        {
+            Dispose();
+            return ValueTask.CompletedTask;
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Use cached dungeon portrait media for Mythic+ "Any dungeon" run detail headers.
- Rotate through available dungeon backgrounds on a five-second timer while the detail card is visible.
- Stop the rotation timer when the selected detail changes, collapses, errors, or disposes.

## Environment / schema
- None.

## Screenshots
- Not captured for this timer-only follow-up. The behavior is covered by a bUnit component test that verifies the first background, five-second timer interval, next background, and raid exclusion.

## Verification
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release`
- `dotnet build lfm.sln -c Release`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `git diff --check`