### PR TITLE
Fix localization switching

### DIFF
--- a/api/Validation/RequestValidators.cs
+++ b/api/Validation/RequestValidators.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 using System.Globalization;
 using FluentValidation;
 using Lfm.Contracts.Guild;
+using Lfm.Contracts.Localization;
 using Lfm.Contracts.Me;
 using Lfm.Contracts.Raiders;
 using Lfm.Contracts.Runs;
@@ -178,15 +179,13 @@ public partial class AddCharacterRequestValidator : AbstractValidator<AddCharact
 
 public sealed class UpdateMeRequestValidator : AbstractValidator<UpdateMeRequest>
 {
-    private static readonly string[] SupportedLocales = ["en", "fi"];
-
     public UpdateMeRequestValidator()
     {
         RuleFor(x => x.Locale)
             .NotEmpty()
             .WithMessage("locale is required")
-            .Must(l => l is not null && SupportedLocales.Contains(l))
-            .WithMessage($"Invalid locale. Supported: {string.Join(", ", SupportedLocales)}");
+            .Must(l => SupportedAppLocales.Contains(l))
+            .WithMessage($"Invalid locale. Supported: {string.Join(", ", SupportedAppLocales.Codes)}");
     }
 }
 

--- a/app/Components/ToggleGroup.razor
+++ b/app/Components/ToggleGroup.razor
@@ -47,7 +47,7 @@
         <button type="button"
                 role="radio"
                 aria-checked="@(isSelected ? "true" : "false")"
-                tabindex="@(isSelected ? 0 : -1)"
+                tabindex="@(isSelected ? "0" : "-1")"
                 disabled="@Disabled"
                 class="toggle-group__option @OptionClassFor(opt.Value)"
                 style="@OptionStyleFor(opt.Value)"

--- a/app/Layout/MainLayout.razor
+++ b/app/Layout/MainLayout.razor
@@ -4,11 +4,15 @@
 @using Microsoft.AspNetCore.Components.Authorization
 @using Lfm.App.Auth
 @using Lfm.App.Services
+@using Lfm.Contracts.Me
 @inject NavigationManager Nav
 @inject IConfiguration Config
 @inject IThemeService ThemeService
 @inject IStringLocalizer Loc
 @inject ILocaleService LocaleService
+@inject AuthenticationStateProvider AuthStateProvider
+@inject IMeClient MeClient
+@inject ToastHelper Toast
 @inject IJSRuntime JS
 
 <FluentToastProvider />
@@ -145,20 +149,17 @@
             <FluentAnchor Href="@_sourceUrl" Target="_blank" rel="noopener external">@Loc["footer.source"]</FluentAnchor>
         </FluentStack>
         <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="4" Wrap="true" Class="footer-language">
-            <FluentButton Appearance="Appearance.Stealth"
-                          Class="@LanguageButtonClass("en")"
-                          aria-pressed="@IsCurrentLocale("en").ToString().ToLowerInvariant()"
-                          OnClick="@(() => LocaleService.SetLocale("en"))"
-                          Title="@Loc["locale.en"]">
-                @Loc["locale.en"]
-            </FluentButton>
-            <FluentButton Appearance="Appearance.Stealth"
-                          Class="@LanguageButtonClass("fi")"
-                          aria-pressed="@IsCurrentLocale("fi").ToString().ToLowerInvariant()"
-                          OnClick="@(() => LocaleService.SetLocale("fi"))"
-                          Title="@Loc["locale.fi"]">
-                @Loc["locale.fi"]
-            </FluentButton>
+            @foreach (var locale in SupportedLocales.All)
+            {
+                var labelKey = SupportedLocales.LabelKeyOrDefault(locale);
+                <FluentButton Appearance="Appearance.Stealth"
+                              Class="@LanguageButtonClass(locale)"
+                              aria-pressed="@IsCurrentLocale(locale).ToString().ToLowerInvariant()"
+                              OnClick="@(() => ChangeLocaleAsync(locale))"
+                              Title="@Loc[labelKey]">
+                    @Loc[labelKey]
+                </FluentButton>
+            }
         </FluentStack>
     </footer>
 </div>
