### PR TITLE
Fix current M+ dungeon leaderboard endpoint

### DIFF
--- a/api/Services/BlizzardGameDataClient.cs
+++ b/api/Services/BlizzardGameDataClient.cs
@@ -14,13 +14,13 @@ namespace Lfm.Api.Services;
 /// Implements <see cref="IBlizzardGameDataClient"/> against the Blizzard Game Data API.
 ///
 /// Mirrors the pattern in reference-sync-blizzard.ts:
-///   fetchBlizzardToken  → <see cref="GetClientCredentialsTokenAsync"/>
-///   fetchStaticJson     → <see cref="GetStaticJsonAsync{T}"/>
+///   fetchBlizzardToken  -> <see cref="GetClientCredentialsTokenAsync"/>
+///   fetchStaticJson     -> <see cref="GetStaticJsonAsync{T}"/>
 ///
 /// HttpClient base address: https://{region}.api.blizzard.com/ (set in Program.cs).
 /// Token endpoint:          https://{region}.battle.net/oauth/token (separate request).
 ///
-/// JSON deserialization uses camelCase → PascalCase via PropertyNameCaseInsensitive.
+/// JSON deserialization uses camelCase -> PascalCase via PropertyNameCaseInsensitive.
 /// The Blizzard API uses snake_case for some fields; those are mapped with
 /// [JsonPropertyName] on the DTO record properties.
 /// </summary>
@@ -138,7 +138,7 @@ public sealed class BlizzardGameDataClient : IBlizzardGameDataClient
         string accessToken,
         CancellationToken ct)
         => GetDynamicJsonAsync<BlizzardMythicKeystoneLeaderboardIndex>(
-            $"data/wow/connected-realm/{connectedRealmId}/mythic-leaderboard/", accessToken, ct);
+            $"data/wow/connected-realm/{connectedRealmId}/mythic-leaderboard/index", accessToken, ct);
 
     /// <inheritdoc/>
     public Task<BlizzardJournalInstanceIndex> GetJournalInstanceIndexAsync(string accessToken, CancellationToken ct)

--- a/api/Services/BlizzardGameDataClient.cs
+++ b/api/Services/BlizzardGameDataClient.cs
@@ -14,13 +14,13 @@ namespace Lfm.Api.Services;
 /// Implements <see cref="IBlizzardGameDataClient"/> against the Blizzard Game Data API.
 ///
 /// Mirrors the pattern in reference-sync-blizzard.ts:
-///   fetchBlizzardToken  -> <see cref="GetClientCredentialsTokenAsync"/>
-///   fetchStaticJson     -> <see cref="GetStaticJsonAsync{T}"/>
+///   fetchBlizzardToken  → <see cref="GetClientCredentialsTokenAsync"/>
+///   fetchStaticJson     → <see cref="GetStaticJsonAsync{T}"/>
 ///
 /// HttpClient base address: https://{region}.api.blizzard.com/ (set in Program.cs).
 /// Token endpoint:          https://{region}.battle.net/oauth/token (separate request).
 ///
-/// JSON deserialization uses camelCase -> PascalCase via PropertyNameCaseInsensitive.
+/// JSON deserialization uses camelCase → PascalCase via PropertyNameCaseInsensitive.
 /// The Blizzard API uses snake_case for some fields; those are mapped with
 /// [JsonPropertyName] on the DTO record properties.
 /// </summary>

--- a/tests/Lfm.Api.Tests/Services/BlizzardGameDataClientTests.cs
+++ b/tests/Lfm.Api.Tests/Services/BlizzardGameDataClientTests.cs
@@ -54,7 +54,7 @@ public class BlizzardGameDataClientTests
 
         Assert.Equal(1201, result.CurrentLeaderboards!.Single().Id);
         Assert.Equal(
-            "https://eu.api.blizzard.com/data/wow/connected-realm/1084/mythic-leaderboard/?namespace=dynamic-eu&locale=en_US",
+            "https://eu.api.blizzard.com/data/wow/connected-realm/1084/mythic-leaderboard/index?namespace=dynamic-eu&locale=en_US",
             handler.RequestUri!.ToString());
         Assert.Equal("Bearer", handler.Authorization!.Scheme);
         Assert.Equal("access-token-2", handler.Authorization.Parameter);


### PR DESCRIPTION
## Summary
- call Blizzard's Mythic Keystone leaderboard index endpoint with `/index`
- update the HTTP client regression test to assert the indexed endpoint URI

## Verification
- Not run locally: the terminal wrapper failed before spawning commands (`bwrap: execvp .../codex: No such file or directory`).
- GitHub checks are the verification source for this PR.

No env, schema, or config changes.