### PR TITLE
Bump .NET SDK to 10.0.108

### DIFF
--- a/app/packages.lock.json
+++ b/app/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.AspNetCore.App.Internal.Assets": {
         "type": "Direct",
-        "requested": "[10.0.7, )",
-        "resolved": "10.0.7",
-        "contentHash": "ao3i+ks0uOQ7FWacI1hqHkUczebmXrGkUB63Xhkc34QbSzG9nYBlDv9v5l6rtCrHMsDW+13kZlpJrSj1HXddqg=="
+        "requested": "[10.0.8, )",
+        "resolved": "10.0.8",
+        "contentHash": "v6KocthydFtUHBIRI29YsOHKOgsqcQubkNywVOxiYr4GSDSv+XO/AeyMJywlX+1tGUTGdydu/X7V+Tzeq4SsoA=="
       },
       "Microsoft.AspNetCore.Components.WebAssembly": {
         "type": "Direct",
@@ -39,9 +39,9 @@
       },
       "Microsoft.DotNet.HotReload.WebAssembly.Browser": {
         "type": "Direct",
-        "requested": "[10.0.107, )",
-        "resolved": "10.0.107",
-        "contentHash": "PkusSbB46QQD/X4MHjxelrG67Av2TPxlYkkBgW5PJAPR4d9I6zprYAOhOUovO3WkdaFUyVYO7vGtFKdjJGg6MA=="
+        "requested": "[10.0.108, )",
+        "resolved": "10.0.108",
+        "contentHash": "NLGmqCbkWslYuPGrOR8BRq3yTaYYTe8xtnRnCSNE3kwOBSjRhW60vH28l6s6/wywBPyjStfx94uuxJusGVWnhA=="
       },
       "Microsoft.Extensions.Http": {
         "type": "Direct",
@@ -99,15 +99,15 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.7, )",
-        "resolved": "10.0.7",
-        "contentHash": "AA/yhzFHNtQZXLdqjzujPy25G8EWwGWsAnxOE2zYSBoT/8QHP6ketN3CToD3DFreO653ipUwnKHo22B8AlBMCw=="
+        "requested": "[10.0.8, )",
+        "resolved": "10.0.8",
+        "contentHash": "dVbSXGIFNR5nZcv2tOLoWI+a9T4jtFd77IYjuND+QVe360qWgAF7H0WtoopYhRw/+SgpGUTyrkrh+65+ClNnfw=="
       },
       "Microsoft.NET.Sdk.WebAssembly.Pack": {
         "type": "Direct",
-        "requested": "[10.0.7, )",
-        "resolved": "10.0.7",
-        "contentHash": "FXBvIwh/CAORqmO75qTy+mnTUuIYidOdNHYhMky0yLcsK6DNFBIP+eeiglhMggtatUSCnAzrCqb1EdwvZq+KAg=="
+        "requested": "[10.0.8, )",
+        "resolved": "10.0.8",
+        "contentHash": "xQ05xw4t8wjFxwD7a/Nye/IPEihIyUkZIbRzTytVFqko6Ows3UvjqHIEjk3gCOIZloNFOLykYPsTyKRCvEs6ng=="
       },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",

--- a/docker/local-init/Dockerfile
+++ b/docker/local-init/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2026 LFM contributors
 
 # Base image pinned to sha256 digest (matching repo Docker pin policy).
-FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:8a90a473da5205a16979de99d2fc20975e922c68304f5c79d564e666dc3982fc
+FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:c0790639332692a0d56cdd81ed581cfd24d040d9839764c138994866df89a3b6
 
 RUN dotnet tool install --tool-path /opt/cosmosdbshell CosmosDBShell --version 1.0.213-preview \
     && chmod -R a+rX /opt/cosmosdbshell

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.107",
+    "version": "10.0.108",
     "rollForward": "disable",
     "allowPrerelease": false
   }

--- a/tests/Lfm.App.Tests/packages.lock.json
+++ b/tests/Lfm.App.Tests/packages.lock.json
@@ -195,8 +195,8 @@
       },
       "Microsoft.DotNet.HotReload.WebAssembly.Browser": {
         "type": "Transitive",
-        "resolved": "10.0.107",
-        "contentHash": "PkusSbB46QQD/X4MHjxelrG67Av2TPxlYkkBgW5PJAPR4d9I6zprYAOhOUovO3WkdaFUyVYO7vGtFKdjJGg6MA=="
+        "resolved": "10.0.108",
+        "contentHash": "NLGmqCbkWslYuPGrOR8BRq3yTaYYTe8xtnRnCSNE3kwOBSjRhW60vH28l6s6/wywBPyjStfx94uuxJusGVWnhA=="
       },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "Transitive",
@@ -514,7 +514,7 @@
           "Lfm.Contracts": "[1.0.0, )",
           "Microsoft.AspNetCore.Components.WebAssembly": "[10.0.8, )",
           "Microsoft.AspNetCore.Components.WebAssembly.Authentication": "[10.0.8, )",
-          "Microsoft.DotNet.HotReload.WebAssembly.Browser": "[10.0.107, )",
+          "Microsoft.DotNet.HotReload.WebAssembly.Browser": "[10.0.108, )",
           "Microsoft.Extensions.Http": "[10.0.8, )",
           "Microsoft.Extensions.Localization": "[10.0.8, )",
           "Microsoft.Extensions.Logging.Configuration": "[10.0.8, )",


### PR DESCRIPTION
## Summary
- bump the pinned .NET SDK in `global.json` to `10.0.108`
- refresh generated WebAssembly SDK lockfile entries
- update the local-init Docker SDK digest to the current `mcr.microsoft.com/dotnet/sdk:10.0` digest

## Verification
- `dotnet restore lfm.sln -m:1 --force-evaluate`
- `env CI=true dotnet restore lfm.sln -m:1`
- `dotnet build lfm.sln -c Release --no-restore`
- `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release --no-build`
- `jq empty global.json app/packages.lock.json tests/Lfm.App.Tests/packages.lock.json`
- `git diff --check`
- `git ls-files -ci --exclude-standard`

## Notes
- checked tracked .NET pins, Docker SDK/runtime pins, and setup-dotnet usage; no `10.0.107` references remain.