@@ -379,6 +380,51 @@
 
     private string LanguageButtonClass(string locale) =>
         IsCurrentLocale(locale) ? "footer-language__button footer-language--active" : "footer-language__button";
+
+    private async Task ChangeLocaleAsync(string locale)
+    {
+        if (!SupportedLocales.Contains(locale))
+        {
+            return;
+        }
+
+        var normalized = SupportedLocales.NormalizeOrDefault(locale);
+        LocaleService.SetLocale(normalized);
+        await PersistLocalePreferenceAsync(normalized);
+    }
+
+    private async Task PersistLocalePreferenceAsync(string locale)
+    {
+        try
+        {
+            var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+            if (authState.User.Identity?.IsAuthenticated != true)
+            {
+                return;
+            }
+
+            var updated = await MeClient.UpdateAsync(new UpdateMeRequest(locale), CancellationToken.None);
+            if (updated is null)
+            {
+                Toast.ShowError(Loc["locale.saveFailed"]);
+                return;
+            }
+
+            var persistedLocale = SupportedLocales.NormalizeOrDefault(updated.Locale);
+            if (!IsCurrentLocale(persistedLocale))
+            {
+                LocaleService.SetLocale(persistedLocale);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // The user navigated away while the preference save was in flight.
+        }
+        catch
+        {
+            Toast.ShowError(Loc["locale.saveFailed"]);
+        }
+    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {

--- a/app/Lfm.App.Core/Runs/RunDateFormatter.cs
+++ b/app/Lfm.App.Core/Runs/RunDateFormatter.cs
@@ -11,7 +11,7 @@ public static class RunDateFormatter
     {
         if (string.IsNullOrEmpty(isoDate)) return "\u2014";
         return DateTimeOffset.TryParse(isoDate, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var dto)
-            ? dto.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture)
+            ? dto.ToString("g", CultureInfo.CurrentCulture)
             : isoDate;
     }
 }

--- a/app/Lfm.App.Core/i18n/LocaleService.cs
+++ b/app/Lfm.App.Core/i18n/LocaleService.cs
@@ -3,6 +3,8 @@
 
 namespace Lfm.App.i18n;
 
+using System.Globalization;
+
 /// <summary>
 /// Singleton locale tracker. Default is "en"; callers may switch to any
 /// supported locale ("en", "fi") via <see cref="SetLocale"/>.
@@ -12,6 +14,11 @@ public sealed class LocaleService : ILocaleService
     public string CurrentLocale { get; private set; } = SupportedLocales.Default;
 
     public event Action? OnLocaleChanged;
+
+    public LocaleService()
+    {
+        ApplyCulture(CurrentLocale);
+    }
 
     public void SetLocale(string locale)
     {
@@ -23,6 +30,16 @@ public sealed class LocaleService : ILocaleService
             return;
 
         CurrentLocale = normalized;
+        ApplyCulture(normalized);
         OnLocaleChanged?.Invoke();
+    }
+
+    private static void ApplyCulture(string locale)
+    {
+        var culture = SupportedLocales.CultureOrDefault(locale);
+        CultureInfo.CurrentCulture = culture;
+        CultureInfo.CurrentUICulture = culture;
+        CultureInfo.DefaultThreadCurrentCulture = culture;
+        CultureInfo.DefaultThreadCurrentUICulture = culture;
     }
 }

--- a/app/Lfm.App.Core/i18n/SupportedLocales.cs
+++ b/app/Lfm.App.Core/i18n/SupportedLocales.cs
@@ -3,29 +3,32 @@
 
 namespace Lfm.App.i18n;
 
