### PR TITLE
Filter current keystone leaderboard dungeons

### DIFF
--- a/api/Services/ReferenceSync.cs
+++ b/api/Services/ReferenceSync.cs
@@ -1,15 +1,17 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
+using Lfm.Api.Options;
 using Lfm.Api.Repositories;
 using Lfm.Contracts.Admin;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Lfm.Api.Services;
 
 /// <summary>
 /// Syncs Blizzard reference data (journal-instance, journal-expansion,
-/// playable-specialization, Mythic Keystone season membership, plus media blobs)
+/// playable-specialization, Mythic Keystone leaderboard membership, plus media blobs)
 /// from the Blizzard Game Data API into the
 /// <c>lfmstore/wow/reference/</c> blob container — see
 /// <c>docs/storage-architecture.md</c>.
@@ -27,12 +29,16 @@ namespace Lfm.Api.Services;
 public sealed class ReferenceSync(
     IBlizzardGameDataClient gameData,
     IBlobReferenceClient blobs,
+    IOptions<BlizzardOptions> blizzardOptions,
     ILogger<ReferenceSync> logger) : IReferenceSync
 {
-    private const string CurrentSeasonExpansion = "Current Season";
     private const int CurrentRaidTierJournalExpansionId = 516;
-    private const string KeystoneDungeonsGroup = "Keystone Dungeons";
-    private const int MaxLeaderboardConnectedRealmProbeCount = 5;
+    private static readonly IReadOnlyDictionary<string, int> DefaultLeaderboardConnectedRealms =
+        new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["eu"] = 1080,
+            ["us"] = 11,
+        };
 
     /// <inheritdoc/>
     public async Task<WowReferenceRefreshResponse> SyncAllAsync(
@@ -114,7 +120,7 @@ public sealed class ReferenceSync(
     {
         var expansions = await gameData.GetJournalExpansionIndexAsync(token, ct);
         var currentRaidTierIds = await ResolveCurrentRaidTierRaidIdsAsync(token, ct);
-        var currentKeystoneIds = await ResolveCurrentMythicKeystoneDungeonIdsAsync(expansions, token, ct);
+        var currentKeystoneIds = await ResolveCurrentMythicKeystoneDungeonIdsAsync(token, ct);
         var hasMembershipFilter = currentRaidTierIds.Count > 0 || currentKeystoneIds.Count > 0;
         var index = await gameData.GetJournalInstanceIndexAsync(token, ct);
         var manifest = new List<InstanceIndexEntry>();
@@ -219,45 +225,19 @@ public sealed class ReferenceSync(
     }
 
     private async Task<HashSet<int>> ResolveCurrentMythicKeystoneDungeonIdsAsync(
-        BlizzardJournalExpansionIndex expansions,
         string token,
         CancellationToken ct)
     {
         try
         {
             var index = await gameData.GetMythicKeystoneSeasonIndexAsync(token, ct);
-            var currentSeasonId = index.CurrentSeason?.Id;
-            if (currentSeasonId is null) return [];
+            if (index.CurrentSeason is null) return [];
 
-            var leaderboards = await ResolveCurrentMythicKeystoneDungeonIdsFromLeaderboardsAsync(token, ct);
-            if (leaderboards.Count > 0) return leaderboards;
-
-            var season = await FetchWithRetryAsync(
-                () => gameData.GetMythicKeystoneSeasonAsync(currentSeasonId.Value, token, ct),
-                $"mythic keystone season {currentSeasonId.Value}",
-                ct);
-
-            if (season?.Dungeons is { Count: > 0 })
-                return season.Dungeons.Select(d => d.Id).ToHashSet();
-
-            var currentSeasonExpansion = expansions.Tiers.FirstOrDefault(e => e.Name == CurrentSeasonExpansion);
-            if (currentSeasonExpansion is null) return [];
-
-            var detail = await FetchWithRetryAsync(
-                () => gameData.GetJournalExpansionAsync(currentSeasonExpansion.Id, token, ct),
-                $"journal expansion {currentSeasonExpansion.Id}",
-                ct);
-
-            return detail?.Dungeons is null
-                ? []
-                : detail.Dungeons
-                    .Where(d => d.Name != KeystoneDungeonsGroup)
-                    .Select(d => d.Id)
-                    .ToHashSet();
+            return await ResolveCurrentMythicKeystoneDungeonIdsFromLeaderboardsAsync(token, ct);
         }
         catch (Exception ex)
         {
-            logger.LogWarning(ex, "Could not resolve current Mythic Keystone season dungeons");
+            logger.LogWarning(ex, "Could not resolve current Mythic Keystone leaderboard dungeons");
             return [];
         }
     }
@@ -268,6 +248,18 @@ public sealed class ReferenceSync(
     {
         try
         {
+            var defaultConnectedRealmId = ResolveDefaultLeaderboardConnectedRealmId();
+            if (defaultConnectedRealmId is int id)
+            {
+                var leaderboards = await FetchWithRetryAsync(
+                    () => gameData.GetMythicKeystoneLeaderboardsIndexAsync(id, token, ct),
+                    $"mythic keystone leaderboard index {id}",
+                    ct);
+
+                if (leaderboards?.CurrentLeaderboards is { Count: > 0 })
+                    return leaderboards.CurrentLeaderboards.Select(d => d.Id).ToHashSet();
+            }
+
             var connectedRealms = await FetchWithRetryAsync(
                 () => gameData.GetConnectedRealmIndexAsync(token, ct),
                 "connected realm index",
@@ -277,8 +269,7 @@ public sealed class ReferenceSync(
             foreach (var connectedRealmId in connectedRealms.ConnectedRealms
                          .Select(r => TryGetConnectedRealmId(r.Key.Href))
                          .Where(id => id.HasValue)
-                         .Select(id => id!.Value)
-                         .Take(MaxLeaderboardConnectedRealmProbeCount))
+                         .Select(id => id!.Value))
             {
                 var leaderboards = await FetchWithRetryAsync(
                     () => gameData.GetMythicKeystoneLeaderboardsIndexAsync(connectedRealmId, token, ct),
@@ -295,6 +286,14 @@ public sealed class ReferenceSync(
         }
 
         return [];
+    }
+
+    private int? ResolveDefaultLeaderboardConnectedRealmId()
+    {
+        var region = blizzardOptions.Value.Region.ToLowerInvariant();
+        return DefaultLeaderboardConnectedRealms.TryGetValue(region, out var connectedRealmId)
+            ? connectedRealmId
+            : null;
     }
 
     private static int? TryGetConnectedRealmId(string href)

--- a/app/Lfm.App.Core/Services/ExpansionsClient.cs
+++ b/app/Lfm.App.Core/Services/ExpansionsClient.cs
@@ -8,7 +8,12 @@ namespace Lfm.App.Services;
 
 public sealed class ExpansionsClient(IHttpClientFactory factory) : IExpansionsClient
 {
-    public async Task<IReadOnlyList<ExpansionDto>> ListAsync(CancellationToken ct)
+    private readonly ReferenceListCache<ExpansionDto> _cache = new();
+
+    public Task<IReadOnlyList<ExpansionDto>> ListAsync(CancellationToken ct) =>
+        _cache.GetOrLoadAsync(FetchAsync, ct);
+
+    private async Task<IReadOnlyList<ExpansionDto>> FetchAsync(CancellationToken ct)
     {
         var http = factory.CreateClient("api");
         var items = await http.GetFromJsonAsync<List<ExpansionDto>>("api/v1/wow/reference/expansions", ct);

--- a/app/Lfm.App.Core/Services/InstancesClient.cs
+++ b/app/Lfm.App.Core/Services/InstancesClient.cs
@@ -8,7 +8,12 @@ namespace Lfm.App.Services;
 
 public sealed class InstancesClient(IHttpClientFactory factory) : IInstancesClient
 {
-    public async Task<IReadOnlyList<InstanceDto>> ListAsync(CancellationToken ct)
+    private readonly ReferenceListCache<InstanceDto> _cache = new();
+
+    public Task<IReadOnlyList<InstanceDto>> ListAsync(CancellationToken ct) =>
+        _cache.GetOrLoadAsync(FetchAsync, ct);
+
+    private async Task<IReadOnlyList<InstanceDto>> FetchAsync(CancellationToken ct)
     {
         var http = factory.CreateClient("api");
         var items = await http.GetFromJsonAsync<List<InstanceDto>>("api/v1/wow/reference/instances", ct);

--- a/app/Lfm.App.Core/Services/ReferenceListCache.cs
+++ b/app/Lfm.App.Core/Services/ReferenceListCache.cs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+namespace Lfm.App.Services;
+
+internal sealed class ReferenceListCache<T>
+{
+    private readonly object _sync = new();
+    private Task<IReadOnlyList<T>>? _items;
+
+    public Task<IReadOnlyList<T>> GetOrLoadAsync(
+        Func<CancellationToken, Task<IReadOnlyList<T>>> loadAsync,
+        CancellationToken ct)
+    {
+        lock (_sync)
+        {
+            if (_items is not null)
+                return _items;
+
+            _items = LoadAndResetOnFailureAsync(loadAsync, ct);
+            return _items;
+        }
+    }
+
+    private async Task<IReadOnlyList<T>> LoadAndResetOnFailureAsync(
+        Func<CancellationToken, Task<IReadOnlyList<T>>> loadAsync,
+        CancellationToken ct)
+    {
+        try
+        {
+            return await loadAsync(ct);
+        }
+        catch
+        {
+            lock (_sync)
+            {
+                _items = null;
+            }
+
+            throw;
+        }
+    }
+}

--- a/app/Lfm.App.Core/Services/SpecializationsClient.cs
+++ b/app/Lfm.App.Core/Services/SpecializationsClient.cs
@@ -8,7 +8,12 @@ namespace Lfm.App.Services;
 
 public sealed class SpecializationsClient(IHttpClientFactory factory) : ISpecializationsClient
 {
-    public async Task<IReadOnlyList<SpecializationDto>> ListAsync(CancellationToken ct)
+    private readonly ReferenceListCache<SpecializationDto> _cache = new();
+
+    public Task<IReadOnlyList<SpecializationDto>> ListAsync(CancellationToken ct) =>
+        _cache.GetOrLoadAsync(FetchAsync, ct);
+
+    private async Task<IReadOnlyList<SpecializationDto>> FetchAsync(CancellationToken ct)
     {
         var http = factory.CreateClient("api");
         var items = await http.GetFromJsonAsync<List<SpecializationDto>>("api/v1/wow/reference/specializations", ct);

--- a/docs/storage-architecture.md
+++ b/docs/storage-architecture.md
@@ -93,15 +93,22 @@ For every reference kind that has a list endpoint, the ingester emits `reference
 
 The per-id detail blobs (`{kind}/{id}.json`, `{kind}-media/{id}.json`) stay for future endpoints (detail pages, hero talents) and as the source of truth the manifest is derived from. Manifest media fields store Blizzard source URLs; HTTP handlers and Blazor image components convert them to `/api/v1/wow/media/cache` before browser rendering.
 
+The Blazor app memoizes successful reference-list API responses for the current
+browser session (`instances`, `expansions`, and `specializations`). This avoids
+a fresh app-to-API request each time a user revisits create/edit run screens.
+Failed requests are not cached, so a later navigation can retry.
+
 The journal-instance manifest is filtered to the scheduleable surface: raids from
 the current raid tier (`journal-expansion/516` raids) and dungeons from the
-current Mythic Keystone season only. Normal/heroic/mythic non-keystone dungeons
-are not scheduleable. Current Mythic Keystone membership is stored as
+current Mythic Keystone leaderboard only. Normal/heroic/mythic non-keystone
+dungeons are not scheduleable. Current Mythic Keystone membership is stored as
 `isCurrentMythicKeystone` from Blizzard's current Mythic Keystone leaderboard
-index, scoped through a connected realm from the dynamic connected-realm index.
-The Mythic Keystone season detail remains a fallback when the leaderboard index
-is unavailable; the `Current Season` journal-expansion detail is the last-resort
-fallback and filters out the `Keystone Dungeons` grouping row.
+index. Reference sync uses stable default connected-realm ids for the common
+regions (`eu` → `1080`, `us` → `11`) to avoid an extra index fetch. If the
+configured region has no default or the default does not return leaderboard
+rows, it falls back to Blizzard's region-scoped dynamic connected-realm index
+and probes connected-realm leaderboard indexes from that same Blizzard region
+until one returns the current leaderboard rows.
 
 ## Known exceptions to flag
 

--- a/shared/Lfm.Contracts/Instances/InstanceDto.cs
+++ b/shared/Lfm.Contracts/Instances/InstanceDto.cs
@@ -51,7 +51,7 @@ namespace Lfm.Contracts.Instances;
 /// dropped, trim this field at the next audit.
 /// </param>
 /// <param name="IsCurrentMythicKeystone">
-/// True when the row belongs to the current Mythic Keystone season membership.
+/// True when the row appears in the current Mythic Keystone leaderboard.
 /// The create/edit run forms use this to populate specific M+ dungeon choices
 /// because non-keystone dungeons are not scheduleable.
 /// </param>

--- a/tests/Lfm.Api.Tests/ReferenceSyncTests.cs
+++ b/tests/Lfm.Api.Tests/ReferenceSyncTests.cs
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
+using Lfm.Api.Options;
 using Lfm.Api.Repositories;
 using Lfm.Api.Services;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
+using MsOptions = Microsoft.Extensions.Options.Options;
 
 namespace Lfm.Api.Tests;
 
@@ -92,7 +94,7 @@ public class ReferenceSyncTests
         ReferenceSync sut,
         Mock<IBlizzardGameDataClient> blizzard,
         Mock<IBlobReferenceClient> blobs,
-        TestLogger<ReferenceSync> logger) MakeSut()
+        TestLogger<ReferenceSync> logger) MakeSut(string region = "eu")
     {
         var blizzard = new Mock<IBlizzardGameDataClient>();
         blizzard.Setup(b => b.GetClientCredentialsTokenAsync(It.IsAny<CancellationToken>()))
@@ -110,7 +112,15 @@ public class ReferenceSyncTests
 
         var blobs = new Mock<IBlobReferenceClient>();
         var logger = new TestLogger<ReferenceSync>();
-        var sut = new ReferenceSync(blizzard.Object, blobs.Object, logger);
+        var blizzardOptions = MsOptions.Create(new BlizzardOptions
+        {
+            ClientId = "client-id",
+            ClientSecret = "client-secret",
+            Region = region,
+            RedirectUri = "https://example.com/api/battlenet/callback",
+            AppBaseUrl = "https://example.com",
+        });
+        var sut = new ReferenceSync(blizzard.Object, blobs.Object, blizzardOptions, logger);
         return (sut, blizzard, blobs, logger);
     }
 
@@ -259,7 +269,7 @@ public class ReferenceSyncTests
     }
 
     [Fact]
-    public async Task SyncInstancesAsync_uses_current_raid_tier_and_current_keystone_season()
+    public async Task SyncInstancesAsync_uses_current_raid_tier_and_current_leaderboard()
     {
         var (sut, blizzard, blobs, _) = MakeSut();
         blizzard.Setup(b => b.GetJournalExpansionIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
@@ -277,10 +287,10 @@ public class ReferenceSyncTests
             .ReturnsAsync(MakeExpansionDetail(503, "Dragonflight"));
         blizzard.Setup(b => b.GetMythicKeystoneSeasonIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
             .ReturnsAsync(MakeKeystoneSeasonIndex(currentSeasonId: 17));
-        blizzard.Setup(b => b.GetMythicKeystoneSeasonAsync(17, FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeKeystoneSeasonDetail(
-                17,
-                dungeons: [new BlizzardIndexEntry(1201, "Algeth'ar Academy")]));
+        blizzard.Setup(b => b.GetConnectedRealmIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeConnectedRealmIndex(1084));
+        blizzard.Setup(b => b.GetMythicKeystoneLeaderboardsIndexAsync(1084, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeLeaderboardIndex((1201, "Algeth'ar Academy")));
 
         blizzard.Setup(b => b.GetJournalInstanceIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
             .ReturnsAsync(MakeJournalIndex(
@@ -365,7 +375,7 @@ public class ReferenceSyncTests
     }
 
     [Fact]
-    public async Task SyncInstancesAsync_falls_back_to_current_season_expansion_when_keystone_season_has_no_dungeons()
+    public async Task SyncInstancesAsync_does_not_fall_back_to_current_season_expansion_when_leaderboard_has_no_dungeons()
     {
         var (sut, blizzard, blobs, _) = MakeSut();
         blizzard.Setup(b => b.GetJournalExpansionIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
@@ -382,28 +392,33 @@ public class ReferenceSyncTests
                     new BlizzardIndexEntry(1319, "Keystone Dungeons"),
                 ]));
         blizzard.Setup(b => b.GetJournalExpansionAsync(516, FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeExpansionDetail(516, "Midnight"));
+            .ReturnsAsync(MakeExpansionDetail(
+                516,
+                "Midnight",
+                raids: [new BlizzardIndexEntry(1400, "The Voidspire")]));
         blizzard.Setup(b => b.GetMythicKeystoneSeasonIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
             .ReturnsAsync(MakeKeystoneSeasonIndex(currentSeasonId: 17));
-        blizzard.Setup(b => b.GetMythicKeystoneSeasonAsync(17, FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeKeystoneSeasonDetail(17, dungeons: null));
+        blizzard.Setup(b => b.GetConnectedRealmIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeConnectedRealmIndex(1084));
+        blizzard.Setup(b => b.GetMythicKeystoneLeaderboardsIndexAsync(1084, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeLeaderboardIndex());
 
         blizzard.Setup(b => b.GetJournalInstanceIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
             .ReturnsAsync(MakeJournalIndex(
                 (1201, "Algeth'ar Academy"),
-                (1319, "Keystone Dungeons")));
-        blizzard.Setup(b => b.GetJournalInstanceAsync(1201, FakeToken, It.IsAny<CancellationToken>()))
+                (1400, "The Voidspire")));
+        blizzard.Setup(b => b.GetJournalInstanceAsync(1400, FakeToken, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BlizzardJournalInstanceDetail(
-                Id: 1201,
-                Name: "Algeth'ar Academy",
-                Category: new BlizzardJournalInstanceCategory("DUNGEON"),
-                Expansion: new BlizzardJournalExpansion(503, "Dragonflight"),
-                MinimumLevel: 70,
+                Id: 1400,
+                Name: "The Voidspire",
+                Category: new BlizzardJournalInstanceCategory("RAID"),
+                Expansion: new BlizzardJournalExpansion(516, "Midnight"),
+                MinimumLevel: 80,
                 Modes:
                 [
                     new BlizzardJournalInstanceMode(
-                        new BlizzardJournalModeRef("MYTHIC_KEYSTONE", "Mythic Keystone"),
-                        5,
+                        new BlizzardJournalModeRef("HEROIC", "Heroic"),
+                        20,
                         true),
                 ],
                 Media: null));
@@ -414,14 +429,16 @@ public class ReferenceSyncTests
             "reference/journal-instance/index.json",
             It.Is<List<InstanceIndexEntry>>(ix =>
                 ix.Count == 1 &&
-                ix[0].Id == 1201 &&
-                ix[0].IsCurrentMythicKeystone),
+                ix[0].Id == 1400 &&
+                !ix[0].IsCurrentMythicKeystone),
             It.IsAny<CancellationToken>()), Times.Once);
-        blizzard.Verify(b => b.GetJournalInstanceAsync(1319, FakeToken, It.IsAny<CancellationToken>()), Times.Never);
+        blizzard.Verify(b => b.GetJournalExpansionAsync(505, FakeToken, It.IsAny<CancellationToken>()), Times.Never);
+        blizzard.Verify(b => b.GetMythicKeystoneSeasonAsync(17, FakeToken, It.IsAny<CancellationToken>()), Times.Never);
+        blizzard.Verify(b => b.GetJournalInstanceAsync(1201, FakeToken, It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
-    public async Task SyncInstancesAsync_uses_current_leaderboard_index_when_keystone_season_has_no_dungeons()
+    public async Task SyncInstancesAsync_uses_current_leaderboard_index_for_mythic_plus_dungeons()
     {
         var (sut, blizzard, blobs, _) = MakeSut();
         blizzard.Setup(b => b.GetJournalExpansionIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
@@ -437,8 +454,6 @@ public class ReferenceSyncTests
                 dungeons: [new BlizzardIndexEntry(9999, "Stale Current Season Dungeon")]));
         blizzard.Setup(b => b.GetMythicKeystoneSeasonIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
             .ReturnsAsync(MakeKeystoneSeasonIndex(currentSeasonId: 17));
-        blizzard.Setup(b => b.GetMythicKeystoneSeasonAsync(17, FakeToken, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(MakeKeystoneSeasonDetail(17, dungeons: null));
         blizzard.Setup(b => b.GetConnectedRealmIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
             .ReturnsAsync(MakeConnectedRealmIndex(1084));
         blizzard.Setup(b => b.GetMythicKeystoneLeaderboardsIndexAsync(1084, FakeToken, It.IsAny<CancellationToken>()))
@@ -474,11 +489,118 @@ public class ReferenceSyncTests
                 ix[0].IsCurrentMythicKeystone),
             It.IsAny<CancellationToken>()), Times.Once);
         blizzard.Verify(b => b.GetJournalExpansionAsync(505, FakeToken, It.IsAny<CancellationToken>()), Times.Never);
+        blizzard.Verify(b => b.GetMythicKeystoneSeasonAsync(17, FakeToken, It.IsAny<CancellationToken>()), Times.Never);
         blizzard.Verify(b => b.GetJournalInstanceAsync(9999, FakeToken, It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    [Theory]
+    [InlineData("eu", 1080)]
+    [InlineData("us", 11)]
+    public async Task SyncInstancesAsync_uses_known_region_connected_realm_without_index_lookup(
+        string region,
+        int connectedRealmId)
+    {
+        var (sut, blizzard, blobs, _) = MakeSut(region);
+        blizzard.Setup(b => b.GetJournalExpansionIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeExpansionIndex((516, "Midnight")));
+        blizzard.Setup(b => b.GetJournalExpansionAsync(516, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeExpansionDetail(516, "Midnight"));
+        blizzard.Setup(b => b.GetMythicKeystoneSeasonIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeKeystoneSeasonIndex(currentSeasonId: 17));
+        blizzard.Setup(b => b.GetMythicKeystoneLeaderboardsIndexAsync(
+                connectedRealmId,
+                FakeToken,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeLeaderboardIndex((1201, "Algeth'ar Academy")));
+
+        blizzard.Setup(b => b.GetJournalInstanceIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeJournalIndex((1201, "Algeth'ar Academy")));
+        blizzard.Setup(b => b.GetJournalInstanceAsync(1201, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BlizzardJournalInstanceDetail(
+                Id: 1201,
+                Name: "Algeth'ar Academy",
+                Category: new BlizzardJournalInstanceCategory("DUNGEON"),
+                Expansion: new BlizzardJournalExpansion(503, "Dragonflight"),
+                MinimumLevel: 70,
+                Modes:
+                [
+                    new BlizzardJournalInstanceMode(
+                        new BlizzardJournalModeRef("MYTHIC_KEYSTONE", "Mythic Keystone"),
+                        5,
+                        true),
+                ],
+                Media: null));
+
+        await sut.SyncAllAsync(CancellationToken.None);
+
+        blobs.Verify(b => b.UploadAsync(
+            "reference/journal-instance/index.json",
+            It.Is<List<InstanceIndexEntry>>(ix =>
+                ix.Count == 1 &&
+                ix[0].Id == 1201 &&
+                ix[0].IsCurrentMythicKeystone),
+            It.IsAny<CancellationToken>()), Times.Once);
+        blizzard.Verify(b => b.GetConnectedRealmIndexAsync(FakeToken, It.IsAny<CancellationToken>()), Times.Never);
+    }
+
     [Fact]
-    public async Task SyncInstancesAsync_prefers_current_leaderboard_index_over_broader_keystone_season_dungeons()
+    public async Task SyncInstancesAsync_scans_all_region_connected_realms_until_leaderboard_exists()
+    {
+        var (sut, blizzard, blobs, _) = MakeSut(region: "kr");
+        blizzard.Setup(b => b.GetJournalExpansionIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeExpansionIndex((516, "Midnight")));
+        blizzard.Setup(b => b.GetJournalExpansionAsync(516, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeExpansionDetail(516, "Midnight"));
+        blizzard.Setup(b => b.GetMythicKeystoneSeasonIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeKeystoneSeasonIndex(currentSeasonId: 17));
+        blizzard.Setup(b => b.GetConnectedRealmIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeConnectedRealmIndex(1001, 1002, 1003, 1004, 1005, 1006));
+        foreach (var connectedRealmId in new[] { 1001, 1002, 1003, 1004, 1005 })
+        {
+            blizzard.Setup(b => b.GetMythicKeystoneLeaderboardsIndexAsync(
+                    connectedRealmId,
+                    FakeToken,
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(MakeLeaderboardIndex());
+        }
+        blizzard.Setup(b => b.GetMythicKeystoneLeaderboardsIndexAsync(1006, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeLeaderboardIndex((1201, "Algeth'ar Academy")));
+
+        blizzard.Setup(b => b.GetJournalInstanceIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeJournalIndex((1201, "Algeth'ar Academy")));
+        blizzard.Setup(b => b.GetJournalInstanceAsync(1201, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BlizzardJournalInstanceDetail(
+                Id: 1201,
+                Name: "Algeth'ar Academy",
+                Category: new BlizzardJournalInstanceCategory("DUNGEON"),
+                Expansion: new BlizzardJournalExpansion(503, "Dragonflight"),
+                MinimumLevel: 70,
+                Modes:
+                [
+                    new BlizzardJournalInstanceMode(
+                        new BlizzardJournalModeRef("MYTHIC_KEYSTONE", "Mythic Keystone"),
+                        5,
+                        true),
+                ],
+                Media: null));
+
+        await sut.SyncAllAsync(CancellationToken.None);
+
+        blobs.Verify(b => b.UploadAsync(
+            "reference/journal-instance/index.json",
+            It.Is<List<InstanceIndexEntry>>(ix =>
+                ix.Count == 1 &&
+                ix[0].Id == 1201 &&
+                ix[0].IsCurrentMythicKeystone),
+            It.IsAny<CancellationToken>()), Times.Once);
+        blizzard.Verify(b => b.GetMythicKeystoneLeaderboardsIndexAsync(
+            1006,
+            FakeToken,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SyncInstancesAsync_ignores_broader_keystone_season_dungeons_when_leaderboard_exists()
     {
         var (sut, blizzard, blobs, _) = MakeSut();
         blizzard.Setup(b => b.GetJournalExpansionIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
@@ -530,6 +652,78 @@ public class ReferenceSyncTests
                 ix.Count == 1 &&
                 ix[0].Id == 1201 &&
                 ix[0].IsCurrentMythicKeystone),
+            It.IsAny<CancellationToken>()), Times.Once);
+        blizzard.Verify(b => b.GetMythicKeystoneSeasonAsync(17, FakeToken, It.IsAny<CancellationToken>()), Times.Never);
+        blizzard.Verify(b => b.GetJournalInstanceAsync(9999, FakeToken, It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SyncInstancesAsync_excludes_non_leaderboard_keystone_season_dungeons_from_manifest()
+    {
+        var (sut, blizzard, blobs, _) = MakeSut();
+        blizzard.Setup(b => b.GetJournalExpansionIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeExpansionIndex(
+                (505, "Current Season"),
+                (516, "Midnight")));
+        blizzard.Setup(b => b.GetJournalExpansionAsync(516, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeExpansionDetail(
+                516,
+                "Midnight",
+                raids: [new BlizzardIndexEntry(1400, "The Voidspire")]));
+        blizzard.Setup(b => b.GetMythicKeystoneSeasonIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeKeystoneSeasonIndex(currentSeasonId: 17));
+        blizzard.Setup(b => b.GetConnectedRealmIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeConnectedRealmIndex(1084));
+        blizzard.Setup(b => b.GetMythicKeystoneLeaderboardsIndexAsync(1084, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeLeaderboardIndex());
+        blizzard.Setup(b => b.GetMythicKeystoneSeasonAsync(17, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeKeystoneSeasonDetail(
+                17,
+                dungeons: [new BlizzardIndexEntry(9999, "Broader Season Dungeon")]));
+
+        blizzard.Setup(b => b.GetJournalInstanceIndexAsync(FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeJournalIndex(
+                (1400, "The Voidspire"),
+                (9999, "Broader Season Dungeon")));
+        blizzard.Setup(b => b.GetJournalInstanceAsync(1400, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BlizzardJournalInstanceDetail(
+                Id: 1400,
+                Name: "The Voidspire",
+                Category: new BlizzardJournalInstanceCategory("RAID"),
+                Expansion: new BlizzardJournalExpansion(516, "Midnight"),
+                MinimumLevel: 80,
+                Modes:
+                [
+                    new BlizzardJournalInstanceMode(
+                        new BlizzardJournalModeRef("HEROIC", "Heroic"),
+                        20,
+                        true),
+                ],
+                Media: null));
+        blizzard.Setup(b => b.GetJournalInstanceAsync(9999, FakeToken, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BlizzardJournalInstanceDetail(
+                Id: 9999,
+                Name: "Broader Season Dungeon",
+                Category: new BlizzardJournalInstanceCategory("DUNGEON"),
+                Expansion: new BlizzardJournalExpansion(505, "Current Season"),
+                MinimumLevel: 80,
+                Modes:
+                [
+                    new BlizzardJournalInstanceMode(
+                        new BlizzardJournalModeRef("MYTHIC_KEYSTONE", "Mythic Keystone"),
+                        5,
+                        true),
+                ],
+                Media: null));
+
+        await sut.SyncAllAsync(CancellationToken.None);
+
+        blobs.Verify(b => b.UploadAsync(
+            "reference/journal-instance/index.json",
+            It.Is<List<InstanceIndexEntry>>(ix =>
+                ix.Count == 1 &&
+                ix[0].Id == 1400 &&
+                !ix[0].IsCurrentMythicKeystone),
             It.IsAny<CancellationToken>()), Times.Once);
         blizzard.Verify(b => b.GetJournalInstanceAsync(9999, FakeToken, It.IsAny<CancellationToken>()), Times.Never);
     }

--- a/tests/Lfm.App.Core.Tests/Services/ExpansionsClientTests.cs
+++ b/tests/Lfm.App.Core.Tests/Services/ExpansionsClientTests.cs
@@ -54,6 +54,30 @@ public class ExpansionsClientTests
     }
 
     [Fact]
+    public async Task ListAsync_reuses_successful_response()
+    {
+        var first = new[]
+        {
+            new ExpansionDto(505, "The War Within"),
+        };
+        var second = new[]
+        {
+            new ExpansionDto(503, "Dragonflight"),
+        };
+        var handlerCallCount = 0;
+        var handler = new StubHttpMessageHandler(_ =>
+            StubHttpMessageHandler.CreateJsonResponse(HttpStatusCode.OK, handlerCallCount++ == 0 ? first : second));
+        var (client, _) = MakeClient(handler);
+
+        var firstResult = await client.ListAsync(CancellationToken.None);
+        var secondResult = await client.ListAsync(CancellationToken.None);
+
+        Assert.Equal(505, Assert.Single(firstResult).Id);
+        Assert.Equal(505, Assert.Single(secondResult).Id);
+        Assert.Equal(1, handler.CallCount);
+    }
+
+    [Fact]
     public async Task ListAsync_throws_HttpRequestException_on_5xx()
     {
         var (client, _) = MakeClient(new StubHttpMessageHandler(HttpStatusCode.ServiceUnavailable));

--- a/tests/Lfm.App.Core.Tests/Services/InstancesClientTests.cs
+++ b/tests/Lfm.App.Core.Tests/Services/InstancesClientTests.cs
@@ -66,6 +66,30 @@ public class InstancesClientTests
     }
 
     [Fact]
+    public async Task ListAsync_reuses_successful_response()
+    {
+        var first = new[]
+        {
+            new InstanceDto("1234:raid", 1234, "Liberation of Undermine", "raid", "tww"),
+        };
+        var second = new[]
+        {
+            new InstanceDto("5678:mythic-plus", 5678, "Operation: Mechagon", "mythic-plus", "bfa"),
+        };
+        var handlerCallCount = 0;
+        var handler = new StubHttpMessageHandler(_ =>
+            StubHttpMessageHandler.CreateJsonResponse(HttpStatusCode.OK, handlerCallCount++ == 0 ? first : second));
+        var (client, _) = MakeClient(handler);
+
+        var firstResult = await client.ListAsync(CancellationToken.None);
+        var secondResult = await client.ListAsync(CancellationToken.None);
+
+        Assert.Equal("1234:raid", Assert.Single(firstResult).Id);
+        Assert.Equal("1234:raid", Assert.Single(secondResult).Id);
+        Assert.Equal(1, handler.CallCount);
+    }
+
+    [Fact]
     public async Task ListAsync_throws_HttpRequestException_on_5xx()
     {
         // InstancesClient doesn't catch — pinning current contract.

--- a/tests/Lfm.App.Core.Tests/Services/SpecializationsClientTests.cs
+++ b/tests/Lfm.App.Core.Tests/Services/SpecializationsClientTests.cs
@@ -55,6 +55,30 @@ public class SpecializationsClientTests
     }
 
     [Fact]
+    public async Task ListAsync_reuses_successful_response()
+    {
+        var first = new[]
+        {
+            new SpecializationDto(257, "Holy", 5, "HEALER", "https://render.example/holy.jpg"),
+        };
+        var second = new[]
+        {
+            new SpecializationDto(258, "Shadow", 5, "DPS", "https://render.example/shadow.jpg"),
+        };
+        var handlerCallCount = 0;
+        var handler = new StubHttpMessageHandler(_ =>
+            StubHttpMessageHandler.CreateJsonResponse(HttpStatusCode.OK, handlerCallCount++ == 0 ? first : second));
+        var (client, _) = MakeClient(handler);
+
+        var firstResult = await client.ListAsync(CancellationToken.None);
+        var secondResult = await client.ListAsync(CancellationToken.None);
+
+        Assert.Equal(257, Assert.Single(firstResult).Id);
+        Assert.Equal(257, Assert.Single(secondResult).Id);
+        Assert.Equal(1, handler.CallCount);
+    }
+
+    [Fact]
     public async Task ListAsync_throws_HttpRequestException_on_5xx()
     {
         var (client, _) = MakeClient(new StubHttpMessageHandler(HttpStatusCode.ServiceUnavailable));


### PR DESCRIPTION
## Summary
- restrict create/edit run M+ dungeon choices to instances present in the current Mythic Keystone leaderboard
- use stable default connected-realm ids for US/EU leaderboard fetches, with region-index fallback when needed
- memoize successful reference-list responses in the Blazor app for the current browser session

## Verification
- `dotnet format lfm.sln --verify-no-changes`
- `dotnet build lfm.sln -c Release --no-restore`
- `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release --no-build` (905 passed)
- `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release --no-build` (293 passed)
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --no-build` (319 passed)
- `git diff --check`
- `git ls-files -ci --exclude-standard`

## Ops
- Env vars: none
- Schema/migrations: none
- Screenshots: not included; behavior is data filtering and app-core caching