### PR TITLE
Randomize any dungeon artwork

### DIFF
--- a/app/Lfm.App.Core/Runs/RunArtworkRotation.cs
+++ b/app/Lfm.App.Core/Runs/RunArtworkRotation.cs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+namespace Lfm.App.Runs;
+
+public interface IArtworkRotationRandomizer
+{
+    int Next(int exclusiveMax);
+}
+
+public sealed class ArtworkRotationRandomizer : IArtworkRotationRandomizer
+{
+    public int Next(int exclusiveMax) => Random.Shared.Next(exclusiveMax);
+}
+
+public static class RunArtworkRotation
+{
+    public static IReadOnlyList<string> Shuffle(
+        IReadOnlyList<string> portraitUrls,
+        IArtworkRotationRandomizer randomizer)
+    {
+        ArgumentNullException.ThrowIfNull(portraitUrls);
+        ArgumentNullException.ThrowIfNull(randomizer);
+
+        var shuffled = portraitUrls.ToArray();
+        for (var index = shuffled.Length - 1; index > 0; index--)
+        {
+            var swapIndex = randomizer.Next(index + 1);
+            if (swapIndex < 0 || swapIndex > index)
+            {
+                throw new InvalidOperationException(
+                    $"Artwork randomizer returned {swapIndex} for range [0, {index}].");
+            }
+
+            (shuffled[index], shuffled[swapIndex]) = (shuffled[swapIndex], shuffled[index]);
+        }
+
+        return shuffled;
+    }
+}

--- a/app/Pages/RunsPage.razor
+++ b/app/Pages/RunsPage.razor
@@ -15,6 +15,7 @@
 @inject IMeClient MeClient
 @inject IRunsClient RunsClient
 @inject ISpecializationsClient SpecializationsClient
+@inject IArtworkRotationRandomizer ArtworkRotationRandomizer
 @inject NavigationManager Nav
 @inject IStringLocalizer Loc
 @inject TimeProvider TimeProvider
@@ -319,6 +320,7 @@
     private IReadOnlyDictionary<string, string> _specIconUrlsByClassAndName = new Dictionary<string, string>();
     private IReadOnlyDictionary<int, string> _instancePortraitUrlsById = new Dictionary<int, string>();
     private IReadOnlyList<string> _dungeonPortraitUrls = [];
+    private IReadOnlyList<string> _dungeonPortraitRotationUrls = [];
     private string? _currentInstancePortraitUrl;
     private string? _previousInstancePortraitUrl;
     private bool _currentInstancePortraitUsesSecondLayer;