+using System.Globalization;
+using Lfm.Contracts.Localization;
+
 public static class SupportedLocales
 {
-    public const string English = "en";
-    public const string Finnish = "fi";
-    public const string Default = English;
+    public const string English = SupportedAppLocales.English;
+    public const string Finnish = SupportedAppLocales.Finnish;
+    public const string Default = SupportedAppLocales.Default;
 
-    private static readonly HashSet<string> Values = new(StringComparer.OrdinalIgnoreCase)
-    {
-        English,
-        Finnish,
-    };
-
-    public static IReadOnlyList<string> All { get; } = [English, Finnish];
+    public static IReadOnlyList<string> All => SupportedAppLocales.Codes;
 
     public static bool Contains(string? locale) =>
-        !string.IsNullOrWhiteSpace(locale) && Values.Contains(locale);
+        SupportedAppLocales.Contains(locale);
 
-    public static string NormalizeOrDefault(string? locale)
-    {
-        if (string.IsNullOrWhiteSpace(locale))
-            return Default;
+    public static string NormalizeOrDefault(string? locale) =>
+        SupportedAppLocales.NormalizeOrDefault(locale);
 
-        var normalized = locale.ToLowerInvariant();
-        return Values.Contains(normalized) ? normalized : Default;
-    }
+    public static string MatchBrowserLanguageOrDefault(string? browserLanguage) =>
+        SupportedAppLocales.MatchBrowserLanguageOrDefault(browserLanguage);
+
+    public static string LabelKeyOrDefault(string? locale) =>
+        SupportedAppLocales.LabelKeyOrDefault(locale);
+
+    public static CultureInfo CultureOrDefault(string? locale) =>
+        CultureInfo.GetCultureInfo(SupportedAppLocales.CultureNameOrDefault(locale));
+
+    public static bool IsRtl(string? locale) =>
+        SupportedAppLocales.IsRtl(locale);
 }

--- a/app/Lfm.App.csproj
+++ b/app/Lfm.App.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RootNamespace>Lfm.App</RootNamespace>
+    <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
     <!-- Blazor WASM SDK ships implicit package refs (HotReload, WebAssembly.Pack) whose
          versions drift independently of global.json's SDK pin, so locked-mode restore
          fails on CI even with the SDK pinned. Lockfile generation stays on; enforcement

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -87,11 +87,12 @@ var js = host.Services.GetRequiredService<IJSRuntime>();
 try
 {
     var browserLang = await js.InvokeAsync<string>("lfmGetBrowserLanguage");
-    if (browserLang?.StartsWith("fi", StringComparison.OrdinalIgnoreCase) == true)
+    var browserLocale = SupportedLocales.MatchBrowserLanguageOrDefault(browserLang);
+    if (browserLocale != SupportedLocales.Default)
     {
         var localeService = host.Services.GetRequiredService<ILocaleService>();
-        await localizer.LoadLocaleAsync("fi");
-        localeService.SetLocale("fi");
+        await localizer.LoadLocaleAsync(browserLocale);
+        localeService.SetLocale(browserLocale);
     }
 }
 catch

--- a/app/wwwroot/locales/en.json
+++ b/app/wwwroot/locales/en.json
@@ -358,5 +358,6 @@
     "guildAdmin.settings.save": "Save Settings",
 
     "locale.en": "EN",
-    "locale.fi": "FI"
+    "locale.fi": "FI",
+    "locale.saveFailed": "Language changed for this session, but it could not be saved to your profile."
 }

--- a/app/wwwroot/locales/fi.json
+++ b/app/wwwroot/locales/fi.json
@@ -333,6 +333,7 @@
     "guildAdmin.settings.save": "Tallenna asetukset",
     "locale.en": "EN",
     "locale.fi": "FI",
+    "locale.saveFailed": "Kieli vaihdettiin t\u00e4lle istunnolle, mutta sit\u00e4 ei voitu tallentaa profiiliisi.",
     "privacy.contact.reveal": "N\u00e4yt\u00e4 yhteyss\u00e4hk\u00f6posti",
     "privacy.contact.revealing": "Ladataan\u2026",
     "privacy.contact.error": "Yhteyss\u00e4hk\u00f6postin lataaminen ep\u00e4onnistui. Yrit\u00e4 my\u00f6hemmin uudelleen."

