### PR TITLE
Use leaderboard API for current M+ dungeons

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Docker volume mounted into the Functions container as
 such as `PRIVACY_EMAIL`, `API_HOSTNAME`, and `FRONTEND_HOSTNAME` are documented
 under Deployment and are intentionally not part of the local `.env` template.
 
-### 3. Start the local dev environment
+### 3. Start local stack
 
 ```bash
 scripts/start-worktree-dev.sh

--- a/api/Services/BlizzardGameDataClient.cs
+++ b/api/Services/BlizzardGameDataClient.cs
@@ -14,13 +14,13 @@ namespace Lfm.Api.Services;
 /// Implements <see cref="IBlizzardGameDataClient"/> against the Blizzard Game Data API.
 ///
 /// Mirrors the pattern in reference-sync-blizzard.ts:
-///   fetchBlizzardToken  → <see cref="GetClientCredentialsTokenAsync"/>
-///   fetchStaticJson     → <see cref="GetStaticJsonAsync{T}"/>
+///   fetchBlizzardToken  -> <see cref="GetClientCredentialsTokenAsync"/>
+///   fetchStaticJson     -> <see cref="GetStaticJsonAsync{T}"/>
 ///
 /// HttpClient base address: https://{region}.api.blizzard.com/ (set in Program.cs).
 /// Token endpoint:          https://{region}.battle.net/oauth/token (separate request).
 ///
-/// JSON deserialization uses camelCase → PascalCase via PropertyNameCaseInsensitive.
+/// JSON deserialization uses camelCase -> PascalCase via PropertyNameCaseInsensitive.
 /// The Blizzard API uses snake_case for some fields; those are mapped with
 /// [JsonPropertyName] on the DTO record properties.
 /// </summary>
@@ -124,6 +124,21 @@ public sealed class BlizzardGameDataClient : IBlizzardGameDataClient
         CancellationToken ct)
         => GetDynamicJsonAsync<BlizzardMythicKeystoneSeasonDetail>(
             $"data/wow/mythic-keystone/season/{seasonId}", accessToken, ct);
+
+    /// <inheritdoc/>
+    public Task<BlizzardConnectedRealmIndex> GetConnectedRealmIndexAsync(
+        string accessToken,
+        CancellationToken ct)
+        => GetDynamicJsonAsync<BlizzardConnectedRealmIndex>(
+            "data/wow/connected-realm/index", accessToken, ct);
+
+    /// <inheritdoc/>
+    public Task<BlizzardMythicKeystoneLeaderboardIndex> GetMythicKeystoneLeaderboardsIndexAsync(
+        int connectedRealmId,
+        string accessToken,
+        CancellationToken ct)
+        => GetDynamicJsonAsync<BlizzardMythicKeystoneLeaderboardIndex>(
+            $"data/wow/connected-realm/{connectedRealmId}/mythic-leaderboard/index", accessToken, ct);
 
     /// <inheritdoc/>
     public Task<BlizzardJournalInstanceIndex> GetJournalInstanceIndexAsync(string accessToken, CancellationToken ct)

--- a/api/Services/BlizzardGameDataClient.cs
+++ b/api/Services/BlizzardGameDataClient.cs
@@ -14,13 +14,13 @@ namespace Lfm.Api.Services;
 /// Implements <see cref="IBlizzardGameDataClient"/> against the Blizzard Game Data API.
 ///
 /// Mirrors the pattern in reference-sync-blizzard.ts:
-///   fetchBlizzardToken  -> <see cref="GetClientCredentialsTokenAsync"/>
-///   fetchStaticJson     -> <see cref="GetStaticJsonAsync{T}"/>
+///   fetchBlizzardToken  → <see cref="GetClientCredentialsTokenAsync"/>
+///   fetchStaticJson     → <see cref="GetStaticJsonAsync{T}"/>
 ///
 /// HttpClient base address: https://{region}.api.blizzard.com/ (set in Program.cs).
 /// Token endpoint:          https://{region}.battle.net/oauth/token (separate request).
 ///
-/// JSON deserialization uses camelCase -> PascalCase via PropertyNameCaseInsensitive.
+/// JSON deserialization uses camelCase → PascalCase via PropertyNameCaseInsensitive.
 /// The Blizzard API uses snake_case for some fields; those are mapped with
 /// [JsonPropertyName] on the DTO record properties.
 /// </summary>

--- a/api/Services/IBlizzardGameDataClient.cs
+++ b/api/Services/IBlizzardGameDataClient.cs
@@ -82,6 +82,23 @@ public interface IBlizzardGameDataClient
         CancellationToken ct);
 
     /// <summary>
+    /// Fetches the connected-realm index from the dynamic namespace. The
+    /// Mythic Keystone leaderboard index is scoped by connected realm.
+    /// </summary>
+    Task<BlizzardConnectedRealmIndex> GetConnectedRealmIndexAsync(
+        string accessToken,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Fetches the current Mythic Keystone leaderboard index for a connected realm
+    /// from the dynamic namespace.
+    /// </summary>
+    Task<BlizzardMythicKeystoneLeaderboardIndex> GetMythicKeystoneLeaderboardsIndexAsync(
+        int connectedRealmId,
+        string accessToken,
+        CancellationToken ct);
+
+    /// <summary>
     /// Fetches the journal-instance index.
     /// </summary>
     Task<BlizzardJournalInstanceIndex> GetJournalInstanceIndexAsync(string accessToken, CancellationToken ct);
@@ -151,6 +168,18 @@ public sealed record BlizzardMythicKeystoneSeasonDetail(
     int Id,
     [property: JsonPropertyName("season_name")] string? SeasonName,
     IReadOnlyList<BlizzardIndexEntry>? Dungeons);
+
+public sealed record BlizzardHrefReference(string Href);
+
+public sealed record BlizzardConnectedRealmReference(BlizzardHrefReference Key);
+
+public sealed record BlizzardConnectedRealmIndex(
+    [property: JsonPropertyName("connected_realms")]
+    IReadOnlyList<BlizzardConnectedRealmReference> ConnectedRealms);
+
+public sealed record BlizzardMythicKeystoneLeaderboardIndex(
+    [property: JsonPropertyName("current_leaderboards")]
+    IReadOnlyList<BlizzardIndexEntry>? CurrentLeaderboards);
 
 public sealed record BlizzardJournalInstanceIndex(IReadOnlyList<BlizzardIndexEntry> Instances);
 

--- a/api/Services/ReferenceSync.cs
+++ b/api/Services/ReferenceSync.cs
@@ -32,6 +32,7 @@ public sealed class ReferenceSync(
     private const string CurrentSeasonExpansion = "Current Season";
     private const int CurrentRaidTierJournalExpansionId = 516;
     private const string KeystoneDungeonsGroup = "Keystone Dungeons";
+    private const int MaxLeaderboardConnectedRealmProbeCount = 5;
 
     /// <inheritdoc/>
     public async Task<WowReferenceRefreshResponse> SyncAllAsync(
@@ -236,6 +237,9 @@ public sealed class ReferenceSync(
             if (season?.Dungeons is { Count: > 0 })
                 return season.Dungeons.Select(d => d.Id).ToHashSet();
 
+            var leaderboards = await ResolveCurrentMythicKeystoneDungeonIdsFromLeaderboardsAsync(token, ct);
+            if (leaderboards.Count > 0) return leaderboards;
+
             var currentSeasonExpansion = expansions.Tiers.FirstOrDefault(e => e.Name == CurrentSeasonExpansion);
             if (currentSeasonExpansion is null) return [];
 
@@ -256,6 +260,52 @@ public sealed class ReferenceSync(
             logger.LogWarning(ex, "Could not resolve current Mythic Keystone season dungeons");
             return [];
         }
+    }
+
+    private async Task<HashSet<int>> ResolveCurrentMythicKeystoneDungeonIdsFromLeaderboardsAsync(
+        string token,
+        CancellationToken ct)
+    {
+        try
+        {
+            var connectedRealms = await FetchWithRetryAsync(
+                () => gameData.GetConnectedRealmIndexAsync(token, ct),
+                "connected realm index",
+                ct);
+            if (connectedRealms?.ConnectedRealms is null) return [];
+
+            foreach (var connectedRealmId in connectedRealms.ConnectedRealms
+                         .Select(r => TryGetConnectedRealmId(r.Key.Href))
+                         .Where(id => id.HasValue)
+                         .Select(id => id!.Value)
+                         .Take(MaxLeaderboardConnectedRealmProbeCount))
+            {
+                var leaderboards = await FetchWithRetryAsync(
+                    () => gameData.GetMythicKeystoneLeaderboardsIndexAsync(connectedRealmId, token, ct),
+                    $"mythic keystone leaderboard index {connectedRealmId}",
+                    ct);
+
+                if (leaderboards?.CurrentLeaderboards is { Count: > 0 })
+                    return leaderboards.CurrentLeaderboards.Select(d => d.Id).ToHashSet();
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Could not resolve current Mythic Keystone dungeons from leaderboard index");
+        }
+
+        return [];
+    }
+
+    private static int? TryGetConnectedRealmId(string href)
+    {
+        if (!Uri.TryCreate(href, UriKind.Absolute, out var uri)) return null;
+
+        var lastSegment = uri.Segments
+            .Select(s => s.Trim('/'))
+            .LastOrDefault(s => s.Length > 0);
+
+        return int.TryParse(lastSegment, out var id) ? id : null;
     }
 
     // ---------------------------------------------------------------------------

--- a/docs/storage-architecture.md
+++ b/docs/storage-architecture.md
@@ -111,7 +111,7 @@ These look like they violate the rule but don't, because they are per-entity *ca
 - `raiders.PortraitCache` — map of `characterId → render URL`, refreshed by the portrait-fetch flow, tied to the raider doc's TTL.
 - `raiders.AccountProfileSummary` — cached Blizzard WoW account profile, tracked by `AccountProfileFetchedAt`.
 - `raiders.Characters[*].MediaSummary` — cached Blizzard character media, tracked by `MediaFetchedAt`.
-- `guilds.BlizzardRosterRaw` + `guilds.BlizzardProfileRaw` — cached Blizzard guild roster + profile, tracked by `BlizzardRosterFetchedAt`.
+- `guilds.BlizzardRosterRaw` + `guilds.BlizzardProfileRaw` — cached Blizzard guild roster + profile, tracked by `BlizzardRosterFetchedAt` / `BlizzardProfileFetchedAt`.
 
 Splitting any of these out to blob would add round-trips and a consistency surface for zero cost win, because each cache's lifecycle is *the owner's* lifecycle, not a shared patch-day lifecycle.
 

--- a/docs/storage-architecture.md
+++ b/docs/storage-architecture.md
@@ -98,9 +98,11 @@ the current raid tier (`journal-expansion/516` raids) and dungeons from the
 current Mythic Keystone season only. Normal/heroic/mythic non-keystone dungeons
 are not scheduleable. Current Mythic Keystone membership is stored as
 `isCurrentMythicKeystone` when Blizzard's Mythic Keystone season detail exposes
-dungeon ids. When the season detail omits dungeon ids, the ingester falls back to
-the `Current Season` journal-expansion detail for M+ membership and filters out
-the `Keystone Dungeons` grouping row.
+dungeon ids. When the season detail omits dungeon ids, the ingester resolves a
+connected realm from Blizzard's dynamic connected-realm index and reads the
+current Mythic Keystone leaderboard index for dungeon membership. The
+`Current Season` journal-expansion detail remains a last-resort fallback and
+filters out the `Keystone Dungeons` grouping row.
 
 ## Known exceptions to flag
 
@@ -109,7 +111,7 @@ These look like they violate the rule but don't, because they are per-entity *ca
 - `raiders.PortraitCache` — map of `characterId → render URL`, refreshed by the portrait-fetch flow, tied to the raider doc's TTL.
 - `raiders.AccountProfileSummary` — cached Blizzard WoW account profile, tracked by `AccountProfileFetchedAt`.
 - `raiders.Characters[*].MediaSummary` — cached Blizzard character media, tracked by `MediaFetchedAt`.
-- `guilds.BlizzardRosterRaw` + `guilds.BlizzardProfileRaw` — cached Blizzard guild roster + profile, tracked by `BlizzardRosterFetchedAt` / `BlizzardProfileFetchedAt`.
+- `guilds.BlizzardRosterRaw` + `guilds.BlizzardProfileRaw` — cached Blizzard guild roster + profile, tracked by `BlizzardRosterFetchedAt`.
 
 Splitting any of these out to blob would add round-trips and a consistency surface for zero cost win, because each cache's lifecycle is *the owner's* lifecycle, not a shared patch-day lifecycle.
 

--- a/tests/Lfm.Api.Tests/ReferenceSyncTests.cs
+++ b/tests/Lfm.Api.Tests/ReferenceSyncTests.cs
@@ -70,6 +70,16 @@ public class ReferenceSyncTests
         IReadOnlyList<BlizzardIndexEntry>? dungeons = null) =>
         new(Id: id, SeasonName: $"Season {id}", Dungeons: dungeons);
 
+    private static BlizzardConnectedRealmIndex MakeConnectedRealmIndex(params int[] connectedRealmIds) =>
+        new(connectedRealmIds
+            .Select(id => new BlizzardConnectedRealmReference(
+                new BlizzardHrefReference($"https://eu.api.blizzard.com/data/wow/connected-realm/{id}?namespace=dynamic-eu")))
+            .ToList());
+
+    private static BlizzardMythicKeystoneLeaderboardIndex MakeLeaderboardIndex(
+        params (int Id, string Name)[] currentLeaderboards) =>
+        new(currentLeaderboards.Select(l => new BlizzardIndexEntry(l.Id, l.Name)).ToList());
+
     private static BlizzardPlayableSpecDetail MakeSpecDetail(
         int id, string name, int classId, string roleType) =>
         new(
@@ -95,6 +105,8 @@ public class ReferenceSyncTests
             .ReturnsAsync(MakeExpansionIndex());
         blizzard.Setup(b => b.GetMythicKeystoneSeasonIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
             .ReturnsAsync(MakeKeystoneSeasonIndex());
+        blizzard.Setup(b => b.GetConnectedRealmIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeConnectedRealmIndex());
 
         var blobs = new Mock<IBlobReferenceClient>();
         var logger = new TestLogger<ReferenceSync>();
@@ -401,10 +413,68 @@ public class ReferenceSyncTests
         blobs.Verify(b => b.UploadAsync(
             "reference/journal-instance/index.json",
             It.Is<List<InstanceIndexEntry>>(ix =>
-                ix.Single().Id == 1201 &&
-                ix.Single().IsCurrentMythicKeystone),
+                ix.Count == 1 &&
+                ix[0].Id == 1201 &&
+                ix[0].IsCurrentMythicKeystone),
             It.IsAny<CancellationToken>()), Times.Once);
         blizzard.Verify(b => b.GetJournalInstanceAsync(1319, FakeToken, It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SyncInstancesAsync_uses_current_leaderboard_index_when_keystone_season_has_no_dungeons()
+    {
+        var (sut, blizzard, blobs, _) = MakeSut();
+        blizzard.Setup(b => b.GetJournalExpansionIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeExpansionIndex(
+                (505, "Current Season"),
+                (516, "Midnight")));
+        blizzard.Setup(b => b.GetJournalExpansionAsync(516, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeExpansionDetail(516, "Midnight"));
+        blizzard.Setup(b => b.GetJournalExpansionAsync(505, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeExpansionDetail(
+                505,
+                "Current Season",
+                dungeons: [new BlizzardIndexEntry(9999, "Stale Current Season Dungeon")]));
+        blizzard.Setup(b => b.GetMythicKeystoneSeasonIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeKeystoneSeasonIndex(currentSeasonId: 17));
+        blizzard.Setup(b => b.GetMythicKeystoneSeasonAsync(17, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeKeystoneSeasonDetail(17, dungeons: null));
+        blizzard.Setup(b => b.GetConnectedRealmIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeConnectedRealmIndex(1084));
+        blizzard.Setup(b => b.GetMythicKeystoneLeaderboardsIndexAsync(1084, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeLeaderboardIndex((1201, "Algeth'ar Academy")));
+
+        blizzard.Setup(b => b.GetJournalInstanceIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeJournalIndex(
+                (1201, "Algeth'ar Academy"),
+                (9999, "Stale Current Season Dungeon")));
+        blizzard.Setup(b => b.GetJournalInstanceAsync(1201, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BlizzardJournalInstanceDetail(
+                Id: 1201,
+                Name: "Algeth'ar Academy",
+                Category: new BlizzardJournalInstanceCategory("DUNGEON"),
+                Expansion: new BlizzardJournalExpansion(503, "Dragonflight"),
+                MinimumLevel: 70,
+                Modes:
+                [
+                    new BlizzardJournalInstanceMode(
+                        new BlizzardJournalModeRef("MYTHIC_KEYSTONE", "Mythic Keystone"),
+                        5,
+                        true),
+                ],
+                Media: null));
+
+        await sut.SyncAllAsync(CancellationToken.None);
+
+        blobs.Verify(b => b.UploadAsync(
+            "reference/journal-instance/index.json",
+            It.Is<List<InstanceIndexEntry>>(ix =>
+                ix.Count == 1 &&
+                ix[0].Id == 1201 &&
+                ix[0].IsCurrentMythicKeystone),
+            It.IsAny<CancellationToken>()), Times.Once);
+        blizzard.Verify(b => b.GetJournalExpansionAsync(505, FakeToken, It.IsAny<CancellationToken>()), Times.Never);
+        blizzard.Verify(b => b.GetJournalInstanceAsync(9999, FakeToken, It.IsAny<CancellationToken>()), Times.Never);
     }
 
     // ── Resilience ───────────────────────────────────────────────────────────

--- a/tests/Lfm.Api.Tests/Services/BlizzardGameDataClientTests.cs
+++ b/tests/Lfm.Api.Tests/Services/BlizzardGameDataClientTests.cs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using Lfm.Api.Options;
+using Lfm.Api.Services;
+using Xunit;
+
+namespace Lfm.Api.Tests.Services;
+
+public class BlizzardGameDataClientTests
+{
+    [Fact]
+    public async Task GetConnectedRealmIndexAsync_uses_dynamic_namespace_and_bearer_token()
+    {
+        using var handler = new RecordingHandler(
+            """{"connected_realms":[{"key":{"href":"https://eu.api.blizzard.com/data/wow/connected-realm/1084?namespace=dynamic-eu"}}]}""");
+        using var http = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://eu.api.blizzard.com/"),
+        };
+        var client = MakeClient(http);
+
+        var result = await client.GetConnectedRealmIndexAsync("access-token-1", CancellationToken.None);
+
+        Assert.Equal(
+            "https://eu.api.blizzard.com/data/wow/connected-realm/1084?namespace=dynamic-eu",
+            result.ConnectedRealms.Single().Key.Href);
+        Assert.Equal(HttpMethod.Get, handler.Method);
+        Assert.Equal(
+            "https://eu.api.blizzard.com/data/wow/connected-realm/index?namespace=dynamic-eu&locale=en_US",
+            handler.RequestUri!.ToString());
+        Assert.Equal("Bearer", handler.Authorization!.Scheme);
+        Assert.Equal("access-token-1", handler.Authorization.Parameter);
+    }
+
+    [Fact]
+    public async Task GetMythicKeystoneLeaderboardsIndexAsync_uses_connected_realm_leaderboard_endpoint()
+    {
+        using var handler = new RecordingHandler(
+            """{"current_leaderboards":[{"key":{"href":"https://eu.api.blizzard.com/data/wow/connected-realm/1084/mythic-leaderboard/1201/period/1000?namespace=dynamic-eu"},"name":"Algeth'ar Academy","id":1201}]}""");
+        using var http = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://eu.api.blizzard.com/"),
+        };
+        var client = MakeClient(http);
+
+        var result = await client.GetMythicKeystoneLeaderboardsIndexAsync(
+            1084,
+            "access-token-2",
+            CancellationToken.None);
+
+        Assert.Equal(1201, result.CurrentLeaderboards!.Single().Id);
+        Assert.Equal(
+            "https://eu.api.blizzard.com/data/wow/connected-realm/1084/mythic-leaderboard/index?namespace=dynamic-eu&locale=en_US",
+            handler.RequestUri!.ToString());
+        Assert.Equal("Bearer", handler.Authorization!.Scheme);
+        Assert.Equal("access-token-2", handler.Authorization.Parameter);
+    }
+
+    private static BlizzardGameDataClient MakeClient(HttpClient http)
+    {
+        var options = Microsoft.Extensions.Options.Options.Create(new BlizzardOptions
+        {
+            ClientId = "client",
+            ClientSecret = "secret",
+            Region = "eu",
+            RedirectUri = "https://example.com/api/battlenet/callback",
+            AppBaseUrl = "https://example.com",
+        });
+        return new BlizzardGameDataClient(http, options);
+    }
+
+    private sealed class RecordingHandler(string responseJson) : HttpMessageHandler
+    {
+        public Uri? RequestUri { get; private set; }
+        public HttpMethod? Method { get; private set; }
+        public AuthenticationHeaderValue? Authorization { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            RequestUri = request.RequestUri;
+            Method = request.Method;
+            Authorization = request.Headers.Authorization;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseJson, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Blizzard connected-realm and Mythic Keystone leaderboard index calls
- use current leaderboards as the M+ dungeon source when season detail omits dungeons
- keep the current-season journal-expansion fallback and update storage docs/tests
- fix the README local-stack heading so the existing local configuration contract can extract the documented section

## Verification
- `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release --filter "ReferenceSyncTests|BlizzardGameDataClientTests"`
- `dotnet build lfm.sln -c Release`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `git diff --check`