@@ -820,10 +822,11 @@
     {
         if (!run.InstanceId.HasValue)
         {
-            if (!UsesRotatingDungeonPortrait(run) || _dungeonPortraitUrls.Count == 0)
+            var portraitUrls = DungeonPortraitRotationUrls;
+            if (!UsesRotatingDungeonPortrait(run) || portraitUrls.Count == 0)
                 return null;
 
-            return _dungeonPortraitUrls[_rotatingInstancePortraitIndex % _dungeonPortraitUrls.Count];
+            return portraitUrls[_rotatingInstancePortraitIndex % portraitUrls.Count];
         }
 
         return _instancePortraitUrlsById.TryGetValue(run.InstanceId.Value, out var portraitUrl)
@@ -842,15 +845,28 @@
     private void ConfigureInstanceArtwork(RunDetailDto run)
     {
         _rotatingInstancePortraitIndex = 0;
+        ConfigureDungeonPortraitRotationOrder(run);
         SetInstancePortraitUrl(InstancePortraitUrlFor(run), crossfade: false);
         ConfigureInstancePortraitRotation(run);
+    }
+
+    private IReadOnlyList<string> DungeonPortraitRotationUrls =>
+        _dungeonPortraitRotationUrls.Count > 0
+            ? _dungeonPortraitRotationUrls
+            : _dungeonPortraitUrls;
+
+    private void ConfigureDungeonPortraitRotationOrder(RunDetailDto run)
+    {
+        _dungeonPortraitRotationUrls = UsesRotatingDungeonPortrait(run) && _dungeonPortraitUrls.Count > 0
+            ? RunArtworkRotation.Shuffle(_dungeonPortraitUrls, ArtworkRotationRandomizer)
+            : [];
     }
 
     private void ConfigureInstancePortraitRotation(RunDetailDto run)
     {
         StopInstancePortraitRotation();
 
-        if (!UsesRotatingDungeonPortrait(run) || _dungeonPortraitUrls.Count <= 1)
+        if (!UsesRotatingDungeonPortrait(run) || DungeonPortraitRotationUrls.Count <= 1)
             return;
 
         _instancePortraitRotationTimer = TimeProvider.CreateTimer(
@@ -864,13 +880,13 @@
     {
         if (selectedRun is null ||
             !UsesRotatingDungeonPortrait(selectedRun) ||
-            _dungeonPortraitUrls.Count <= 1)
+            DungeonPortraitRotationUrls.Count <= 1)
         {
             StopInstancePortraitRotation();
             return;
         }
 
-        _rotatingInstancePortraitIndex = (_rotatingInstancePortraitIndex + 1) % _dungeonPortraitUrls.Count;
+        _rotatingInstancePortraitIndex = (_rotatingInstancePortraitIndex + 1) % DungeonPortraitRotationUrls.Count;
         SetInstancePortraitUrl(InstancePortraitUrlFor(selectedRun), crossfade: true);
         StateHasChanged();
     }
@@ -907,6 +923,7 @@
         _previousInstancePortraitUrl = null;
         _currentInstancePortraitUsesSecondLayer = false;
         _rotatingInstancePortraitIndex = 0;
+        _dungeonPortraitRotationUrls = [];
     }
 
     private async Task EnsureInstancePortraitsLoaded()

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -10,6 +10,7 @@ using Microsoft.JSInterop;
 using Lfm.App;
 using Lfm.App.Auth;
 using Lfm.App.i18n;
+using Lfm.App.Runs;
 using Lfm.App.Services;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
@@ -23,6 +24,7 @@ builder.Services.AddSingleton<IDataCache, InMemoryDataCache>();
 builder.Services.AddSingleton<IThemeService, ThemeService>();
 builder.Services.AddScoped<ToastHelper>();
 builder.Services.AddSingleton<ILocaleService, LocaleService>();
+builder.Services.AddSingleton<IArtworkRotationRandomizer, ArtworkRotationRandomizer>();
 builder.Services.AddLocalization();
 
 var apiBaseUrl = builder.Configuration["ApiBaseUrl"]

--- a/tests/Lfm.App.Core.Tests/Runs/RunArtworkRotationTests.cs
+++ b/tests/Lfm.App.Core.Tests/Runs/RunArtworkRotationTests.cs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using Lfm.App.Runs;
+using Xunit;
+
+namespace Lfm.App.Core.Tests.Runs;
+
+public class RunArtworkRotationTests
+{
+    [Fact]
+    public void Shuffle_Uses_Randomizer_To_Prepare_Rotation_Order()
+    {
+        var randomizer = new SequenceArtworkRotationRandomizer([1, 0]);
+
+        var shuffled = RunArtworkRotation.Shuffle(["cinderbrew", "rookery", "stonevault"], randomizer);
+
+        Assert.Equal(["stonevault", "cinderbrew", "rookery"], shuffled);
+        Assert.Equal([3, 2], randomizer.ExclusiveMaxValues);
+    }
+
+    private sealed class SequenceArtworkRotationRandomizer(IReadOnlyList<int> values) : IArtworkRotationRandomizer
+    {
+        private readonly List<int> _exclusiveMaxValues = [];
+        private int _index;
+
+        public IReadOnlyList<int> ExclusiveMaxValues => _exclusiveMaxValues;
+
+        public int Next(int exclusiveMax)
+        {
+            _exclusiveMaxValues.Add(exclusiveMax);
+            return values[_index++];
+        }
+    }
+}

--- a/tests/Lfm.App.Tests/RenderWithProviders.cs
+++ b/tests/Lfm.App.Tests/RenderWithProviders.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using Bunit;
 using Lfm.App.Auth;
 using Lfm.App.i18n;
+using Lfm.App.Runs;
 using Lfm.App.Services;
 using Lfm.Contracts.Characters;
 using Lfm.Contracts.Instances;
@@ -42,6 +43,7 @@ public abstract class ComponentTestBase : BunitContext
 
         Services.AddSingleton<IThemeService, ThemeService>();
         Services.AddSingleton(TimeProvider.System);
+        Services.AddSingleton<IArtworkRotationRandomizer, ArtworkRotationRandomizer>();
 
         Services.AddSingleton<IDataCache, InMemoryDataCache>();
         Services.AddSingleton<ILocaleService, LocaleService>();

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -1562,13 +1562,15 @@ public class RunsPagesTests : ComponentTestBase
     }
 
     [Fact]
