### PR TITLE
Prefer leaderboard M+ dungeon set

### DIFF
--- a/api/Services/BlizzardGameDataClient.cs
+++ b/api/Services/BlizzardGameDataClient.cs
@@ -138,7 +138,7 @@ public sealed class BlizzardGameDataClient : IBlizzardGameDataClient
         string accessToken,
         CancellationToken ct)
         => GetDynamicJsonAsync<BlizzardMythicKeystoneLeaderboardIndex>(
-            $"data/wow/connected-realm/{connectedRealmId}/mythic-leaderboard/index", accessToken, ct);
+            $"data/wow/connected-realm/{connectedRealmId}/mythic-leaderboard/", accessToken, ct);
 
     /// <inheritdoc/>
     public Task<BlizzardJournalInstanceIndex> GetJournalInstanceIndexAsync(string accessToken, CancellationToken ct)

--- a/api/Services/ReferenceSync.cs
+++ b/api/Services/ReferenceSync.cs
@@ -229,6 +229,9 @@ public sealed class ReferenceSync(
             var currentSeasonId = index.CurrentSeason?.Id;
             if (currentSeasonId is null) return [];
 
+            var leaderboards = await ResolveCurrentMythicKeystoneDungeonIdsFromLeaderboardsAsync(token, ct);
+            if (leaderboards.Count > 0) return leaderboards;
+
             var season = await FetchWithRetryAsync(
                 () => gameData.GetMythicKeystoneSeasonAsync(currentSeasonId.Value, token, ct),
                 $"mythic keystone season {currentSeasonId.Value}",
@@ -236,9 +239,6 @@ public sealed class ReferenceSync(
 
             if (season?.Dungeons is { Count: > 0 })
                 return season.Dungeons.Select(d => d.Id).ToHashSet();
-
-            var leaderboards = await ResolveCurrentMythicKeystoneDungeonIdsFromLeaderboardsAsync(token, ct);
-            if (leaderboards.Count > 0) return leaderboards;
 
             var currentSeasonExpansion = expansions.Tiers.FirstOrDefault(e => e.Name == CurrentSeasonExpansion);
             if (currentSeasonExpansion is null) return [];

--- a/docs/storage-architecture.md
+++ b/docs/storage-architecture.md
@@ -97,12 +97,11 @@ The journal-instance manifest is filtered to the scheduleable surface: raids fro
 the current raid tier (`journal-expansion/516` raids) and dungeons from the
 current Mythic Keystone season only. Normal/heroic/mythic non-keystone dungeons
 are not scheduleable. Current Mythic Keystone membership is stored as
-`isCurrentMythicKeystone` when Blizzard's Mythic Keystone season detail exposes
-dungeon ids. When the season detail omits dungeon ids, the ingester resolves a
-connected realm from Blizzard's dynamic connected-realm index and reads the
-current Mythic Keystone leaderboard index for dungeon membership. The
-`Current Season` journal-expansion detail remains a last-resort fallback and
-filters out the `Keystone Dungeons` grouping row.
+`isCurrentMythicKeystone` from Blizzard's current Mythic Keystone leaderboard
+index, scoped through a connected realm from the dynamic connected-realm index.
+The Mythic Keystone season detail remains a fallback when the leaderboard index
+is unavailable; the `Current Season` journal-expansion detail is the last-resort
+fallback and filters out the `Keystone Dungeons` grouping row.
 
 ## Known exceptions to flag
 

--- a/tests/Lfm.Api.Tests/ReferenceSyncTests.cs
+++ b/tests/Lfm.Api.Tests/ReferenceSyncTests.cs
@@ -477,6 +477,63 @@ public class ReferenceSyncTests
         blizzard.Verify(b => b.GetJournalInstanceAsync(9999, FakeToken, It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    [Fact]
+    public async Task SyncInstancesAsync_prefers_current_leaderboard_index_over_broader_keystone_season_dungeons()
+    {
+        var (sut, blizzard, blobs, _) = MakeSut();
+        blizzard.Setup(b => b.GetJournalExpansionIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeExpansionIndex(
+                (505, "Current Season"),
+                (516, "Midnight")));
+        blizzard.Setup(b => b.GetJournalExpansionAsync(516, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeExpansionDetail(516, "Midnight"));
+        blizzard.Setup(b => b.GetMythicKeystoneSeasonIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeKeystoneSeasonIndex(currentSeasonId: 17));
+        blizzard.Setup(b => b.GetMythicKeystoneSeasonAsync(17, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeKeystoneSeasonDetail(
+                17,
+                dungeons:
+                [
+                    new BlizzardIndexEntry(1201, "Algeth'ar Academy"),
+                    new BlizzardIndexEntry(9999, "Broader Season Dungeon"),
+                ]));
+        blizzard.Setup(b => b.GetConnectedRealmIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeConnectedRealmIndex(1084));
+        blizzard.Setup(b => b.GetMythicKeystoneLeaderboardsIndexAsync(1084, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeLeaderboardIndex((1201, "Algeth'ar Academy")));
+
+        blizzard.Setup(b => b.GetJournalInstanceIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeJournalIndex(
+                (1201, "Algeth'ar Academy"),
+                (9999, "Broader Season Dungeon")));
+        blizzard.Setup(b => b.GetJournalInstanceAsync(1201, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BlizzardJournalInstanceDetail(
+                Id: 1201,
+                Name: "Algeth'ar Academy",
+                Category: new BlizzardJournalInstanceCategory("DUNGEON"),
+                Expansion: new BlizzardJournalExpansion(503, "Dragonflight"),
+                MinimumLevel: 70,
+                Modes:
+                [
+                    new BlizzardJournalInstanceMode(
+                        new BlizzardJournalModeRef("MYTHIC_KEYSTONE", "Mythic Keystone"),
+                        5,
+                        true),
+                ],
+                Media: null));
+
+        await sut.SyncAllAsync(CancellationToken.None);
+
+        blobs.Verify(b => b.UploadAsync(
+            "reference/journal-instance/index.json",
+            It.Is<List<InstanceIndexEntry>>(ix =>
+                ix.Count == 1 &&
+                ix[0].Id == 1201 &&
+                ix[0].IsCurrentMythicKeystone),
+            It.IsAny<CancellationToken>()), Times.Once);
+        blizzard.Verify(b => b.GetJournalInstanceAsync(9999, FakeToken, It.IsAny<CancellationToken>()), Times.Never);
+    }
+
     // ── Resilience ───────────────────────────────────────────────────────────
 
     [Fact]

--- a/tests/Lfm.Api.Tests/Services/BlizzardGameDataClientTests.cs
+++ b/tests/Lfm.Api.Tests/Services/BlizzardGameDataClientTests.cs
@@ -54,7 +54,7 @@ public class BlizzardGameDataClientTests
 
         Assert.Equal(1201, result.CurrentLeaderboards!.Single().Id);
         Assert.Equal(
-            "https://eu.api.blizzard.com/data/wow/connected-realm/1084/mythic-leaderboard/index?namespace=dynamic-eu&locale=en_US",
+            "https://eu.api.blizzard.com/data/wow/connected-realm/1084/mythic-leaderboard/?namespace=dynamic-eu&locale=en_US",
             handler.RequestUri!.ToString());
         Assert.Equal("Bearer", handler.Authorization!.Scheme);
         Assert.Equal("access-token-2", handler.Authorization.Parameter);


### PR DESCRIPTION
## Summary
- prefer current Mythic Keystone leaderboard membership over broader season-detail dungeon lists
- use Blizzard's connected-realm mythic-leaderboard collection endpoint without `/index`
- document the leaderboard-first fallback order and add regression coverage for broader season dungeon lists

## Verification
- `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release --filter "SyncInstancesAsync_prefers_current_leaderboard_index_over_broader_keystone_season_dungeons|GetMythicKeystoneLeaderboardsIndexAsync_uses_connected_realm_leaderboard_endpoint"`
- `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release --no-restore --filter "ReferenceSyncTests|BlizzardGameDataClientTests"`
- `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release --no-build`
- `dotnet build lfm.sln -c Release`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `git diff --check`