### PR TITLE
Use source-specific dungeon lists

### DIFF
--- a/api/Repositories/InstancesRepository.cs
+++ b/api/Repositories/InstancesRepository.cs
@@ -31,7 +31,8 @@ internal sealed record InstanceIndexEntry(
     string? Expansion,
     string? PortraitUrl,
     string? Category = null,
-    int? ExpansionId = null);
+    int? ExpansionId = null,
+    bool IsCurrentMythicKeystone = false);
 
 /// <summary>
 /// Per-mode manifest entry. <c>ModeKey</c> is the legacy composite
@@ -172,7 +173,8 @@ public sealed class InstancesRepository(IBlobReferenceClient blobs) : IInstances
                     ExpansionId: entry.ExpansionId,
                     Difficulty: "UNKNOWN",
                     Size: 0,
-                    PortraitUrl: entry.PortraitUrl));
+                    PortraitUrl: entry.PortraitUrl,
+                    IsCurrentMythicKeystone: entry.IsCurrentMythicKeystone));
                 continue;
             }
 
@@ -189,7 +191,8 @@ public sealed class InstancesRepository(IBlobReferenceClient blobs) : IInstances
                     ExpansionId: entry.ExpansionId,
                     Difficulty: difficulty,
                     Size: size,
-                    PortraitUrl: entry.PortraitUrl));
+                    PortraitUrl: entry.PortraitUrl,
+                    IsCurrentMythicKeystone: entry.IsCurrentMythicKeystone));
             }
         }
         return rows;

--- a/api/Services/BlizzardGameDataClient.cs
+++ b/api/Services/BlizzardGameDataClient.cs
@@ -103,6 +103,29 @@ public sealed class BlizzardGameDataClient : IBlizzardGameDataClient
             "data/wow/journal-expansion/index", accessToken, ct);
 
     /// <inheritdoc/>
+    public Task<BlizzardJournalExpansionDetail> GetJournalExpansionAsync(
+        int expansionId,
+        string accessToken,
+        CancellationToken ct)
+        => GetStaticJsonAsync<BlizzardJournalExpansionDetail>(
+            $"data/wow/journal-expansion/{expansionId}", accessToken, ct);
+
+    /// <inheritdoc/>
+    public Task<BlizzardMythicKeystoneSeasonIndex> GetMythicKeystoneSeasonIndexAsync(
+        string accessToken,
+        CancellationToken ct)
+        => GetDynamicJsonAsync<BlizzardMythicKeystoneSeasonIndex>(
+            "data/wow/mythic-keystone/season/index", accessToken, ct);
+
+    /// <inheritdoc/>
+    public Task<BlizzardMythicKeystoneSeasonDetail> GetMythicKeystoneSeasonAsync(
+        int seasonId,
+        string accessToken,
+        CancellationToken ct)
+        => GetDynamicJsonAsync<BlizzardMythicKeystoneSeasonDetail>(
+            $"data/wow/mythic-keystone/season/{seasonId}", accessToken, ct);
+
+    /// <inheritdoc/>
     public Task<BlizzardJournalInstanceIndex> GetJournalInstanceIndexAsync(string accessToken, CancellationToken ct)
         => GetStaticJsonAsync<BlizzardJournalInstanceIndex>(
             "data/wow/journal-instance/index", accessToken, ct);
@@ -118,20 +141,27 @@ public sealed class BlizzardGameDataClient : IBlizzardGameDataClient
             $"data/wow/media/journal-instance/{instanceId}", accessToken, ct);
 
     // ---------------------------------------------------------------------------
-    // Generic static-namespace fetch
+    // Generic namespace fetch
     // ---------------------------------------------------------------------------
 