--- a/shared/Lfm.Contracts/Localization/SupportedAppLocales.cs
+++ b/shared/Lfm.Contracts/Localization/SupportedAppLocales.cs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+namespace Lfm.Contracts.Localization;
+
+internal sealed record AppLocaleInfo(
+    string Code,
+    string LabelKey,
+    string CultureName,
+    bool IsRtl,
+    IReadOnlyList<string> BrowserLanguagePrefixes);
+
+public static class SupportedAppLocales
+{
+    public const string English = "en";
+    public const string Finnish = "fi";
+    public const string Default = English;
+
+    private static readonly AppLocaleInfo[] Locales =
+    [
+        new(English, "locale.en", "en-GB", false, [English]),
+        new(Finnish, "locale.fi", "fi-FI", false, [Finnish]),
+    ];
+
+    private static readonly HashSet<string> Values = new(
+        Locales.Select(l => l.Code),
+        StringComparer.OrdinalIgnoreCase);
+
+    public static IReadOnlyList<string> Codes { get; } =
+        Locales.Select(l => l.Code).ToArray();
+
+    public static bool Contains(string? locale) =>
+        !string.IsNullOrWhiteSpace(locale) && Values.Contains(locale.Trim());
+
+    public static string NormalizeOrDefault(string? locale)
+    {
+        if (string.IsNullOrWhiteSpace(locale))
+            return Default;
+
+        var normalized = locale.Trim().ToLowerInvariant();
+        return Values.Contains(normalized) ? normalized : Default;
+    }
+
+    public static string LabelKeyOrDefault(string? locale) =>
+        ResolveOrDefault(locale).LabelKey;
+
+    public static string CultureNameOrDefault(string? locale) =>
+        ResolveOrDefault(locale).CultureName;
+
+    public static bool IsRtl(string? locale) =>
+        ResolveOrDefault(locale).IsRtl;
+
+    private static AppLocaleInfo ResolveOrDefault(string? locale)
+    {
+        var normalized = NormalizeOrDefault(locale);
+        return Locales.First(l => string.Equals(l.Code, normalized, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public static string MatchBrowserLanguageOrDefault(string? browserLanguage)
+    {
+        if (string.IsNullOrWhiteSpace(browserLanguage))
+            return Default;
+
+        var normalized = browserLanguage.Trim().ToLowerInvariant().Replace('_', '-');
+        return Locales.FirstOrDefault(l => l.BrowserLanguagePrefixes.Any(prefix =>
+            normalized.Equals(prefix, StringComparison.OrdinalIgnoreCase)
+            || normalized.StartsWith(prefix + "-", StringComparison.OrdinalIgnoreCase)))?.Code
+            ?? Default;
+    }
+}

--- a/tests/Lfm.App.Core.Tests/Runs/RunDateFormatterTests.cs
+++ b/tests/Lfm.App.Core.Tests/Runs/RunDateFormatterTests.cs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Globalization;
+using Lfm.App.Runs;
+using Xunit;
+
+namespace Lfm.App.Core.Tests.Runs;
+
+public class RunDateFormatterTests
+{
+    [Fact]
+    public void FormatDisplay_Uses_Current_Culture()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            var culture = CultureInfo.GetCultureInfo("fi-FI");
+            CultureInfo.CurrentCulture = culture;
+            var start = new DateTimeOffset(2026, 5, 20, 15, 30, 0, TimeSpan.Zero);
+
+            var result = RunDateFormatter.FormatDisplay(start.ToString("o", CultureInfo.InvariantCulture));
+
+            Assert.Equal(start.ToString("g", culture), result);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+}

--- a/tests/Lfm.App.Core.Tests/i18n/LocaleServiceTests.cs
+++ b/tests/Lfm.App.Core.Tests/i18n/LocaleServiceTests.cs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2026 LFM contributors
 
 using Lfm.App.i18n;
+using System.Globalization;
 using Xunit;
 
 namespace Lfm.App.Core.Tests.i18n;
@@ -71,6 +72,33 @@ public class LocaleServiceTests
         sut.SetLocale("FI");
 
         Assert.Equal("fi", sut.CurrentLocale);
+    }
+
+    [Fact]
+    public void SetLocale_Updates_Current_Culture()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        var originalUiCulture = CultureInfo.CurrentUICulture;
+        var originalDefaultCulture = CultureInfo.DefaultThreadCurrentCulture;
+        var originalDefaultUiCulture = CultureInfo.DefaultThreadCurrentUICulture;
+        try
+        {
+            var sut = new LocaleService();
+
+            sut.SetLocale("fi");
+
+            Assert.Equal("fi-FI", CultureInfo.CurrentCulture.Name);
+            Assert.Equal("fi-FI", CultureInfo.CurrentUICulture.Name);
+            Assert.Equal("fi-FI", CultureInfo.DefaultThreadCurrentCulture?.Name);
+            Assert.Equal("fi-FI", CultureInfo.DefaultThreadCurrentUICulture?.Name);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+            CultureInfo.CurrentUICulture = originalUiCulture;
+            CultureInfo.DefaultThreadCurrentCulture = originalDefaultCulture;
+            CultureInfo.DefaultThreadCurrentUICulture = originalDefaultUiCulture;
+        }
     }
 
     [Theory]

--- a/tests/Lfm.App.Tests/BlazorProjectContractTests.cs
+++ b/tests/Lfm.App.Tests/BlazorProjectContractTests.cs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 LFM contributors
+
+using System.Xml.Linq;
+using Xunit;
+
+namespace Lfm.App.Tests;
+
+public class BlazorProjectContractTests
+{
+    [Fact]
+    public void App_project_loads_all_globalization_data_for_runtime_locale_switches()
+    {
+        var projectPath = Path.Combine(FindRepositoryRoot(), "app", "Lfm.App.csproj");
+        var project = XDocument.Load(projectPath);
+
+        var loadAllGlobalizationData = project
+            .Descendants("BlazorWebAssemblyLoadAllGlobalizationData")
+            .Select(element => element.Value)
+            .SingleOrDefault();
+
+        Assert.Equal("true", loadAllGlobalizationData);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "lfm.sln")))
+                return directory.FullName;
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not find repository root from test output directory.");
+    }
+}

