### PR TITLE
Narrow run scheduling to current raids and Mythic Plus

### DIFF
--- a/api/Services/ReferenceSync.cs
+++ b/api/Services/ReferenceSync.cs
@@ -30,6 +30,7 @@ public sealed class ReferenceSync(
     ILogger<ReferenceSync> logger) : IReferenceSync
 {
     private const string CurrentSeasonExpansion = "Current Season";
+    private const int CurrentRaidTierJournalExpansionId = 516;
     private const string KeystoneDungeonsGroup = "Keystone Dungeons";
 
     /// <inheritdoc/>
@@ -111,9 +112,9 @@ public sealed class ReferenceSync(
         CancellationToken ct)
     {
         var expansions = await gameData.GetJournalExpansionIndexAsync(token, ct);
-        var journalExpansionIds = await ResolveJournalExpansionInstanceIdsAsync(expansions, token, ct);
+        var currentRaidTierIds = await ResolveCurrentRaidTierRaidIdsAsync(token, ct);
         var currentKeystoneIds = await ResolveCurrentMythicKeystoneDungeonIdsAsync(expansions, token, ct);
-        var hasMembershipFilter = journalExpansionIds.Count > 0 || currentKeystoneIds.Count > 0;
+        var hasMembershipFilter = currentRaidTierIds.Count > 0 || currentKeystoneIds.Count > 0;
         var index = await gameData.GetJournalInstanceIndexAsync(token, ct);
         var manifest = new List<InstanceIndexEntry>();
         var total = index.Instances.Count;
@@ -124,7 +125,7 @@ public sealed class ReferenceSync(
         foreach (var entry in index.Instances)
         {
             if (hasMembershipFilter
-                && !journalExpansionIds.Contains(entry.Id)
+                && !currentRaidTierIds.Contains(entry.Id)
                 && !currentKeystoneIds.Contains(entry.Id))
             {
                 continue;
@@ -202,27 +203,18 @@ public sealed class ReferenceSync(
         return manifest.Count;
     }
 
-    private async Task<HashSet<int>> ResolveJournalExpansionInstanceIdsAsync(
-        BlizzardJournalExpansionIndex expansions,
+    private async Task<HashSet<int>> ResolveCurrentRaidTierRaidIdsAsync(
         string token,
         CancellationToken ct)
     {
-        var ids = new HashSet<int>();
-        foreach (var expansion in expansions.Tiers.Where(e => e.Name != CurrentSeasonExpansion))
-        {
-            var detail = await FetchWithRetryAsync(
-                () => gameData.GetJournalExpansionAsync(expansion.Id, token, ct),
-                $"journal expansion {expansion.Id}",
-                ct);
-            if (detail is null) continue;
+        var detail = await FetchWithRetryAsync(
+            () => gameData.GetJournalExpansionAsync(CurrentRaidTierJournalExpansionId, token, ct),
+            $"journal expansion {CurrentRaidTierJournalExpansionId}",
+            ct);
 
-            foreach (var dungeon in detail.Dungeons ?? [])
-                ids.Add(dungeon.Id);
-            foreach (var raid in detail.Raids ?? [])
-                ids.Add(raid.Id);
-        }
-
-        return ids;
+        return detail?.Raids is null
+            ? []
+            : detail.Raids.Select(r => r.Id).ToHashSet();
     }
 
     private async Task<HashSet<int>> ResolveCurrentMythicKeystoneDungeonIdsAsync(

--- a/app/Lfm.App.Core/Runs/RunFormState.cs
+++ b/app/Lfm.App.Core/Runs/RunFormState.cs
@@ -23,6 +23,7 @@ public enum RunFormSubmitBlocker
 public sealed class RunFormState
 {
     public const string CurrentSeasonExpansion = "Current Season";
+    private const string MythicKeystoneDifficulty = "MYTHIC_KEYSTONE";
 
     public IReadOnlyList<InstanceOption> AllInstances { get; private set; } = Array.Empty<InstanceOption>();
     public IReadOnlyList<ExpansionDto> Expansions { get; private set; } = Array.Empty<ExpansionDto>();
@@ -47,22 +48,19 @@ public sealed class RunFormState
     {
         get
         {
-            var isSpecificMythicPlus = Activity == ActivityKind.Dungeon
-                && Difficulty == "MYTHIC_KEYSTONE"
-                && !AnyDungeon;
-
             return AllInstances.Where(o =>
                 o.Activity == Activity &&
-                (isSpecificMythicPlus
+                (Activity == ActivityKind.Dungeon
                     ? o.IsCurrentMythicKeystone
                     : o.ExpansionId == ExpansionId));
         }
     }
 
     public bool ShowInstanceDropdown =>
-        !(Activity == ActivityKind.Dungeon && Difficulty == "MYTHIC_KEYSTONE" && AnyDungeon);
+        !(Activity == ActivityKind.Dungeon && AnyDungeon);
 
-    public bool ShowDifficultyToggle => InstanceId != 0 || !ShowInstanceDropdown;
+    public bool ShowDifficultyToggle =>
+        Activity != ActivityKind.Dungeon && (InstanceId != 0 || !ShowInstanceDropdown);
 
     public RunFormSubmitBlocker SubmitBlocker
     {
@@ -70,7 +68,7 @@ public sealed class RunFormState
         {
             if (StartTimeLocal is null) return RunFormSubmitBlocker.MissingStartTime;
 
-            var isMythicPlus = Activity == ActivityKind.Dungeon && Difficulty == "MYTHIC_KEYSTONE";
+            var isMythicPlus = Activity == ActivityKind.Dungeon && Difficulty == MythicKeystoneDifficulty;
             if (isMythicPlus && AnyDungeon)
             {
                 if (KeystoneLevel is null) return RunFormSubmitBlocker.MissingKeystoneLevel;
@@ -102,7 +100,7 @@ public sealed class RunFormState
         Activity = value;
         InstanceId = 0;
         AnyDungeon = value == ActivityKind.Dungeon;
-        Difficulty = value == ActivityKind.Dungeon ? "MYTHIC_KEYSTONE" : "";
+        Difficulty = value == ActivityKind.Dungeon ? MythicKeystoneDifficulty : "";
         Size = value == ActivityKind.Dungeon ? 5 : 0;
         KeystoneLevel = null;
         RefreshDifficultyOptions();
@@ -112,6 +110,11 @@ public sealed class RunFormState
     {
         AnyDungeon = anyDungeon;
         if (anyDungeon) InstanceId = 0;
+        if (Activity == ActivityKind.Dungeon)
+        {
+            Difficulty = MythicKeystoneDifficulty;
+            Size = 5;
+        }
         RefreshDifficultyOptions();
     }
 
@@ -134,26 +137,42 @@ public sealed class RunFormState
 
     public void OnDifficultyChanged(string value)
     {
+        if (Activity == ActivityKind.Dungeon)
+        {
+            Difficulty = MythicKeystoneDifficulty;
+            Size = FilteredInstances
+                .FirstOrDefault(o => o.InstanceId == InstanceId)?
+                .Difficulties.FirstOrDefault(d => d.DifficultyId == MythicKeystoneDifficulty)?
+                .Size ?? 5;
+            return;
+        }
+
         Difficulty = value;
         var match = FilteredInstances
             .FirstOrDefault(o => o.InstanceId == InstanceId)?
             .Difficulties.FirstOrDefault(d => d.DifficultyId == value);
         Size = match?.Size ?? 0;
-        if (value != "MYTHIC_KEYSTONE") KeystoneLevel = null;
+        if (value != MythicKeystoneDifficulty) KeystoneLevel = null;
     }
 
     public void RefreshDifficultyOptions()
     {
         var match = FilteredInstances.FirstOrDefault(o => o.InstanceId == InstanceId);
-        DifficultyOptions = match is null
-            ? Array.Empty<DifficultyOption>()
+        if (match is null)
+        {
+            DifficultyOptions = Array.Empty<DifficultyOption>();
+            return;
+        }
+
+        DifficultyOptions = Activity == ActivityKind.Dungeon
+            ? match.Difficulties.Where(d => d.DifficultyId == MythicKeystoneDifficulty).ToList()
             : match.Difficulties.ToList();
     }
 
     public void SetMode(string difficulty, int size, int? keystoneLevel)
     {
-        Difficulty = difficulty;
-        Size = size;
+        Difficulty = Activity == ActivityKind.Dungeon ? MythicKeystoneDifficulty : difficulty;
+        Size = Activity == ActivityKind.Dungeon ? 5 : size;
         KeystoneLevel = keystoneLevel;
     }
 
@@ -179,8 +198,8 @@ public sealed class RunFormState
         Activity = activity;
         ExpansionId = expansionId;
         InstanceId = instanceId;
-        Difficulty = difficulty;
-        Size = size;
+        Difficulty = activity == ActivityKind.Dungeon ? MythicKeystoneDifficulty : difficulty;
+        Size = activity == ActivityKind.Dungeon ? 5 : size;
         KeystoneLevel = keystoneLevel;
         AnyDungeon = anyDungeon;
         StartTimeLocal = startTimeLocal;

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -39,8 +39,8 @@ builder.Services.AddHttpClient("api", client =>
 }).AddHttpMessageHandler<CredentialsHandler>();
 
 // Long-running admin operations. POST /api/wow/reference/refresh iterates
-// every Blizzard journal-instance + playable-specialization + journal-expansion,
-// plus Mythic Keystone season membership, sequentially with ~80 rps
+// Blizzard journal-instance data for the current raid tier + M+ season,
+// playable-specialization, journal-expansion, and media, sequentially with ~80 rps
 // rate-limiting — a cold-cache run takes minutes,
 // well past the 10 s default the regular "api" client uses. Shares the same
 // credentials handler; just relaxes the per-request ceiling.

--- a/app/wwwroot/locales/en.json
+++ b/app/wwwroot/locales/en.json
@@ -307,7 +307,7 @@
     "guildAdmin.saveError": "An error occurred while saving.",
 
     "adminReference.title": "Reference data",
-    "adminReference.description": "Pulls the latest journal-instance, playable-specialization, journal-expansion, and Mythic Keystone season data from the Blizzard Game Data API and writes it to blob. Takes about a minute.",
+    "adminReference.description": "Pulls the latest current raid tier, Mythic Keystone season, playable-specialization, and journal-expansion data from the Blizzard Game Data API and writes it to blob. Takes about a minute.",
     "adminReference.status.idle": "No reference refresh has run in this session yet.",
     "adminReference.status.refreshing": "Reference refresh is running.",
     "adminReference.status.success": "Reference refresh completed in this session.",

--- a/app/wwwroot/locales/fi.json
+++ b/app/wwwroot/locales/fi.json
@@ -288,7 +288,7 @@
     "guildAdmin.saveSuccess": "Asetukset tallennettu onnistuneesti.",
     "guildAdmin.saveError": "Virhe tallennettaessa.",
     "adminReference.title": "Referenssitiedot",
-    "adminReference.description": "Hakee uusimmat journal-instance-, playable-specialization-, journal-expansion- ja Mythic Keystone -kausitiedot Blizzardin Game Data API:sta ja kirjoittaa ne blobiin. Kest\u00e4\u00e4 noin minuutin.",
+    "adminReference.description": "Hakee uusimmat nykyisen raid-tierin, Mythic Keystone -kauden, playable-specialization- ja journal-expansion-tiedot Blizzardin Game Data API:sta ja kirjoittaa ne blobiin. Kest\u00e4\u00e4 noin minuutin.",
     "adminReference.status.idle": "T\u00e4ss\u00e4 istunnossa ei ole viel\u00e4 ajettu referenssip\u00e4ivityst\u00e4.",
     "adminReference.status.refreshing": "Referenssip\u00e4ivitys on k\u00e4ynniss\u00e4.",
     "adminReference.status.success": "Referenssip\u00e4ivitys valmistui t\u00e4ss\u00e4 istunnossa.",

--- a/docs/storage-architecture.md
+++ b/docs/storage-architecture.md
@@ -93,10 +93,10 @@ For every reference kind that has a list endpoint, the ingester emits `reference
 
 The per-id detail blobs (`{kind}/{id}.json`, `{kind}-media/{id}.json`) stay for future endpoints (detail pages, hero talents) and as the source of truth the manifest is derived from. Manifest media fields store Blizzard source URLs; HTTP handlers and Blazor image components convert them to `/api/v1/wow/media/cache` before browser rendering.
 
-The journal-instance manifest is filtered through `journal-expansion/{id}` detail
-membership for non-M+ raid/dungeon choices. The `Current Season` journal-expansion
-alias is not used as a normal expansion because Blizzard can place grouping rows
-such as `Keystone Dungeons` there. Current Mythic Keystone membership is stored as
+The journal-instance manifest is filtered to the scheduleable surface: raids from
+the current raid tier (`journal-expansion/516` raids) and dungeons from the
+current Mythic Keystone season only. Normal/heroic/mythic non-keystone dungeons
+are not scheduleable. Current Mythic Keystone membership is stored as
 `isCurrentMythicKeystone` when Blizzard's Mythic Keystone season detail exposes
 dungeon ids. When the season detail omits dungeon ids, the ingester falls back to
 the `Current Season` journal-expansion detail for M+ membership and filters out

--- a/shared/Lfm.Contracts/Instances/InstanceDto.cs
+++ b/shared/Lfm.Contracts/Instances/InstanceDto.cs
@@ -53,7 +53,7 @@ namespace Lfm.Contracts.Instances;
 /// <param name="IsCurrentMythicKeystone">
 /// True when the row belongs to the current Mythic Keystone season membership.
 /// The create/edit run forms use this to populate specific M+ dungeon choices
-/// separately from normal journal-expansion dungeon membership.
+/// because non-keystone dungeons are not scheduleable.
 /// </param>
 public sealed record InstanceDto(
     string Id,

--- a/tests/Lfm.Api.Tests/ReferenceSyncTests.cs
+++ b/tests/Lfm.Api.Tests/ReferenceSyncTests.cs
@@ -247,7 +247,7 @@ public class ReferenceSyncTests
     }
 
     [Fact]
-    public async Task SyncInstancesAsync_uses_journal_expansion_membership_and_current_keystone_season()
+    public async Task SyncInstancesAsync_uses_current_raid_tier_and_current_keystone_season()
     {
         var (sut, blizzard, blobs, _) = MakeSut();
         blizzard.Setup(b => b.GetJournalExpansionIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
@@ -259,7 +259,8 @@ public class ReferenceSyncTests
             .ReturnsAsync(MakeExpansionDetail(
                 516,
                 "Midnight",
-                dungeons: [new BlizzardIndexEntry(1311, "Den of Nalorakk")]));
+                dungeons: [new BlizzardIndexEntry(1311, "Den of Nalorakk")],
+                raids: [new BlizzardIndexEntry(1400, "The Voidspire")]));
         blizzard.Setup(b => b.GetJournalExpansionAsync(503, FakeToken, It.IsAny<CancellationToken>()))
             .ReturnsAsync(MakeExpansionDetail(503, "Dragonflight"));
         blizzard.Setup(b => b.GetMythicKeystoneSeasonIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
@@ -272,6 +273,7 @@ public class ReferenceSyncTests
         blizzard.Setup(b => b.GetJournalInstanceIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
             .ReturnsAsync(MakeJournalIndex(
                 (1311, "Den of Nalorakk"),
+                (1400, "The Voidspire"),
                 (1201, "Algeth'ar Academy"),
                 (1319, "Keystone Dungeons")));
         blizzard.Setup(b => b.GetJournalInstanceAsync(1311, FakeToken, It.IsAny<CancellationToken>()))
@@ -304,6 +306,21 @@ public class ReferenceSyncTests
                         true),
                 ],
                 Media: null));
+        blizzard.Setup(b => b.GetJournalInstanceAsync(1400, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BlizzardJournalInstanceDetail(
+                Id: 1400,
+                Name: "The Voidspire",
+                Category: new BlizzardJournalInstanceCategory("RAID"),
+                Expansion: new BlizzardJournalExpansion(516, "Midnight"),
+                MinimumLevel: 80,
+                Modes:
+                [
+                    new BlizzardJournalInstanceMode(
+                        new BlizzardJournalModeRef("HEROIC", "Heroic"),
+                        20,
+                        true),
+                ],
+                Media: null));
         blizzard.Setup(b => b.GetJournalInstanceAsync(1319, FakeToken, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BlizzardJournalInstanceDetail(
                 Id: 1319,
@@ -326,10 +343,12 @@ public class ReferenceSyncTests
             "reference/journal-instance/index.json",
             It.Is<List<InstanceIndexEntry>>(ix =>
                 ix.Count == 2 &&
-                ix.Any(e => e.Id == 1311 && !e.IsCurrentMythicKeystone) &&
+                ix.Any(e => e.Id == 1400 && !e.IsCurrentMythicKeystone) &&
                 ix.Any(e => e.Id == 1201 && e.IsCurrentMythicKeystone) &&
+                ix.All(e => e.Id != 1311) &&
                 ix.All(e => e.Id != 1319)),
             It.IsAny<CancellationToken>()), Times.Once);
+        blizzard.Verify(b => b.GetJournalInstanceAsync(1311, FakeToken, It.IsAny<CancellationToken>()), Times.Never);
         blizzard.Verify(b => b.GetJournalExpansionAsync(505, FakeToken, It.IsAny<CancellationToken>()), Times.Never);
     }
 

--- a/tests/Lfm.App.Core.Tests/Runs/RunFormStateTests.cs
+++ b/tests/Lfm.App.Core.Tests/Runs/RunFormStateTests.cs
@@ -88,7 +88,7 @@ public class RunFormStateTests
     }
 
     [Fact]
-    public void FilteredInstances_uses_current_mythic_keystone_membership_for_mplus_specific_dungeons()
+    public void FilteredInstances_uses_current_mythic_keystone_membership_for_all_dungeon_scheduling()
     {
         var seasonDungeon = new InstanceOption(
             InstanceId: 1001,
@@ -112,7 +112,20 @@ public class RunFormStateTests
 
         state.OnDifficultyChanged("HEROIC");
 
-        Assert.Equal(new[] { 1002 }, state.FilteredInstances.Select(i => i.InstanceId).ToArray());
+        Assert.Equal("MYTHIC_KEYSTONE", state.Difficulty);
+        Assert.Equal(new[] { 1001 }, state.FilteredInstances.Select(i => i.InstanceId).ToArray());
+    }
+
+    [Fact]
+    public void Dungeon_scheduling_does_not_offer_non_mythic_plus_difficulty_toggle()
+    {
+        var state = new RunFormState();
+        state.LoadOptions(Instances, Expansions);
+
+        state.OnDungeonScopeChanged(false);
+        state.OnInstanceChanged(1023);
+
+        Assert.False(state.ShowDifficultyToggle);
     }
 
     [Fact]
@@ -123,7 +136,8 @@ public class RunFormStateTests
             Name: "Current Dungeon",
             Activity: ActivityKind.Dungeon,
             ExpansionId: 700,
-            Difficulties: [new DifficultyOption("MYTHIC_KEYSTONE", 5, "M+")]);
+            Difficulties: [new DifficultyOption("MYTHIC_KEYSTONE", 5, "M+")],
+            IsCurrentMythicKeystone: true);
         var raid = new InstanceOption(
             InstanceId: 1002,
             Name: "Current Raid",
@@ -151,7 +165,7 @@ public class RunFormStateTests
         state.LoadOptions(Instances, Expansions);
 
         Assert.False(state.ShowInstanceDropdown);
-        Assert.True(state.ShowDifficultyToggle);
+        Assert.False(state.ShowDifficultyToggle);
 
         state.OnDungeonScopeChanged(false);
 
@@ -161,7 +175,7 @@ public class RunFormStateTests
         state.OnInstanceChanged(1023);
 
         Assert.True(state.ShowInstanceDropdown);
-        Assert.True(state.ShowDifficultyToggle);
+        Assert.False(state.ShowDifficultyToggle);
 
         state.OnActivityChanged(ActivityKind.Raid);
 
@@ -171,7 +185,8 @@ public class RunFormStateTests
         state.OnActivityChanged(ActivityKind.Dungeon);
         state.SetMode("HEROIC", 5, null);
 
-        Assert.True(state.ShowInstanceDropdown);
+        Assert.False(state.ShowInstanceDropdown);
+        Assert.Equal("MYTHIC_KEYSTONE", state.Difficulty);
     }
 
     [Fact]
@@ -232,7 +247,7 @@ public class RunFormStateTests
     }
 
     [Fact]
-    public void OnDifficultyChanged_NonMythicPlus_ClearsKeystone()
+    public void OnDifficultyChanged_DungeonNonMythicPlus_keeps_mythic_plus_and_keystone()
     {
         var state = new RunFormState();
         state.LoadOptions(Instances, Expansions);
@@ -241,8 +256,8 @@ public class RunFormStateTests
         state.KeystoneLevel = 12;
         state.OnDifficultyChanged("HEROIC");
 
-        Assert.Equal("HEROIC", state.Difficulty);
-        Assert.Null(state.KeystoneLevel);
+        Assert.Equal("MYTHIC_KEYSTONE", state.Difficulty);
+        Assert.Equal(12, state.KeystoneLevel);
     }
 
     [Fact]
@@ -256,9 +271,9 @@ public class RunFormStateTests
 
         state.OnDifficultyChanged("HEROIC");
 
-        Assert.Equal("HEROIC", state.Difficulty);
+        Assert.Equal("MYTHIC_KEYSTONE", state.Difficulty);
         Assert.Equal(5, state.Size);
-        Assert.Null(state.KeystoneLevel);
+        Assert.Equal(12, state.KeystoneLevel);
 
         state.KeystoneLevel = 10;
         state.OnDifficultyChanged("MYTHIC_KEYSTONE");
@@ -373,13 +388,17 @@ public class RunFormStateTests
     }
 
     [Fact]
-    public void CanSubmit_DungeonHeroicWithInstance_does_not_require_keystone()
+    public void CanSubmit_DungeonNonMythicPlusInput_still_requires_mythic_plus_keystone()
     {
         var state = new RunFormState();
         state.LoadOptions(Instances, Expansions);
         state.OnInstanceChanged(1023);
         state.OnDifficultyChanged("HEROIC");
         state.StartTimeLocal = DateTime.Now.AddDays(1);
+
+        Assert.False(state.CanSubmit);
+
+        state.KeystoneLevel = 10;
 
         Assert.True(state.CanSubmit);
     }
@@ -436,8 +455,8 @@ public class RunFormStateTests
         {
             new InstanceOption(
                 InstanceId: 3001,
-                Name: "Flexible Dungeon",
-                Activity: ActivityKind.Dungeon,
+                Name: "Flexible Raid",
+                Activity: ActivityKind.Raid,
                 ExpansionId: 14,
                 Difficulties: new[]
                 {
@@ -447,6 +466,7 @@ public class RunFormStateTests
         };
         var state = new RunFormState();
         state.LoadOptions(customInstances, Expansions);
+        state.OnActivityChanged(ActivityKind.Raid);
 
         state.OnDifficultyChanged("SMALL");
 
@@ -524,6 +544,7 @@ public class RunFormStateTests
     public void SetMode_replaces_difficulty_size_and_keystone()
     {
         var state = new RunFormState();
+        state.OnActivityChanged(ActivityKind.Raid);
 
         state.SetMode("HEROIC", 10, 7);
 


### PR DESCRIPTION
## Summary
- Filter scheduled reference instances to raids from `journal-expansion/516` and dungeons from the current Mythic Keystone season.
- Make dungeon scheduling M+ only in the create/edit form state, including specific-dungeon filtering and difficulty handling.
- Update reference refresh copy and storage docs to describe the narrower scheduling surface.

## Verification
- `dotnet build lfm.sln -c Release --no-restore`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release --no-restore`
- `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release --no-restore`
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --no-restore`
- `jq empty app/wwwroot/locales/en.json app/wwwroot/locales/fi.json`
- `git diff --check`

## Screenshots
- Not captured; this narrows reference data and form-state behavior without changing page layout.