-    private async Task<T> GetStaticJsonAsync<T>(string path, string accessToken, CancellationToken ct)
-    {
-        var region = _opts.Region.ToLowerInvariant();
-        var staticNamespace = $"static-{region}";
+    private Task<T> GetStaticJsonAsync<T>(string path, string accessToken, CancellationToken ct)
+        => GetJsonAsync<T>(path, $"static-{_opts.Region.ToLowerInvariant()}", accessToken, ct);
 
+    private Task<T> GetDynamicJsonAsync<T>(string path, string accessToken, CancellationToken ct)
+        => GetJsonAsync<T>(path, $"dynamic-{_opts.Region.ToLowerInvariant()}", accessToken, ct);
+
+    private async Task<T> GetJsonAsync<T>(
+        string path,
+        string ns,
+        string accessToken,
+        CancellationToken ct)
+    {
         // path is a relative path; HttpClient base address is already set to
         // https://{region}.api.blizzard.com/  in Program.cs.
         var uriBuilder = new UriBuilder(_httpClient.BaseAddress!)
         {
             Path = $"/{path}",
-            Query = $"namespace={Uri.EscapeDataString(staticNamespace)}&locale=en_US",
+            Query = $"namespace={Uri.EscapeDataString(ns)}&locale=en_US",
         };
 
         var request = new HttpRequestMessage(HttpMethod.Get, uriBuilder.Uri);

--- a/api/Services/IBlizzardGameDataClient.cs
+++ b/api/Services/IBlizzardGameDataClient.cs
@@ -12,7 +12,8 @@ namespace Lfm.Api.Services;
 /// user access token, mirroring fetchBlizzardToken in reference-sync-blizzard.ts.
 ///
 /// Base URL: https://{region}.api.blizzard.com/ (set in Program.cs).
-/// All static-data requests append namespace=static-{region}&amp;locale=en_US.
+/// Static-data requests append namespace=static-{region}&amp;locale=en_US.
+/// Dynamic Mythic Keystone requests append namespace=dynamic-{region}&amp;locale=en_US.
 /// </summary>
 public interface IBlizzardGameDataClient
 {
@@ -50,10 +51,35 @@ public interface IBlizzardGameDataClient
     /// Fetches the journal-expansion index — the canonical ordered list of
     /// WoW expansions. Used to populate the expansion selector on the
     /// create-run form. Each entry carries only <c>Id</c> and <c>Name</c>;
-    /// we never fetch per-expansion detail because the dungeon / raid
-    /// membership is already carried on each journal-instance row.
+    /// per-expansion detail carries the non-M+ dungeon / raid membership.
     /// </summary>
     Task<BlizzardJournalExpansionIndex> GetJournalExpansionIndexAsync(string accessToken, CancellationToken ct);
+
+    /// <summary>
+    /// Fetches a single journal-expansion detail document, including Blizzard's
+    /// dungeon and raid membership lists for that expansion.
+    /// </summary>
+    Task<BlizzardJournalExpansionDetail> GetJournalExpansionAsync(
+        int expansionId,
+        string accessToken,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Fetches the Mythic Keystone season index from the dynamic namespace.
+    /// </summary>
+    Task<BlizzardMythicKeystoneSeasonIndex> GetMythicKeystoneSeasonIndexAsync(
+        string accessToken,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Fetches one Mythic Keystone season detail document from the dynamic namespace.
+    /// Blizzard's current response may omit dungeon membership; callers must
+    /// tolerate <see cref="BlizzardMythicKeystoneSeasonDetail.Dungeons"/> being null.
+    /// </summary>
+    Task<BlizzardMythicKeystoneSeasonDetail> GetMythicKeystoneSeasonAsync(
+        int seasonId,
+        string accessToken,
+        CancellationToken ct);
 
     /// <summary>
     /// Fetches the journal-instance index.
@@ -107,6 +133,24 @@ public sealed record BlizzardMediaAssets(IReadOnlyList<BlizzardMediaAsset>? Asse
 public sealed record BlizzardJournalExpansionIndex(
     [property: JsonPropertyName("tiers")]
     IReadOnlyList<BlizzardIndexEntry> Tiers);
+
+public sealed record BlizzardJournalExpansionDetail(
+    int Id,
+    string Name,
+    IReadOnlyList<BlizzardIndexEntry>? Dungeons,
+    IReadOnlyList<BlizzardIndexEntry>? Raids);
+
+public sealed record BlizzardMythicKeystoneSeasonReference(int Id);
+
+public sealed record BlizzardMythicKeystoneSeasonIndex(
+    [property: JsonPropertyName("current_season")]
+    BlizzardMythicKeystoneSeasonReference? CurrentSeason,
+    IReadOnlyList<BlizzardMythicKeystoneSeasonReference> Seasons);
+
+public sealed record BlizzardMythicKeystoneSeasonDetail(
+    int Id,
+    [property: JsonPropertyName("season_name")] string? SeasonName,
+    IReadOnlyList<BlizzardIndexEntry>? Dungeons);
 
 public sealed record BlizzardJournalInstanceIndex(IReadOnlyList<BlizzardIndexEntry> Instances);
 

--- a/api/Services/ReferenceSync.cs
+++ b/api/Services/ReferenceSync.cs
@@ -8,8 +8,9 @@ using Microsoft.Extensions.Logging;
 namespace Lfm.Api.Services;
 
 /// <summary>
-/// Syncs static Blizzard reference data (journal-instance, playable-specialization,
-/// plus their media blobs) from the Blizzard Game Data API into the
+/// Syncs Blizzard reference data (journal-instance, journal-expansion,
+/// playable-specialization, Mythic Keystone season membership, plus media blobs)
+/// from the Blizzard Game Data API into the
 /// <c>lfmstore/wow/reference/</c> blob container — see
 /// <c>docs/storage-architecture.md</c>.
 ///
@@ -28,6 +29,9 @@ public sealed class ReferenceSync(
     IBlobReferenceClient blobs,
     ILogger<ReferenceSync> logger) : IReferenceSync
 {
+    private const string CurrentSeasonExpansion = "Current Season";
+    private const string KeystoneDungeonsGroup = "Keystone Dungeons";
+
     /// <inheritdoc/>
     public async Task<WowReferenceRefreshResponse> SyncAllAsync(
         CancellationToken ct,
@@ -106,6 +110,10 @@ public sealed class ReferenceSync(
         IProgress<WowReferenceRefreshProgress>? progress,
         CancellationToken ct)
     {
+        var expansions = await gameData.GetJournalExpansionIndexAsync(token, ct);
+        var journalExpansionIds = await ResolveJournalExpansionInstanceIdsAsync(expansions, token, ct);
+        var currentKeystoneIds = await ResolveCurrentMythicKeystoneDungeonIdsAsync(expansions, token, ct);
+        var hasMembershipFilter = journalExpansionIds.Count > 0 || currentKeystoneIds.Count > 0;
         var index = await gameData.GetJournalInstanceIndexAsync(token, ct);
         var manifest = new List<InstanceIndexEntry>();
         var total = index.Instances.Count;
@@ -115,6 +123,13 @@ public sealed class ReferenceSync(
 
         foreach (var entry in index.Instances)
         {
+            if (hasMembershipFilter
+                && !journalExpansionIds.Contains(entry.Id)
+                && !currentKeystoneIds.Contains(entry.Id))
+            {
+                continue;
+            }
+
             processed++;
             progress?.Report(new WowReferenceRefreshProgress(
                 "instances", "progress", processed, total, Current: entry.Name));
@@ -179,11 +194,76 @@ public sealed class ReferenceSync(
                 Expansion: detail.Expansion?.Name ?? "",
                 PortraitUrl: portraitUrl,
                 Category: detail.Category?.Type,
-                ExpansionId: detail.Expansion?.Id));
+                ExpansionId: detail.Expansion?.Id,
+                IsCurrentMythicKeystone: currentKeystoneIds.Contains(detail.Id)));
         }
 
         await blobs.UploadAsync("reference/journal-instance/index.json", manifest, ct);
         return manifest.Count;
+    }
+
+    private async Task<HashSet<int>> ResolveJournalExpansionInstanceIdsAsync(
+        BlizzardJournalExpansionIndex expansions,
+        string token,
+        CancellationToken ct)
+    {
+        var ids = new HashSet<int>();
+        foreach (var expansion in expansions.Tiers.Where(e => e.Name != CurrentSeasonExpansion))
+        {
+            var detail = await FetchWithRetryAsync(
+                () => gameData.GetJournalExpansionAsync(expansion.Id, token, ct),
+                $"journal expansion {expansion.Id}",
+                ct);
+            if (detail is null) continue;
+
+            foreach (var dungeon in detail.Dungeons ?? [])
+                ids.Add(dungeon.Id);
+            foreach (var raid in detail.Raids ?? [])
+                ids.Add(raid.Id);
+        }
+
+        return ids;
+    }
+
+    private async Task<HashSet<int>> ResolveCurrentMythicKeystoneDungeonIdsAsync(
+        BlizzardJournalExpansionIndex expansions,
+        string token,
+        CancellationToken ct)
+    {
+        try
+        {
+            var index = await gameData.GetMythicKeystoneSeasonIndexAsync(token, ct);
+            var currentSeasonId = index.CurrentSeason?.Id;
+            if (currentSeasonId is null) return [];
+
+            var season = await FetchWithRetryAsync(
+                () => gameData.GetMythicKeystoneSeasonAsync(currentSeasonId.Value, token, ct),
+                $"mythic keystone season {currentSeasonId.Value}",
+                ct);
+
+            if (season?.Dungeons is { Count: > 0 })
+                return season.Dungeons.Select(d => d.Id).ToHashSet();
+
+            var currentSeasonExpansion = expansions.Tiers.FirstOrDefault(e => e.Name == CurrentSeasonExpansion);
+            if (currentSeasonExpansion is null) return [];
+
+            var detail = await FetchWithRetryAsync(
+                () => gameData.GetJournalExpansionAsync(currentSeasonExpansion.Id, token, ct),
+                $"journal expansion {currentSeasonExpansion.Id}",
+                ct);
+
+            return detail?.Dungeons is null
+                ? []
+                : detail.Dungeons
+                    .Where(d => d.Name != KeystoneDungeonsGroup)
+                    .Select(d => d.Id)
+                    .ToHashSet();
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Could not resolve current Mythic Keystone season dungeons");
+            return [];
+        }
     }
 
     // ---------------------------------------------------------------------------

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -880,6 +880,8 @@ components:
           format: int32
         portraitUrl:
           type: string
+        isCurrentMythicKeystone:
+          type: boolean
       additionalProperties: false
     MeResponse:
       type: object

--- a/app/Lfm.App.Core/Runs/InstanceOptions.cs
+++ b/app/Lfm.App.Core/Runs/InstanceOptions.cs
@@ -21,7 +21,8 @@ public sealed record InstanceOption(
     string Name,
     ActivityKind Activity,
     int? ExpansionId,
-    IReadOnlyList<DifficultyOption> Difficulties);
+    IReadOnlyList<DifficultyOption> Difficulties,
+    bool IsCurrentMythicKeystone = false);
 
 public static class InstanceOptions
 {
@@ -54,7 +55,8 @@ public static class InstanceOptions
                     Name: first.Name,
                     Activity: activity,
                     ExpansionId: first.ExpansionId,
-                    Difficulties: difficulties);
+                    Difficulties: difficulties,
+                    IsCurrentMythicKeystone: rows.Any(i => i.IsCurrentMythicKeystone));
             })
             .OrderBy(o => o.Name, StringComparer.OrdinalIgnoreCase)
             .ToList();

--- a/app/Lfm.App.Core/Runs/RunFormState.cs
+++ b/app/Lfm.App.Core/Runs/RunFormState.cs
@@ -43,10 +43,21 @@ public sealed class RunFormState
     public bool CanCreateGuildRuns { get; set; }
     public IReadOnlyList<DifficultyOption> DifficultyOptions { get; private set; } = Array.Empty<DifficultyOption>();
 
-    public IEnumerable<InstanceOption> FilteredInstances =>
-        AllInstances.Where(o =>
-            (o.ExpansionId is null || o.ExpansionId == ExpansionId) &&
-            o.Activity == Activity);
+    public IEnumerable<InstanceOption> FilteredInstances
+    {
+        get
+        {
+            var isSpecificMythicPlus = Activity == ActivityKind.Dungeon
+                && Difficulty == "MYTHIC_KEYSTONE"
+                && !AnyDungeon;
+
+            return AllInstances.Where(o =>
+                o.Activity == Activity &&
+                (isSpecificMythicPlus
+                    ? o.IsCurrentMythicKeystone
+                    : o.ExpansionId == ExpansionId));
+        }
+    }
 
     public bool ShowInstanceDropdown =>
         !(Activity == ActivityKind.Dungeon && Difficulty == "MYTHIC_KEYSTONE" && AnyDungeon);

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -39,8 +39,9 @@ builder.Services.AddHttpClient("api", client =>
 }).AddHttpMessageHandler<CredentialsHandler>();
 
 // Long-running admin operations. POST /api/wow/reference/refresh iterates
-// every Blizzard journal-instance + playable-specialization + journal-expansion
-// sequentially with ~80 rps rate-limiting — a cold-cache run takes minutes,
+// every Blizzard journal-instance + playable-specialization + journal-expansion,
+// plus Mythic Keystone season membership, sequentially with ~80 rps
+// rate-limiting — a cold-cache run takes minutes,
 // well past the 10 s default the regular "api" client uses. Shares the same
 // credentials handler; just relaxes the per-request ceiling.
 builder.Services.AddHttpClient("api-admin", client =>

--- a/app/wwwroot/locales/en.json
+++ b/app/wwwroot/locales/en.json
@@ -307,7 +307,7 @@
     "guildAdmin.saveError": "An error occurred while saving.",
 
     "adminReference.title": "Reference data",
-    "adminReference.description": "Pulls the latest journal-instance, playable-specialization, and journal-expansion data from the Blizzard Game Data API and writes it to blob. Takes about a minute.",
+    "adminReference.description": "Pulls the latest journal-instance, playable-specialization, journal-expansion, and Mythic Keystone season data from the Blizzard Game Data API and writes it to blob. Takes about a minute.",
     "adminReference.status.idle": "No reference refresh has run in this session yet.",
     "adminReference.status.refreshing": "Reference refresh is running.",
     "adminReference.status.success": "Reference refresh completed in this session.",

--- a/app/wwwroot/locales/fi.json
+++ b/app/wwwroot/locales/fi.json
@@ -288,7 +288,7 @@
     "guildAdmin.saveSuccess": "Asetukset tallennettu onnistuneesti.",
     "guildAdmin.saveError": "Virhe tallennettaessa.",
     "adminReference.title": "Referenssitiedot",
-    "adminReference.description": "Hakee uusimmat journal-instance-, playable-specialization- ja journal-expansion-tiedot Blizzardin Game Data API:sta ja kirjoittaa ne blobiin. Kest\u00e4\u00e4 noin minuutin.",
+    "adminReference.description": "Hakee uusimmat journal-instance-, playable-specialization-, journal-expansion- ja Mythic Keystone -kausitiedot Blizzardin Game Data API:sta ja kirjoittaa ne blobiin. Kest\u00e4\u00e4 noin minuutin.",
     "adminReference.status.idle": "T\u00e4ss\u00e4 istunnossa ei ole viel\u00e4 ajettu referenssip\u00e4ivityst\u00e4.",
     "adminReference.status.refreshing": "Referenssip\u00e4ivitys on k\u00e4ynniss\u00e4.",
     "adminReference.status.success": "Referenssip\u00e4ivitys valmistui t\u00e4ss\u00e4 istunnossa.",

--- a/docs/storage-architecture.md
+++ b/docs/storage-architecture.md
@@ -6,7 +6,7 @@ This document is the rule for where any piece of data the app persists should li
 
 | Kind | Store | Location |
 |---|---|---|
-| **Static Blizzard reference data** (journal-instance, playable-specialization, playable-class, playable-race, hero-talent-tree — same shape for every user) | **Blob** | `lfmstore/wow/reference/{kind}/{id}.json` + `reference/{kind}/index.json` manifest |
+| **Static Blizzard reference data** (journal-instance, journal-expansion membership, Mythic Keystone season membership, playable-specialization, playable-class, playable-race, hero-talent-tree — same shape for every user) | **Blob** | `lfmstore/wow/reference/{kind}/{id}.json` + `reference/{kind}/index.json` manifest |
 | **Dynamic per-user / per-guild / per-run data** (raider profiles, run signups, guild docs, admin overrides) | **Cosmos** | `lfm-cosmos/lfm/{raiders,runs,guilds}` |
 | **Per-entity caches of Blizzard responses** (one user's account profile, one guild's roster) | **Cosmos, embedded** | inside the owning raider/guild document, with a `*FetchedAt` timestamp |
 | **Operational bytes** (ASP.NET Data Protection keys, Functions runtime state, deploy zip artifacts) | **Blob** | `lfmstore/{dataprotection,deployments,azure-webjobs-hosts,azure-webjobs-secrets}` |
@@ -85,12 +85,22 @@ For every reference kind that has a list endpoint, the ingester emits `reference
   { "id": 1200, "name": "Liberation of Undermine",
     "modes": [ { "modeKey": "NORMAL:25" }, { "modeKey": "HEROIC:25" } ],
     "expansion": "The War Within",
+    "isCurrentMythicKeystone": false,
     "portraitUrl": "https://render.worldofwarcraft.com/.../tile.jpg" },
   ...
 ]
 ```
 
 The per-id detail blobs (`{kind}/{id}.json`, `{kind}-media/{id}.json`) stay for future endpoints (detail pages, hero talents) and as the source of truth the manifest is derived from. Manifest media fields store Blizzard source URLs; HTTP handlers and Blazor image components convert them to `/api/v1/wow/media/cache` before browser rendering.
+
+The journal-instance manifest is filtered through `journal-expansion/{id}` detail
+membership for non-M+ raid/dungeon choices. The `Current Season` journal-expansion
+alias is not used as a normal expansion because Blizzard can place grouping rows
+such as `Keystone Dungeons` there. Current Mythic Keystone membership is stored as
+`isCurrentMythicKeystone` when Blizzard's Mythic Keystone season detail exposes
+dungeon ids. When the season detail omits dungeon ids, the ingester falls back to
+the `Current Season` journal-expansion detail for M+ membership and filters out
+the `Keystone Dungeons` grouping row.
 
 ## Known exceptions to flag
 

--- a/shared/Lfm.Contracts/Instances/InstanceDto.cs
+++ b/shared/Lfm.Contracts/Instances/InstanceDto.cs
@@ -50,6 +50,11 @@ namespace Lfm.Contracts.Instances;
 /// exception — see docs/wire-payload-contract.md. If the portrait surface is
 /// dropped, trim this field at the next audit.
 /// </param>
+/// <param name="IsCurrentMythicKeystone">
+/// True when the row belongs to the current Mythic Keystone season membership.
+/// The create/edit run forms use this to populate specific M+ dungeon choices
+/// separately from normal journal-expansion dungeon membership.
+/// </param>
 public sealed record InstanceDto(
     string Id,
     int InstanceNumericId,
@@ -60,4 +65,5 @@ public sealed record InstanceDto(
     int? ExpansionId = null,
     string Difficulty = "",
     int Size = 0,
-    string? PortraitUrl = null);
+    string? PortraitUrl = null,
+    bool IsCurrentMythicKeystone = false);

--- a/tests/Lfm.Api.Tests/ReferenceSyncTests.cs
+++ b/tests/Lfm.Api.Tests/ReferenceSyncTests.cs
@@ -49,6 +49,27 @@ public class ReferenceSyncTests
     private static BlizzardJournalExpansionIndex MakeExpansionIndex(params (int Id, string Name)[] entries) =>
         new(entries.Select(e => new BlizzardIndexEntry(e.Id, e.Name)).ToList());
 
+    private static BlizzardJournalExpansionDetail MakeExpansionDetail(
+        int id,
+        string name,
+        IReadOnlyList<BlizzardIndexEntry>? dungeons = null,
+        IReadOnlyList<BlizzardIndexEntry>? raids = null) =>
+        new(Id: id, Name: name, Dungeons: dungeons ?? [], Raids: raids ?? []);
+
+    private static BlizzardMythicKeystoneSeasonIndex MakeKeystoneSeasonIndex(int? currentSeasonId = null) =>
+        new(
+            CurrentSeason: currentSeasonId is null
+                ? null
+                : new BlizzardMythicKeystoneSeasonReference(currentSeasonId.Value),
+            Seasons: currentSeasonId is null
+                ? []
+                : [new BlizzardMythicKeystoneSeasonReference(currentSeasonId.Value)]);
+
+    private static BlizzardMythicKeystoneSeasonDetail MakeKeystoneSeasonDetail(
+        int id,
+        IReadOnlyList<BlizzardIndexEntry>? dungeons = null) =>
+        new(Id: id, SeasonName: $"Season {id}", Dungeons: dungeons);
+
     private static BlizzardPlayableSpecDetail MakeSpecDetail(
         int id, string name, int classId, string roleType) =>
         new(
@@ -72,6 +93,8 @@ public class ReferenceSyncTests
             .ReturnsAsync(MakeSpecIndex());
         blizzard.Setup(b => b.GetJournalExpansionIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
             .ReturnsAsync(MakeExpansionIndex());
+        blizzard.Setup(b => b.GetMythicKeystoneSeasonIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeKeystoneSeasonIndex());
 
         var blobs = new Mock<IBlobReferenceClient>();
         var logger = new TestLogger<ReferenceSync>();
@@ -221,6 +244,148 @@ public class ReferenceSyncTests
                 ix.Single().Modes!.Count == 3 &&
                 ix.Single().Modes!.Any(m => m.ModeKey == "HEROIC:25")),
             It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SyncInstancesAsync_uses_journal_expansion_membership_and_current_keystone_season()
+    {
+        var (sut, blizzard, blobs, _) = MakeSut();
+        blizzard.Setup(b => b.GetJournalExpansionIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeExpansionIndex(
+                (505, "Current Season"),
+                (516, "Midnight"),
+                (503, "Dragonflight")));
+        blizzard.Setup(b => b.GetJournalExpansionAsync(516, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeExpansionDetail(
+                516,
+                "Midnight",
+                dungeons: [new BlizzardIndexEntry(1311, "Den of Nalorakk")]));
+        blizzard.Setup(b => b.GetJournalExpansionAsync(503, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeExpansionDetail(503, "Dragonflight"));
+        blizzard.Setup(b => b.GetMythicKeystoneSeasonIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeKeystoneSeasonIndex(currentSeasonId: 17));
+        blizzard.Setup(b => b.GetMythicKeystoneSeasonAsync(17, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeKeystoneSeasonDetail(
+                17,
+                dungeons: [new BlizzardIndexEntry(1201, "Algeth'ar Academy")]));
+
+        blizzard.Setup(b => b.GetJournalInstanceIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeJournalIndex(
+                (1311, "Den of Nalorakk"),
+                (1201, "Algeth'ar Academy"),
+                (1319, "Keystone Dungeons")));
+        blizzard.Setup(b => b.GetJournalInstanceAsync(1311, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BlizzardJournalInstanceDetail(
+                Id: 1311,
+                Name: "Den of Nalorakk",
+                Category: new BlizzardJournalInstanceCategory("DUNGEON"),
+                Expansion: new BlizzardJournalExpansion(516, "Midnight"),
+                MinimumLevel: 80,
+                Modes:
+                [
+                    new BlizzardJournalInstanceMode(
+                        new BlizzardJournalModeRef("MYTHIC_KEYSTONE", "Mythic Keystone"),
+                        5,
+                        true),
+                ],
+                Media: null));
+        blizzard.Setup(b => b.GetJournalInstanceAsync(1201, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BlizzardJournalInstanceDetail(
+                Id: 1201,
+                Name: "Algeth'ar Academy",
+                Category: new BlizzardJournalInstanceCategory("DUNGEON"),
+                Expansion: new BlizzardJournalExpansion(503, "Dragonflight"),
+                MinimumLevel: 70,
+                Modes:
+                [
+                    new BlizzardJournalInstanceMode(
+                        new BlizzardJournalModeRef("MYTHIC_KEYSTONE", "Mythic Keystone"),
+                        5,
+                        true),
+                ],
+                Media: null));
+        blizzard.Setup(b => b.GetJournalInstanceAsync(1319, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BlizzardJournalInstanceDetail(
+                Id: 1319,
+                Name: "Keystone Dungeons",
+                Category: new BlizzardJournalInstanceCategory("DUNGEON"),
+                Expansion: null,
+                MinimumLevel: null,
+                Modes:
+                [
+                    new BlizzardJournalInstanceMode(
+                        new BlizzardJournalModeRef("MYTHIC_KEYSTONE", "Mythic Keystone"),
+                        5,
+                        true),
+                ],
+                Media: null));
+
+        await sut.SyncAllAsync(CancellationToken.None);
+
+        blobs.Verify(b => b.UploadAsync(
+            "reference/journal-instance/index.json",
+            It.Is<List<InstanceIndexEntry>>(ix =>
+                ix.Count == 2 &&
+                ix.Any(e => e.Id == 1311 && !e.IsCurrentMythicKeystone) &&
+                ix.Any(e => e.Id == 1201 && e.IsCurrentMythicKeystone) &&
+                ix.All(e => e.Id != 1319)),
+            It.IsAny<CancellationToken>()), Times.Once);
+        blizzard.Verify(b => b.GetJournalExpansionAsync(505, FakeToken, It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SyncInstancesAsync_falls_back_to_current_season_expansion_when_keystone_season_has_no_dungeons()
+    {
+        var (sut, blizzard, blobs, _) = MakeSut();
+        blizzard.Setup(b => b.GetJournalExpansionIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeExpansionIndex(
+                (505, "Current Season"),
+                (516, "Midnight")));
+        blizzard.Setup(b => b.GetJournalExpansionAsync(505, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeExpansionDetail(
+                505,
+                "Current Season",
+                dungeons:
+                [
+                    new BlizzardIndexEntry(1201, "Algeth'ar Academy"),
+                    new BlizzardIndexEntry(1319, "Keystone Dungeons"),
+                ]));
+        blizzard.Setup(b => b.GetJournalExpansionAsync(516, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeExpansionDetail(516, "Midnight"));
+        blizzard.Setup(b => b.GetMythicKeystoneSeasonIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeKeystoneSeasonIndex(currentSeasonId: 17));
+        blizzard.Setup(b => b.GetMythicKeystoneSeasonAsync(17, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeKeystoneSeasonDetail(17, dungeons: null));
+
+        blizzard.Setup(b => b.GetJournalInstanceIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeJournalIndex(
+                (1201, "Algeth'ar Academy"),
+                (1319, "Keystone Dungeons")));
+        blizzard.Setup(b => b.GetJournalInstanceAsync(1201, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BlizzardJournalInstanceDetail(
+                Id: 1201,
+                Name: "Algeth'ar Academy",
+                Category: new BlizzardJournalInstanceCategory("DUNGEON"),
+                Expansion: new BlizzardJournalExpansion(503, "Dragonflight"),
+                MinimumLevel: 70,
+                Modes:
+                [
+                    new BlizzardJournalInstanceMode(
+                        new BlizzardJournalModeRef("MYTHIC_KEYSTONE", "Mythic Keystone"),
+                        5,
+                        true),
+                ],
+                Media: null));
+
+        await sut.SyncAllAsync(CancellationToken.None);
+
+        blobs.Verify(b => b.UploadAsync(
+            "reference/journal-instance/index.json",
+            It.Is<List<InstanceIndexEntry>>(ix =>
+                ix.Single().Id == 1201 &&
+                ix.Single().IsCurrentMythicKeystone),
+            It.IsAny<CancellationToken>()), Times.Once);
+        blizzard.Verify(b => b.GetJournalInstanceAsync(1319, FakeToken, It.IsAny<CancellationToken>()), Times.Never);
     }
 
     // ── Resilience ───────────────────────────────────────────────────────────
@@ -386,7 +551,7 @@ public class ReferenceSyncTests
     }
 
     [Fact]
-    public async Task SyncAllAsync_records_failure_for_expansions_but_still_syncs_others()
+    public async Task SyncAllAsync_records_expansion_source_failure_for_instances_and_expansions_but_still_syncs_specializations()
     {
         var (sut, blizzard, _, logger) = MakeSut();
         blizzard.Setup(b => b.GetJournalExpansionIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
@@ -394,11 +559,12 @@ public class ReferenceSyncTests
 
         var response = await sut.SyncAllAsync(CancellationToken.None);
 
+        var instancesResult = response.Results.Single(r => r.Name == "instances");
         var expansionsResult = response.Results.Single(r => r.Name == "expansions");
+        Assert.StartsWith("failed:", instancesResult.Status);
         Assert.StartsWith("failed:", expansionsResult.Status);
-        // instances + specializations should still have succeeded (empty indexes)
-        Assert.StartsWith("synced", response.Results.Single(r => r.Name == "instances").Status);
         Assert.StartsWith("synced", response.Results.Single(r => r.Name == "specializations").Status);
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Error && (e.Message ?? "").Contains("instances"));
         Assert.Contains(logger.Entries, e => e.Level == LogLevel.Error && (e.Message ?? "").Contains("expansions"));
     }
 

--- a/tests/Lfm.App.Core.Tests/Runs/InstanceOptionsTests.cs
+++ b/tests/Lfm.App.Core.Tests/Runs/InstanceOptionsTests.cs
@@ -15,7 +15,8 @@ public class InstanceOptionsTests
         string difficulty,
         int size,
         string? category = "RAID",
-        int? expansionId = 505) =>
+        int? expansionId = 505,
+        bool isCurrentMythicKeystone = false) =>
         new(
             Id: $"{numericId}:{difficulty}:{size}",
             InstanceNumericId: numericId,
@@ -25,7 +26,8 @@ public class InstanceOptionsTests
             Category: category,
             ExpansionId: expansionId,
             Difficulty: difficulty,
-            Size: size);
+            Size: size,
+            IsCurrentMythicKeystone: isCurrentMythicKeystone);
 
     [Fact]
     public void Groups_multiple_mode_rows_into_one_option_per_instance()
@@ -122,5 +124,19 @@ public class InstanceOptionsTests
         var flat = new List<InstanceDto> { Row(1200, "L", "HEROIC", 25, expansionId: 505) };
         var opt = Assert.Single(InstanceOptions.Build(flat));
         Assert.Equal(505, opt.ExpansionId);
+    }
+
+    [Fact]
+    public void Carries_current_mythic_keystone_membership_from_any_row()
+    {
+        var flat = new List<InstanceDto>
+        {
+            Row(1200, "L", "HEROIC", 5),
+            Row(1200, "L", "MYTHIC_KEYSTONE", 5, isCurrentMythicKeystone: true),
+        };
+
+        var opt = Assert.Single(InstanceOptions.Build(flat));
+
+        Assert.True(opt.IsCurrentMythicKeystone);
     }
 }

--- a/tests/Lfm.App.Core.Tests/Runs/RunFormStateTests.cs
+++ b/tests/Lfm.App.Core.Tests/Runs/RunFormStateTests.cs
@@ -27,7 +27,8 @@ public class RunFormStateTests
             {
                 new DifficultyOption("MYTHIC_KEYSTONE", 5, "Mythic+ (5)"),
                 new DifficultyOption("HEROIC", 5, "Heroic (5)"),
-            }),
+            },
+            IsCurrentMythicKeystone: true),
         new InstanceOption(
             InstanceId: 2055,
             Name: "Some Raid",
@@ -55,11 +56,11 @@ public class RunFormStateTests
     }
 
     [Fact]
-    public void FilteredInstances_include_global_options_and_match_activity_and_expansion()
+    public void FilteredInstances_match_activity_and_expansion_without_global_pseudo_entries()
     {
-        var globalDungeon = new InstanceOption(
+        var pseudoDungeon = new InstanceOption(
             InstanceId: 1001,
-            Name: "Global Dungeon",
+            Name: "Keystone Dungeons",
             Activity: ActivityKind.Dungeon,
             ExpansionId: null,
             Difficulties: [new DifficultyOption("MYTHIC_KEYSTONE", 5, "Mythic+ (5)")]);
@@ -76,14 +77,42 @@ public class RunFormStateTests
             ExpansionId: 14,
             Difficulties: [new DifficultyOption("NORMAL", 10, "Normal (10)")]);
         var state = new RunFormState();
-        state.LoadOptions([globalDungeon, oldDungeon, currentRaid], Expansions);
+        state.LoadOptions([pseudoDungeon, oldDungeon, currentRaid], Expansions);
 
         var dungeonIds = state.FilteredInstances.Select(i => i.InstanceId).ToArray();
 
-        Assert.Equal(new[] { 1001 }, dungeonIds);
+        Assert.Empty(dungeonIds);
 
         state.OnActivityChanged(ActivityKind.Raid);
         Assert.Equal(new[] { 1003 }, state.FilteredInstances.Select(i => i.InstanceId).ToArray());
+    }
+
+    [Fact]
+    public void FilteredInstances_uses_current_mythic_keystone_membership_for_mplus_specific_dungeons()
+    {
+        var seasonDungeon = new InstanceOption(
+            InstanceId: 1001,
+            Name: "Season Dungeon",
+            Activity: ActivityKind.Dungeon,
+            ExpansionId: 11,
+            Difficulties: [new DifficultyOption("MYTHIC_KEYSTONE", 5, "Mythic+ (5)")],
+            IsCurrentMythicKeystone: true);
+        var expansionDungeon = new InstanceOption(
+            InstanceId: 1002,
+            Name: "Expansion Dungeon",
+            Activity: ActivityKind.Dungeon,
+            ExpansionId: 14,
+            Difficulties: [new DifficultyOption("MYTHIC_KEYSTONE", 5, "Mythic+ (5)")]);
+        var state = new RunFormState();
+        state.LoadOptions([seasonDungeon, expansionDungeon], Expansions);
+
+        state.OnDungeonScopeChanged(false);
+
+        Assert.Equal(new[] { 1001 }, state.FilteredInstances.Select(i => i.InstanceId).ToArray());
+
+        state.OnDifficultyChanged("HEROIC");
+
+        Assert.Equal(new[] { 1002 }, state.FilteredInstances.Select(i => i.InstanceId).ToArray());
     }
 
     [Fact]

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -2097,7 +2097,7 @@ public class RunsPagesTests : ComponentTestBase
             instances:
             [
                 new("1:MYTHIC_KEYSTONE:5", 1, "Windrunner Spire", "MYTHIC_KEYSTONE:5",
-                    "Midnight", "DUNGEON", 700, "MYTHIC_KEYSTONE", 5),
+                    "Midnight", "DUNGEON", 700, "MYTHIC_KEYSTONE", 5, IsCurrentMythicKeystone: true),
                 new("2:HEROIC:25", 2, "The Voidspire", "HEROIC:25",
                     "Midnight", "RAID", 700, "HEROIC", 25),
             ],
@@ -2227,11 +2227,10 @@ public class RunsPagesTests : ComponentTestBase
     [Fact]
     public void CreateRunPage_DoesNotRenderExpansionSelector()
     {
-        // The create-run form scopes its instance list to the Blizzard
-        // "Current Season" tier unconditionally — M+, raids, and non-M+
-        // dungeons all come from the current rotation. Pin the absence of
-        // an expansion dropdown so a regression that reintroduces cross-
-        // expansion selection surfaces here.
+        // The create-run form chooses the current expansion / M+ membership
+        // from reference data instead of exposing an expansion selector.
+        // Pin the absence of an expansion dropdown so a regression that
+        // reintroduces cross-expansion selection surfaces here.
         WireCreateRunServices(expansions: new List<ExpansionDto>
         {
             new(505, "The War Within"),
@@ -2492,7 +2491,8 @@ public class RunsPagesTests : ComponentTestBase
             "DUNGEON",
             505,
             "MYTHIC_KEYSTONE",
-            5);
+            5,
+            IsCurrentMythicKeystone: true);
         var runsClient = new Mock<IRunsClient>();
         runsClient.Setup(c => c.GetWithEtagAsync("run-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new RunDetailWithEtag(
@@ -2538,7 +2538,7 @@ public class RunsPagesTests : ComponentTestBase
     public void EditRunPage_DoesNotRenderExpansionSelector()
     {
         // Same rationale as CreateRunPage_DoesNotRenderExpansionSelector:
-        // the edit form also scopes to the Current Season tier only.
+        // the edit form also derives instance scope from reference data.
         var runsClient = new Mock<IRunsClient>();
         runsClient.Setup(c => c.GetWithEtagAsync("run-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new RunDetailWithEtag(MakeDetail(), "\"etag-v1\""));


### PR DESCRIPTION
## Summary
- Use journal-expansion detail data as the source for non-Mythic+ dungeon membership.
- Use Mythic Keystone season data for current M+ dungeon membership, with a current-season journal fallback when Blizzard omits dungeon IDs from the season detail response.
- Exclude pseudo/global dungeon rows such as `Keystone Dungeons` from specific dungeon choices and add `isCurrentMythicKeystone` to instance reference data.

## Verification
- `dotnet format lfm.sln`
- `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release --no-restore`
- `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release --no-restore`
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --no-restore`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `dotnet build lfm.sln -c Release --no-restore`
- `git diff --check`

## Screenshots
- Not captured; this changes reference data sourcing and form option filtering rather than layout or visual presentation.