--- a/tests/Lfm.App.Tests/LayoutTests.cs
+++ b/tests/Lfm.App.Tests/LayoutTests.cs
@@ -7,7 +7,9 @@ using Lfm.App.Auth;
 using Lfm.App.Layout;
 using Lfm.App.Services;
 using Lfm.App.i18n;
+using Lfm.Contracts.Characters;
 using Lfm.Contracts.Media;
+using Lfm.Contracts.Me;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
@@ -152,6 +154,48 @@ public class LayoutTests : ComponentTestBase
         handler.ReleaseFinnishLocale();
 
         cut.WaitForAssertion(() => Assert.Contains("Tietosuojaseloste", cut.Markup));
+    }
+
+    [Fact]
+    public void MainLayout_Footer_Language_Click_Persists_Authenticated_User_Locale()
+    {
+        var auth = this.AddAuthorization();
+        auth.SetAuthorized("player#1234");
+        var meClient = new RecordingMeClient(new UpdateMeResponse("fi"));
+        Services.RemoveAll<IMeClient>();
+        Services.AddSingleton<IMeClient>(meClient);
+
+        var cut = Render<MainLayout>(p =>
+            p.Add(x => x.Body, builder => builder.AddContent(0, "page content")));
+
+        cut.Find("fluent-button[title='FI']").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Equal("fi", meClient.LastLocale);
+            Assert.Equal(1, meClient.UpdateCalls);
+        });
+    }
+
+    [Fact]
+    public void MainLayout_Footer_Language_Click_Does_Not_Persist_Anonymous_Locale()
+    {
+        this.AddAuthorization();
+        var meClient = new RecordingMeClient(new UpdateMeResponse("fi"));
+        Services.RemoveAll<IMeClient>();
+        Services.AddSingleton<IMeClient>(meClient);
+
+        var cut = Render<MainLayout>(p =>
+            p.Add(x => x.Body, builder => builder.AddContent(0, "page content")));
+
+        cut.Find("fluent-button[title='FI']").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            var localeService = Services.GetRequiredService<ILocaleService>();
+            Assert.Equal("fi", localeService.CurrentLocale);
+        });
+        Assert.Equal(0, meClient.UpdateCalls);
     }
 
     [Fact]