-    public void RunsPage_AnyDungeonDetail_Rotates_Dungeon_Portrait_Backgrounds()
+    public void RunsPage_AnyDungeonDetail_Uses_Shuffled_Dungeon_Portrait_Backgrounds()
     {
         const string FirstDungeonSource = "https://render.worldofwarcraft.com/eu/dungeon/cinderbrew-meadery.jpg";
         const string SecondDungeonSource = "https://render.worldofwarcraft.com/eu/dungeon/rookery.jpg";
+        const string ThirdDungeonSource = "https://render.worldofwarcraft.com/eu/dungeon/stonevault.jpg";
         const string RaidSource = "https://render.worldofwarcraft.com/eu/raid/liberation-of-undermine.jpg";
         var timeProvider = new ManualTimerTimeProvider();
         Services.AddSingleton<TimeProvider>(timeProvider);
+        Services.AddSingleton<IArtworkRotationRandomizer>(new SequenceArtworkRotationRandomizer([1, 0]));
         var summary = MakeSummary() with
         {
             InstanceId = null,
@@ -1615,6 +1617,15 @@ public class RunsPagesTests : ComponentTestBase
                 MakeInstanceFixture() with
                 {
                     InstanceNumericId = 4,
+                    Name = "The Stonevault",
+                    Category = "DUNGEON",
+                    Difficulty = "MYTHIC_KEYSTONE",
+                    Size = 5,
+                    PortraitUrl = CachedMediaUrl(ThirdDungeonSource),
+                },
+                MakeInstanceFixture() with
+                {
+                    InstanceNumericId = 5,
                     Name = "Liberation of Undermine",
                     Category = "RAID",
                     Difficulty = "HEROIC",
@@ -1633,7 +1644,7 @@ public class RunsPagesTests : ComponentTestBase
             Assert.Equal(2, layers.Count);
             var activeLayer = layers.Single(l => (l.ClassName ?? "").Contains("run-detail-artwork-layer--active", StringComparison.Ordinal));
             var style = activeLayer.GetAttribute("style") ?? "";
-            Assert.Contains(BlizzardMediaCache.EncodeSource(FirstDungeonSource), style);
+            Assert.Contains(BlizzardMediaCache.EncodeSource(ThirdDungeonSource), style);
             Assert.DoesNotContain(BlizzardMediaCache.EncodeSource(RaidSource), style);
             Assert.Equal(TimeSpan.FromSeconds(5), timeProvider.CreatedTimer?.DueTime);
             Assert.Equal(TimeSpan.FromSeconds(5), timeProvider.CreatedTimer?.Period);
@@ -1649,10 +1660,21 @@ public class RunsPagesTests : ComponentTestBase
                 .GetAttribute("style") ?? "";
             var outgoingStyle = layers.Single(l => !(l.ClassName ?? "").Contains("run-detail-artwork-layer--active", StringComparison.Ordinal))
                 .GetAttribute("style") ?? "";
-            Assert.Contains(BlizzardMediaCache.EncodeSource(SecondDungeonSource), activeStyle);
-            Assert.Contains(BlizzardMediaCache.EncodeSource(FirstDungeonSource), outgoingStyle);
+            Assert.Contains(BlizzardMediaCache.EncodeSource(FirstDungeonSource), activeStyle);
+            Assert.Contains(BlizzardMediaCache.EncodeSource(ThirdDungeonSource), outgoingStyle);
             Assert.DoesNotContain(BlizzardMediaCache.EncodeSource(RaidSource), activeStyle);
             Assert.DoesNotContain(BlizzardMediaCache.EncodeSource(RaidSource), outgoingStyle);
+        });
+
+        timeProvider.CreatedTimer!.Fire();
+
+        cut.WaitForAssertion(() =>
+        {
+            var activeStyle = cut.FindAll("[data-testid='run-detail-artwork-layer']")
+                .Single(l => (l.ClassName ?? "").Contains("run-detail-artwork-layer--active", StringComparison.Ordinal))
+                .GetAttribute("style") ?? "";
+            Assert.Contains(BlizzardMediaCache.EncodeSource(SecondDungeonSource), activeStyle);
+            Assert.DoesNotContain(BlizzardMediaCache.EncodeSource(RaidSource), activeStyle);
         });
     }
 
@@ -2339,6 +2361,13 @@ public class RunsPagesTests : ComponentTestBase
             Dispose();
             return ValueTask.CompletedTask;
         }
+    }
+
+    private sealed class SequenceArtworkRotationRandomizer(IReadOnlyList<int> values) : IArtworkRotationRandomizer
+    {
+        private int _index;
+
+        public int Next(int exclusiveMax) => values[_index++];
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- shuffle Any Dungeon artwork per detail session so it does not always start from the same dungeon
- cycle the existing 5-second crossfade through that shuffled order
- keep named-instance artwork unchanged

## Environment / schema changes
- None

## Screenshots
- Not captured; this is a behavior-only refinement of the existing run detail artwork surface, covered by component and core tests.

## Verification
- `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release`
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release`
- `dotnet build lfm.sln -c Release`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `git diff --check`