@@ -504,5 +548,30 @@ public class LayoutTests : ComponentTestBase
                 Content = new StringContent(JsonSerializer.Serialize(strings)),
             };
         }
+    }
+
+    private sealed class RecordingMeClient(UpdateMeResponse? updateResponse) : IMeClient
+    {
+        public int UpdateCalls { get; private set; }
+        public string? LastLocale { get; private set; }
+
+        public Task<MeResponse?> GetAsync(CancellationToken ct) =>
+            Task.FromResult<MeResponse?>(null);
+
+        public Task<UpdateMeResponse?> UpdateAsync(UpdateMeRequest request, CancellationToken ct)
+        {
+            UpdateCalls++;
+            LastLocale = request.Locale;
+            return Task.FromResult(updateResponse);
+        }
+
+        public Task<bool> SelectCharacterAsync(string id, CancellationToken ct) =>
+            Task.FromResult(false);
+
+        public Task<bool> DeleteAsync(CancellationToken ct) =>
+            Task.FromResult(false);
+
+        public Task<CharacterDto?> EnrichCharacterAsync(string id, CancellationToken ct) =>
+            Task.FromResult<CharacterDto?>(null);
     }
 }

--- a/tests/Lfm.App.Tests/RunsPagesTests.cs
+++ b/tests/Lfm.App.Tests/RunsPagesTests.cs
@@ -325,9 +325,9 @@ public class RunsPagesTests : ComponentTestBase
             var runButton = cut.Find("button.run-list-item");
             var ariaLabel = runButton.GetAttribute("aria-label") ?? string.Empty;
             // FormatDate (private in RunsPage) parses the ISO string and
-            // formats as "yyyy-MM-dd HH:mm" with InvariantCulture; mirror that
-            // here so the test pins the exact localized output screen readers
-            // get, without reaching into the page object's private helpers.
+            // delegates culture-sensitive display formatting; mirror that here
+            // so the test pins the exact localized output screen readers get,
+            // without reaching into the page object's private helpers.
             var formattedDate = RunDateFormatter.FormatDisplay(summary.StartTime);
             var expected = Loc("runs.listItemAriaLabel", summary.InstanceName ?? "", formattedDate);
             Assert.Equal(expected, ariaLabel);


### PR DESCRIPTION
## Summary
- Persist authenticated footer language switches through the existing profile locale API
- Centralize supported app locale metadata for startup detection and API validation
- Apply .NET culture on locale changes and use culture-aware run date formatting
- Keep HTML `tabindex` values culture-invariant under localized cultures

## Verification
- `dotnet test tests/Lfm.App.Core.Tests/Lfm.App.Core.Tests.csproj -c Release --no-restore`
- `dotnet test tests/Lfm.App.Tests/Lfm.App.Tests.csproj -c Release --no-restore`
- `dotnet test tests/Lfm.Api.Tests/Lfm.Api.Tests.csproj -c Release --no-restore`
- `dotnet format lfm.sln --verify-no-changes --no-restore --severity error`
- `dotnet build lfm.sln -c Release`
- `git diff --check`